### PR TITLE
docs: rfc-016 foreach + rfc-017 native data source metadata

### DIFF
--- a/docs/rfcs/rfc-016.md
+++ b/docs/rfcs/rfc-016.md
@@ -1,0 +1,212 @@
+# RFC-016: Collection Operations
+
+**Status:** Proposed
+**Date:** 2026-04-07
+**Authors:** Anne Schuth
+
+## Context
+
+Dutch law frequently reasons about collections of variable length: children in a household, employment periods, registrations, household members. The current v0.5.1 operation set has no way to iterate over a collection and apply logic per element.
+
+The poc-machine-law corpus has 19 law files with 58 occurrences of a `FOREACH` operation that was present in schema v0.2.0-v0.4.0 but removed in v0.5.0. The engine's `context.rs` already has the infrastructure for FOREACH (local scope, `create_child()`, variable resolution for loop variables) but no `execute_foreach` in `operations.rs`.
+
+### Real examples from Dutch law
+
+**Kindgebonden budget (artikel 2 WKB)**. The leeftijdstoeslag depends on each child's age: €703 for 12-15 year olds, €936 for 16-17 year olds. The number of children varies per household.
+
+**Wet BRP**. Counting household members for huurtoeslag income thresholds. Each member's income contribution depends on their age (above or below 21).
+
+**Burgerlijk Wetboek delegaties**. Filtering active registrations (curatele, bewind, mentorschap, executeurschap, volmacht) from a list of all registrations, then extracting subject names and permission sets.
+
+**AWB bezwaar/beroep**. Counting relevant events (submissions, decisions) from a case event history.
+
+### The alternative without FOREACH
+
+Without FOREACH, the law author must pre-aggregate data in the data source layer. For the kindgebonden budget example:
+
+```yaml
+# Without FOREACH: data source must provide category counts
+- output: leeftijdstoeslagen
+  operation: ADD
+  values:
+    - operation: MULTIPLY
+      values: [$aantal_kinderen_12_15, $extra_12_15_jaar]
+    - operation: MULTIPLY
+      values: [$aantal_kinderen_16_17, $extra_16_17_jaar]
+```
+
+This works for simple sums-by-category, but pushes legal logic (the age thresholds 12, 16, 17) into the data source layer. The law says "voor een kind dat 12 jaar of ouder is" - that condition belongs in the law YAML, not in a pre-processing step.
+
+For filter-and-transform patterns (active registrations, delegation permissions), pre-aggregation requires the data source to understand legal concepts like "active curatele" - exactly what regelrecht aims to avoid.
+
+## Decision
+
+Add a `FOREACH` operation to the v0.5.x schema and engine. FOREACH iterates over a collection, evaluates an expression per element with the element available as a local scope variable, and optionally combines results.
+
+### YAML syntax
+
+```yaml
+operation: FOREACH
+subject: $kinderen_leeftijden       # collection to iterate over
+as: leeftijd                         # local variable name (optional, defaults to "current")
+value:                               # expression evaluated per element
+  operation: IF
+  cases:
+    - when:
+        operation: GREATER_THAN_OR_EQUAL
+        subject: $leeftijd
+        value: 16
+      then: $extra_16_17_jaar
+    - when:
+        operation: GREATER_THAN_OR_EQUAL
+        subject: $leeftijd
+        value: 12
+      then: $extra_12_15_jaar
+  default: 0
+combine: ADD                         # aggregation (optional)
+```
+
+With optional filter:
+
+```yaml
+operation: FOREACH
+subject: $curatele_registraties
+as: registratie
+where:                               # filter condition (optional)
+  operation: EQUALS
+  subject: $registratie.status
+  value: ACTIEF
+value: $registratie
+```
+
+### Schema definition
+
+```json
+"foreachOperation": {
+  "type": "object",
+  "required": ["operation", "subject", "value"],
+  "additionalProperties": false,
+  "properties": {
+    "operation": { "const": "FOREACH" },
+    "subject": { "$ref": "#/definitions/operationValue" },
+    "as": {
+      "type": "string",
+      "description": "Local variable name for current element. Defaults to 'current'."
+    },
+    "value": { "$ref": "#/definitions/operationValue" },
+    "where": {
+      "$ref": "#/definitions/operationValue",
+      "description": "Optional filter: skip elements where this evaluates to false."
+    },
+    "combine": {
+      "type": "string",
+      "enum": ["ADD", "OR", "AND", "MIN", "MAX", "LIST"],
+      "description": "Aggregation operation applied to collected results."
+    },
+    "legal_basis": { "$ref": "#/definitions/legalBasis" }
+  }
+}
+```
+
+### Semantics
+
+1. Evaluate `subject` to get a collection (array). If not an array, wrap in single-element array.
+2. For each element:
+   a. Create a child execution context (via existing `create_child()`).
+   b. Set the element as a local variable named `as` (default: `current`).
+   c. If `where` is present, evaluate it. If falsy, skip this element.
+   d. Evaluate `value` in the child context. Collect the result.
+3. If `combine` is set, apply the aggregation to collected results and return.
+4. If `combine` is not set, return the collected results as an array.
+
+### Dot notation for element properties
+
+When iterating over arrays of objects, dot notation accesses properties:
+
+```yaml
+subject: $curatele_registraties    # [{status: "ACTIEF", bsn: "123"}, ...]
+as: reg
+value: $reg.bsn                    # accesses the bsn property
+```
+
+This uses the existing dot notation support in `context.rs` (`resolve_variable` with path splitting).
+
+### Combine operations
+
+| Combine | Description | Empty collection result |
+|---------|-------------|------------------------|
+| `ADD` | Sum numeric results | 0 |
+| `OR` | Any result truthy | false |
+| `AND` | All results truthy | true |
+| `MIN` | Minimum value | null |
+| `MAX` | Maximum value | null |
+| `LIST` | Collect as array | [] |
+| *(none)* | Collect as array | [] |
+
+### Security constraints
+
+- Maximum iteration count: `MAX_ARRAY_SIZE` (existing config, default 1000).
+- Maximum nesting depth: `MAX_RECURSION_DEPTH` (existing config).
+- Elements must be finite (no lazy/infinite sequences).
+
+## Why
+
+### Benefits
+
+**Law logic stays in law YAML.** Age thresholds, status filters, and permission mappings are legal decisions. They belong in the regulation, not in pre-processing code.
+
+**Matches legal language.** "Voor elk kind" (for each child), "alle actieve registraties" (all active registrations) - FOREACH maps directly to how legislators write.
+
+**Engine infrastructure exists.** `context.rs` already has `create_child()`, `set_local()`, `clear_local()`, and local scope variable resolution. FOREACH was removed from the schema before the engine implementation was completed, not because iteration was rejected as a concept.
+
+**19 law files need it.** The poc-machine-law corpus has concrete, tested use cases across toeslagen, BW delegaties, AWB procedures, and BRP household calculations.
+
+### Tradeoffs
+
+**Non-termination risk.** Mitigated by `MAX_ARRAY_SIZE` and `MAX_RECURSION_DEPTH`. All collections come from finite data sources.
+
+**Complexity.** FOREACH is the only operation that introduces variable scoping. The engine already handles this (child contexts), but it adds a concept that other operations don't have.
+
+**Alternative modeling exists for some cases.** Simple count-by-category patterns (kindgebonden budget) can be modeled without FOREACH by pre-aggregating in the data source. But this doesn't cover filter-and-transform patterns.
+
+### Alternatives Considered
+
+**Pre-aggregation in data sources.** Push counting/filtering to the data layer. Rejected: moves legal logic out of law YAML. The age threshold "12 jaar of ouder" is a legal decision, not a data concern.
+
+**Fixed maximum with unrolled operations.** Cap at N children and generate N IF branches. Rejected: arbitrary limits, verbose YAML, doesn't handle filter patterns.
+
+**Higher-order functions (MAP, FILTER, REDUCE).** Three separate operations instead of one FOREACH with options. Rejected: over-engineered for the use cases. FOREACH with `where` and `combine` covers all three patterns in a single construct that maps to natural language.
+
+**No iteration - restructure all laws.** Rejected: 19 law files would need non-trivial restructuring, pushing legal logic to data sources. The engine infrastructure for iteration already exists.
+
+### Implementation Notes
+
+**Engine changes:**
+- Add `ForEach` variant to `ActionOperation` enum in `article.rs`
+- Add `execute_foreach()` in `operations.rs`
+- Use existing `ExecutionContext::create_child()` and `set_local()`
+- Trace: `PathNodeType::ForEachIteration` with element index
+- Untranslatable propagation: if any element produces `Untranslatable`, the combined result is `Untranslatable`
+
+**Schema changes:**
+- Add `foreachOperation` definition to `schema/v0.5.x/schema.json`
+- Add `FOREACH` to `operationType` enum
+- Add to `operation` oneOf list
+
+**Conformance tests:**
+- `foreach_basic.json`: iterate over numbers, combine with ADD
+- `foreach_filter.json`: iterate with `where` clause
+- `foreach_objects.json`: iterate over objects, access properties via dot notation
+- `foreach_nested.json`: nested FOREACH (e.g., children within households)
+- `foreach_empty.json`: empty collection handling
+- `foreach_no_combine.json`: collect results as array
+
+## References
+
+- Engine context infrastructure: `packages/engine/src/context.rs` (lines 146-220)
+- FOREACH in schema v0.2.0-v0.4.0: `schema/v0.4.0/schema.json`
+- poc-machine-law FOREACH usage: 19 files, 58 occurrences
+- RFC-004: Uniform Operation Syntax
+- RFC-007: Cross-Law Execution Model (operation set extension)
+- RFC-012: Untranslatables (FOREACH files currently marked as untranslatable)
+- [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/rfcs/rfc-016.md
+++ b/docs/rfcs/rfc-016.md
@@ -6,26 +6,24 @@
 
 ## Context
 
-Dutch law frequently reasons about collections of variable length: children in a household, employment periods, registrations, household members. The current v0.5.1 operation set has no way to iterate over a collection and apply logic per element.
-
-The poc-machine-law corpus has 19 law files with 58 occurrences of a `FOREACH` operation that was present in schema v0.2.0-v0.4.0 but removed in v0.5.0. The engine's `context.rs` already has the infrastructure for FOREACH (local scope, `create_child()`, variable resolution for loop variables) but no `execute_foreach` in `operations.rs`.
+Dutch law frequently reasons about collections of variable length: children in a household, employment periods, registrations, household members. The current v0.5.1 operation set has no way to iterate over a collection and apply per-element logic.
 
 ### Real examples from Dutch law
 
-**Kindgebonden budget (artikel 2 WKB)**. The leeftijdstoeslag depends on each child's age: €703 for 12-15 year olds, €936 for 16-17 year olds. The number of children varies per household.
+**Kindgebonden budget (artikel 2 WKB).** The *leeftijdstoeslag* depends on each child's age: €703 for children aged 12-15, €936 for children aged 16-17. The law text reads: *"Voor een kind dat 12 jaar of ouder is, maar jonger is dan 16 jaar bedraagt de verhoging van het kindgebonden budget € 703."* The number of children varies per household.
 
-**Wet BRP**. Counting household members for huurtoeslag income thresholds. Each member's income contribution depends on their age (above or below 21).
+**Wet BRP / Huurtoeslag.** Counting household members for income thresholds. Each member's income contribution depends on their age (above or below 21). The law says *"medebewoners"* without specifying a maximum.
 
-**Burgerlijk Wetboek delegaties**. Filtering active registrations (curatele, bewind, mentorschap, executeurschap, volmacht) from a list of all registrations, then extracting subject names and permission sets.
+**Burgerlijk Wetboek.** Filtering active registrations (curatele, bewind, mentorschap, executeurschap, volmacht) from a registry. Whether a registration is *"actief"* is a legal determination that depends on status fields, not a data-layer concern.
 
-**AWB bezwaar/beroep**. Counting relevant events (submissions, decisions) from a case event history.
+**AWB bezwaar/beroep.** Counting relevant procedural events (submissions, decisions) from a case history to determine deadlines and rights.
 
-### The alternative without FOREACH
+### The alternative without iteration
 
-Without FOREACH, the law author must pre-aggregate data in the data source layer. For the kindgebonden budget example:
+Without a collection operation, the law author must pre-aggregate data in the data source layer:
 
 ```yaml
-# Without FOREACH: data source must provide category counts
+# Pre-aggregated: data source provides category counts
 - output: leeftijdstoeslagen
   operation: ADD
   values:
@@ -35,21 +33,21 @@ Without FOREACH, the law author must pre-aggregate data in the data source layer
       values: [$aantal_kinderen_16_17, $extra_16_17_jaar]
 ```
 
-This works for simple sums-by-category, but pushes legal logic (the age thresholds 12, 16, 17) into the data source layer. The law says "voor een kind dat 12 jaar of ouder is" - that condition belongs in the law YAML, not in a pre-processing step.
+This works for simple sums-by-category. But it pushes the legal thresholds (12, 16, 17) into the data source layer. The data source must know what "12 jaar of ouder" means in the context of this specific law, which is exactly what regelrecht aims to avoid.
 
-For filter-and-transform patterns (active registrations, delegation permissions), pre-aggregation requires the data source to understand legal concepts like "active curatele" - exactly what regelrecht aims to avoid.
+For filter-and-transform patterns (e.g., selecting active registrations), pre-aggregation requires the data source to understand legal concepts like *"actief bewind"*. That couples the data layer to legal semantics.
 
 ## Decision
 
-Add a `FOREACH` operation to the v0.5.x schema and engine. FOREACH iterates over a collection, evaluates an expression per element with the element available as a local scope variable, and optionally combines results.
+Add a `FOREACH` operation to the schema and engine. FOREACH iterates over a collection, evaluates an expression per element with the element bound to a local variable, and optionally aggregates results.
 
 ### YAML syntax
 
 ```yaml
 operation: FOREACH
-subject: $kinderen_leeftijden       # collection to iterate over
-as: leeftijd                         # local variable name (optional, defaults to "current")
-value:                               # expression evaluated per element
+collection: $kinderen_leeftijden     # array to iterate over
+as: leeftijd                         # local variable name (optional, defaults to "item")
+body:                                # expression evaluated per element
   operation: IF
   cases:
     - when:
@@ -70,38 +68,81 @@ With optional filter:
 
 ```yaml
 operation: FOREACH
-subject: $curatele_registraties
+collection: $curatele_registraties
 as: registratie
-where:                               # filter condition (optional)
+filter:                              # skip elements where this evaluates to false
   operation: EQUALS
   subject: $registratie.status
   value: ACTIEF
-value: $registratie
+body: $registratie
 ```
+
+### Property naming rationale
+
+FOREACH introduces properties that don't exist in other operations. The names are chosen to be distinct from existing property semantics:
+
+| Property | Why this name |
+|----------|---------------|
+| `collection` | Distinct from `subject` (used for comparisons) and `values` (used for arithmetic). Describes what it is: the collection to iterate. |
+| `body` | Distinct from `value` (used for comparison target and action assignment). Describes what it is: the expression body to evaluate per element. |
+| `as` | Standard iteration variable binding, familiar from SQL and template languages. |
+| `filter` | Distinct from `conditions` (used for AND/OR). Describes intent: filtering elements. |
+| `combine` | Describes intent: combining per-element results into a single value. |
+
+### Variable binding with `as`
+
+FOREACH is the only operation that introduces a new variable name into scope. This is a new concept in the schema: all other operations reference existing variables, none define them.
+
+The `as` parameter names a local variable that exists only within the `body` and `filter` expressions. It shadows any outer variable with the same name. When `as` is omitted, the default name is `item`.
+
+**Nested FOREACH scoping:** Each FOREACH creates an independent child scope. Inner iterations cannot see outer iteration variables unless they are passed explicitly. If an inner FOREACH uses the same `as` name as an outer one, the inner binding shadows the outer within its body.
+
+```yaml
+# Nested: outer $household, inner $member
+operation: FOREACH
+collection: $households
+as: household
+body:
+  operation: FOREACH
+  collection: $household.members     # access outer variable via dot notation
+  as: member
+  body: $member.income               # inner scope only sees $member, not $household
+  combine: ADD
+combine: ADD
+```
+
+To access the outer variable in the inner body, extract it to a separate output first, or restructure to avoid nesting.
 
 ### Schema definition
 
 ```json
 "foreachOperation": {
   "type": "object",
-  "required": ["operation", "subject", "value"],
+  "required": ["operation", "collection", "body"],
   "additionalProperties": false,
   "properties": {
     "operation": { "const": "FOREACH" },
-    "subject": { "$ref": "#/definitions/operationValue" },
+    "collection": {
+      "$ref": "#/definitions/operationValue",
+      "description": "Expression that evaluates to an array."
+    },
     "as": {
       "type": "string",
-      "description": "Local variable name for current element. Defaults to 'current'."
+      "pattern": "^[a-z_][a-z0-9_]*$",
+      "description": "Local variable name bound to the current element. Defaults to 'item'."
     },
-    "value": { "$ref": "#/definitions/operationValue" },
-    "where": {
+    "body": {
       "$ref": "#/definitions/operationValue",
-      "description": "Optional filter: skip elements where this evaluates to false."
+      "description": "Expression evaluated for each element."
+    },
+    "filter": {
+      "$ref": "#/definitions/operationValue",
+      "description": "Boolean expression. Elements where this evaluates to false are skipped."
     },
     "combine": {
       "type": "string",
-      "enum": ["ADD", "OR", "AND", "MIN", "MAX", "LIST"],
-      "description": "Aggregation operation applied to collected results."
+      "enum": ["ADD", "OR", "AND", "MIN", "MAX"],
+      "description": "Aggregation applied to collected results. When omitted, results are returned as an array."
     },
     "legal_basis": { "$ref": "#/definitions/legalBasis" }
   }
@@ -110,103 +151,106 @@ value: $registratie
 
 ### Semantics
 
-1. Evaluate `subject` to get a collection (array). If not an array, wrap in single-element array.
-2. For each element:
-   a. Create a child execution context (via existing `create_child()`).
-   b. Set the element as a local variable named `as` (default: `current`).
-   c. If `where` is present, evaluate it. If falsy, skip this element.
-   d. Evaluate `value` in the child context. Collect the result.
-3. If `combine` is set, apply the aggregation to collected results and return.
-4. If `combine` is not set, return the collected results as an array.
+1. Evaluate `collection` to get an array. If the result is not an array, wrap it in a single-element array. If null, treat as empty array.
+2. For each element in the array:
+   a. Create a child execution context (isolated local scope).
+   b. Bind the element to the local variable named by `as` (default: `item`).
+   c. If `filter` is present, evaluate it in the child context. If the result is falsy, skip this element.
+   d. Evaluate `body` in the child context. Collect the result.
+3. If `combine` is specified, apply the aggregation to collected results and return a single value.
+4. If `combine` is omitted, return the collected results as an array.
 
 ### Dot notation for element properties
 
 When iterating over arrays of objects, dot notation accesses properties:
 
 ```yaml
-subject: $curatele_registraties    # [{status: "ACTIEF", bsn: "123"}, ...]
+collection: $curatele_registraties   # [{status: "ACTIEF", bsn_curator: "123"}, ...]
 as: reg
-value: $reg.bsn                    # accesses the bsn property
+body: $reg.bsn_curator               # accesses the bsn_curator property
 ```
 
-This uses the existing dot notation support in `context.rs` (`resolve_variable` with path splitting).
+This uses existing dot notation support in variable resolution.
 
 ### Combine operations
 
-| Combine | Description | Empty collection result |
-|---------|-------------|------------------------|
-| `ADD` | Sum numeric results | 0 |
-| `OR` | Any result truthy | false |
-| `AND` | All results truthy | true |
+| Combine | Description | Empty collection |
+|---------|-------------|-----------------|
+| `ADD` | Sum numeric results (polymorphic: also concatenates strings and arrays) | 0 |
+| `OR` | Logical: any result truthy | false |
+| `AND` | Logical: all results truthy | true |
 | `MIN` | Minimum value | null |
 | `MAX` | Maximum value | null |
-| `LIST` | Collect as array | [] |
-| *(none)* | Collect as array | [] |
+| *(omitted)* | Collect results as array | [] |
+
+Note: `ADD` is polymorphic per RFC-007. When results are strings, `ADD` concatenates them. When results are arrays, `ADD` flattens them. This covers string-building use cases without a separate `CONCAT` combiner.
 
 ### Security constraints
 
-- Maximum iteration count: `MAX_ARRAY_SIZE` (existing config, default 1000).
-- Maximum nesting depth: `MAX_RECURSION_DEPTH` (existing config).
-- Elements must be finite (no lazy/infinite sequences).
+- Maximum iteration count: `MAX_ARRAY_SIZE` (existing engine config, default 1000). If the collection exceeds this, the engine returns an error.
+- Maximum nesting depth: FOREACH increments `depth` for recursive evaluation, bounded by `MAX_RECURSION_DEPTH`.
+- All collections originate from finite data sources. The schema does not support generators or lazy sequences.
 
 ## Why
 
 ### Benefits
 
-**Law logic stays in law YAML.** Age thresholds, status filters, and permission mappings are legal decisions. They belong in the regulation, not in pre-processing code.
+**Legal logic stays in law YAML.** Age thresholds, status checks, and permission rules are legal decisions. The data source provides raw facts (list of children with birth dates); the law determines what to do with them.
 
-**Matches legal language.** "Voor elk kind" (for each child), "alle actieve registraties" (all active registrations) - FOREACH maps directly to how legislators write.
+**Matches legal language.** *"Voor elk kind"*, *"alle actieve registraties"*, *"medebewoners van 21 jaar of ouder"* - these are iteration patterns in natural legal language. FOREACH maps directly.
 
-**Engine infrastructure exists.** `context.rs` already has `create_child()`, `set_local()`, `clear_local()`, and local scope variable resolution. FOREACH was removed from the schema before the engine implementation was completed, not because iteration was rejected as a concept.
+**Engine infrastructure exists.** The engine already has child context creation, local variable binding, and scoped variable resolution. The execution machinery is in place; only the operation dispatch is missing.
 
-**19 law files need it.** The poc-machine-law corpus has concrete, tested use cases across toeslagen, BW delegaties, AWB procedures, and BRP household calculations.
+**Concrete use cases.** Multiple Dutch laws across toeslagen, BW delegaties, AWB procedures, and BRP household rules require per-element evaluation over variable-length collections. These are not hypothetical needs.
 
 ### Tradeoffs
 
-**Non-termination risk.** Mitigated by `MAX_ARRAY_SIZE` and `MAX_RECURSION_DEPTH`. All collections come from finite data sources.
+**Variable binding is a new concept.** Every other operation in the schema is purely referential - it reads existing variables but never creates them. `as` introduces a definition point. This makes FOREACH fundamentally different from arithmetic or logical operations.
 
-**Complexity.** FOREACH is the only operation that introduces variable scoping. The engine already handles this (child contexts), but it adds a concept that other operations don't have.
+**Non-termination risk.** Mitigated by `MAX_ARRAY_SIZE` (collection size limit) and `MAX_RECURSION_DEPTH` (nesting limit). Both are existing engine configuration values.
 
-**Alternative modeling exists for some cases.** Simple count-by-category patterns (kindgebonden budget) can be modeled without FOREACH by pre-aggregating in the data source. But this doesn't cover filter-and-transform patterns.
+**Pre-aggregation works for simple cases.** When the pattern is purely "count items in categories," pre-aggregation in the data source is simpler. FOREACH is needed for cases where per-element logic involves legal conditions or where the output is a transformed collection rather than a single aggregate.
 
 ### Alternatives Considered
 
-**Pre-aggregation in data sources.** Push counting/filtering to the data layer. Rejected: moves legal logic out of law YAML. The age threshold "12 jaar of ouder" is a legal decision, not a data concern.
+**Pre-aggregation in data sources.** Push all counting and filtering to the data layer. Rejected: this works for simple sums but moves legal conditions (age thresholds, status definitions) out of law YAML. The boundary between data and law becomes unclear.
 
-**Fixed maximum with unrolled operations.** Cap at N children and generate N IF branches. Rejected: arbitrary limits, verbose YAML, doesn't handle filter patterns.
+**Fixed maximum with unrolled operations.** Generate N branches for up to N items. Rejected: arbitrary limits, verbose YAML, does not handle filter-and-transform patterns, and breaks when the real count exceeds N.
 
-**Higher-order functions (MAP, FILTER, REDUCE).** Three separate operations instead of one FOREACH with options. Rejected: over-engineered for the use cases. FOREACH with `where` and `combine` covers all three patterns in a single construct that maps to natural language.
+**Separate MAP, FILTER, REDUCE operations.** Three operations instead of one. Rejected: these three concepts compose in practice (filter, then transform, then aggregate). Splitting them forces intermediate outputs and makes YAML verbose for the common case. FOREACH with `filter` and `combine` covers all three in one readable construct.
 
-**No iteration - restructure all laws.** Rejected: 19 law files would need non-trivial restructuring, pushing legal logic to data sources. The engine infrastructure for iteration already exists.
+**No iteration, restructure all laws.** Accept that laws needing iteration must be restructured to avoid it. Rejected: this is possible for simple aggregation cases but not for filter-and-transform patterns. It also forces legal knowledge into the data layer, which conflicts with regelrecht's design principle of keeping legal logic in law YAML.
 
 ### Implementation Notes
 
 **Engine changes:**
-- Add `ForEach` variant to `ActionOperation` enum in `article.rs`
-- Add `execute_foreach()` in `operations.rs`
-- Use existing `ExecutionContext::create_child()` and `set_local()`
-- Trace: `PathNodeType::ForEachIteration` with element index
-- Untranslatable propagation: if any element produces `Untranslatable`, the combined result is `Untranslatable`
+- Add `ForEach` variant to `ActionOperation` enum in `article.rs` with fields: `collection`, `as_name`, `body`, `filter`, `combine`
+- Add `execute_foreach()` in `operations.rs`:
+  1. Evaluate `collection` to `Value::Array`
+  2. For each element: `ctx.create_child()`, `ctx.set_local(as_name, element)`, optionally evaluate `filter`, evaluate `body`
+  3. Apply `combine` aggregation or return array
+- Trace: add `PathNodeType::ForEachIteration` with element index for execution tracing
+- Untranslatable propagation: if any element produces `Value::Untranslatable`, the combined result is `Value::Untranslatable` (per RFC-012)
 
 **Schema changes:**
-- Add `foreachOperation` definition to `schema/v0.5.x/schema.json`
+- Add `foreachOperation` to `definitions` in `schema/v0.5.x/schema.json`
 - Add `FOREACH` to `operationType` enum
-- Add to `operation` oneOf list
+- Add `foreachOperation` to the `operation` oneOf discriminator
 
 **Conformance tests:**
-- `foreach_basic.json`: iterate over numbers, combine with ADD
-- `foreach_filter.json`: iterate with `where` clause
-- `foreach_objects.json`: iterate over objects, access properties via dot notation
-- `foreach_nested.json`: nested FOREACH (e.g., children within households)
-- `foreach_empty.json`: empty collection handling
-- `foreach_no_combine.json`: collect results as array
+- `foreach_basic.json`: iterate over number array, combine with ADD
+- `foreach_filter.json`: iterate with `filter` clause, verify skipped elements
+- `foreach_objects.json`: iterate over object array, access properties via dot notation
+- `foreach_nested.json`: nested FOREACH with independent scopes
+- `foreach_empty.json`: empty and null collection handling
+- `foreach_no_combine.json`: collect results as array (no combine)
+- `foreach_string_combine.json`: combine with ADD on string results (concatenation)
 
 ## References
 
-- Engine context infrastructure: `packages/engine/src/context.rs` (lines 146-220)
-- FOREACH in schema v0.2.0-v0.4.0: `schema/v0.4.0/schema.json`
-- poc-machine-law FOREACH usage: 19 files, 58 occurrences
-- RFC-004: Uniform Operation Syntax
-- RFC-007: Cross-Law Execution Model (operation set extension)
-- RFC-012: Untranslatables (FOREACH files currently marked as untranslatable)
+- RFC-004: Uniform Operation Syntax (property naming conventions)
+- RFC-007: Cross-Law Execution Model (operation set, polymorphic ADD)
+- RFC-012: Untranslatables (current workaround for laws needing iteration)
+- Wet op het kindgebonden budget, artikel 2: https://wetten.overheid.nl/BWBR0022751/2025-01-01#Artikel2
+- Burgerlijk Wetboek Boek 1, titel 16 (curatele): https://wetten.overheid.nl/BWBR0002656/2025-01-01
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/rfcs/rfc-016.md
+++ b/docs/rfcs/rfc-016.md
@@ -16,7 +16,7 @@ Dutch law frequently reasons about collections of variable length: children in a
 
 **Burgerlijk Wetboek.** Filtering active registrations (curatele, bewind, mentorschap, executeurschap, volmacht) from a registry. Whether a registration is *"actief"* is a legal determination that depends on status fields, not a data-layer concern.
 
-**AWB bezwaar/beroep.** Counting relevant procedural events (submissions, decisions) from a case history to determine deadlines and rights.
+**AWB bezwaar/beroep.** Counting relevant procedural events (submissions, decisions) from a case history to determine whether deadlines have passed or rights have been exercised.
 
 ### The alternative without iteration
 
@@ -46,18 +46,18 @@ Add a `FOREACH` operation to the schema and engine. FOREACH iterates over a coll
 ```yaml
 operation: FOREACH
 collection: $kinderen_leeftijden     # array to iterate over
-as: leeftijd                         # local variable name (optional, defaults to "item")
+as: kind                             # local variable name (optional, defaults to "item")
 body:                                # expression evaluated per element
   operation: IF
   cases:
     - when:
         operation: GREATER_THAN_OR_EQUAL
-        subject: $leeftijd
+        subject: $kind
         value: 16
       then: $extra_16_17_jaar
     - when:
         operation: GREATER_THAN_OR_EQUAL
-        subject: $leeftijd
+        subject: $kind
         value: 12
       then: $extra_12_15_jaar
   default: 0
@@ -77,6 +77,44 @@ filter:                              # skip elements where this evaluates to fal
 body: $registratie
 ```
 
+Counting events (AWB bezwaar):
+
+```yaml
+# Count the number of objection submissions in the event history
+operation: FOREACH
+collection: $gebeurtenissen
+as: event
+filter:
+  operation: EQUALS
+  subject: $event.event_type
+  value: BEZWAAR_INGEDIEND
+body: 1
+combine: ADD
+```
+
+Household income aggregation (huurtoeslag):
+
+```yaml
+# Sum income contributions, with different rules per age group
+operation: FOREACH
+collection: $huishoudleden
+as: bewoner
+body:
+  operation: IF
+  cases:
+    - when:
+        operation: GREATER_THAN_OR_EQUAL
+        subject: $bewoner.leeftijd
+        value: 21
+      then: $bewoner.inkomen
+  default:
+    operation: SUBTRACT
+    values:
+      - $bewoner.inkomen
+      - $kind_vrijstelling
+combine: ADD
+```
+
 ### Property naming rationale
 
 FOREACH introduces properties that don't exist in other operations. The names are chosen to be distinct from existing property semantics:
@@ -93,9 +131,11 @@ FOREACH introduces properties that don't exist in other operations. The names ar
 
 FOREACH is the only operation that introduces a new variable name into scope. This is a new concept in the schema: all other operations reference existing variables, none define them.
 
-The `as` parameter names a local variable that exists only within the `body` and `filter` expressions. It shadows any outer variable with the same name. When `as` is omitted, the default name is `item`.
+The `as` parameter names a local variable that exists only within the `body` and `filter` expressions of that FOREACH. It shadows any outer variable with the same name. When `as` is omitted, the default name is `item`. The default `item` is chosen as a neutral, language-independent term that does not collide with common domain variable names (unlike `element` which could conflict with XML-related fields, or `current` which suggests temporal context).
 
-**Nested FOREACH scoping:** Each FOREACH creates an independent child scope. Inner iterations cannot see outer iteration variables unless they are passed explicitly. If an inner FOREACH uses the same `as` name as an outer one, the inner binding shadows the outer within its body.
+The `filter` expression runs in the child scope where the `as` variable is already bound. This means the filter can access element properties: `$registratie.status` works because `$registratie` is the current element.
+
+**Nested FOREACH scoping:** Each FOREACH creates an independent child scope. The `collection` expression is evaluated in the **outer** scope (before the child context is created), so it can reference outer iteration variables. The `body` and `filter` expressions are evaluated in the **inner** scope, where only the innermost `as` binding is visible.
 
 ```yaml
 # Nested: outer $household, inner $member
@@ -104,14 +144,14 @@ collection: $households
 as: household
 body:
   operation: FOREACH
-  collection: $household.members     # access outer variable via dot notation
+  collection: $household.members     # evaluated in OUTER scope → can see $household
   as: member
-  body: $member.income               # inner scope only sees $member, not $household
+  body: $member.income               # evaluated in INNER scope → sees $member, not $household
   combine: ADD
 combine: ADD
 ```
 
-To access the outer variable in the inner body, extract it to a separate output first, or restructure to avoid nesting.
+If an inner FOREACH uses the same `as` name as an outer one, the inner binding shadows the outer within its body. To access both, use different `as` names.
 
 ### Schema definition
 
@@ -137,7 +177,7 @@ To access the outer variable in the inner body, extract it to a separate output 
     },
     "filter": {
       "$ref": "#/definitions/operationValue",
-      "description": "Boolean expression. Elements where this evaluates to false are skipped."
+      "description": "Boolean expression evaluated in the child scope. Elements where this evaluates to false are skipped."
     },
     "combine": {
       "type": "string",
@@ -151,7 +191,7 @@ To access the outer variable in the inner body, extract it to a separate output 
 
 ### Semantics
 
-1. Evaluate `collection` to get an array. If the result is not an array, wrap it in a single-element array. If null, treat as empty array.
+1. Evaluate `collection` in the current scope to get an array. If the result is not an array, wrap it in a single-element array. If null, treat as empty array.
 2. For each element in the array:
    a. Create a child execution context (isolated local scope).
    b. Bind the element to the local variable named by `as` (default: `item`).
@@ -159,6 +199,14 @@ To access the outer variable in the inner body, extract it to a separate output 
    d. Evaluate `body` in the child context. Collect the result.
 3. If `combine` is specified, apply the aggregation to collected results and return a single value.
 4. If `combine` is omitted, return the collected results as an array.
+
+### Error handling
+
+If `body` produces an error for an element, the FOREACH operation propagates the error immediately. Partial results are not returned. Rationale: legal computations must be complete - a partial sum over "some children" is not a valid legal determination.
+
+If `filter` produces an error, the same rule applies: the error propagates and FOREACH fails.
+
+If any element produces `Value::Untranslatable` (per RFC-012), the combined result is `Value::Untranslatable`. Untranslatable taints the entire collection result, because a partial determination that silently drops untranslatable elements would be misleading.
 
 ### Dot notation for element properties
 
@@ -176,14 +224,25 @@ This uses existing dot notation support in variable resolution.
 
 | Combine | Description | Empty collection |
 |---------|-------------|-----------------|
-| `ADD` | Sum numeric results (polymorphic: also concatenates strings and arrays) | 0 |
+| `ADD` | Sum numeric results (polymorphic: concatenates strings/arrays per RFC-007) | 0 |
 | `OR` | Logical: any result truthy | false |
 | `AND` | Logical: all results truthy | true |
 | `MIN` | Minimum value | null |
 | `MAX` | Maximum value | null |
 | *(omitted)* | Collect results as array | [] |
 
-Note: `ADD` is polymorphic per RFC-007. When results are strings, `ADD` concatenates them. When results are arrays, `ADD` flattens them. This covers string-building use cases without a separate `CONCAT` combiner.
+**Why only these five combiners?** The combine operations map to meaningful legal aggregation patterns:
+
+- `ADD`: *"het totaal van alle bedragen"* (the total of all amounts)
+- `OR`: *"indien ten minste een van de voorwaarden is vervuld"* (if at least one condition is met)
+- `AND`: *"indien aan alle voorwaarden is voldaan"* (if all conditions are met)
+- `MIN`/`MAX`: *"het laagste/hoogste van de bedragen"* (the lowest/highest of the amounts)
+
+`SUBTRACT`, `MULTIPLY`, and `DIVIDE` are excluded because they are not associative over collections in a meaningful legal sense. Subtracting a list of values is ambiguous (from what?). Multiplying a list of values has no common legal pattern. If a specific law needs such an aggregation, it can be expressed by collecting results as an array (no `combine`) and then applying the arithmetic operation to the array.
+
+**Empty collection semantics:** `ADD` returns `0` (additive identity), `OR` returns `false`, and `AND` returns `true` (standard logical identities). `MIN` and `MAX` return `null` because there is no meaningful minimum or maximum of nothing - the caller must handle this case. When `combine` is omitted, an empty collection produces an empty array `[]`.
+
+Note: `ADD` is polymorphic per RFC-007. When all results are strings, `ADD` concatenates them. When all results are arrays, `ADD` flattens them. This covers string-building use cases (e.g., assembling a list of names) without a separate `CONCAT` combiner.
 
 ### Security constraints
 
@@ -197,7 +256,7 @@ Note: `ADD` is polymorphic per RFC-007. When results are strings, `ADD` concaten
 
 **Legal logic stays in law YAML.** Age thresholds, status checks, and permission rules are legal decisions. The data source provides raw facts (list of children with birth dates); the law determines what to do with them.
 
-**Matches legal language.** *"Voor elk kind"*, *"alle actieve registraties"*, *"medebewoners van 21 jaar of ouder"* - these are iteration patterns in natural legal language. FOREACH maps directly.
+**Matches legal language.** Legislators write *"voor elk kind"*, *"alle actieve registraties"*, *"medebewoners van 21 jaar of ouder"*. These are not separate filter-map-reduce steps in legal text - they are single clauses that combine selection and transformation. FOREACH with `filter` and `combine` maps to this integrated phrasing. Splitting into separate MAP, FILTER, REDUCE operations would force a decomposition that the law text does not make.
 
 **Engine infrastructure exists.** The engine already has child context creation, local variable binding, and scoped variable resolution. The execution machinery is in place; only the operation dispatch is missing.
 
@@ -209,7 +268,7 @@ Note: `ADD` is polymorphic per RFC-007. When results are strings, `ADD` concaten
 
 **Non-termination risk.** Mitigated by `MAX_ARRAY_SIZE` (collection size limit) and `MAX_RECURSION_DEPTH` (nesting limit). Both are existing engine configuration values.
 
-**Pre-aggregation works for simple cases.** When the pattern is purely "count items in categories," pre-aggregation in the data source is simpler. FOREACH is needed for cases where per-element logic involves legal conditions or where the output is a transformed collection rather than a single aggregate.
+**Pre-aggregation works for simple cases.** When the pattern is purely "count items in categories," pre-aggregation in the data source is simpler. FOREACH is needed when per-element logic involves legal conditions, or when the output is a transformed collection rather than a single aggregate.
 
 ### Alternatives Considered
 
@@ -217,7 +276,7 @@ Note: `ADD` is polymorphic per RFC-007. When results are strings, `ADD` concaten
 
 **Fixed maximum with unrolled operations.** Generate N branches for up to N items. Rejected: arbitrary limits, verbose YAML, does not handle filter-and-transform patterns, and breaks when the real count exceeds N.
 
-**Separate MAP, FILTER, REDUCE operations.** Three operations instead of one. Rejected: these three concepts compose in practice (filter, then transform, then aggregate). Splitting them forces intermediate outputs and makes YAML verbose for the common case. FOREACH with `filter` and `combine` covers all three in one readable construct.
+**Separate MAP, FILTER, REDUCE operations.** Three operations following functional programming conventions. Rejected: Dutch legal text does not decompose collection logic into separate functional steps. A clause like *"de som van de bedragen voor elk kind dat 12 jaar of ouder is"* combines filtering (12 jaar of ouder), transformation (het bedrag), and aggregation (de som) in a single sentence. Three operations would require intermediate outputs (`filtered_children`, `child_amounts`, `total`) that exist nowhere in the law. FOREACH with `filter` and `combine` keeps the YAML close to the legal text.
 
 **No iteration, restructure all laws.** Accept that laws needing iteration must be restructured to avoid it. Rejected: this is possible for simple aggregation cases but not for filter-and-transform patterns. It also forces legal knowledge into the data layer, which conflicts with regelrecht's design principle of keeping legal logic in law YAML.
 
@@ -229,6 +288,7 @@ Note: `ADD` is polymorphic per RFC-007. When results are strings, `ADD` concaten
   1. Evaluate `collection` to `Value::Array`
   2. For each element: `ctx.create_child()`, `ctx.set_local(as_name, element)`, optionally evaluate `filter`, evaluate `body`
   3. Apply `combine` aggregation or return array
+- Error propagation: any element error aborts the entire FOREACH
 - Trace: add `PathNodeType::ForEachIteration` with element index for execution tracing
 - Untranslatable propagation: if any element produces `Value::Untranslatable`, the combined result is `Value::Untranslatable` (per RFC-012)
 
@@ -241,10 +301,11 @@ Note: `ADD` is polymorphic per RFC-007. When results are strings, `ADD` concaten
 - `foreach_basic.json`: iterate over number array, combine with ADD
 - `foreach_filter.json`: iterate with `filter` clause, verify skipped elements
 - `foreach_objects.json`: iterate over object array, access properties via dot notation
-- `foreach_nested.json`: nested FOREACH with independent scopes
-- `foreach_empty.json`: empty and null collection handling
+- `foreach_nested.json`: nested FOREACH with independent scopes, verify outer variable accessible in inner `collection` but not inner `body`
+- `foreach_empty.json`: empty and null collection handling per combine type
 - `foreach_no_combine.json`: collect results as array (no combine)
 - `foreach_string_combine.json`: combine with ADD on string results (concatenation)
+- `foreach_error.json`: error in body propagates, partial results not returned
 
 ## References
 
@@ -252,5 +313,7 @@ Note: `ADD` is polymorphic per RFC-007. When results are strings, `ADD` concaten
 - RFC-007: Cross-Law Execution Model (operation set, polymorphic ADD)
 - RFC-012: Untranslatables (current workaround for laws needing iteration)
 - Wet op het kindgebonden budget, artikel 2: https://wetten.overheid.nl/BWBR0022751/2025-01-01#Artikel2
+- Wet op de huurtoeslag, artikel 7: https://wetten.overheid.nl/BWBR0008659/2025-01-01#Artikel7
+- AWB, artikel 6:7: https://wetten.overheid.nl/BWBR0005537/2024-01-01#Artikel6:7
 - Burgerlijk Wetboek Boek 1, titel 16 (curatele): https://wetten.overheid.nl/BWBR0002656/2025-01-01
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/rfcs/rfc-017.md
+++ b/docs/rfcs/rfc-017.md
@@ -1,0 +1,187 @@
+# RFC-017: Native Data Source Metadata
+
+**Status:** Proposed
+**Date:** 2026-04-12
+**Authors:** Anne Schuth
+
+## Context
+
+Schema v0.5.1 reduced `source` to three properties: `regulation`, `output`, `parameters`. This makes the YAML cleaner for cross-law references but loses the ability to describe **native data source resolution** — when an input does not call another law but pulls a value (or several values) from a tabular data source registered with the engine.
+
+In v0.5.0, an input that came from a data source could declare its table, projection, and filter criteria inline:
+
+```yaml
+- name: leeftijd
+  source:
+    source_type: RvIG
+    table: personen
+    field: leeftijd
+    select_on:
+      - name: bsn
+        value: $bsn
+```
+
+The engine's data source registry would read this and resolve the value at evaluation time without any external help.
+
+In v0.5.1, the same input had to be reduced to:
+
+```yaml
+- name: leeftijd
+  source: {}
+```
+
+with the table/field/select_on metadata moved into a side channel: an external mapping file kept by the host application (e.g. `source_ref_mapping.json` in the poc-machine-law project, 2057 lines covering 177 inputs across 61 laws). The host application's Python wrapper then had to pre-resolve every data source input on every evaluation, build a synthetic parameter dict, and pass it to the engine — duplicating work the engine could have done natively.
+
+This RFC restores the ability to express data source bindings inline, while preserving the v0.5.1 cross-law model.
+
+## Decision
+
+Extend `inputField.source` with optional native-resolution properties. All existing v0.5.1 source forms remain valid; the new properties are additive.
+
+### Schema additions
+
+```yaml
+source:
+  # existing properties (cross-law reference)
+  regulation: <law_id>
+  output: <output_name>
+  parameters: { ... }
+
+  # new properties (native data source binding)
+  source_type: <kind tag>          # optional, e.g. "RvIG", "claim", "cases"
+  service: <service code>          # optional, e.g. "BELASTINGDIENST"
+  table: <data source name>        # the data source to query
+  field: <column name>             # single-column projection
+  fields: [<column>, <column>]     # multi-column projection (object input)
+  select_on:                       # filter criteria
+    - name: <column>
+      value: $<param> | <literal>
+```
+
+### Resolution semantics
+
+When the engine encounters an input whose `source` contains `table`:
+
+1. Look up the named data source in the registry.
+2. If `select_on` is present, filter records where each `name` column equals the resolved `value` (literal or `$param`).
+3. Apply the projection:
+   - `field` → return that column from the matched record (scalar input)
+   - `fields` → return an object with those columns (object input)
+   - neither → for inputs of `type: array`, return all matched records as an array
+4. If the input declares `type: array`, return *all* matched records (after `select_on`) instead of just the first.
+
+Cross-law and native bindings are mutually exclusive on a single input: `regulation` or `table`, not both. Setting both is a schema error.
+
+### Backwards compatibility
+
+* Empty `source: {}` still parses and still resolves via the host application's existing pathways.
+* `source` with only `regulation`/`output`/`parameters` parses identically to v0.5.1.
+* Existing law YAMLs need no changes unless they want native resolution.
+
+## Why
+
+**Single source of truth.** A law's external dependencies belong in the law itself, not in a sidecar file maintained by the host. Reading a law YAML now tells you exactly which tables and columns it consumes.
+
+**No host pre-resolution.** Hosts no longer need a Python (or any other) layer that walks every input, looks up an external mapping, queries DataFrames, and stuffs results into a parameter dict. The engine resolves data source inputs the same way it resolves cross-law inputs: during execution, on demand.
+
+**FOREACH compatibility.** Inputs of `type: array` with `table` + `fields` produce a `Value::Array(Object)` that FOREACH (RFC-016) can iterate over directly. The two RFCs compose without extra glue.
+
+**Diff-friendly.** Renaming a column or changing a `select_on` criterion is a one-line change in the YAML rather than a coordination problem between a law file and a JSON mapping file.
+
+## Examples
+
+### Single-column projection
+
+```yaml
+- name: leeftijd
+  type: number
+  source:
+    source_type: RvIG
+    table: personen
+    field: leeftijd
+    select_on:
+      - name: bsn
+        value: $bsn
+```
+
+### Multi-column object input
+
+```yaml
+- name: kinderen_data
+  type: object
+  source:
+    source_type: SVB
+    table: algemene_kinderbijslagwet
+    fields:
+      - aantal_kinderen
+      - kinderen_leeftijden
+      - ontvangt_kinderbijslag
+    select_on:
+      - name: ouder_bsn
+        value: $bsn
+```
+
+### Array for FOREACH iteration
+
+```yaml
+- name: kinderen
+  type: array
+  source:
+    source_type: RvIG
+    table: kinderen
+    fields:
+      - bsn
+      - geboortedatum
+      - naam
+    select_on:
+      - name: ouder_bsn
+        value: $bsn
+```
+
+This produces an array of `{bsn, geboortedatum, naam}` objects that the law can pass into a FOREACH (RFC-016) operation.
+
+### Field aliasing (input name differs from column name)
+
+When the input is named differently from the underlying column, `field` carries the column name:
+
+```yaml
+- name: bsn_curator
+  type: string
+  source:
+    table: curatele_registraties
+    field: bsn         # column is `bsn`, input is `bsn_curator`
+    select_on:
+      - name: onder_curatele_bsn
+        value: $bsn
+```
+
+### Multi-criteria filter
+
+```yaml
+- name: ontheffing
+  type: object
+  source:
+    source_type: GEMEENTE_ROTTERDAM
+    table: ontheffingen_geluid
+    fields: [datum, status, motivering]
+    select_on:
+      - name: kvk_nummer
+        value: $kvk_nummer
+      - name: jaar
+        value: $jaar
+      - name: gemeente_code
+        value: "0599"
+```
+
+## Implementation notes
+
+* The engine's data source registry already supports key-based lookup (`DictDataSource`). A new `RecordSetDataSource` adds multi-criteria filtering, field aliases, and array projection.
+* Hosts still register data sources at runtime (the engine has no I/O); what changes is that hosts no longer need to know which inputs map to which columns. They register the records, the engine resolves the inputs.
+* For Python hosts, the existing `register_record_set_source(name, records, key_field, select_on, aliases, array_field, array_field_projection)` PyO3 binding remains useful as an *imperative* alternative — but the recommended path is YAML-driven.
+
+## References
+
+* RFC-007: Engine policy on built-in domain knowledge
+* RFC-013: Schema v0.5 lineage
+* RFC-016: FOREACH collection operations (consumes array data source inputs)
+* poc-machine-law: removed `machine/source_ref_mapping.json` in favor of inline YAML metadata

--- a/docs/rfcs/rfc-017.md
+++ b/docs/rfcs/rfc-017.md
@@ -173,6 +173,86 @@ When the input is named differently from the underlying column, `field` carries 
         value: "0599"
 ```
 
+## Resolution order
+
+Inputs in an article can reference each other through `$name` inside
+`source.parameters`, `source.select_on[*].value`, and
+`temporal.reference`. The engine resolves inputs in a **topological
+order** driven by those references, not in YAML order.
+
+### Why topological, not YAML
+
+Take the Rotterdam alcohol-licence article from poc-machine-law:
+
+```yaml
+input:
+  - name: leeftijd_exploitant
+    source:
+      regulation: wet_brp
+      output: leeftijd
+      parameters: {bsn: $bsn}
+  - name: voldoet_aan_nationale_eisen
+    source:
+      regulation: alcoholwet/vergunning
+      parameters:
+        leeftijd_leidinggevende: $leeftijd_exploitant
+        vloeroppervlakte: $vloeroppervlakte_horecalokaliteit
+        type_bedrijf: $type_bedrijf
+  - name: bsn
+    source: {table: leidinggevenden, field: bsn, select_on: [{name: kvk_nummer, value: $kvk_nummer}]}
+  - name: vloeroppervlakte_horecalokaliteit
+    source: {table: inrichtingen, field: vloeroppervlakte_horecalokaliteit, select_on: [{name: kvk_nummer, value: $kvk_nummer}]}
+  - name: type_bedrijf
+    source: {table: inrichtingen, field: type_bedrijf, select_on: [{name: kvk_nummer, value: $kvk_nummer}]}
+```
+
+`leeftijd_exploitant` references `$bsn`, but `bsn` is declared later.
+A strict YAML-order walk resolves `leeftijd_exploitant` first, sees
+`$bsn` as Null (lenient resolution returns Null for unknown names),
+and feeds a null BSN into the cross-law call, which returns garbage.
+`voldoet_aan_nationale_eisen` has the same problem against three later
+inputs. `kieswet/KIESRAAD-2024-01-01.yaml` shows the same pattern with
+`$verkiezingsdatum` as the last input of the article.
+
+Law authors write inputs grouped by semantic cluster (all BRP inputs
+together, all licensing criteria together, all raw municipal table
+inputs at the bottom), not in dependency order. Forcing them to reorder
+by dependency makes the YAML less readable and ties the file to an
+implementation detail.
+
+### Rule
+
+Before resolving the inputs of an article, the engine computes a
+directed graph:
+
+* Node per declared input.
+* Edge from `I` to `J` when `I` carries a `$J` reference in
+  `source.parameters`, `source.select_on[*].value`, or
+  `temporal.reference`, and `J` is the name of another input in the
+  same article.
+* References to runtime parameters (names that match
+  `execution.parameters`, not `execution.input`) are **not** edges.
+* Dot notation `$obj.field` creates an edge on the base name `obj`.
+
+The engine resolves inputs in a topological order of this graph. When
+multiple orderings are legal, YAML order breaks ties so the trace
+output stays stable and predictable.
+
+### Cycles
+
+If the graph contains a cycle (input A references B references A, or
+an input references itself), the engine logs a warning via `tracing`
+and falls back to YAML order for the whole article. No panic, no
+hard error. This preserves the prior behaviour for malformed articles
+while making the failure visible.
+
+### Host implications
+
+Hosts that pre-resolve inputs before calling the engine (legacy path)
+must either resolve in the same topological order or let the engine do
+it. Hosts that register data sources and hand the parameters dict to
+`evaluate_law_output` get the correct behaviour automatically.
+
 ## Implementation notes
 
 * The engine's data source registry already supports key-based lookup (`DictDataSource`). A new `RecordSetDataSource` adds multi-criteria filtering, field aliases, and array projection.


### PR DESCRIPTION
## Summary

Two RFCs that, taken together, restore expressive power to v0.5.1 laws so the engine can resolve everything natively without host-side pre-resolution glue.

### RFC-016: Collection Operations (FOREACH)

Adds a `FOREACH` operation to the schema and engine for iterating over dynamic-length collections (children, registrations, employment periods, events, …). FOREACH was present in v0.2.0–v0.4.0 but removed in v0.5.0; this RFC restores it with cleaner semantics.

- Single operation with optional `where` (filter) and `combine` (aggregate) instead of separate MAP/FILTER/REDUCE
- Uses existing child-context infrastructure for scoping
- Bounded by `MAX_ARRAY_SIZE` and `MAX_RECURSION_DEPTH`
- Dot notation for property access on collection elements

### RFC-017: Native Data Source Metadata

Restores inline `source.{table, field, fields, select_on, source_type, service}` metadata on inputs in v0.5.1 YAML. Schema v0.5.1 had reduced `source` to just `regulation`/`output`/`parameters`, forcing host applications to maintain external mapping files (e.g. `source_ref_mapping.json`) and pre-resolve every data source input in Python before calling the engine.

With this RFC the engine reads the metadata directly from the YAML and resolves data source inputs natively via its `DataSourceRegistry`. Hosts only register raw records; the engine handles select_on filtering, field aliasing, and array projection.

The two RFCs compose: a FOREACH body can iterate over an array input that was sourced via the new native data source path.

## Implementation

Implementation lands in PR #511 (`feat/foreach-implementation` branch). It:

- Adds the `FOREACH` operation to `operations.rs` with where/combine support and full execution trace
- Extends the `Source` struct in `article.rs` with the new optional fields
- Adds `RecordSetDataSource` (multi-criteria filter, field aliases, array projection) to `data_source.rs`
- Updates `service.rs` to query the registry from YAML metadata, falling back to legacy lookups for laws that don't migrate
- Extends `schema/v0.5.1/schema.json` with the new optional source properties (backwards compatible)
- Adds 14 new unit tests covering the new code paths

## Test plan

- [x] All existing tests pass: 375/375 in regelrecht
- [x] poc-machine-law BDD suite passes: 340/340 scenarios across 80 laws
- [x] Schema v0.5.1 backwards compatibility verified (existing `source: {}` and `source: {regulation, ...}` still parse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)