### PR TITLE
feat(textguard): per-lid text-fidelity gate (golden-text)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
               - corpus/regulation/**
               - schema/**
               - script/**
+              - textguard/**
               - Justfile
               - .pre-commit-config.yaml
               - .yamllint
@@ -230,6 +231,29 @@ jobs:
       - name: Skip (no relevant changes)
         if: needs.changes.outputs.ci != 'true'
         run: echo "No relevant changes, skipping provenance checks"
+
+  text-fidelity:
+    name: Text fidelity (textguard)
+    needs: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: needs.changes.outputs.ci == 'true'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: '3.x'
+
+      - name: Install pyyaml
+        run: pip install pyyaml
+
+      # Hermetic gate: recompute the normalised per-lid text hashes from the
+      # corpus and compare them to the committed textguard fixtures. A mismatch
+      # means an article's text changed without re-blessing (run `just
+      # textguard-bless` after a verified text change). Exits non-zero on drift.
+      - name: Check per-lid text fidelity
+        run: python3 script/textguard.py check
 
   pre-commit:
     name: Pre-commit

--- a/.yamllint
+++ b/.yamllint
@@ -75,3 +75,6 @@ ignore: |
   .tox/
   node_modules/
   .github/workflows/
+  # Machine-generated text-fidelity fixtures: verbatim legal text, often
+  # exceeding the line-length rule. Integrity is enforced by script/textguard.py.
+  textguard/

--- a/Justfile
+++ b/Justfile
@@ -41,6 +41,15 @@ validate *FILES:
 validate-annotations *FILES:
     script/validate-annotations.sh {{FILES}}
 
+# Per-lid text-fidelity gate: corpus `text:` chunks vs committed textguard fixtures
+textguard-check:
+    python3 script/textguard.py check
+
+# (Re)capture textguard fixtures from the current corpus text (the "bless" step).
+# Run after a verified text change; review the fixture diff before committing.
+textguard-bless:
+    python3 script/textguard.py bless
+
 # Run all quality checks (format + lint + check + validate + validate-annotations + tests)
 # Note: pipeline-integration-test excluded — it requires Docker (testcontainers)
 check: format lint build-check validate validate-annotations test harvester-test pipeline-test admin-fmt admin-lint admin-check admin-test admin-frontend editor-api-fmt editor-api-lint editor-api-check

--- a/script/textguard.py
+++ b/script/textguard.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""textguard — per-lid tekstgetrouwheid voor regelrecht-corpus.
+
+Two-layer text-fidelity guard (see the drift-check skill for the rationale):
+
+  bless  - capture the current normalised `text:` chunks of every regulation
+           into a committed fixture (hash + text + provenance). This is the
+           "approval" step; provenance starts as `verified_against: pending`
+           until the live drift-check upgrades it to a wetten.overheid.nl date.
+  check  - recompute the normalised chunk hashes from the corpus and compare
+           them to the committed fixtures. Any mismatch (changed/added/removed
+           chunk) exits non-zero. Hermetic: a pure function of repo content,
+           usable as a CI gate.
+
+A "chunk" is one blank-line-delimited paragraph of an article's `text:` block —
+in this corpus that is exactly one lid / onderdeel / aanhef. Chunk identity is
+positional (article number + ordinal index); the label (aanhef / lid N /
+onderdeel x) is derived for readability only.
+
+Normalisation is the SINGLE allowed rule from
+`law-version-drift-check/reference.md` §2: within a paragraph collapse every run
+of whitespace to one space and trim; paragraph boundaries are preserved.
+
+Usage:
+  python3 script/textguard.py bless [corpus_root] [fixture_root]
+  python3 script/textguard.py check [corpus_root] [fixture_root]
+Defaults: corpus_root=corpus/regulation  fixture_root=textguard
+"""
+import sys
+import os
+import re
+import glob
+import hashlib
+import datetime
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("textguard requires pyyaml (pip install pyyaml)\n")
+    sys.exit(2)
+
+DEFAULT_CORPUS = "corpus/regulation"
+DEFAULT_FIXTURES = "textguard"
+
+_LID = re.compile(r"^(\d+)\.\s")
+_ONDERDEEL = re.compile(r"^([a-z])\.\s")
+
+
+def normalize_paragraph(p):
+    """Collapse every run of whitespace (incl. newlines) to one space, trim."""
+    return " ".join(p.split())
+
+
+def chunks(text):
+    """Split an article `text:` into normalised, labelled chunks.
+
+    Returns a list of dicts: {index, label, text, sha256}.
+    """
+    if not isinstance(text, str):
+        return []
+    paras = re.split(r"\n[ \t]*\n", text.strip("\n"))
+    out = []
+    for p in paras:
+        norm = normalize_paragraph(p)
+        if not norm:
+            continue
+        idx = len(out)
+        out.append({
+            "index": idx,
+            "label": _label(norm, idx),
+            "text": norm,
+            "sha256": hashlib.sha256(norm.encode("utf-8")).hexdigest(),
+        })
+    return out
+
+
+def _label(norm, idx):
+    m = _LID.match(norm)
+    if m:
+        return f"lid {m.group(1)}"
+    m = _ONDERDEEL.match(norm)
+    if m:
+        return f"onderdeel {m.group(1)}"
+    return "aanhef" if idx == 0 else "tekst"
+
+
+def regulation_files(corpus_root):
+    return sorted(glob.glob(f"{corpus_root}/**/*.yaml", recursive=True))
+
+
+def fixture_path(corpus_root, law_path, fixture_root):
+    rel = os.path.relpath(law_path, corpus_root)
+    return os.path.join(fixture_root, rel)
+
+
+def article_chunks(doc):
+    """law doc -> list of (article_number_str, [chunk dicts])."""
+    res = []
+    for art in doc.get("articles", []) or []:
+        num = str(art.get("number", "?"))
+        res.append((num, chunks(art.get("text"))))
+    return res
+
+
+# --- YAML emission: force block scalars for the multi-line text, keep order ---
+def _str_representer(dumper, data):
+    style = "|" if "\n" in data else None
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
+
+
+yaml.add_representer(str, _str_representer)
+
+
+def cmd_bless(corpus_root, fixture_root):
+    today = datetime.date.today().isoformat()
+    written = 0
+    for law_path in regulation_files(corpus_root):
+        try:
+            doc = yaml.safe_load(open(law_path))
+        except Exception:
+            continue
+        if not isinstance(doc, dict) or "$id" not in doc:
+            continue
+        arts = []
+        for num, chs in article_chunks(doc):
+            if not chs:
+                continue
+            arts.append({
+                "number": num,
+                "chunks": [{
+                    "index": c["index"],
+                    "label": c["label"],
+                    "sha256": c["sha256"],
+                    "verified_against": "pending",
+                    "captured_at": today,
+                    "text": c["text"],
+                } for c in chs],
+            })
+        if not arts:
+            continue
+        fixture = {
+            "$id": doc["$id"],
+            "valid_from": doc.get("valid_from"),
+            "source": law_path,
+            "articles": arts,
+        }
+        fpath = fixture_path(corpus_root, law_path, fixture_root)
+        os.makedirs(os.path.dirname(fpath), exist_ok=True)
+        with open(fpath, "w") as fh:
+            yaml.dump(fixture, fh, default_flow_style=False,
+                      sort_keys=False, allow_unicode=True, width=4096)
+        written += 1
+    print(f"textguard bless: {written} fixtures geschreven onder {fixture_root}/")
+    return 0
+
+
+def cmd_check(corpus_root, fixture_root):
+    findings = []
+    n_chunks = 0
+    for law_path in regulation_files(corpus_root):
+        try:
+            doc = yaml.safe_load(open(law_path))
+        except Exception:
+            continue
+        if not isinstance(doc, dict) or "$id" not in doc:
+            continue
+        live = {num: chs for num, chs in article_chunks(doc) if chs}
+        if not live:
+            continue
+        fpath = fixture_path(corpus_root, law_path, fixture_root)
+        if not os.path.exists(fpath):
+            findings.append(f"{law_path}: geen fixture (run `bless`)")
+            continue
+        fix = yaml.safe_load(open(fpath)) or {}
+        fix_arts = {str(a.get("number")): a.get("chunks", []) for a in fix.get("articles", []) or []}
+        for num, chs in live.items():
+            expected = fix_arts.get(num)
+            if expected is None:
+                findings.append(f"{law_path} art {num}: artikel niet in fixture")
+                continue
+            if len(chs) != len(expected):
+                findings.append(f"{law_path} art {num}: {len(chs)} chunks, fixture heeft {len(expected)}")
+                continue
+            for c, e in zip(chs, expected):
+                n_chunks += 1
+                if c["sha256"] != e.get("sha256"):
+                    findings.append(
+                        f"{law_path} art {num} [{c['label']}]: tekst wijkt af van geverifieerde fixture")
+        # articles present in fixture but gone from the law
+        for num in fix_arts:
+            if num not in live:
+                findings.append(f"{law_path} art {num}: in fixture maar niet meer in de wet")
+
+    print(f"textguard check: {n_chunks} chunks vergeleken, {len(findings)} afwijkingen")
+    for f in findings:
+        print("  DRIFT", f)
+    return 1 if findings else 0
+
+
+def main():
+    cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+    corpus_root = sys.argv[2] if len(sys.argv) > 2 else DEFAULT_CORPUS
+    fixture_root = sys.argv[3] if len(sys.argv) > 3 else DEFAULT_FIXTURES
+    if cmd == "bless":
+        return cmd_bless(corpus_root, fixture_root)
+    if cmd == "check":
+        return cmd_check(corpus_root, fixture_root)
+    sys.stderr.write(__doc__)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/textguard/README.md
+++ b/textguard/README.md
@@ -1,0 +1,50 @@
+# textguard — per-lid tekstgetrouwheid
+
+Golden-text fixtures die bewaken dat de `text:`-blokken in `corpus/regulation/`
+niet stilletjes wijzigen ten opzichte van een geverifieerde baseline. Per-lid
+granulariteit, deterministisch, hermetisch — bruikbaar als CI-gate.
+
+## Twee lagen
+
+Tekstgetrouwheid splitst in een hermetisch (CI) en een niet-hermetisch (methodologisch) deel:
+
+1. **Capture & bless** — *methodologisch, periodiek.* De geldende wettekst leeft op
+   wetten.overheid.nl (een remote, mutabele bron die geïnterpreteerd moet worden — geen
+   CI-orakel). De `law-version-drift-check`-skill haalt die tekst op, normaliseert en
+   verifieert hem, en legt het resultaat hier vast. `just textguard-bless` capture't de
+   huidige corpus-tekst als fixture; de skill upgrade't `verified_against` van `pending`
+   naar een `wetten.overheid.nl/<bwb>/<datum>`-bron.
+
+2. **Gate** — *deterministisch, elke commit.* `just textguard-check` (CI-job
+   `text-fidelity`) herberekent per lid de genormaliseerde hash uit de corpus en
+   vergelijkt met de fixture. Mismatch → faal. Zuivere functie van repo-inhoud.
+
+**De eerlijke grens:** de gate bewaakt *"YAML-tekst ≡ laatst geverifieerde tekst"*, niet
+*"YAML-tekst ≡ huidige live wet"*. Een stille YAML-edit faalt direct in CI. Verandert de
+wet zélf in de wereld, dan vangt alleen de periodieke drift-check (laag 1) dat — daarna
+re-bless je.
+
+## Wat is een chunk
+
+Eén chunk = één lege-regel-gescheiden alinea van een artikel-`text:` — in deze corpus
+precies één lid / onderdeel / aanhef. Identiteit is positioneel (artikelnummer + index);
+het label (`aanhef` / `lid 1` / `onderdeel a`) is afgeleid, puur voor leesbaarheid.
+
+Normalisatie is de enige toegestane regel uit `law-version-drift-check/reference.md` §2:
+binnen een alinea elke witruimte-reeks naar één spatie, trimmen; alinea-grenzen blijven.
+
+## Fixture-formaat
+
+Sidecar per regeling, gespiegeld pad onder `textguard/` (buiten `corpus/regulation/**`
+zodat de wet-schema-validator ze niet oppakt). Per chunk: `sha256` (de gate), `text` (de
+genormaliseerde tekst, mens-auditeerbaar) en herkomst (`verified_against`, `captured_at`).
+
+## Workflow bij een tekstwijziging
+
+1. Wijzig de `text:` in de corpus (na verificatie tegen de geldende wet).
+2. `just textguard-bless` — herbevestig de fixtures.
+3. Bekijk de fixture-diff (de hash + tekst veranderen zichtbaar mee).
+4. Commit corpus + fixtures samen. CI's `text-fidelity` is daarna weer groen.
+
+Wie de tekst wél wijzigt maar de fixture niet her-blesst, krijgt een rode gate — precies
+de bedoeling.

--- a/textguard/nl/gemeentelijke_verordening/amsterdam/apv_erfgrens/2024-01-01.yaml
+++ b/textguard/nl/gemeentelijke_verordening/amsterdam/apv_erfgrens/2024-01-01.yaml
@@ -1,0 +1,24 @@
+$id: apv_erfgrens_amsterdam
+valid_from: '2024-01-01'
+source: corpus/regulation/nl/gemeentelijke_verordening/amsterdam/apv_erfgrens/2024-01-01.yaml
+articles:
+- number: '2.75'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d26a68648afeb5bff9f9914703b05f1aa29cd9268210d819554fe47b3ebae824
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Afstand van bomen, heesters en heggen tot de erfgrens
+  - index: 1
+    label: lid 1
+    sha256: dd17b2a12891d86a719c97e3677df8b23e96077bd902c7561fdf7e98f075317f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. In afwijking van artikel 5:42 lid 2 van het Burgerlijk Wetboek bedraagt de afstand voor bomen in het centrum van Amsterdam (postcodegebied 1011-1018) een meter.
+  - index: 2
+    label: lid 2
+    sha256: dd41db3a148777c6151e0ce51df4c204d09051a2dce9ae910ebcb96729f0f3b8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Voor heesters en heggen geldt in heel Amsterdam de afstand van een halve meter als bedoeld in artikel 5:42 lid 2 van het Burgerlijk Wetboek.

--- a/textguard/nl/gemeentelijke_verordening/diemen/afstemmingsverordening_participatiewet/2015-01-01.yaml
+++ b/textguard/nl/gemeentelijke_verordening/diemen/afstemmingsverordening_participatiewet/2015-01-01.yaml
@@ -1,0 +1,56 @@
+$id: afstemmingsverordening_participatiewet_diemen
+valid_from: '2015-01-01'
+source: corpus/regulation/nl/gemeentelijke_verordening/diemen/afstemmingsverordening_participatiewet/2015-01-01.yaml
+articles:
+- number: '7'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 7cd0306f73604eba56f086bf77f2c1b5661f519f1ea43a9f3fec2b80e82acdd9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '**Gedragingen Participatiewet**'
+  - index: 1
+    label: tekst
+    sha256: 1f44216f44ec7edf81ff27b481ebfd1012ca42c17dca8d2d38a78eff4a46613c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Gedragingen van een belanghebbende waardoor de verplichting op grond van artikel 9, eerste lid, van de Participatiewet niet of onvoldoende is nagekomen worden onderscheiden in de volgende categorieën:'
+  - index: 2
+    label: onderdeel a
+    sha256: ebe75680d0819fd5195f92a5fa12d99db8556eaa8b104c0c8565b82c96bf7bf8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'a. eerste categorie: het zich niet tijdig laten registreren als werkzoekende bij het Uitvoeringsinstituut werknemersverzekeringen;'
+  - index: 3
+    label: onderdeel b
+    sha256: ed1eb00fa2eb8bf1f3be515d58356ab4ef1786b8c7078b481c5f7b1868469ce4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'b. tweede categorie: 1. het niet of onvoldoende meewerken aan het opstellen, uitvoeren en evalueren van een plan van aanpak als bedoeld in artikel 44a van de Participatiewet; 2. het niet binnen vier weken na melding als bedoeld in artikel 43, vierde en vijfde lid, van de Participatiewet voldoende meewerken aan het onderzoek naar de mogelijkheden tot arbeidsinschakeling of sociale activering als dit een persoon jonger dan 27 jaar betreft; 3. het als alleenstaande ouder niet naar vermogen trachten arbeid in deeltijd te verkrijgen; 4. het niet of onvoldoende verrichten van de door het college opgedragen tegenprestatie als bedoeld in artikel 9, eerste lid, onderdeel c, van de Participatiewet;'
+  - index: 4
+    label: onderdeel c
+    sha256: a8209ad7f6610a974bdeb5dd7ac1203e58d8298e16fef87285aa6abc1df1f79c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'c. derde categorie: het niet naar vermogen proberen algemeen geaccepteerde arbeid te verkrijgen.'
+- number: '9'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: eaefdd6c309801d9a140a5e97e4a117797ce724dc50d5574a5c10e97b66e9d2f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '**Hoogte en duur van de verlaging**'
+  - index: 1
+    label: lid 1
+    sha256: a814d66631a85dc2a76eb8d9d57221927e0f1b6a368812cc43720f23f98bd4ef
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. De verlaging bij gedragingen als bedoeld in de artikelen 7 en 8 bedraagt: a. eerste categorie: 5 procent van de bijstandsnorm gedurende 1 maand; b. tweede categorie: 30 procent van de bijstandsnorm gedurende 1 maand; c. derde categorie: 100 procent van de bijstandsnorm gedurende 1 maand.'
+  - index: 2
+    label: lid 2
+    sha256: 661410c5b7ad12d171030e520f65531fc1e10241058d3037c949080835892d92
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het college kan de verlaging afwijkend vaststellen, met een minimum van 5% en een maximum van 100% van de bijstandsnorm, als de ernst van de gedraging, de mate van verwijtbaarheid of de individuele omstandigheden van de belanghebbende daartoe aanleiding geven.

--- a/textguard/nl/ministeriele_regeling/regeling_standaardpremie/2024-01-01.yaml
+++ b/textguard/nl/ministeriele_regeling/regeling_standaardpremie/2024-01-01.yaml
@@ -1,0 +1,36 @@
+$id: regeling_standaardpremie
+valid_from: '2024-01-01'
+source: corpus/regulation/nl/ministeriele_regeling/regeling_standaardpremie/2024-01-01.yaml
+articles:
+- number: '1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c44e6ef087096c9448f6ca8876aeee9334943543bae43b38cd570ccb39ee8256
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'De standaardpremie, bedoeld in [artikel 4 van de Wet op de zorgtoeslag](https://wetten.overheid.nl/BWBR0018451/2024-01-01#Artikel4), bedraagt voor het berekeningsjaar 2024: € 1.987,–.'
+- number: '2'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 88c538d9e0f65a903f118b0924750399ab6c2a700fcbea4b515bc6fe0fe11fdd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '[Red: Wijzigt de Regeling zorgverzekering.]'
+- number: '3'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 60f22aafdfe56a4efdeafcefe557a31e0ebeb94f36e5622f493f41fda8238890
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Deze regeling treedt in werking met ingang van 1 januari 2024.
+- number: '4'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a6b98918b51415da240173737034f14da397845aa05bd9691a8ccf58200fc775
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Deze regeling wordt aangehaald als: Regeling vaststelling standaardpremie en bestuursrechtelijke premies 2024.'

--- a/textguard/nl/ministeriele_regeling/regeling_standaardpremie/2025-01-01.yaml
+++ b/textguard/nl/ministeriele_regeling/regeling_standaardpremie/2025-01-01.yaml
@@ -1,0 +1,36 @@
+$id: regeling_standaardpremie
+valid_from: '2025-01-01'
+source: corpus/regulation/nl/ministeriele_regeling/regeling_standaardpremie/2025-01-01.yaml
+articles:
+- number: '1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 0d3a5e42897fbba700841b0c4530d407dc5bf211858ee4ec3fb697b16004f579
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'De standaardpremie, bedoeld in [artikel 4 van de Wet op de zorgtoeslag](https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel4), bedraagt voor het berekeningsjaar 2025: € 2.112,–.'
+- number: '2'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 88c538d9e0f65a903f118b0924750399ab6c2a700fcbea4b515bc6fe0fe11fdd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '[Red: Wijzigt de Regeling zorgverzekering.]'
+- number: '3'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 90333c4a3cce35c4dc3ce5e2f369bbcddefada0bb3bf9138155fe403785da291
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Deze regeling treedt in werking met ingang van 1 januari 2025.
+- number: '4'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 3657c7767c912430fe3e87aadc2d63170437dc701f3a0c9a3b68731a1077641a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Deze regeling wordt aangehaald als: Regeling vaststelling standaardpremie en bestuursrechtelijke premies 2025.'

--- a/textguard/nl/wet/algemene_wet_bestuursrecht/1994-01-01.yaml
+++ b/textguard/nl/wet/algemene_wet_bestuursrecht/1994-01-01.yaml
@@ -1,0 +1,28 @@
+$id: algemene_wet_bestuursrecht
+valid_from: '1994-01-01'
+source: corpus/regulation/nl/wet/algemene_wet_bestuursrecht/1994-01-01.yaml
+articles:
+- number: '3:46'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 7989060f711a41790d2cfd8546b61451790233b95fce82bc7b8bbb5383904ee1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Een besluit dient te berusten op een deugdelijke motivering.
+- number: '6:7'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d167979a5b6f2faa1f48d9854fb0b95e5e29785da211ea8ee7002541ed5190f4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: De termijn voor het indienen van een bezwaar- of beroepschrift bedraagt zes weken.
+- number: '6:8'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: c715a1e2654c38ae0bd3f846e9d6bfd094cda19bcdb4c0c447d588da76b99798
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. De termijn vangt aan met ingang van de dag na die waarop het besluit op de voorgeschreven wijze is bekendgemaakt.

--- a/textguard/nl/wet/algemene_wet_inkomensafhankelijke_regelingen/2025-01-01.yaml
+++ b/textguard/nl/wet/algemene_wet_inkomensafhankelijke_regelingen/2025-01-01.yaml
@@ -1,0 +1,420 @@
+$id: algemene_wet_inkomensafhankelijke_regelingen
+valid_from: null
+source: corpus/regulation/nl/wet/algemene_wet_inkomensafhankelijke_regelingen/2025-01-01.yaml
+articles:
+- number: '1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 456dbd0a8d93bd56560479df3f0b0b7d780b0ee99447b74f86606bd6185efa77
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 1. Toepassingsgebied 1. Deze wet geldt voor inkomensafhankelijke regelingen. 2. In afwijking van het eerste lid is deze wet op inkomensafhankelijke regelingen die vóór 1. januari 2006. van kracht zijn, slechts van toepassing voor zover dit in de desbetreffende inkomensafhankelijke regeling is bepaald. 3. Onder inkomensafhankelijke regelingen worden verstaan bij of krachtens wet vastgestelde regelingen die natuurlijke personen aanspraak geven op een financiële bijdrage van het Rijk in kosten of bijdrageverplichtingen, waarbij de hoogte van de bijdrage in die regelingen afhankelijk is gesteld van draagkracht.
+- number: '2'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 45e0478977a015dd4f3889d0129525f5bd40dd5e5f2aac1b507c00216dab38ef
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 2. Definities 1. In deze wet en de daarop berustende bepalingen, alsmede in inkomensafhankelijke regelingen, wordt verstaan onder: a. belastbaar loon: het belastbare loon bedoeld in [artikel 9. van de Wet op de loonbelasting 1964](jci1.3:c:BWBR0002471&artikel=9) ; b. berekeningsjaar: het kalenderjaar waarop de tegemoetkoming betrekking heeft; c. bestuurlijke boete: de bestuurlijke sanctie, inhoudende een onvoorwaardelijke verplichting tot betaling van een geldsom, die is gericht op bestraffing van de overtreder; d. jaaropgaaf: de opgaaf bedoeld in [artikel 28, onderdeel e, van de Wet op de loonbelasting 1964](jci1.3:c:BWBR0002471&artikel=28) ; e. kind: de persoon bedoeld in artikel 4. ; f. lidstaat: een Staat die lid is van de Europese Unie of een andere Staat, niet zijnde een lidstaat van de Europese Unie, die partij is bij de Overeenkomst betreffende de Europese Economische Ruimte; g. medebewoner: de persoon die op hetzelfde woonadres als de belanghebbende staat ingeschreven in de gemeentelijke basisadministratie persoonsgegevens, met dien verstande dat als medebewoner niet wordt aangemerkt: 1°. de partner van de belanghebbende, 2°. de persoon die op basis van een schriftelijke overeenkomst met de belanghebbende een deel van de woning huurt, tenzij deze een bloed- of aanverwant in de eerste graad is van de belanghebbende of van diens partner, 3°. degene die tot het huishouden van de onder 2° bedoelde persoon behoort; 1°. de partner van de belanghebbende, 2°. de persoon die op basis van een schriftelijke overeenkomst met de belanghebbende een deel van de woning huurt, tenzij deze een bloed- of aanverwant in de eerste graad is van de belanghebbende of van diens partner, 3°. degene die tot het huishouden van de onder 2° bedoelde persoon behoort; h. partner: de persoon bedoeld in artikel 3. ; i. sociaal-fiscaalnummer: het nummer bedoeld in [artikel 2, derde lid, onderdeel j, van de Algemene wet inzake rijksbelastingen](jci1.3:c:BWBR0002320&artikel=2) ; j. tegemoetkoming: een financiële bijdrage van het Rijk op grond van een inkomensafhankelijke regeling; k. toetsingsinkomen: het inkomen bedoeld in artikel 8. ; l. verzamelinkomen: het verzamelinkomen bedoeld in [artikel 2.18 van de Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353&artikel=2.18) ; m. vreemdeling: hetgeen daaronder wordt verstaan in de [Vreemdelingenwet 2000](jci1.3:c:BWBR0011823) . 2. In deze wet en de daarop berustende bepalingen wordt verstaan onder Onze Minister: Onze Minister van Financiën.'
+- number: '3'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 30ce73f4b5965815e2ddb1ac797d27f9513ce3949fc7b8d0d380caf352c0b66c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 3. Partner 1. De partner van de belanghebbende is degene die hierna als eerste wordt genoemd: a. de niet duurzaam gescheiden levende echtgenoot of geregistreerde partner; b. degene die op hetzelfde woonadres als de belanghebbende staat ingeschreven in de gemeentelijke basisadministratie persoonsgegevens en: 1°. voor de toepassing van de [Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353) voor het berekeningsjaar kiest voor kwalificatie als partner van de belanghebbende; 2°. ten overstaan van een notaris een samenlevingscontract heeft gesloten met de belanghebbende; 3°. uit wiens relatie met de belanghebbende een kind is geboren; 4°. een kind van de belanghebbende heeft erkend dan wel van wie een kind door de belanghebbende is erkend; 5°. in een aan het berekeningsjaar voorafgaand kalenderjaar partner van de belanghebbende was; 6°. voor de toepassing van een pensioenregeling als partner van de belanghebbende is aangemeld, of 7°. samen met de belanghebbende een woning bewoont die voor hen een eigen woning is in de zin van [artikel 3.111 van de Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353&artikel=3.111) , en aansprakelijk is of mede aansprakelijk is voor een schuld waarbij die woning als onderpand dient; 1°. voor de toepassing van de [Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353) voor het berekeningsjaar kiest voor kwalificatie als partner van de belanghebbende; 2°. ten overstaan van een notaris een samenlevingscontract heeft gesloten met de belanghebbende; 3°. uit wiens relatie met de belanghebbende een kind is geboren; 4°. een kind van de belanghebbende heeft erkend dan wel van wie een kind door de belanghebbende is erkend; 5°. in een aan het berekeningsjaar voorafgaand kalenderjaar partner van de belanghebbende was; 6°. voor de toepassing van een pensioenregeling als partner van de belanghebbende is aangemeld, of 7°. samen met de belanghebbende een woning bewoont die voor hen een eigen woning is in de zin van [artikel 3.111 van de Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353&artikel=3.111) , en aansprakelijk is of mede aansprakelijk is voor een schuld waarbij die woning als onderpand dient; c. de meerderjarige die in het berekeningsjaar gedurende meer dan zes maanden onafgebroken een gezamenlijke huishouding voert met de meerderjarige belanghebbende en gedurende die tijd op hetzelfde woonadres als de belanghebbende staat ingeschreven in de gemeentelijke basisadministratie persoonsgegevens, met uitzondering van: 1°. de bloed- of aanverwant in de rechte lijn van de belanghebbende; 2°. de bloed- of aanverwant in de tweede graad van de zijlijn van de belanghebbende gedurende de periode dat de belanghebbende op hetzelfde woonadres als zijn ouder staat ingeschreven in de gemeentelijke basisadministratie persoonsgegevens. 1°. de bloed- of aanverwant in de rechte lijn van de belanghebbende; 2°. de bloed- of aanverwant in de tweede graad van de zijlijn van de belanghebbende gedurende de periode dat de belanghebbende op hetzelfde woonadres als zijn ouder staat ingeschreven in de gemeentelijke basisadministratie persoonsgegevens. 2. Degene die ingevolge het eerste lid voor een deel van het berekeningsjaar als partner wordt aangemerkt, wordt ook als partner aangemerkt in de andere perioden van het berekeningsjaar, voor zover hij in die perioden op het zelfde woonadres als de belanghebbende staat ingeschreven in de gemeentelijke basisadministratie persoonsgegevens. 3. Indien ingevolge het eerste lid, onderdeel c, tegelijkertijd meer dan één persoon als partner wordt aangemerkt, wijst de belanghebbende bij de aanvraag van de tegemoetkoming een van deze personen aan als partner.'
+- number: '4'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 3636fd5a7bfb515d06451db39c7d26cf74cc33ca61795b2e5f19d355973f2069
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4. Kind 1. Kind is de bloedverwant of aanverwant in de neergaande lijn van de belanghebbende of zijn partner, die in belangrijke mate wordt onderhouden door de belanghebbende of zijn partner en op hetzelfde woonadres als de belanghebbende staat ingeschreven in de gemeentelijke basisadministratie persoonsgegevens. Met een bloedverwant of aanverwant in de neergaande lijn wordt gelijkgesteld een pleegkind. 2. De in het eerste lid opgenomen voorwaarde van inschrijving in de gemeentelijke basisadministratie persoonsgegevens geldt niet gedurende de periode waarin de aldaar bedoelde persoon tegelijkertijd tot de huishoudens van zijn beide ouders behoort en hij op hetzelfde woonadres als een van die ouders staat ingeschreven in de gemeentelijke basisadministratie persoonsgegevens. Voor de toepassing van de eerste volzin behoort iemand tegelijkertijd tot het huishouden van beide ouders indien hij doorgaans ten minste drie gehele dagen per week in elk van beide huishoudens verblijft. 3. Een kind wordt in belangrijke mate onderhouden als bedoeld in het eerste lid indien is voldaan aan de regels gesteld krachtens [artikel 1.5 van de Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353&artikel=1.5) .
+- number: '5'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 5d59ae968ec7db908d6b394b3a656bf75e190bb7acf0de798e169b970f6be9f0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 5. Tijdvak partnerschap en medebewonerschap Voor de toepassing van deze wet en de daarop berustende bepalingen, alsmede voor de toepassing van inkomensafhankelijke regelingen, wordt met de aanwezigheid van een partner of medebewoner geen rekening gehouden in de kalendermaand waarin het partnerschap of medebewonerschap aanvangt of eindigt.
+- number: '6'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 53ed4b022fb31187635a175449bde2f9a2fec22ef539fe706306218c608afcf7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 6. Gelijkstelling met gemeentelijke basisadministratie persoonsgegevens 1. Voor de toepassing van deze wet en de daarop berustende bepalingen wordt met de gemeentelijke basisadministratie persoonsgegevens gelijkgesteld een daarmee naar aard en strekking overeenkomende administratie buiten Nederland. 2. Bij regeling van Onze Minister in overeenstemming met Onze Minister van Sociale Zaken en Werkgelegenheid kunnen regels worden gesteld op basis waarvan iemand die niet in Nederland woont, geacht wordt op zijn woonadres te zijn ingeschreven in een naar aard en strekking met de gemeentelijke basisadministratie persoonsgegevens overeenkomende administratie buiten Nederland. 3. Bij regeling van Onze Minister in overeenstemming met Onze Minister van Sociale Zaken en Werkgelegenheid kunnen regels worden gesteld op basis waarvan iemand die niet kan worden ingeschreven in de gemeentelijke basisadministratie persoonsgegevens, geacht wordt daarin op zijn woonadres te zijn ingeschreven. 4. Voor de toepassing van het tweede en derde lid wordt naar de omstandigheden beoordeeld waar iemand woont.
+- number: '7'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 93b5758aebdc9b9a285bd61fa02891a5ac02ca5dc7e59e8bb110b422642268c5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 7. Draagkracht 1. Ter bepaling van de draagkracht voor de toepassing van een inkomensafhankelijke regeling wordt het toetsingsinkomen, bedoeld in artikel 8. , van de belanghebbende en dat van zijn partner in aanmerking genomen. 2. Indien in een inkomensafhankelijke regeling is bepaald dat naast de draagkracht van de belanghebbende en diens partner ook de draagkracht van medebewoners van belang is voor de beoordeling van de aanspraak op of de bepaling van de hoogte van een tegemoetkoming, wordt mede het toetsingsinkomen van de medebewoners in aanmerking genomen. 3. Indien in een inkomensafhankelijke regeling de aanspraak op een tegemoetkoming mede afhankelijk is gesteld van het vermogen, bestaat geen aanspraak op een tegemoetkoming, indien bij de belanghebbende of, indien de belanghebbende het gehele berekeningsjaar dezelfde partner heeft, zijn partner over het berekeningsjaar voordeel uit sparen en beleggen als bedoeld in [artikel 5.2 van de Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353&artikel=5.2) in aanmerking wordt genomen. 4. Indien in een inkomensafhankelijke regeling de aanspraak op een tegemoetkoming mede afhankelijk is gesteld van het vermogen van medebewoners, bestaat tevens geen aanspraak op een tegemoetkoming indien bij een medebewoner over het berekeningsjaar voordeel uit sparen en beleggen als bedoeld in [artikel 5.2 van de Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353&artikel=5.2) in aanmerking wordt genomen. Het bepaalde in de eerste volzin geldt alleen ten aanzien van degenen van wie het medebewonerschap het gehele berekeningsjaar heeft geduurd. 5. Het toetsingsinkomen van een medebewoner die een eerstegraads bloed- of aanverwant in de neergaande lijn of een pleegkind is van de belanghebbende, van zijn partner, of van een medebewoner, en die bij de aanvang van het berekeningsjaar de leeftijd van 23. jaar niet heeft bereikt, wordt voor de toepassing van het tweede lid slechts in aanmerking genomen voor zover het meer bedraagt dan € 4. 100. 6. Met betrekking tot het bedrag vermeld in het vijfde lid zijn de [artikelen 10.1](jci1.3:c:BWBR0011353&artikel=10.1) en [10.2 van de Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353&artikel=10.2) van overeenkomstige toepassing.
+- number: '8'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: f04b3a2441e44b4dd2a00b2d6b35c228366fcb50127a40a67b3dd70c137e877b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 8. Toetsingsinkomen 1. Toetsingsinkomen is: a. indien over het berekeningsjaar een aanslag inkomstenbelasting is of wordt vastgesteld: het verzamelinkomen, zoals dat in die aanslag is opgenomen; b. indien over het berekeningsjaar geen aanslag inkomstenbelasting is of wordt vastgesteld: het belastbare loon, zoals dat blijkt uit de op het berekeningsjaar betrekking hebbende jaaropgaven. 2. Indien over het berekeningsjaar een navorderingsaanslag inkomstenbelasting is vastgesteld is, in afwijking van het eerste lid, het in die navorderingsaanslag opgenomen verzamelinkomen het toetsingsinkomen. 3. Inkomen dat niet in een verzamelinkomen of belastbaar loon is begrepen omdat het niet behoort tot het Nederlandse inkomen als bedoeld in [artikel 7.1 van de Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353&artikel=7.1) of is vrijgesteld op grond van bepalingen van internationaal recht, wordt in aanvulling van het eerste en tweede lid mede als toetsingsinkomen in aanmerking genomen als ware het aan de Nederlandse belastingheffing onderworpen. 4. Indien zulks leidt tot een ten minste 10. percent lager toetsingsinkomen, wordt bij beëindiging van het partnerschap in het berekeningsjaar, in afwijking in zoverre van het eerste tot en met het derde lid, op verzoek van de belanghebbende bij de berekening van het toetsingsinkomen van de partner: a. geen rekening gehouden met: 1°. belastbaar loon dat is genoten na de beëindiging van het partnerschap; 2°. winst uit een onderneming die na de beëindiging van het partnerschap is gestart; en 3°. belastbaar resultaat uit overige werkzaamheden indien de werkzaamheden na beëindiging van het partnerschap zijn gestart; 1°. belastbaar loon dat is genoten na de beëindiging van het partnerschap; 2°. winst uit een onderneming die na de beëindiging van het partnerschap is gestart; en 3°. belastbaar resultaat uit overige werkzaamheden indien de werkzaamheden na beëindiging van het partnerschap zijn gestart; b. het belastbare loon dat in de periode van partnerschap is genoten tijdsevenredig herleid naar een jaarloon. 5. Bij beëindiging van het medebewonerschap in het berekeningsjaar is het vierde lid van overeenkomstige toepassing met betrekking tot het toetsingsinkomen van de medebewoner. 6. Bij overlijden van de belanghebbende, zijn partner, of een medebewoner wordt, in afwijking in zoverre van het eerste tot en met het derde lid het toetsingsinkomen van de overledene berekend door het op grond van die leden bepaalde toetsingsinkomen tijdsevenredig te herleiden naar een jaarinkomen. 7. Bij ministeriële regeling kunnen nadere regels worden gesteld voor de toepassing van het vierde tot en met het zesde lid.'
+- number: '9'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ade6f0c52f4592575b804eb633427aa2a4ac919c31aeea2ec17195482262bc64
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 9. Wijziging status vreemdelingen; partner of medebewoner is vreemdeling 1. Indien aan een vreemdeling tijdens een rechtmatig verblijf als bedoeld in [artikel 8, onderdelen a tot en met e, en l, van de Vreemdelingenwet 2000](jci1.3:c:BWBR0011823&artikel=8) een tegemoetkoming is toegekend, heeft de omstandigheid dat hij aansluitend aan dit verblijf rechtmatig verblijf houdt in de zin van [artikel 8, onderdeel g of h, van die wet](jci1.3:c:BWBR0011823&artikel=8) niet tot gevolg dat hij daardoor zijn aanspraak verliest op eenzelfde tegemoetkoming gedurende de periode van laatstgenoemd verblijf. 2. Ingeval de partner van de belanghebbende een vreemdeling is die niet rechtmatig verblijf houdt in de zin van [artikel 8. van de Vreemdelingenwet 2000](jci1.3:c:BWBR0011823&artikel=8) , heeft de belanghebbende geen aanspraak op een tegemoetkoming. 3. Indien in een inkomensafhankelijke regeling is bepaald dat naast de draagkracht van de belanghebbende en diens partner ook de draagkracht van medebewoners van belang is voor de beoordeling van de aanspraak op of de bepaling van de hoogte van een tegemoetkoming, heeft de belanghebbende geen aanspraak op een tegemoetkoming ingeval een medebewoner een vreemdeling is die niet rechtmatig verblijf houdt in de zin van [artikel 8. van de Vreemdelingenwet 2000](jci1.3:c:BWBR0011823&artikel=8) .
+- number: '10'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8113d128e5f1ed29053e3b6f98ac38d17fdbbe48388a7538683026014fbc3cac
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 10. Uitoefening rechten door minderjarigen 1. Een minderjarige is bekwaam de rechtshandelingen te verrichten die noodzakelijk zijn om een tegemoetkoming te verkrijgen. Hij is voorts bekwaam de rechtshandelingen te verrichten die noodzakelijk zijn met betrekking tot de uitoefening, onderscheidenlijk de nakoming van de voor hem uit de toekenning van tegemoetkomingen voortvloeiende rechten en verplichtingen. 2. Indien op grond van een inkomensafhankelijke regeling alleen meerderjarigen aanspraak op een tegemoetkoming hebben, wordt voor die regeling mede als meerderjarige aangemerkt de minderjarige met een kind of de minderjarige van wie beide ouders zijn overleden.
+- number: '11'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: f345d838f70fa47476d87c6d2dd0af71e3c3838eaccb22f4c73610447b55f1a1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 11. Toepassingsgebied 1. De bepalingen van dit hoofdstuk gelden voor de inkomensafhankelijke regelingen waarvan de uitvoering bij die regeling is opgedragen aan de Belastingdienst/Toeslagen. 2. Onder Belastingdienst/Toeslagen wordt verstaan: het organisatieonderdeel van de rijksbelastingdienst dat is belast met het toekennen, uitbetalen en terugvorderen van tegemoetkomingen.'
+- number: '12'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 954b7f4c0fee6a6f2009730940f2ddcdb28cfbc4bc7c1ff5042a52a379c577dd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 12. Uitzonderingen op de Algemene wet bestuursrecht Voor de toepassing van dit hoofdstuk blijft [titel 4.2 van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&titeldeel=4.2) buiten toepassing en zijn [artikel 3:40](jci1.3:c:BWBR0005537&artikel=3:40) en de [hoofdstukken 4](jci1.3:c:BWBR0005537&hoofdstuk=4) , [6](jci1.3:c:BWBR0005537&hoofdstuk=6) en [7 van die wet](jci1.3:c:BWBR0005537&hoofdstuk=7) niet van toepassing op de verrekeningsbeschikking als bedoeld in artikel 30. , en de aanmaning en het dwangbevel als bedoeld in artikel 32. .
+- number: '13'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d14f1af1baada6a3cb576ea636db24f23314335f0b9fbcacccc31dd2d8214fad
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 13. Gebruik sociaal-fiscaalnummer De Belastingdienst/Toeslagen maakt voor de uitvoering van deze wet gebruik van het sociaal-fiscaalnummer.
+- number: '14'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: cf6d21396aa9cae04083fcd0847eb2a6f091cb6b3302ccde88647d807e0902c2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 14. Toekennen tegemoetkoming 1. Een tegemoetkoming wordt op aanvraag toegekend door de Belastingdienst/Toeslagen. 2. Indien partners een gezamenlijke aanspraak op een tegemoetkoming hebben, wordt de tegemoetkoming uitsluitend toegekend aan de aanvrager. 3. Het bedrag van de tegemoetkoming wordt rekenkundig afgerond op hele euro’s. 4. Een tegemoetkoming wordt niet toegekend indien deze minder dan € 24. zou bedragen.
+- number: '15'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4dceb7d9d91d6e745c53ad5febae66ed51a94d12ead0f8a5ede300423d2a798c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 15. Aanvraag tegemoetkoming 1. Een aanvraag om een tegemoetkoming met betrekking tot een berekeningsjaar kan tot 1. april van het jaar volgend op het berekeningsjaar worden ingediend bij de Belastingdienst/Toeslagen. 2. Indien de belanghebbende een partner heeft, wordt de aanvraag mede ondertekend door de partner. 3. Indien in een inkomensafhankelijke regeling is bepaald dat naast de draagkracht van belanghebbende en diens partner ook de draagkracht van medebewoners van belang is voor de beoordeling van de aanspraak op of de bepaling van de hoogte van een tegemoetkoming, wordt de aanvraag mede ondertekend door de medebewoners. 4. Een aanvraag wordt geacht mede te zijn gedaan voor op het berekeningsjaar volgende berekeningsjaren. 5. Indien de Belastingdienst/Toeslagen van oordeel is dat toepassing van het vierde lid kan worden beëindigd, deelt hij dit de belanghebbende schriftelijk mee. 6. De Belastingdienst/Toeslagen kan op eigen initiatief een aanvraagformulier toezenden aan degene die vermoedelijk voor een tegemoetkoming in aanmerking komt. Op dat formulier kunnen voor de belanghebbende en zijn niet duurzaam gescheiden levende echtgenoot of geregistreerde partner de gegevens worden vermeld die van belang kunnen zijn voor de beoordeling van de aanspraak of de bepaling van de hoogte van de tegemoetkoming. 7. In bij algemene maatregel van bestuur te bepalen gevallen kan de in het zesde lid bedoelde vermelding van gegevens ook plaatsvinden voor de partner die niet is de in dat lid bedoelde partner. De voordracht voor een krachtens de eerste volzin vast te stellen algemene maatregel van bestuur wordt niet eerder gedaan dan vier weken nadat het ontwerp aan beide kamers der Staten-Generaal is overgelegd.
+- number: '16'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 41ef446fe9854e0f80ffdc47ca950f90e8ad0203262e7db8af78258091f5e263
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 16. Voorschot op tegemoetkoming 1. Indien de tegemoetkoming naar verwachting niet binnen acht weken na ontvangst van de aanvraag zal worden toegekend, verleent de Belastingdienst/Toeslagen de belanghebbende een voorschot tot het bedrag waarop de tegemoetkoming vermoedelijk zal worden vastgesteld. 2. Ingeval de belanghebbende voor het gehele berekeningsjaar aanspraak heeft op een tegemoetkoming wordt het voorschot verleend: a. indien de aanvraag ten minste acht weken vóór het berekeningsjaar is ingediend of indien de tegemoetkoming wordt toegekend met toepassing van artikel 15, vierde lid : vóór de aanvang van het berekeningsjaar; b. in andere gevallen: binnen acht weken na de ontvangst van de aanvraag. 3. Indien de belanghebbende slechts voor een deel van het berekeningsjaar aanspraak heeft op een tegemoetkoming wordt het voorschot niet eerder verleend dan in de maand voorafgaand aan de maand waarin de aanspraak ontstaat. 4. De Belastingdienst/Toeslagen kan het voorschot herzien. 5. Een herziening van het voorschot kan leiden tot een terug te vorderen bedrag.'
+- number: '17'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 574ec6a6050e02d61683fcf1943ffe48d596d9b8fa24ea70f4811814a30914a2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 17. Na voorschot melding wijziging omstandigheden 1. Indien een voorschot op de tegemoetkoming is verleend en er een relevante wijziging optreedt in de omstandigheden die van belang zijn voor de beoordeling van de aanspraak op of de bepaling van de hoogte van de tegemoetkoming, is de belanghebbende gehouden die wijziging te melden aan de Belastingdienst/Toeslagen. 2. Bij regeling van Onze Minister wordt bepaald welke wijzigingen in omstandigheden aanleiding geven voor een melding en op welke wijze en binnen welke termijn de melding wordt gedaan. 3. Indien de belanghebbende een partner heeft wordt de melding mede ondertekend door de partner. 4. Indien de melding betrekking heeft op een medebewoner, wordt de melding mede ondertekend door die medebewoner.
+- number: '18'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c1418ce1a24ac44818348d358779c690c3e764702a023005bfcdd0ef5555a294
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 18. Verzoeken van Belastingdienst/Toeslagen tot informatieverstrekking 1. Een belanghebbende, een partner en een medebewoner verstrekken de Belastingdienst/Toeslagen desgevraagd alle gegevens en inlichtingen die voor de beoordeling van de aanspraak op of de bepaling van de hoogte van de tegemoetkoming van belang kunnen zijn. 2. De gegevens en inlichtingen worden verstrekt binnen een door de Belastingdienst/Toeslagen te stellen termijn. 3. Indien de gegevens of inlichtingen niet op tijd zijn verstrekt door de persoon aan wie dit is gevraagd, maant de Belastingdienst/Toeslagen hem aan onder het stellen van een nadere termijn om alsnog de gevraagde gegevens en inlichtingen te verstrekken. 4. Indien niet aan de in de vorige leden genoemde verplichtingen is voldaan, bepaalt de Belastingdienst/Toeslagen ambtshalve de hoogte van de tegemoetkoming.
+- number: '19'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: dddadff46d1a8c448161042e5ec12222fc32ed4a63b6cbbbe6414eb986fbf23e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 19. Beslistermijn toekenning tegemoetkoming 1. Indien ten name van de belanghebbende, zijn partner of een medebewoner over het berekeningsjaar een aanslag inkomstenbelasting wordt vastgesteld, kent de Belastingdienst/Toeslagen de tegemoetkoming met betrekking tot dat berekeningsjaar toe binnen acht weken na de vaststelling van de laatste in dit kader van belang zijnde aanslag. 2. Indien voor geen van de in het eerste lid bedoelde personen over het berekeningsjaar een aanslag inkomstenbelasting wordt vastgesteld, kent de Belastingdienst/Toeslagen de tegemoetkoming met betrekking tot dat berekeningsjaar toe vóór 1. december van het jaar volgend op het berekeningsjaar. 3. Indien de tegemoetkoming niet binnen de in de vorige leden genoemde termijn kan worden toegekend, stelt de Belastingdienst/Toeslagen de belanghebbende hiervan schriftelijk in kennis onder het noemen van een redelijke termijn waarbinnen toekenning zal plaatsvinden.
+- number: '20'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 30388e59fade547235cc7217cc99fbaa190c883cacb06489025b454f5b64f65f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 20. Herziening tegemoetkoming wegens wijziging fiscale gegevens na toekenning 1. Indien na de toekenning van de tegemoetkoming uit een wijziging van een verzamelinkomen of belastbaar loon of uit een eerste vaststelling van een verzamelinkomen blijkt dat de tegemoetkoming tot een te hoog of te laag bedrag is toegekend, herziet de Belastingdienst/Toeslagen de tegemoetkoming met inachtneming van die wijziging of vaststelling. 2. De herziening geschiedt binnen acht weken na het tijdstip waarop de beschikking of uitspraak strekkende tot de in het eerste lid bedoelde wijziging of vaststelling onherroepelijk is geworden dan wel de herziene jaaropgaaf terzake van het belastbare loon bij de Belastingdienst/Toeslagen bekend is geworden. 3. Een herziening op grond van dit artikel kan leiden tot een uit te betalen bedrag doch ook tot een terug te vorderen bedrag.
+- number: '21'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 19d1e6433ce0677882dbe0c8ec8c533168a7f301c6440f061053a2709f4348cc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 21. Herziening tegemoetkoming om andere reden 1. De Belastingdienst/Toeslagen kan een toegekende tegemoetkoming herzien: a. op grond van feiten of omstandigheden waarvan de dienst bij de toekenning redelijkerwijs niet op de hoogte kon zijn en op grond waarvan de tegemoetkoming vermoedelijk tot een te hoog bedrag is toegekend, of b. indien de tegemoetkoming tot een te hoog bedrag is toegekend en de belanghebbende of zijn partner dit wist of behoorde te weten. 2. Een tegemoetkoming kan met toepassing van dit artikel niet meer worden herzien indien vijf jaren zijn verstreken na de laatste dag van het berekeningsjaar waarop de tegemoetkoming betrekking heeft. 3. Een herziening op grond van dit artikel kan leiden tot een terug te vorderen bedrag.'
+- number: '22'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 672716528994ce3902e58000bc06a089c0e845044d802ce607fdb58c6909a8de
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 22. Uitbetaling voorschot 1. Een voorschot dat wordt verleend vóór de aanvang van het berekeningsjaar waarop het voorschot betrekking heeft, wordt uitbetaald in 12. gelijke termijnen. De uitbetaling van de eerste termijn vindt plaats in de maand december voorafgaand aan het berekeningsjaar en elke volgende termijn telkens een maand later. 2. Een voorschot dat wordt verleend in de loop van het berekeningsjaar waarop het voorschot betrekking heeft, en waarvan de beschikking een dagtekening heeft die ligt vóór 1. november van dat jaar, wordt uitbetaald in zoveel gelijke termijnen als er na de maand van dagtekening nog kalendermaanden van dat jaar overblijven. De uitbetaling van de eerste termijn vindt plaats in de maand van dagtekening en elke volgende termijn telkens een maand later. 3. Een voorschot dat wordt verleend in de loop van of na afloop van het berekeningsjaar waarop het voorschot betrekking heeft en waarvan de beschikking een dagtekening heeft die ligt na 31. oktober van dat jaar, wordt in één bedrag uitbetaald in de maand van dagtekening.
+- number: '23'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ccbbd5b8c3b0db077c0e2b7450af270eaf7102f19ba19795c4cc86bd2ba97a92
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 23. Opschorten uitbetaling voorschot De Belastingdienst/Toeslagen kan de uitbetaling van een voorschot geheel of gedeeltelijk opschorten indien redelijkerwijs kan worden vermoed dat het voorschot ten onrechte of tot een te hoog bedrag is verleend. De belanghebbende wordt van de opschorting schriftelijk in kennis gesteld.
+- number: '24'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 220aa586e1ba21566a24b897707b0696ca461dd0cd74ec409b1974aa2f1bb2d7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 24. Uitbetaling tegemoetkoming 1. Een tegemoetkoming wordt uitbetaald binnen vier weken na dagtekening van de beschikking. 2. Indien voorschotten zijn verleend, worden deze verrekend met de tegemoetkoming. 3. De in het tweede lid bedoelde verrekening kan leiden tot een terug te vorderen bedrag.
+- number: '25'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: cd1326e9e3f404bec28f20606ea32abd961025ad56aaa52654ba712bbeb6fdef
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 25. Wijze van uitbetaling 1. Uitbetaling van een voorschot of een tegemoetkoming geschiedt door de Belastingdienst/Toeslagen door middel van een bijschrijving op een ten name van de belanghebbende of diens partner bestaande bankrekening, bestemd voor girale betaling, tenzij daartoe door de belanghebbende een andere rekening is aangewezen. 2. Bij ministeriële regeling worden regels gesteld met betrekking tot de aanwijzing van een andere rekening als bedoeld in het eerste lid.
+- number: '26'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: db87b22fdf030cd18bca5253dd8628bcee10bc6505a4a7df68f1773f8aa344a4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 26. Terugvordering is verschuldigd door belanghebbende Indien een herziening van een tegemoetkoming of een herziening van een voorschot leidt tot een terug te vorderen bedrag dan wel een verrekening van een voorschot met een tegemoetkoming daartoe leidt, is de belanghebbende het bedrag van de terugvordering in zijn geheel verschuldigd.
+- number: '27'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4406130522012e3974491e8229486601f3ab73c445c04d67cc4c02c15e640d86
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 27. Rente bij beschikkingen na een half jaar na berekeningsjaar 1. Over uit te betalen bedragen wordt rente vergoed en over terug te vorderen bedragen wordt rente in rekening gebracht. 2. De rente wordt enkelvoudig berekend over het tijdvak dat aanvangt op 1. juli van het jaar volgend op het berekeningsjaar en eindigt op de dag van de dagtekening van de beschikking tot toekenning onderscheidenlijk de beschikking tot herziening van de tegemoetkoming. 3. Het percentage van de rente is gelijk aan het percentage, bedoeld in [artikel 30f, vijfde lid, van de Algemene wet inzake rijksbelastingen](jci1.3:c:BWBR0002320&artikel=30f) .
+- number: '28'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 52e1437d42b1bb4365f107254b66822772ca6854854ac366a6173dc29ae0c8b6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 28. Betalingstermijn van twee maanden bij terugvordering 1. De belanghebbende heeft de verplichting om het bedrag van een terugvordering alsmede de op de voet van artikel 27. verschuldigde rente binnen twee maanden na de dagtekening van de beschikking tot terugvordering te betalen aan de Belastingdienst/Toeslagen. 2. Het bedrag van een bestuurlijke boete moet worden betaald binnen twee maanden na de dagtekening van de boetebeschikking. 3. De Algemene termijnenwet is niet van toepassing op de in dit artikel gestelde termijnen.
+- number: '29'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 1c7cd532a5185a7d4ed54d81aa22bc558dbd3bcab9045bdc27cab4a14705759f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 29. Rente bij te late betaling terugvordering Bij overschrijding van de in artikel 28. bedoelde betalingstermijn is rente verschuldigd met overeenkomstige toepassing van de [artikelen 28](jci1.3:c:BWBR0004770&artikel=28) en [29 van de Invorderingswet 1990](jci1.3:c:BWBR0004770&artikel=29) .
+- number: '30'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: bc707e34574307d6862340b2bb255932f415e1755a96c58d4386b3ad3fc53867
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 30. Verrekening 1. De Belastingdienst/Toeslagen kan een door de belanghebbende verschuldigd bedrag aan terugvordering verrekenen met een aan hem uit te betalen tegemoetkoming of voorschot daarop, een en ander ongeacht de inkomensafhankelijke regeling die het betreft en ongeacht het berekeningsjaar. 2. De Belastingdienst/Toeslagen is tevens bevoegd, in afwijking van [artikel 3. van de Invorderingswet 1990](jci1.3:c:BWBR0004770&artikel=3) , een door de belanghebbende verschuldigd bedrag aan terugvordering te verrekenen met aan hem uit te betalen bedragen inkomstenbelasting, premie volksverzekeringen, en heffingsrente begrepen in een aanslag of voorlopige aanslag inkomstenbelasting. 3. Een verrekening vindt niet eerder plaats dan nadat de termijn bedoeld in artikel 28. is verstreken. De in de artikelen 27. en 29. bedoelde rente alsmede bestuurlijke boeten kunnen in de verrekening worden betrokken.
+- number: '31'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ba8726e22d9df9cec820c080419625f98dc7ef0e3d65f88d3182e42e78f8b6f9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 31. Uitstel van betaling bij terugvordering 1. De Belastingdienst/Toeslagen kan onder voorwaarden aan de belanghebbende voor een bepaalde tijd bij beschikking uitstel van betaling verlenen. Gedurende het uitstel vangt de in artikel 32. bedoelde dwanginvordering niet aan, of wordt deze geschorst. Het uitstel kan tussentijds bij beschikking worden beëindigd. 2. Bij ministeriële regeling worden regels gesteld met betrekking tot het verlenen van uitstel van betaling.
+- number: '32'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 1b0c34f35225976e46e6cc59c34f0a0d6b1d7368dab265a9d8bae805b2b6bf85
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 32. Dwanginvordering bij terugvordering 1. Indien de belanghebbende het bedrag van de terugvordering, daaronder begrepen de in artikel 27. bedoelde rente alsmede bestuurlijke boeten, niet binnen de gestelde termijn betaalt, maant de Belastingdienst/Toeslagen hem schriftelijk aan om alsnog binnen tien dagen na de dagtekening van de aanmaning te betalen, onder kennisgeving dat hij anders door middelen bij de wet bepaald tot betaling zal worden gedwongen. De aanmaning kan betrekking hebben op meerdere terugvorderingsbeschikkingen. 2. Indien de belanghebbende na de aanmaning in gebreke blijft, kan de invordering van het verschuldigde bedrag geschieden bij een door de Belastingdienst/Toeslagen uit te vaardigen dwangbevel. Bij het dwangbevel kunnen tevens de kosten van de aanmaning, de kosten van het dwangbevel en de verschuldigde renten of boete worden ingevorderd. Het dwangbevel kan betrekking hebben op meer terugvorderingsbeschikkingen. 3. De betekening van het dwangbevel geschiedt met overeenkomstige toepassing van [artikel 13. van de Invorderingswet 1990](jci1.3:c:BWBR0004770&artikel=13) . 4. Het dwangbevel levert een executoriale titel op, die met overeenkomstige toepassing van [artikel 14. van de Invorderingswet 1990](jci1.3:c:BWBR0004770&artikel=14) kan worden tenuitvoergelegd. 5. De belanghebbende kan met overeenkomstige toepassing van [artikel 17. van de Invorderingswet 1990](jci1.3:c:BWBR0004770&artikel=17) , tegen de tenuitvoerlegging van het dwangbevel in verzet komen. 6. Een derde die aan de belanghebbende loon, pensioen, lijfrente of uitkeringen, een en ander als bedoeld in [artikel 19. van de Invorderingswet 1990](jci1.3:c:BWBR0004770&artikel=19) , verschuldigd is, kan met overeenkomstige toepassing van dat artikel op vordering van de Belastingdienst/Toeslagen worden verplicht het door de belanghebbende verschuldigde bedrag aan terugvordering te betalen. 7. Het recht tot dwanginvordering alsmede het recht tot verrekening verjaren met overeenkomstige toepassing van [artikel 27. van de Invorderingswet 1990](jci1.3:c:BWBR0004770&artikel=27) .
+- number: '33'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 410a379ec926c61a05e9097a0bdf90ed6d1840277f3067db072d7de604e8b2e1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 33. Aansprakelijkheid bij terugvordering 1. De partner van de belanghebbende is hoofdelijk aansprakelijk voor een door de belanghebbende verschuldigd bedrag aan terugvordering, daaronder begrepen de in de artikelen 27. en 29. bedoelde rente alsmede de kosten van dwanginvordering. De partner is niet aansprakelijk voor een aan de belanghebbende opgelegde boete, tenzij het belopen daarvan mede aan hem is te wijten. 2. Aansprakelijkstelling geschiedt bij beschikking van de Belastingdienst/Toeslagen. Het bedrag waarvoor de aansprakelijkheid bestaat, is invorderbaar twee maanden na de dagtekening van de beschikking. De artikelen 28, derde lid , 30. , 31. en 32. zijn van overeenkomstige toepassing.
+- number: '34'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 9912371dfa0d4b85a73a7b073b8d580650e8f6fe6e08fecca63ef532ac4f60c8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 34. Aanvullende bepalingen inzake invordering van een terugvordering 1. De Belastingdienst/Toeslagen beschikt ten behoeve van de invordering naast de bevoegdheden ingevolge deze wet, ook over de bevoegdheden die een schuldeiser heeft op grond van enige andere wettelijke bepaling. 2. Tot het verrichten van de bij of krachtens een wet aan een deurwaarder opgedragen werkzaamheden is, voor zover die werkzaamheden geschieden in opdracht van de Belastingdienst/Toeslagen en betrekking hebben op een terugvordering ingevolge deze wet, uitsluitend een belastingdeurwaarder als bedoeld in [artikel 2, eerste lid, onderdeel j, van de Invorderingswet 1990](jci1.3:c:BWBR0004770&artikel=2) , bevoegd. 3. De Kostenwet invordering rijksbelastingen is van overeenkomstige toepassing. 4. De toerekening van de betalingen geschiedt achtereenvolgens aan: a. de kosten van invordering; b. de rente bij te late betaling; c. de terugvordering, de in rekening gebrachte rente bedoeld in artikel 27. en de bestuurlijke boete, naar evenredigheid.'
+- number: '35'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a77ef5ce6b6ce9bf3b214729116db23f4637770a8919004be65d26dd627ea383
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 35. Aanvang bezwaartermijn In afwijking van [artikel 6:8 van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&artikel=6:8) vangt de termijn voor het instellen van bezwaar aan op de dag na die van dagtekening van de beschikking, tenzij de dag van dagtekening gelegen is vóór de dag van de bekendmaking.
+- number: '36'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4f8fb7da97424692c80b4a1dc93241b53c34cdafbbf9d9a95a742d055fa46c85
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 36. Aanvang beroepstermijn In afwijking van [artikel 6:8 van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&artikel=6:8) vangt de termijn voor het instellen van beroep tegen een uitspraak op bezwaar aan op de dag na die van dagtekening van de uitspraak, tenzij de dag van dagtekening is gelegen vóór de dag van de bekendmaking.
+- number: '37'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8a20bfac335684ade305fa52722a7a093487ed5c0b0d1cd15568c1457aeaf59f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 37. Bezwaar inzake meer beschikkingen vervat in één geschrift 1. Een bezwaar tegen de toekenning of herziening van een tegemoetkoming wordt, tenzij uit het bezwaarschrift het tegendeel blijkt, geacht mede te zijn gericht tegen de toekenning of herziening van andere tegemoetkomingen over hetzelfde berekeningsjaar die bij hetzelfde geschrift zijn toegekend of herzien, alsmede tegen de in verband daarmee berekende rente. 2. Indien een tegemoetkoming is herzien en naar aanleiding daarvan een bestuurlijke boete is opgelegd die is vervat in hetzelfde geschrift als de herziening, wordt een bezwaarschrift tegen de herziening geacht mede te zijn gericht tegen de boete. 3. De Belastingdienst/Toeslagen kan uitspraken op bezwaar in de in het eerste en tweede lid bedoelde gevallen vervatten in één geschrift.
+- number: '38'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c5e4ddd31bd56bc5f692dc4788702cadc2b2b5291914a8d22e65019b301b2e43
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 38. Informatieverstrekking aan de Belastingdienst/Toeslagen 1. Openbare lichamen en rechtspersonen die bij of krachtens een bijzondere wet rechtspersoonlijkheid hebben verkregen, de onder hen ressorterende instellingen en diensten, alsmede lichamen die hoofdzakelijk uitvoering geven aan het beleid van het Rijk, en bij algemene maatregel van bestuur aangewezen natuurlijke personen, maat- en vennootschappen, verenigingen en andere rechtspersonen, instellingen en diensten verstrekken op bij algemene maatregel van bestuur te bepalen wijze aan de Belastingdienst/Toeslagen kosteloos de gegevens en inlichtingen waarvan de kennisneming van belang kan zijn voor de uitvoering van deze wet. 2. De gegevens en inlichtingen worden verstrekt binnen een door de Belastingdienst/Toeslagen te stellen termijn. 3. Indien de gevraagde gegevens of inlichtingen niet op tijd zijn verstrekt, maant de Belastingdienst/Toeslagen aan onder het stellen van een nadere termijn om alsnog de gevraagde gegevens en inlichtingen te verstrekken. 4. Bij algemene maatregel van bestuur kunnen nadere regels worden gesteld over de vermelding van het sociaal-fiscaalnummer van degene op wie de gegevens en inlichtingen betrekking hebben bij het verstrekken van de gegevens en inlichtingen. 5. In de gevallen waarin het sociaal-fiscaalnummer dient te worden vermeld, is degene op wie de in het eerste lid bedoelde gegevens en inlichtingen betrekking hebben gehouden zijn sociaal-fiscaalnummer te verstrekken aan de in het eerste lid bedoelde openbare lichamen, rechtspersonen, natuurlijke personen, maat- en vennootschappen, verenigingen, instellingen en diensten.
+- number: 38a
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 09893a7d49a937f2fab3c583371d7a2ed270c40b8cf5faca3522bee79aa55f59
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 38a Gegevensverstrekking door de Belastingdienst/Toeslagen De Belastingdienst/Toeslagen kan onder bij of krachtens algemene maatregel van bestuur te bepalen voorwaarden ten behoeve van bij algemene maatregel van bestuur aan te wijzen voorzieningen die de dienstverlening voortvloeiende uit de uitvoering van deze wet verbeteren, gegevens verstrekken die voor deze dienstverlening nodig zijn.
+- number: '39'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: da8e98590932bca5a407d97834747cb9ec3d2e32cebc11954e244b49f94d54ea
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 39. Informatie-uitwisseling 1. De Belastingdienst/Toeslagen en de inspecteur en ontvanger, bedoeld in [artikel 2, derde lid, onderdeel b, van de Algemene wet inzake rijksbelastingen](jci1.3:c:BWBR0002320&artikel=2) , wisselen de gegevens en inlichtingen uit die nodig zijn voor de uitvoering van deze wet en voor de heffing en invordering van rijksbelastingen, onder vermelding van het sociaal-fiscaalnummer van degene op wie de gegevens of inlichtingen betrekking hebben. 2. Onze Minister verstrekt aan Onze Ministers wie het aangaat de inlichtingen die zij nodig hebben voor de beleidsvorming en beleidsevaluatie alsmede voor het volgen van de ontwikkeling van de uitgaven, met betrekking tot inkomensafhankelijke regelingen. 3. Onze Ministers wie het aangaat verstrekken aan Onze Minister de inlichtingen die hij nodig heeft voor de uitvoering van inkomensafhankelijke regelingen door de Belastingdienst/Toeslagen.
+- number: '40'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8c9baed017227e18a765a1b4c55d4c81f0e477343aca0b4ee1f2b1dbeb31bc6a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 40. Boete bij niet, niet tijdige of onjuiste informatieverstrekking door belanghebbenden 1. Indien de belanghebbende, zijn partner of een medebewoner gehouden is tot het verstrekken van gegevens of inlichtingen, en hij deze niet dan wel niet binnen de ingevolge artikel 18, derde lid , gestelde termijn verstrekt, kan de Belastingdienst/Toeslagen hem een bestuurlijke boete van ten hoogste € 1500. opleggen. 2. Indien het aan opzet of grove schuld van de belanghebbende, zijn partner of een medebewoner is te wijten dat geen, dan wel onjuiste of onvolledige gegevens of inlichtingen zijn verstrekt tengevolge waarvan een of meer tegemoetkomingen tot een te hoog bedrag is of zijn toegekend, kan de Belastingdienst/Toeslagen de belanghebbende, zijn partner of de medebewoner een bestuurlijke boete opleggen van 25. procent van het bedrag dat van de belanghebbende in verband daarmee wordt teruggevorderd bij een herziening. De boete bedraagt niet meer dan € 5000. 3. Bij het opleggen van een bestuurlijke boete zijn de artikelen [67g](jci1.3:c:BWBR0002320&artikel=67g) , [67i](jci1.3:c:BWBR0002320&artikel=67i) , [67j](jci1.3:c:BWBR0002320&artikel=67j) , [67l](jci1.3:c:BWBR0002320&artikel=67l) , [67m](jci1.3:c:BWBR0002320&artikel=67m) en [67o van de Algemene wet inzake rijksbelastingen](jci1.3:c:BWBR0002320&artikel=67o) van overeenkomstige toepassing. 4. De bevoegdheid tot het opleggen van een bestuurlijke boete als bedoeld in het eerst lid vervalt vijf jaren na de dag waarop de in artikel 18, derde lid , gestelde termijn is verstreken. De bevoegdheid tot het opleggen van een bestuurlijke boete als bedoeld in het tweede lid vervalt vijf jaren na het einde van het berekeningsjaar waarop de te hoog toegekende tegemoetkoming betrekking heeft.
+- number: '41'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c2b7de7056e29a710bdf96b23a34c48d11c52cd498915df19cbbe407dea67e35
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 41. Boete bij niet, niet tijdige of onjuiste informatieverstrekking door derden 1. Indien een bij algemene maatregel van bestuur aangewezen natuurlijke persoon, maat- of vennootschap, vereniging of andere rechtspersoon, instelling of dienst als bedoeld in artikel 38, eerste lid , op grond van artikel 38. gehouden is tot het verstrekken van gegevens en inlichtingen, en hij of zij deze niet dan wel niet binnen de ingevolge artikel 38, derde lid , gestelde termijn verstrekt, kan de Belastingdienst/Toeslagen hem of haar een bestuurlijke boete van ten hoogste € 1500. opleggen. 2. Indien het aan opzet of grove schuld van een bij algemene maatregel van bestuur aangewezen natuurlijke persoon, maat- of vennootschap, vereniging of andere rechtspersoon, instelling of dienst als bedoeld in artikel 38, eerste lid , die op grond van artikel 38. gehouden is tot het verstrekken van gegevens en inlichtingen, is te wijten dat geen, dan wel onjuiste of onvolledige gegevens of inlichtingen zijn verstrekt kan de Belastingdienst/Toeslagen hem of haar een bestuurlijke boete opleggen van ten hoogste € 5000. 3. Bij het opleggen van een bestuurlijke boete zijn de [artikelen 67g, eerste tot en met derde lid](jci1.3:c:BWBR0002320&artikel=67g) , [67i](jci1.3:c:BWBR0002320&artikel=67i) , [67j](jci1.3:c:BWBR0002320&artikel=67j) , [67l](jci1.3:c:BWBR0002320&artikel=67l) , [67m](jci1.3:c:BWBR0002320&artikel=67m) , [67o](jci1.3:c:BWBR0002320&artikel=67o) en [67p van de Algemene wet inzake rijksbelastinge](jci1.3:c:BWBR0002320&artikel=67p) n van overeenkomstige toepassing. 4. De bevoegdheid tot het opleggen van een bestuurlijke boete vervalt vijf jaren na de dag waarop de in artikel 38, derde lid , gestelde termijn is verstreken.
+- number: '42'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ec1cd5f8c806ad2d84cba27db907507bbb2b490b2b25229db739f980fac477f5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 42. Vrijwillige verbetering Indien de belanghebbende, zijn partner of een medebewoner de Belastingdienst/Toeslagen alsnog de juiste en volledige gegevens en inlichtingen verstrekt voordat hij weet of redelijkerwijs moet vermoeden dat de Belastingdienst/Toeslagen met de onjuistheid of onvolledigheid bekend is of bekend zal worden, wordt aan hem niet de boete, bedoeld in artikel 40. , opgelegd.
+- number: '43'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: dc2afb677e628e68f62ca02270b2e29246a08f6dc6a3af38e159dc826ce6ad5a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 43. Toezichthouders 1. Met het toezicht op de naleving van het bepaalde bij of krachtens deze wet zijn belast de bij besluit van Onze Ministers wie het aangaat, aangewezen ambtenaren. 2. De toezichthouder beschikt niet over de bevoegdheden, genoemd in de [artikelen 5:15](jci1.3:c:BWBR0005537&artikel=5:15) , [5:18](jci1.3:c:BWBR0005537&artikel=5:18) en [5:19 van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&artikel=5:19) . 3. Van een besluit als bedoeld in het eerste lid wordt mededeling gedaan door plaatsing in de Staatscourant.
+- number: '44'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8b629e09fdeba61de11e89b00b6e3681e77073cd00e04340e7bbb657e09ff063
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 44. Opsporingsambtenaren 1. Met de opsporing van de feiten omschreven in de [artikelen 225. tot en met 227b](jci1.3:c:BWBR0001854&artikel=225) , [447c](jci1.3:c:BWBR0001854&artikel=447c) en [447d van het Wetboek van Strafrecht](jci1.3:c:BWBR0001854&artikel=447d) , voor zover het feit voor de toepassing van deze wet van belang is, zijn, onverminderd [artikel 141. van het Wetboek van Strafvordering](jci1.3:c:BWBR0001854&artikel=141) , belast de ambtenaren, aangewezen bij besluit van Onze Ministers wie het aangaat. Deze ambtenaren zijn tevens belast met de opsporing van feiten, strafbaar gesteld in de [artikelen 179. tot en met 182](jci1.3:c:BWBR0001854&artikel=179) , en [184 van het Wetboek van Strafrecht](jci1.3:c:BWBR0001854&artikel=184) , voor zover deze feiten betrekking hebben op een bevel, vordering of handeling, gedaan of ondernomen door henzelf. 2. Van een besluit als bedoeld in het eerste lid wordt mededeling gedaan door plaatsing in de Staatscourant.
+- number: '45'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 55725db18cfb3ad304bbc1cca7f9491bce4b76d006ff407321f25093a7e94d0d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 45. Beslagverbod 1. Een tegemoetkoming is niet vatbaar voor vervreemding, verpanding, belening of beslag, waaronder begrepen beslag ingevolge faillissement of toepassing van de schuldsaneringsregeling natuurlijke personen, tenzij het betreft beslag wegens: a. een vordering tot nakoming van een betalingsverplichting wegens een geleverde prestatie waarbij de betalingsverplichting ter zake van die prestatie oorzaak is voor de tegemoetkoming; b. een door de belanghebbende verschuldigd bedrag aan terugvordering dat betrekking heeft op dezelfde inkomensafhankelijke regeling. 2. Elk beding dat strijdt met het eerste lid is nietig.'
+- number: '46'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8fa50569c8574f7cdb0af4d32a981bab216743a013cd5f0f50fbc5baeba57242
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 46. Samenloop met buitenlandse tegemoetkomingen Bij algemene maatregel van bestuur kunnen regels worden gesteld ter voorkoming of beperking van samenloop van tegemoetkomingen met naar aard en strekking daarmee overeenkomende tegemoetkomingen op grond van wetgeving van een andere mogendheid.
+- number: '47'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ee3d609e2cdc7ead7698363d0093c489f768e2ad50cf49b1f31f05121f19ac33
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 47. Hardheidsclausule Bij regeling van Onze Minister in overeenstemming met Onze Ministers wie het aangaat kan een van deze wet afwijkende maatregel worden getroffen voor groepen van gevallen waarin toepassing van artikel 7, derde of vierde lid , leidt tot een onbillijkheid van overwegende aard.
+- number: '48'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: fbbd1657c6db8a9431e2ec3207545e217ddfa00233c09af32f2259ebd1bc8a58
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 48. Evaluatie Onze Minister zendt, in overeenstemming met Onze Ministers wie het mede aangaat, binnen drie jaar na de inwerkingtreding van deze wet, en vervolgens vijfjaarlijks, aan de Staten-Generaal een verslag over de doeltreffendheid en de effecten van deze wet in de praktijk.
+- number: '49'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 287589e80cab8d4d5efba7e18e6950e464b60a779df8b3c70285c6fa7c0e8e4f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 49. Tijdelijke regeling wijziging van omstandigheden en wijziging leeftijd Voor de berekeningsjaren 2006, 2007. en 2008. wordt voor de beoordeling van de aanspraak op of de bepaling van de hoogte van een tegemoetkoming op grond van een inkomensafhankelijke regeling als bedoeld in artikel 11, eerste lid , een wijziging in de omstandigheden en van de leeftijd van de belanghebbende, de partner of een medebewoner die zich voordoet na de eerste dag van de maand, in aanmerking genomen vanaf de eerste dag van de daaropvolgende maand, en blijft artikel 5. buiten toepassing.
+- number: '50'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d806adac9a353bf1fbebbd1a6938240e40bbb0ffd33e9e02fea6c95424ff159a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 50. Inwerkingtreding Deze wet treedt in werking op 1. september 2005. en geldt voor berekeningsjaren die aanvangen op of na 1. januari 2006.
+- number: '51'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d92124f835db96d966ee87fb7b3dd88de9dce98475ec5866e9f297e74bbc7071
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 51. Citeertitel Deze wet wordt aangehaald als: Algemene wet inkomensafhankelijke regelingen.'

--- a/textguard/nl/wet/burgerlijk_wetboek_boek_5/2024-01-01.yaml
+++ b/textguard/nl/wet/burgerlijk_wetboek_boek_5/2024-01-01.yaml
@@ -1,0 +1,30 @@
+$id: burgerlijk_wetboek_boek_5
+valid_from: null
+source: corpus/regulation/nl/wet/burgerlijk_wetboek_boek_5/2024-01-01.yaml
+articles:
+- number: '42'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 63610b8b63cd48649991f729d9397c55999ec62944dc9dfeae830844af2ba860
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Het is niet geoorloofd binnen de in lid 2 bepaalde afstand van de grenslijn van eens anders erf bomen, heesters of heggen te hebben, tenzij de eigenaar daartoe toestemming heeft gegeven of dat erf een openbare weg of een openbaar water is.
+  - index: 1
+    label: lid 2
+    sha256: 03ae44267c329a8c851d50756e079ebe7e2b6298ca1f3ee6f7c414dae810b698
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De in lid 1 bedoelde afstand bedraagt voor bomen twee meter te rekenen vanaf het midden van de voet van de boom en voor heesters en heggen een halve meter, tenzij ingevolge een verordening of een plaatselijke gewoonte een kleinere afstand is toegelaten.
+  - index: 2
+    label: lid 3
+    sha256: 201145cba5eb01122ea341f9992df23d6847edcfbeafb74afc10aa085a1a4c98
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De nabuur kan zich niet verzetten tegen de aanwezigheid van bomen, heesters of heggen die niet hoger reiken dan de scheidsmuur tussen de erven.
+  - index: 3
+    label: lid 4
+    sha256: 678450e23fb8a7eae58071bff9ff2e4c453e6a943f7069f05cf7a0c90eac0017
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Ter zake van een volgens dit artikel ongeoorloofde toestand is slechts vergoeding verschuldigd van de schade, ontstaan na het tijdstip waartegen tot opheffing van die toestand is aangemaand.

--- a/textguard/nl/wet/kieswet/2025-01-01.yaml
+++ b/textguard/nl/wet/kieswet/2025-01-01.yaml
@@ -1,0 +1,26 @@
+$id: kieswet
+valid_from: '2025-01-01'
+source: corpus/regulation/nl/wet/kieswet/2025-01-01.yaml
+articles:
+- number: B1
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 2eabe7251ebb2b622c6e4f8cc2b4427bf75559f944dbbcb64eb91e1f9b63dccf
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. De leden van de Tweede Kamer der Staten-Generaal worden gekozen door degenen die op de dag van de kandidaatstelling Nederlander zijn en op de dag van de stemming de leeftijd van achttien jaar hebben bereikt, met uitzondering van degenen die op de dag van de kandidaatstelling hun werkelijke woonplaats hebben in Aruba, Curaçao of Sint Maarten.
+  - index: 1
+    label: lid 2
+    sha256: c2e10c79a66b6e5948915ac21fc019b843bbbfe4269ba99e231524b61d2ef41c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. De uitsluiting, bedoeld in het eerste lid, geldt niet ten aanzien van: a. Nederlanders die gedurende ten minste tien jaren ingezetene van Nederland zijn geweest; b. Nederlanders in Nederlandse openbare dienst in de betrokken gebiedsdelen, alsmede hun Nederlandse echtgenoten, geregistreerde partners of levensgezellen en kinderen, voor zover zij met hen een gemeenschappelijke huishouding voeren.'
+- number: B5
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b6d998bc7926bd9653ba1c0b301fbef77343f7e35dfecd303ba81938c68e03eb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Van het kiesrecht zijn uitgesloten zij die bij onherroepelijke rechterlijke uitspraak van het kiesrecht zijn ontzet.

--- a/textguard/nl/wet/participatiewet/2022-03-15.yaml
+++ b/textguard/nl/wet/participatiewet/2022-03-15.yaml
@@ -1,0 +1,362 @@
+$id: participatiewet
+valid_from: '2022-03-15'
+source: corpus/regulation/nl/wet/participatiewet/2022-03-15.yaml
+articles:
+- number: '7'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 5b3ebf4baefc03acdead3ec4e8d7609493c71434ec5afdbef4328c05808e2e31
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '**Opdracht college**'
+  - index: 1
+    label: lid 1
+    sha256: 3c30303367152975839f9776a06af1dbbe50e94911ce697960f470c61a84ef83
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. Het college: a. ondersteunt bij arbeidsinschakeling: 1°. personen die algemene bijstand ontvangen, 2°. personen als bedoeld in de artikelen 34a, vijfde lid, onderdeel b, 35, vierde lid, onderdeel b, en 36, derde lid, onderdeel b, van de Wet werk en inkomen naar arbeidsvermogen tot het moment dat het inkomen uit arbeid in dienstbetrekking gedurende twee aaneengesloten jaren ten minste het minimumloon bedraagt en ten behoeve van die persoon in die twee jaren geen loonkostensubsidie als bedoeld in artikel 10d is verleend, 3°. personen als bedoeld in artikel 10, tweede lid, 4°. personen met een nabestaanden- of wezenuitkering op grond van de Algemene nabestaandenwet, 5°. personen met een uitkering op grond van de Wet inkomensvoorziening oudere en gedeeltelijk arbeidsongeschikte werkloze werknemers, 6°. personen met een uitkering op grond van de Wet inkomensvoorziening oudere en gedeeltelijk arbeidsongeschikte gewezen zelfstandigen, en 7°. niet-uitkeringsgerechtigden en, indien het college daarbij het aanbieden van een voorziening, waaronder begrepen sociale activering gericht op arbeidsinschakeling, noodzakelijk acht, bepaalt en biedt deze voorziening aan; b. verleent bijstand aan personen hier te lande die in zodanige omstandigheden verkeren of dreigen te geraken dat zij niet over de middelen beschikken om in de noodzakelijke kosten van het bestaan te voorzien; en c. verleent uitkeringen als bedoeld in de Wet inkomensvoorziening oudere en gedeeltelijk arbeidsongeschikte werkloze werknemers en de Wet inkomensvoorziening oudere en gedeeltelijk arbeidsongeschikte gewezen zelfstandigen.'
+- number: '8'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4de417b652d82c9439010e775dd1a623297c07076976db0d8b21426aacd93bf8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '**Verordeningen uitkeringen**'
+  - index: 1
+    label: lid 1
+    sha256: b79fa35b5a2a35a77c730826f3238af025dd32e5ce47e0d24109d39aac3ad44b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. De gemeenteraad stelt bij verordening regels met betrekking tot: a. het verlagen van de bijstand, bedoeld in artikel 18, tweede lid en de periode van de verlaging van de bijstand, bedoeld in artikel 18, vijfde en zesde lid; b. het verlenen van een individuele inkomenstoeslag als bedoeld in artikel 36; c. het verlenen van een individuele studietoeslag als bedoeld in artikel 36b; d. het verlagen van de bijstand, bedoeld in artikel 9a, twaalfde lid.'
+  - index: 2
+    label: lid 2
+    sha256: 55f704ee78f285acbc48f01034bdde5c37dcc459dc1cc00e43c2c040e5237ea8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De regels, bedoeld in het eerste lid, hebben voor zover het gaat om het eerste lid, onderdeel b, in ieder geval betrekking op de hoogte van de individuele inkomenstoeslag en de wijze waarop invulling wordt gegeven aan de begrippen langdurig en laag inkomen.
+  - index: 3
+    label: lid 3
+    sha256: 49ebc8823794c5230637808333924d96ca7de451ccf411a3b012f34f07d65a4d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De regels, bedoeld in het eerste lid, hebben voor zover het gaat om het eerste lid, onderdeel c, in ieder geval betrekking op de hoogte en de frequentie van de betaling van de individuele studietoeslag.
+- number: '11'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: cd78f156562796464f9b2781993b3437d8e612fe30f864f492807c0951548454
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '**Rechthebbenden**'
+  - index: 1
+    label: lid 1
+    sha256: 9f7416fd241ea1390c2220e7739f3448c65bf93d282165c015c7361fb29084a5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Iedere in Nederland woonachtige Nederlander die hier te lande in zodanige omstandigheden verkeert of dreigt te geraken dat hij niet over de middelen beschikt om in de noodzakelijke kosten van bestaan te voorzien, heeft recht op bijstand van overheidswege.
+  - index: 2
+    label: lid 2
+    sha256: cb614ed6114c27e009eb9bc1e104bd5310aeeabf16022ea2e4830237e054463f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Met de Nederlander, bedoeld in het eerste lid, wordt gelijkgesteld de hier te lande woonachtige vreemdeling die rechtmatig in Nederland verblijf houdt in de zin van artikel 8, onderdelen a tot en met e en l, van de Vreemdelingenwet 2000, met uitzondering van de gevallen, bedoeld in artikel 24, tweede lid, van Richtlijn 2004/38/EG.
+  - index: 3
+    label: lid 3
+    sha256: 3bd1867b888ffae059d526d3bcd7a485ec9b432b41c7c72560c09ada0840db75
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Bij algemene maatregel van bestuur kunnen andere hier te lande woonachtige vreemdelingen dan de in het tweede lid bedoelde voor de toepassing van deze wet met een Nederlander gelijk worden gesteld: a. ter uitvoering van een verdrag dan wel van een besluit van een volkenrechtelijke organisatie, of b. indien zij, na rechtmatig verblijf te hebben gehouden in de zin van artikel 8, onderdelen a tot en met e en l, van de Vreemdelingenwet 2000, rechtmatig in Nederland verblijf hebben als bedoeld in artikel 8, onderdeel g of h, van die wet en zij aan de in die algemene maatregel van bestuur gestelde voorwaarden voldoen.'
+  - index: 4
+    label: lid 4
+    sha256: e62c5ea26ff6ed191d82a0838e91b1f842dbd696efc12f6b0d5918256bfcb7f4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het recht op bijstand komt de echtgenoten gezamenlijk toe, tenzij een van de echtgenoten geen recht op bijstand heeft.
+- number: '18'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: be5c02210aa8474a01627c2aeb0ba543f886a21361b4a0d2236e8c5cff373157
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '**Afstemming**'
+  - index: 1
+    label: lid 1
+    sha256: 07912b65983f9284dd2dc0111495f5ec5abfdee4491a3a8bad4c53e111621785
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Het college stemt de bijstand en de daaraan verbonden verplichtingen af op de omstandigheden, mogelijkheden en middelen van de belanghebbende.
+  - index: 2
+    label: lid 2
+    sha256: 690368d6e3af0e9e608a75b887807068e0ed159e0471f3a463518e4143f1ffd0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het college verlaagt de bijstand overeenkomstig de verordening, bedoeld in artikel 8, eerste lid, onderdeel a, ter zake van het niet nakomen door de belanghebbende van de verplichtingen voortvloeiende uit deze wet, met uitzondering van artikel 17, eerste lid, dan wel indien de belanghebbende naar het oordeel van het college tekortschietend besef van verantwoordelijkheid betoont voor de voorziening in het bestaan.
+  - index: 3
+    label: lid 3
+    sha256: b11850e2c4d0ed98b544bc4f7392482c96193cc48c972d6736cc0aca2710f5f2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het college heroverweegt een besluit als bedoeld in het tweede lid binnen een door hem te bepalen termijn die ten hoogste drie maanden bedraagt.
+  - index: 4
+    label: lid 4
+    sha256: aa9b98373c6efce9352cc0889e2e2ea587e305ef5ce2887e06b734534051c443
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. Het college verlaagt in ieder geval de bijstand overeenkomstig het vijfde, zesde, zevende of achtste lid ter zake van het niet nakomen door de belanghebbende van de volgende verplichtingen: a. het aanvaarden of het behouden van algemeen geaccepteerde arbeid; b. het uitvoering geven aan de door het college opgelegde verplichting om ingeschreven te staan bij een uitzendbureau; c. het naar vermogen verkrijgen van algemeen geaccepteerde arbeid in een andere dan de gemeente van inwoning, alvorens naar die andere gemeente te verhuizen; d. bereid zijn om te reizen over een afstand met een totale reisduur van 3 uur per dag, indien dat noodzakelijk is voor het naar vermogen verkrijgen, het aanvaarden of het behouden van algemeen geaccepteerde arbeid; e. bereid zijn om te verhuizen, indien het college is gebleken dat er geen andere mogelijkheid is voor het naar vermogen verkrijgen, het aanvaarden of het behouden van algemeen geaccepteerde arbeid, en de belanghebbende een arbeidsovereenkomst met een duur van tenminste een jaar en een netto beloning die ten minste gelijk is aan de voor de belanghebbende geldende bijstandsnorm, kan aangaan; f. het verkrijgen en behouden van kennis en vaardigheden, noodzakelijk voor het naar vermogen verkrijgen, het aanvaarden of het behouden van algemeen geaccepteerde arbeid; g. het naar vermogen verkrijgen, het aanvaarden of het behouden van algemeen geaccepteerde arbeid niet belemmeren door kleding, gebrek aan persoonlijke verzorging of gedrag; h. het gebruik maken van door het college aangeboden voorzieningen, waaronder begrepen sociale activering, gericht op arbeidsinschakeling en mee te werken aan onderzoek naar zijn of haar mogelijkheden tot arbeidsinschakeling.'
+  - index: 5
+    label: lid 5
+    sha256: 7d535b9594cfaab29d186d21f5090a95cb55286016e88fb07219f3950b37cd37
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Indien de belanghebbende een verplichting als bedoeld in het vierde lid niet nakomt, verlaagt het college de bijstand met 100% voor een bij de verordening, bedoeld in artikel 8, eerste lid, onderdeel a, vastgestelde periode van ten minste een maand en ten hoogste drie maanden.
+  - index: 6
+    label: lid 6
+    sha256: 17cff2739b604be8c983ae7b0187916625c685ee8851691a36eadbcde938e852
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Indien de belanghebbende een verplichting als bedoeld in het vierde lid niet nakomt binnen twaalf maanden nadat het vijfde lid toepassing heeft gevonden, verlaagt het college, in afwijking van het vijfde lid, de bijstand met 100% voor een bij de verordening, bedoeld in artikel 8, eerste lid, onderdeel a, vastgestelde periode die in ieder geval langer is dan de op grond van het vijfde lid vastgestelde periode van verlaging en ten hoogste drie maanden.
+  - index: 7
+    label: lid 7
+    sha256: f69898fe218c242bdcf83359a5bc07e2aede7a7dd785fdca30fc91acf8ad3a73
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. Indien de belanghebbende een verplichting als bedoeld in het vierde lid niet nakomt binnen twaalf maanden nadat het zesde lid toepassing heeft gevonden, verlaagt het college, in afwijking van het vijfde en zesde lid, de bijstand met 100% voor een periode van drie maanden.
+  - index: 8
+    label: lid 8
+    sha256: e2da8d00aae5912efc88fae0aa1ab3d53152a42989374d49ce7527ba03e6f240
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 8. Indien de belanghebbende een verplichting als bedoeld in het vierde lid niet nakomt binnen twaalf maanden nadat het zevende lid toepassing heeft gevonden, verlaagt het college, in afwijking van het vijfde, zesde en zevende lid, telkens de bijstand met 100% voor een periode van drie maanden.
+  - index: 9
+    label: lid 9
+    sha256: 68eb5285471000f3524a4a84b0cec394dd9279457820f671e5ac77c0b03fb603
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 9. Het college ziet af van het opleggen van een maatregel, indien elke vorm van verwijtbaarheid ontbreekt.
+  - index: 10
+    label: lid 10
+    sha256: a6b9bfc563189b45cfe932b69b18a6a7916edcbb80d3b05a97a376500d10ef3b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 10. Het college stemt een op te leggen maatregel of een opgelegde maatregel af op de omstandigheden van de belanghebbende en diens mogelijkheden om middelen te verwerven, indien naar zijn oordeel, gelet op bijzondere omstandigheden, dringende redenen daartoe noodzaken.
+  - index: 11
+    label: lid 11
+    sha256: 5c437688e0651937729954758bc9af8f7caf8ae785d216448257a523f5a7d1cc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 11. Indien het college de bijstand overeenkomstig het vijfde, zesde, zevende of achtste lid heeft verlaagd, kan het college op verzoek van de belanghebbende ten aanzien van wie de maatregel is opgelegd, de verlaging herzien zodra uit de houding en gedragingen van de belanghebbende ondubbelzinnig is gebleken dat hij de verplichtingen, bedoeld in het vierde lid, nakomt.
+  - index: 12
+    label: lid 12
+    sha256: 20919a9fc15e8bdb8ed4f20ac82372ac3ee169586eb0bb00c800c1b822a4e9d2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 12. Bij de toepassing van dit artikel wordt onder belanghebbende mede verstaan het gezin.
+- number: '21'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: bda1a6ba062ca5ad43bc6cc699dec3d09e5a1008dd269a3105f75db2aa5ab012
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '**Normen 21–pensioengerechtigde leeftijd**'
+  - index: 1
+    label: tekst
+    sha256: 8e75b623ddb84e0c2fcbb2147c830af4a9882281b39edb29179a956b092e3547
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Voor belanghebbenden van 21 jaar of ouder doch jonger dan de pensioengerechtigde leeftijd is de norm per kalendermaand, indien het betreft:'
+  - index: 2
+    label: onderdeel a
+    sha256: 333bec00b698f526c2a975897e12fb7ec003ea5da6e8c2f65f3ee9400e1c71df
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'a. een alleenstaande of een alleenstaande ouder zonder kostendelende medebewoners: € 1.091,71;'
+  - index: 3
+    label: onderdeel b
+    sha256: da7c98f12f5c0db0821377cf57768788c24812ba5f8ebd55ad8d151d908995d0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'b. gehuwden waarvan beide echtgenoten jonger zijn dan de pensioengerechtigde leeftijd, zonder kostendelende medebewoners: € 1.559,58.'
+- number: '22'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 9982a5802aa5b910d75a11305ecc6e0938ce73bb610cba214df75f232df46adb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '**Normen pensioengerechtigden**'
+  - index: 1
+    label: tekst
+    sha256: e95785814d95167c50202cd90457b70b8a2c8f3862e0820b6b9776fdf685016a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Voor belanghebbenden die de pensioengerechtigde leeftijd hebben bereikt is de norm per kalendermaand, indien het betreft:'
+  - index: 2
+    label: onderdeel a
+    sha256: 48c81efe6fce180e5a76f50d676fdff428a102870084fbe6b5e55e11f61974b5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'a. een alleenstaande of een alleenstaande ouder zonder kostendelende medebewoners: € 1.213,06;'
+  - index: 3
+    label: onderdeel b
+    sha256: 33c82df181d4fafd31718f8cde4f10031a49ff2e2db8950672f59a22692b768b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'b. gehuwden waarvan beide echtgenoten de pensioengerechtigde leeftijd hebben bereikt, zonder kostendelende medebewoners: € 1.642,54;'
+  - index: 4
+    label: onderdeel c
+    sha256: 07621b5f936be0f8b233f39fa17d02bb26282ead8e921f4a51d21ed4fe215f00
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'c. gehuwden waarvan een echtgenoot de pensioengerechtigde leeftijd heeft bereikt en de andere echtgenoot 21 jaar of ouder, doch de pensioengerechtigde leeftijd nog niet heeft bereikt, zonder kostendelende medebewoners: € 1.642,54.'
+- number: 22a
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 90c09043778922de70bb6b607da28845b74c6f5909004d7c116b6d3a9072258e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '**Kostendelersnorm**'
+  - index: 1
+    label: lid 1
+    sha256: 2d15bf56336f8572928fe42a563cdf878a075795b21c44afff93f39b963d1396
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. Indien de belanghebbende van 21 jaar of ouder een of meer kostendelende medebewoners heeft, is de norm per kalendermaand voor de belanghebbende: Hierbij staat: • A voor het aantal kostendelende medebewoners plus de belanghebbende en zijn echtgenoot van 21 jaar of ouder indien hij gehuwd is; en • B voor de norm, bedoeld in artikel:'
+  - index: 2
+    label: lid 2
+    sha256: ff315a6b63a021fab041848419a1e62f1f3e78de0f33acca6fab44d9c4928c61
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De norm voor gehuwden, op wie het eerste lid van toepassing is, is gelijk aan de som van de normen, bedoeld in dat lid, die voor ieder van de rechthebbende echtgenoten afzonderlijk van toepassing is.
+  - index: 3
+    label: lid 3
+    sha256: 95fffedb3a65d86572c2c55efaf306257ed9c5a894b801f7ce1f45e02beed4e0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Voor rechthebbende gehuwden, waarvan een echtgenoot 18, 19 of 20 jaar is en de andere echtgenoot 21 jaar of ouder is, met een of meer kostendelende medebewoners, is de norm per kalendermaand: a. indien ze een of meer ten laste komende kinderen hebben: € 581,43 plus de op basis van dit artikel van toepassing zijnde norm voor de echtgenoot van 21 jaar of ouder, b. indien ze geen ten laste komende kinderen hebben: € 269,51 plus de op basis van dit artikel van toepassing zijnde norm voor de echtgenoot van 21 jaar of ouder.'
+- number: '23'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 0c45bda1954676d3806a5a207bf77d7139a54c84ecc9e62440a08f24c5920b3b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '**Normen in inrichting**'
+  - index: 1
+    label: lid 1
+    sha256: d414f8db43544effaa5bf2e0d5b4887219bef203915c275f10e1b720a0cbf7ca
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. Bij een verblijf in een inrichting is de norm per kalendermaand, indien het betreft: a. een alleenstaande of een alleenstaande ouder: € 345,68; b. gehuwden: € 537,69.'
+  - index: 2
+    label: lid 2
+    sha256: 31f97e046841fa8b80e47e1915c8d6249827cf23b7464127be4234a006e0443c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Het bedrag van de norm, bedoeld in het eerste lid, wordt verhoogd met: a. voor een alleenstaande of een alleenstaande ouder € 34,00; b. voor gehuwden € 79,00.'
+  - index: 3
+    label: lid 3
+    sha256: f0b1c5908eadce4dd14220e8facff8b7c5aacf889eedd1bc517b4a0a3544e2e7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien een van de gehuwden in een inrichting verblijft, is de norm de som van de normen die voor ieder van hen als alleenstaande of alleenstaande ouder zouden gelden.
+- number: '24'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 62606b46dfde866fcd2fa06279f680b93bc38036f6fd9a4c9e534241f084b3e5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '**Afwijking norm gehuwden**'
+  - index: 1
+    label: tekst
+    sha256: 74cbaf033335bc1ebb00572cbe0d3e4f160884b73f7de78ed26eec8980e814e5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Voor gehuwden waarvan een echtgenoot geen recht op algemene bijstand heeft is voor de rechthebbende echtgenoot de norm gelijk aan 50% van de norm die voor hem zou gelden als hij gehuwd zou zijn met een rechthebbende echtgenoot van zijn leeftijd, indien:'
+  - index: 2
+    label: onderdeel a
+    sha256: d94ede2dc90bfce873de1124a127f2f436f55d59e15b7dca8613eadcca595a8d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de rechthebbende echtgenoot 21 jaar of ouder is en geen kostendelende medebewoners heeft; dan wel
+  - index: 3
+    label: onderdeel b
+    sha256: e138718b2893098b12e0c3215f7930588451812aeadcd62f73fac6a8f3386243
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de rechthebbende echtgenoot jonger dan 21 jaar is.
+- number: '43'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 00b34bc4e54ef48aab9d05f7113f266d77ab3d2fad9fe3fca6373c4d54790fb9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '**Vaststelling op aanvraag**'
+  - index: 1
+    label: lid 1
+    sha256: c051c7629c9fa5451e367143041d7eb39f5d85f296d922ac55cbe1de53980154
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Het college stelt het recht op bijstand op schriftelijke aanvraag of, indien een schriftelijke aanvraag niet mogelijk is, ambtshalve vast.
+  - index: 2
+    label: lid 2
+    sha256: 8422c8756eb791eb2b5e8df6b97c8df60961e7ec999f2ddcfd8bc66e417a813e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De bijstand wordt door de echtgenoten gezamenlijk aangevraagd dan wel door een van hen met schriftelijke toestemming van de ander.
+  - index: 3
+    label: lid 3
+    sha256: dd2fa1e096cf64d95cb07e07d1b87ecc501305e92291d5c53b6452ea328021b5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het college stelt het recht op bijstand ambtshalve vast indien een van de echtgenoten niet met de aanvraag instemt, doch bijstandsverlening, gezien de belangen van de overige gezinsleden, niettemin geboden is.
+  - index: 4
+    label: lid 4
+    sha256: 7b1d66091e6ebe2adab67971f8948619be237a65a5d3a3281d4e71292bb363c0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het college houdt, indien artikel 41, vierde lid, van toepassing is, bij de vaststelling van het recht op algemene bijstand rekening met de houding en gedragingen van de meerderjarige personen die ten tijde van de aanvraag van algemene bijstand jonger dan 27 jaar zijn gedurende de vier weken na de melding, bedoeld in artikel 44.
+  - index: 5
+    label: lid 5
+    sha256: 915a3585104119f50a20e6837849650d3757acd09d24db36d6ba2a1867c2df1a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Indien artikel 41, vierde lid, niet van toepassing is, beoordeelt het college in ieder geval de houding en gedragingen gedurende de vier weken na de melding, bedoeld in artikel 44, van de meerderjarige personen die ten tijde van de aanvraag van algemene bijstand jonger dan 27 jaar zijn.
+- number: '69'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6535cd3d08442a7cd364f2453062a7828da25495e91830c8b51a8ff340d28496
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '**Uitkering en verdeling onder de gemeenten**'
+  - index: 1
+    label: lid 1
+    sha256: 80eb48688f864d98ec7e58debc7ef32e91f5544145b144331abefc3acb970f04
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. Onze Minister verstrekt jaarlijks ten laste van ''s Rijks kas aan het college een uitkering om het college van middelen te voorzien met het oog op: a. het toekennen van algemene bijstand en van uitkeringen als bedoeld in de Wet inkomensvoorziening oudere en gedeeltelijk arbeidsongeschikte werkloze werknemers en de Wet inkomensvoorziening oudere en gedeeltelijk arbeidsongeschikte gewezen zelfstandigen en voor de daarbij verschuldigde loonbelasting, premies volksverzekeringen en de inkomensafhankelijke bijdrage, bedoeld in artikel 42 van de Zorgverzekeringswet; b. de kosten van de loonkostensubsidies, die op grond van artikel 10d, worden verstrekt.'
+  - index: 2
+    label: lid 2
+    sha256: ec55dff541bbd83cf471c07cfcf6d82698d04afd8309c6a20969b579a485efce
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij wet wordt het totale bedrag dat beschikbaar is voor de uitkering, bedoeld in het eerste lid, vastgesteld, waarbij uitgangspunt is dat dit bedrag voor het desbetreffende kalenderjaar toereikend is voor de geraamde kosten van alle gemeenten in verband met uitgaven als bedoeld in het eerste lid.
+  - index: 3
+    label: lid 3
+    sha256: 95f583beb1a26548b2c763bbd866c1437add6f4fb599ace7ebe876f08a33ab89
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij of krachtens algemene maatregel van bestuur worden regels gesteld voor de verdeling van de uitkering, bedoeld in het eerste lid, onder de gemeenten en het verzamelen van gegevens noodzakelijk voor het vaststellen van deze verdeling.
+  - index: 4
+    label: lid 4
+    sha256: fca728050673ac89eb0e6bc73190fa82d1c5d847af3ee6491d8323433d809285
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De uitkering aan het college wordt ten minste drie maanden voorafgaand aan het kalenderjaar waarop zij betrekking heeft door Onze Minister bekend gemaakt.

--- a/textguard/nl/wet/penitentiaire_beginselenwet/2025-01-01.yaml
+++ b/textguard/nl/wet/penitentiaire_beginselenwet/2025-01-01.yaml
@@ -1,0 +1,2046 @@
+$id: penitentiaire_beginselenwet
+valid_from: null
+source: corpus/regulation/nl/wet/penitentiaire_beginselenwet/2025-01-01.yaml
+articles:
+- number: '1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ebf6bcbbe26daf3ecab9fe97190be8ffd203ab1c0075aade3b15f285f4d10b88
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 1 Voor de toepassing van deze wet en de daarop rustende bepalingen wordt verstaan onder:'
+  - index: 1
+    label: onderdeel a
+    sha256: 361f28fabb7a031660752a2b7aee224300fcb67e6e8b2d9fdcaa584ce142ac5a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. *Onze Minister:* Onze Minister van Justitie; b. *inrichting:* een penitentiaire inrichting als bedoeld in artikel 3, eerste lid; c. *afdeling:* een afdeling van een inrichting als bedoeld in artikel 8, tweede lid; d. *directeur:* de persoon, bedoeld in artikel 3, derde lid, alsmede diens vervanger of vervangers, bedoeld in artikel 3, vierde lid; e. *gedetineerde:* een persoon ten aanzien van wie de tenuitvoerlegging van een vrijheidsstraf of vrijheidsbenemende maatregel in een inrichting plaatsvindt; f. *ambtenaar of medewerker:* een persoon die een taak uitoefent in het kader van de tenuitvoerlegging van een vrijheidsstraf of vrijheidsbenemende maatregel; g. *selectiefunctionaris:* een persoon belast met de plaatsing en overplaatsing van gedetineerden als bedoeld in artikel 15, derde lid; h. *reclasseringswerker:* een reclasseringswerker als bedoeld in artikel 6, eerste lid, van de Reclasseringsregeling 1995; i. *rechtsbijstandverlener:* de advocaat of de medewerker van de stichting, bedoeld in de Wet op de rechtsbijstand; j. *Raad:* de Raad voor strafrechtstoepassing en jeugdbescherming; k. *commissie van toezicht:* een commissie als bedoeld in artikel 7, eerste lid; l. *beklagcommissie:* een commissie als bedoeld in artikel 62, eerste lid; m. *beroepscommissie:* een commissie als bedoeld in artikel 69, tweede lid; n. *verblijfsruimte:* de aan een gedetineerde door de directeur ingevolge artikel 16, tweede lid, toegewezen ruimte; o. *penitentiair programma:* een programma als bedoeld in artikel 4; p. *huisregels:* regels als bedoeld in artikel 5, eerste lid; q. *regime:* het samenstel van de verzorging en activiteiten, bedoeld in hoofdstuk VIII, en de regels die gelden voor gedetineerden in een inrichting of afdeling; r. *activiteiten:* activiteiten als bedoeld in hoofdstuk VIII; s. *vrijheidsstraf:* gevangenisstraf, (vervangende) hechtenis, militaire detentie en (vervangende) jeugddetentie; t. *vrijheidsbenemende maatregel:* voorlopige hechtenis, vreemdelingenbewaring, gijzeling, terbeschikkingstelling met bevel tot verpleging, plaatsing in een inrichting voor de opvang van verslaafden en vrijheidsbeneming die op andere dan de in artikel 1, onder s, genoemde gronden plaatsvindt; u. *strafrestant:* het gedeelte van een opgelegde vrijheidsstraf dan wel van het samenstel van dergelijke straffen dat nog moet worden ondergaan; v. *goed gedrag:* een zodanige opstelling van een gedetineerde dat hij heeft doen blijken van een bijzondere geschiktheid tot terugkeer in de samenleving.
+- number: '2'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 49379f76317cee446dcf87dce7410f3554fb08e787a868f6f29cd6a9e1334a8e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2 1. De tenuitvoerlegging van een vrijheidsstraf of vrijheidsbenemende maatregel vindt, voor zover niet bij of k rachtens de wet anders is bepaald, plaats door onderbrenging van de persoon aan wie deze is opgelegd in een penitentiair e inrichting dan wel door diens deelname aan een penitentiair programma.
+  - index: 1
+    label: lid 2
+    sha256: e1ce089dbe355846dcc14be77e49e51f71b3fe8f366841fc36b77ceb38c48917
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Met handhaving van het karakter van de vrijheidsstraf of de vrijheidsbenemende maatregel wordt de tenuitvoerlegging h iervan zoveel mogelijk dienstbaar gemaakt aan de voorbereiding van de terugkeer van de betrokkene in de maatschappij.
+  - index: 2
+    label: lid 3
+    sha256: 124f0f862b736188b9beba1d5596c7850fa535e8d69ee68b4110a1f63297af70
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De tenuitvoerlegging van vrijheidsstraffen of vrijheidsbenemende maatregelen vindt zo spoedig mogelijk plaats na de o plegging van de straf of het nemen van de maatregel.
+  - index: 3
+    label: lid 4
+    sha256: 3cc45d2670f7b334cf43581ea010f094652d327ad1ca21c570bb81ce432a2c43
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Personen ten aanzien van wie de tenuitvoerlegging plaatsvindt van een vrijheidsstraf of vrijheidsbenemende maatregel worden aan geen andere beperkingen onderworpen dan die welke voor het doel van de vrijheidsbeneming of in het belang van de handhaving van de orde of de veiligheid in de inrichting noodzakelijk zijn.
+- number: '3'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 33448a909a63ce4a9dd3fd9cda349747aa3288c8c512d5a7c15aca3e8aac4fff
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3 1. Onze Minister wijst penitentiaire inrichtingen aan.
+  - index: 1
+    label: lid 2
+    sha256: 847fb3e46d84ddd9b637fc9990cf157d06a060cfcc478352184beff63358539a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het opperbeheer van de inrichtingen berust bij Onze Minister. Onze Minister kan mandaat verlenen inzake de uitvoering hiervan alsmede betreffende de hem bij of krachtens deze wet toegekende overige bevoegdheden aan het hoofd van de Diens t Justitiële lnrichtingen.
+  - index: 2
+    label: lid 3
+    sha256: a0c5441b78f487a204b2a7dd4f736845086e27dbc4666f4e03574a1b0156e458
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het beheer van een inrichting of afdeling berust bij de directeur, die als zodanig door Onze Minister wordt aangeweze n.
+  - index: 3
+    label: lid 4
+    sha256: bf6856ef58fa43846adcd0e2a990b735373992643ed9a799393de485a6bd78d9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Onze Minister wijst een of meer personen aan als plaatsvervanger van de directeur.
+  - index: 4
+    label: lid 5
+    sha256: ccdc7b891db1a6ef88d625efc162b6fa5b6fd247b0c0a4305e893b92b195ca2e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Bij of krachtens algemene maatregel van bestuur worden nadere regels gesteld betreffende het beheer van en het regime in een inrichting.
+- number: '4'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 0592fa81c9186894b11aa9aa3505fc679a020c371b9f41a2bae58e533886c5b3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4 1. Een penitentiair programma is een samenstel van activiteiten waaraan wordt deelgenomen door personen ter ve rdere tenuitvoerlegging van de aan hen opgelegde vrijheidsstraf of vrijheidsbenemende maatregel in aansluiting op hun ve rblijf in een inrichting en dat als zodanig door Onze Minister is erkend.
+  - index: 1
+    label: lid 2
+    sha256: 8b533d90f1c9b0d3878886ec8eaa9f7d8b6403a236f25d08f5b4728e5c7b9b8a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Een gedetineerde komt slechts in aanmerking voor deelname aan een penitentiair programma, indien: a. b. c.'
+  - index: 2
+    label: lid 3
+    sha256: 87f1a1d88ffef41825aae4735de72c1444e80508abb8c2b5a11aa2e71c4094d7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij of krachtens algemene maatregel van bestuur worden nadere regels gegeven die in elk geval de inhoud, de voorwaard en voor en het toezicht op deelname, de gevolgen van niet-nakoming van de voorwaarden en de rechtspositie van de deelnem ers aan een penitentiair programma betreffen.
+  - index: 3
+    label: lid 4
+    sha256: 621cbe827c3e24de756ed163ee751bf4decfa6e40469174f609c289e7c9467fc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Een krachtens het derde lid vastgestelde algemene maatregel van bestuur treedt niet eerder in werking dan acht weken na de datum van uitgifte van het Staatsblad waarin hij is geplaatst. Van de plaatsing wordt onverwijld mededeling gedaan aan de beide kamers der Staten-Generaal.
+  - index: 4
+    label: lid 5
+    sha256: 4d715bd1688c0b51d50bc518ab22f0ff0a0173c482a7d6d99faeb57ebccdec09
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Met inachtneming van het tweede lid en de regels krachtens het derde lid kan Onze Minister een penitentiair programma erkennen en bepalen welke gedetineerden voor deelname hieraan in aanmerking komen.
+  - index: 5
+    label: lid 6
+    sha256: 7082de8ad2b3985dfac62b271977441c022859cd47cbe45368fd8bdf0db903fb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Het tweede lid is niet van toepassing op de maatregel tot plaatsing in een inrichting voor de opvang van verslaafden als bedoeld in [artikel 38m van het Wetboek van Strafrecht](jci1.3:c:BWBR0001854&artikel=38m).
+- number: '5'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6f30c6681a39cd5b6ac035e7d98e0ab32dc317605d1f7ed8c5e91ae10f518c03
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 5 1. De directeur stelt, in aanvulling op de bij of krachtens deze wet gegeven regels en met inachtneming van he t dienaangaande door Onze Minister vast te stellen model en door deze te geven aanwijzingen, huisregels voor de inrichti ng of afdeling vast.
+  - index: 1
+    label: lid 2
+    sha256: 8d0e4a841b0b96701a09f3cc45ff2584cad9c4b78f710db000bfd911507d2c38
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De directeur kan ambtenaren en medewerkers machtigen tot de uitoefening van hem bij of krachtens deze wet gegeven bev oegdheden en de naleving van zijn zorgplichten, met uitzondering van de bevoegdheden, genoemd in het eerste en vierde li d.
+  - index: 2
+    label: lid 3
+    sha256: 8d42b344efcd2862435481346203235aab9d8ff108d69bfb2b4871b9cdf7e572
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur is, voor zover zulks noodzakelijk is in het belang van de handhaving van de orde of de veiligheid in de inrichting of een ongestoorde tenuitvoerlegging van de vrijheidsbeneming, bevoegd aan de gedetineerden bevelen te geven. De gedetineerden zijn verplicht deze bevelen op te volgen.
+  - index: 3
+    label: lid 4
+    sha256: 774e17bacbf6f29f18b795b060d9262ca994c8e88cb58c8e2750dd463fe9dd09
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. Aan de directeur is voorbehouden de beslissing omtrent: a. b. c. d. e. f. g. h.'
+- number: '6'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 3c49be1d09972bb7eae251ba0d15d7b12c830db8d6c63f7047c91cedf4040ea9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 6 De Raad behandelt beroepschriften ingevolge de [hoofdstukken XII](onbekend), [XIII](onbekend) en [XV](onbekend ), en[ hoofdstuk 7 van de Penitentiaire maatregel](jci1.3:c:BWBR0009398&hoofdstuk=7).
+- number: '7'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6163b7153014f89135916cf549c9101895755989b73de47bd747fbfa9b1bc957
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 7 1. Bij elke inrichting dan wel afdeling wordt door Onze Minister een commissie van toezicht ingesteld.
+  - index: 1
+    label: lid 2
+    sha256: aa9df027f49c1918b3739fafcafb880ed860cda54f585daaaef1ab9e040d7059
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. De commissie van toezicht heeft tot taak: a. b. c. d.'
+  - index: 2
+    label: lid 3
+    sha256: c4d42182c7f71bd3118ce0de0817cae23c94bb71470c9ffacd9e8d61e1c60167
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De commissie van toezicht stelt zich door persoonlijk contact met de gedetineerden regelmatig op de hoogte van onder hen levende wensen en gevoelens. Bij toerbeurt treedt één van haar leden hiertoe op als maandcommissaris.
+  - index: 3
+    label: lid 4
+    sha256: ffc8b0e43f811cfe671a08ccaa9833ccc03dbb15a79bc1581de43b3b1ae1cd8b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij algemene maatregel van bestuur worden regels gesteld over de bevoegdheden, de samenstelling en de werkwijze van d e commissie, de benoeming en het ontslag van haar leden alsmede over de werkzaamheden van de maandcommissaris.
+- number: '8'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8f75ad3d886bb609e838774c72b66469851ad6b5ac0ad1cd0d69df346876f195
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 8 1. Onze Minister bepaalt de bestemming van elke inrichting of afdeling ingevolge de artikelen 9 tot en met 14 en stelt regels voor de plaatsing en overplaatsing van de gedetineerden.
+  - index: 1
+    label: lid 2
+    sha256: f6329510ba80708e40317ed0e230d895dc220fc4b63e1f69a82d4fc6d7fc6b34
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister kan delen van een inrichting als afdeling met een aparte bestemming aanwijzen.
+- number: '9'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2923f3a8840d2b7728bb24d02b2e3f7d99e12a245daf5f4e013e59ec16f500fc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 9 1. Inrichtingen zijn te onderscheiden in huizen van bewaring, gevangenissen en inrichtingen voor de opvang van verslaafden. In bijzondere gevallen kan Onze Minister een inrichting aanwijzen tot zowel huis van bewaring als gevangen is.
+  - index: 1
+    label: lid 2
+    sha256: 76d601476d73eb6dcee1cfafca61c0b3b2905a659dca9b328da2b4b19326b340
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. In huizen van bewaring kunnen worden opgenomen: a. b. c. d. e. f. g. h.'
+  - index: 2
+    label: lid 3
+    sha256: 503d45d9ffcd2748ed54607d300fcc86ea38699a0d8452e58c2a8881eb10d604
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Onze Minister wijst in elk arrondissement ten minste één inrichting of afdeling aan als huis van bewaring.
+- number: '10'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d584e7a347a1f13c0ceb15e8b8917498482f9aef98f6c454adae590bb1cd7e39
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 10 1. Gevangenissen zijn bestemd voor de opneming van personen die tot vrijheidsstraf zijn veroordeeld. Tot geva ngenisstraf veroordeelden aan wie tevens de maatregel van terbeschikkingstelling met bevel tot verpleging van overheidsw ege is opgelegd, kunnen na het einde van de vrijheidsstraf in een gevangenis verblijven, zolang opname in de voor hen be stemde plaats niet mogelijk is.
+  - index: 1
+    label: lid 2
+    sha256: efbe96ad54dd73bbacb9d2113644be9c896aafae7c44db8ca1e193980d05a1cd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In bijzondere gevallen kan gijzeling als bedoeld in [artikel 28 van de Wet administratiefrechtelijke handhaving verke ersvoorschriften](jci1.3:c:BWBR0004581&artikel=28) in een gevangenis ten uitvoer worden gelegd.
+  - index: 2
+    label: lid 3
+    sha256: c4c1487211faca2526bacfc0fd04968e1f6368e5bb2a0b294b2fd69cb2e60485
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Gevangenissen kunnen volgens regels te stellen bij of krachtens algemene maatregel van bestuur worden onderscheiden n aar de lengte van de straf of het strafrestant van de daarin op te nemen tot vrijheidsstraf veroordeelden.
+- number: 10a
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c6f06059127e5965896504a6fbb73a0df61780d8db4624825e0788cfd45b02e5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 10a 1. Inrichtingen voor de opvang van verslaafden zijn bestemd voor de opvang van personen aan wie een maatrege l als bedoeld in [artikel 38m van het Wetboek van Strafrecht ](jci1.3:c:BWBR0001854&artikel=38m)is opgelegd.
+  - index: 1
+    label: lid 2
+    sha256: f9a62e7f34ad23da4db292c32a507abb9809d445eff6cbbd667447c255cde374
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister kan een inrichting voor de opvang van verslaafden aanwijzen als huis van bewaring. Hij kan tevens een h uis van bewaring aanwijzen als een inrichting voor de opvang van verslaafden.
+- number: '11'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 3c2c17298fb0900d50c6bb8aa80d10ba01267a7b54968bf7a342757d4523dcee
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 11 1. Mannelijke en vrouwelijke gedetineerden worden gescheiden ondergebracht.
+  - index: 1
+    label: lid 2
+    sha256: fb8f0c3dfea2b39777f66e5f303fdf8ab0698935e7675a94d7cdca87f25efc30
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister wijst inrichtingen of afdelingen aan die uitsluitend zijn bestemd voor de onderbrenging van vrouwelijke gedetineerden.
+  - index: 2
+    label: lid 3
+    sha256: 914dd95bc8542047b71ba7bf5de0751d396b2222ad94b0c69749fdc146fcd982
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Onze Minister kan inrichtingen of afdelingen aanwijzen waarin van het eerste lid wordt afgeweken vanwege hun bestemmi ng als inrichting of afdeling voor bijzondere opvang als bedoeld in artikel 14.
+  - index: 3
+    label: lid 4
+    sha256: fdeb663f1bc8b5394e72f6a4ece3106a14e334f755955e3e9d9735487f64339b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De directeur kan gedetineerden van verschillend geslacht die in dezelfde inrichting verblijven in de gelegenheid stel len gezamenlijk aan activiteiten deel te nemen.
+- number: '12'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d27644b65491b388a5002051d817d8c486c42b7cf9878674ca5fd12ad5734b37
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 12 1. Onze Minister wijst de inrichtingen of de afdelingen aan waarin kinderen tot een in de aanwijzing aangegev en leeftijd kunnen worden ondergebracht.
+  - index: 1
+    label: lid 2
+    sha256: 7d63cb9dd169937769ad61a0c9d98329bdd878c404d964382c19fa0588a4c07c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Indien een gedetineerde een kind in de inrichting of afdeling, bedoeld in het eerste lid, wil onderbrengen teneinde h et aldaar te verzorgen en op te voeden, behoeft hij de toestemming van de directeur. De directeur kan deze toestemming g even, voor zover dit verblijf zich verdraagt met de volgende belangen: a. b.'
+  - index: 2
+    label: lid 3
+    sha256: 4b8a4db62c69965e1e2a6f3e723680e14efe73357823236895ded73b8a50aa8b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur kan aan de toestemming voorwaarden verbinden met het oog op een belang als bedoeld in het tweede lid.
+  - index: 3
+    label: lid 4
+    sha256: eb69d6874b1028a7f8e20b4b789cbb639d59a3701cf467c9bcd7a7715d1cfa80
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De directeur kan over een door hem voorgenomen onderbrenging van een kind in de inrichting of afdeling het advies inw innen van de Raad voor de Kinderbescherming.
+  - index: 4
+    label: lid 5
+    sha256: 3f0561ff7d5416672388c71bc54ad56b513499d710cd6a0dc6b42ae4e09c71d7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De directeur kan de toestemming intrekken, indien dit noodzakelijk is met het oog op een belang als bedoeld in het tw eede lid of indien de gedetineerde een bepaalde voorwaarde niet nakomt. Indien de directeur een nader onderzoek nodig oo rdeelt, kan hij de medewerking van de Raad voor de Kinderbescherming inroepen.
+  - index: 5
+    label: lid 6
+    sha256: 9683d9dac1b91be41bd30f714b53765f7b043982ce459245ac8db9da19c3d071
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. De directeur is verplicht de toestemming in te trekken, indien de onderbrenging van het kind in de inrichting in stri jd komt met enige op het gezag over het kind betrekking hebbende beslissing.
+  - index: 6
+    label: lid 7
+    sha256: be3e678b0863bf7d20d20d6732098c691e71626299d5703f7287a364f7ca18de
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. In de huisregels worden nadere regels gesteld omtrent het verblijf van kinderen in de inrichting.
+  - index: 7
+    label: lid 8
+    sha256: 29feedec60dd1bc7ae501c60c1f9512a1b9ce5648cb19919cec7f8531d74c436
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 8. De kosten van de verzorging van het kind komen voor rekening van het Rijk, voor zover de gedetineerde niet zelf in di e kosten kan voorzien.
+- number: '13'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 462648e7f5cf2b900b0769b2e3295d80d2026b013769a89181cd29e991643d40
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 13 1. Inrichtingen of afdelingen daarvan zijn naar de mate van beveiliging als volgt te onderscheiden en aan te duiden: a. b. c. d. e.'
+  - index: 1
+    label: lid 2
+    sha256: 8b9b66d1418ab178a71a058e9ad8e0f888a041ed19cbdf367ee48f92037b9b02
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister bepaalt ten aanzien van elke inrichting of afdeling de mate van beveiliging, bedoeld in het eerste lid.
+  - index: 2
+    label: lid 3
+    sha256: 92cf74b3c358019df2261189c632f3cb6c0a84dca01883f1e2af9830380821f1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Onze Minister bepaalt de criteria waaraan gedetineerden moeten voldoen om voor plaatsing in een inrichting of een afd eling als bedoeld in het eerste lid in aanmerking te komen.
+- number: '14'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 75047e79e8fb33962c3c89925fc231139cf8b1be4ba29c3bffa5811aca69d8ba
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 14 1. Inrichtingen of afdelingen daarvan kunnen door Onze Minister worden bestemd voor de onderbrenging van gede tineerden die een bijzondere opvang behoeven.
+  - index: 1
+    label: lid 2
+    sha256: f62d4e53af04dcd8bccb1e58fbe8d81c7f273de9dece822a0106f49cf0142048
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De bijzondere opvang, bedoeld in het eerste lid, kan verband houden met de leeftijd, de persoonlijkheid, de lichameli jke of de geestelijke gezondheidstoestand van de gedetineerden, alsmede met het delict waarvoor zij zijn gedetineerd.
+  - index: 2
+    label: lid 3
+    sha256: 92cf74b3c358019df2261189c632f3cb6c0a84dca01883f1e2af9830380821f1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Onze Minister bepaalt de criteria waaraan gedetineerden moeten voldoen om voor plaatsing in een inrichting of een afd eling als bedoeld in het eerste lid in aanmerking te komen.
+- number: '15'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: bd239179ab7ffaef21d4bd2d0b7a600ced1f446b9c404d64ea43d3413c724298
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 15 1. De personen ten aanzien van wie de tenuitvoerlegging van vrijheidsstraffen of vrijheidsbenemende maatregel en is gelast worden geplaatst in een inrichting of afdeling dan wel overgeplaatst naar een inrichting of afdeling overee nkomstig de bestemming daarvan ingevolge hoofdstuk III. Van het bepaalde omtrent de bestemming kan worden afgeweken op g ronden gelegen in de persoon van de betrokkene. Indien een persoon voor plaatsing in meer dan één inrichting of afdeling in aanmerking komt, geschiedt deze met inachtneming van artikel 2, tweede, derde en vierde lid.
+  - index: 1
+    label: lid 2
+    sha256: 0128fa818dcfebee1e5a1345e68bf553935cb7a3054f8f67ca7450eb01917fde
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Gedetineerden die hiervoor ingevolge artikel 4, vijfde lid, in aanmerking komen, kunnen in de gelegenheid worden gest eld tot deelname aan een penitentiair programma. Bij het niet voldoen aan de voorwaarden voor deelname, bedoeld in artik el 4, derde lid, kan de deelname worden beëindigd.
+  - index: 2
+    label: lid 3
+    sha256: 793dbe79b4abbcb15235701a1c771db5aed7362580223438a29bd3217ee41273
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Met de plaatsing en overplaatsing, bedoeld in het eerste lid, en de beslissingen, bedoeld in het tweede lid, zijn doo r Onze Minister als zodanig aangewezen selectiefunctionarissen belast. Deze zijn bevoegd de overbrenging van personen te bevelen naar de voor hen bestemde inrichting of afdeling dan wel ten behoeve van deelname aan het voor hen bestemde pen itentiair programma dan wel de beëindiging hiervan. Zij kunnen de overbrenging doen geschieden door daartoe aangewezen a mbtenaren of medewerkers. Zij zijn bovendien bevoegd tot de beslissing of ten aanzien van de individuele gedetineerde is gebleken van goed gedrag dat aanleiding geeft tot deelname van de gedetineerde aan een penitentiair programma, zodra aa n de voorwaarden, bedoeld in artikel 4, tweede lid, onderdelen b en c, is voldaan.
+  - index: 3
+    label: lid 4
+    sha256: ba6db9e886888ab65a31b6ddfaf1895ea3ea1c05c3aa78dd84e8d31fb2c97167
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De selectiefunctionarissen nemen bij de beslissingen, bedoeld in het eerste en tweede lid, de aanwijzingen van het op enbaar ministerie en van de autoriteiten die de straf of maatregel hebben opgelegd in aanmerking.
+  - index: 4
+    label: lid 5
+    sha256: 0b0e1af3c91dc8020e20bbe879f5d9d3234e078ea72724d54f445c74a2555be1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. In geval van gebrekkige ontwikkeling of ziekelijke stoornis van de geestvermogens van een gedetineerde kan de selecti efunctionaris bepalen dat de gedetineerde naar een psychiatrisch ziekenhuis als bedoeld in [artikel 1, onder h, van de W et bijzondere opnemingen in psychiatrische ziekenhuizen](jci1.3:c:BWBR0005700&artikel=1) zal worden overgebracht om daar zolang dat noodzakelijk is te worden verpleegd.
+  - index: 5
+    label: lid 6
+    sha256: 94f3109b6f34c835a93b205260b30614a2ca6673ab89efc30533f76f89476689
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Onze Minister stelt nadere regels vast omtrent de procedure van plaatsing en overplaatsing en overbrenging, bedoeld i n het eerste onderscheidenlijk het vijfde lid.
+- number: 15a
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 5b184ebbfb74558bda5324824ddf2163af10bb31a39f0f3dda9633a9c8aad34f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 15a In afwijking van artikel 15, eerste lid, eerste volzin, kan de selectiefunctionaris bepalen dat een persoon ten aanzien van wie de tenuitvoerlegging van een vrijheidsstraf of een vrijheidsbenemende maatregel is gelast en die in een politiecel verblijft, daar voor een periode van maximaal tien dagen zal verblijven, nadat hij heeft vastgesteld dat er voor deze persoon geen plaats is in een inrichting. De politiecel voldoet aan de regels die voor politiecellencomplex en zijn vastgesteld.
+- number: '16'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c369a8ff914f532464a16730cefc9979d432efac1fbfcc2cbbe7b490e10d4b9b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 16 1. De directeur bepaalt de wijze van onderbrenging van de gedetineerden die overeenkomstig artikel 15 zijn ge plaatst in de inrichting of afdeling met het beheer waarvan hij is belast.
+  - index: 1
+    label: lid 2
+    sha256: dd2b84751775c5fe2b8d6207183a3e7d7720c55ed21e786f7b630c784db94456
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De directeur wijst iedere gedetineerde een verblijfsruimte toe met inachtneming van de artikelen 20, tweede lid, 21 e n 22, eerste lid.
+  - index: 2
+    label: lid 3
+    sha256: da324e65468243a65e774f2d2555a41f6b9fbb6907c6deb89200f3f441008434
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur kan onderdelen van de inrichting of afdeling aanwijzen voor de onderbrenging van gedetineerden die een b ijzondere opvang in de zin van artikel 14 behoeven.
+  - index: 3
+    label: lid 4
+    sha256: 7de4694dbb15a1c33ac936bf6a61fa51be17771573919a243d9d596ae1431e17
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De directeur bepaalt de criteria waaraan de gedetineerde moet voldoen om voor onderbrenging als bedoeld in het derde lid in aanmerking te komen.
+  - index: 4
+    label: lid 5
+    sha256: 333cddc7d23373a768582f215928147f58e8e2abf189235e91c62560f8aa43ff
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Onze Minister stelt regels omtrent de eisen waaraan een verblijfsruimte als bedoeld in het tweede lid moet voldoen.
+- number: '17'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 00f0cc3b7c31d68e68f6edc55e4a3cf3b4376b2dbccb8f6cb168210820a0ee41
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 17 1. De betrokkene heeft het recht een met redenen omkleed bezwaarschrift in te dienen tegen de beslissing: a. b.'
+  - index: 1
+    label: lid 2
+    sha256: 056e9229f66f42bcc1d6caf786eec8787c010933e415e5e89ba4493f82bdf66a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Op de wijze van indiening is artikel 61, tweede, vierde en vijfde lid, van overeenkomstige toepassing.
+  - index: 2
+    label: lid 3
+    sha256: 24c830582b20207400dbf6ee2cca8857cd91dea621efd653ea88022b2f8e6230
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De selectiefunctionaris stelt de betrokkene in de gelegenheid schriftelijk of mondeling diens bezwaarschrift toe te l ichten, tenzij hij het aanstonds kennelijk niet-ontvankelijk, kennelijk ongegrond of kennelijk gegrond acht.
+  - index: 3
+    label: lid 4
+    sha256: 3d5dbdcb6ab5cd51f0c5a9c7cde0415d8495864ff0da0cb31cc59c4ea18198ea
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De selectiefunctionaris stelt de indiener van het bezwaarschrift binnen zes weken van zijn met redenen omklede beslis sing schriftelijk en zoveel mogelijk in een voor deze begrijpelijke taal op de hoogte. Hierbij wijst hij hem op de mogel ijkheid van het instellen van beroep, bedoeld in hoofdstuk XIII, alsmede de termijnen waarbinnen en de wijze waarop dit gedaan moet worden.
+  - index: 4
+    label: lid 5
+    sha256: 9de2d3d746cb9ba8922ab280e73403ad68ba2efec712cc0217e4a2046e2675d9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Het indienen van een bezwaarschrift blijft achterwege, indien de betrokkene in de gelegenheid is gesteld zijn bezware n tegen een door de selectiefunctionaris voorgenomen en hem betreffende beslissing als bedoeld in het eerste lid kenbaar te maken.
+- number: '18'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 7695b5317fb4324c257b35965fbacda98880ab8d7c9789b375dbd91ff6043747
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 18 1. De betrokkene heeft het recht bij de selectiefunctionaris een met redenen omkleed verzoekschrift in te die nen strekkende tot: a. b.'
+  - index: 1
+    label: lid 2
+    sha256: 053ba00324935d818ec24d1c5aa282fc246778ead9b574910cd33a85fdfdd436
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De artikelen 61, tweede en vierde lid, en 17, derde en vierde lid, zijn van overeenkomstige toepassing.
+  - index: 2
+    label: lid 3
+    sha256: fb33698b67783b061f07489e693b0085f8c4ff634657765aafe8d5ae883a9226
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien het verzoekschrift, bedoeld in het eerste lid, is afgewezen, kan zes maanden na deze afwijzing opnieuw een der gelijk verzoekschrift worden ingediend.
+- number: 18a
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d154d6775ec7225834583c94dbc243657d9d1046f69c3990fb560d5410319a04
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 18a 1. De directeur draagt zorg dat zo spoedig mogelijk en in ieder geval binnen een maand na binnenkomst van de gedetineerde in een inrichting voor de opvang van verslaafden, zo veel mogelijk in overleg met hem, een plan van opvang wordt vastgesteld.
+  - index: 1
+    label: lid 2
+    sha256: e8435d3727b9dc3353c188581d1d8139045dff3a97fbd25a3c5a102da7f2f019
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij algemene maatregel van bestuur worden regels gesteld omtrent de eisen waaraan een plan van opvang ten minste moet voldoen en de voorschriften die bij de vaststelling of een wijziging van het plan in acht genomen moeten worden.
+- number: 18b
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 31d9ea066262892deca30989c2ec11f18556a7b7da460976a6a0b25602a1c3b5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 18b De directeur draagt zorg dat de opvang overeenkomstig het plan van opvang plaatsvindt.
+- number: 18c
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 9588f9a5fded6b0a813e7187b0e45abbc1bae0e7ba72d8fbcd24ddc7a6a3b0bb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 18c 1. De gedetineerde heeft recht op een periodieke evaluatie door de directeur van het verloop van de opvang. Deze evaluatie vindt ten minste eens per zes maanden plaats.
+  - index: 1
+    label: lid 2
+    sha256: 96a8a0c48adcd6e9850a09f3164597f1b836e0a03da8efd5d3b77e5c2f2d2745
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien de rechter bij het opleggen van de maatregel heeft bepaald dat het openbaar ministerie hem binnen een door hem vastgestelde termijn bericht over de wenselijkheid of de noodzakelijkheid van de voortzetting van de tenuitvoerlegging daarvan, vindt de eerste evaluatie in ieder geval plaats voor het verstrijken van die termijn.
+  - index: 2
+    label: lid 3
+    sha256: f8661f079d10c42551ea32aeb3a1567751039e527d8418b93ec88480a3f88dd1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur draagt zorg dat van iedere evaluatie een verslag wordt gemaakt en dat dit verslag zo spoedig mogelijk me t de gedetineerde wordt besproken.
+  - index: 3
+    label: lid 4
+    sha256: 189a4de7eba7fb20a3352e3ab5f8e8e83f98504bb7e305bcda2c32ad4f7c33f1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Indien de gedetineerde van oordeel is dat het evaluatieverslag feitelijk onjuist of onvolledig is, heeft hij het rech t op dit verslag schriftelijk commentaar te geven. Indien het evaluatieverslag niet overeenkomstig het commentaar wordt verbeterd of aangevuld, draagt de directeur zorg dat het commentaar aan het verslag wordt gehecht.
+  - index: 4
+    label: lid 5
+    sha256: 27d6a5b134977619c37e497da1d23d3826c8e516ae86433b596c785ef20e01b9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Bij algemene maatregel van bestuur worden regels gesteld omtrent de procedure die met betrekking tot de evaluatie die nt te worden gevolgd en de eisen die aan het verslag daarvan ten minste dienen te worden gesteld.
+- number: '19'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a1878c915024e0c57891a4ba1196114970b867490a51be1ac43ccbd63cd0976d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 19 1. De tenuitvoerlegging van een vrijheidsstraf of vrijheidsbenemende maatregel in een inrichting vindt plaats in algehele dan wel beperkte gemeenschap, tenzij plaatsing in een individueel regime noodzakelijk is.
+  - index: 1
+    label: lid 2
+    sha256: f53c29fe00b283ad83fe8ce5f6a1000fe301a107d4c33d682c3b750726b72616
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister bepaalt ten aanzien van elke inrichting of afdeling de mate van gemeenschap.
+- number: '20'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 0566dffb30fee285e63e4e5a55969eec283558c0873ffc047eec3a0454cd07a4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 20 1. In een regime van algehele gemeenschap verblijven gedetineerden tezamen in woon- en werkruimten of nemen g emeenschappelijk deel aan activiteiten.
+  - index: 1
+    label: lid 2
+    sha256: e1b7d7c3150e4368a1693071033e19fc5cb7927301f18b667cd39f62d08d7164
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In een regime van algehele gemeenschap kunnen gedetineerden worden verplicht zich tijdens de maaltijden, gedurende be zoektijden voor zover zij geen bezoek ontvangen, alsmede gedurende activiteiten waaraan zij niet deelnemen, in hun verbl ijfsruimte op te houden. Deze ruimte is voor hen persoonlijk dan wel voor de gemeenschappelijke onderbrenging van gedeti neerden bestemd.
+  - index: 2
+    label: lid 3
+    sha256: 05a4fae7f9fcf47873177f1de1f4470ccf401a6f01a6c448554a46f5c922ed94
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. In een regime van algehele gemeenschap houden gedetineerden zich gedurende de voor de nachtrust bestemde uren en op i n de huisregels bepaalde overige uren gedurende het weekeinde en de algemeen erkende feestdagen in hun verblijfsruimte o p.
+- number: '21'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 9f6e4048cc1cbf03e1482a41eb374402daa1048b6d1fc80c22b21cc654cac131
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 21 In een regime van beperkte gemeenschap worden gedetineerden in de gelegenheid gesteld gemeenschappelijk aan a ctiviteiten deel te nemen. Overigens houden zij zich in de voor hen persoonlijk bestemde verblijfsruimte op.
+- number: '22'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: e3aa8d862260a12f813f35c5949058c91753d8975e1c95b9d2aa0738d5b69b50
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 22 1. In een individueel regime worden gedetineerden in de gelegenheid gesteld aan activiteiten deel te nemen. O verigens houden zij zich in de voor hen persoonlijk bestemde verblijfsruimte op.
+  - index: 1
+    label: lid 2
+    sha256: 13063a0fce53279a43cd8852a9ba7578afb8e8d0850a70fbf0bcdd7a7fd7b60f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In een individueel regime bepaalt de directeur de mate waarin de gedetineerde in staat wordt gesteld individueel dan wel gemeenschappelijk aan activiteiten deel te nemen.
+- number: '23'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 5d57fc494cafd00f2f838ef830ea9e7dfd35a1f84e909ce9c39316ded4f4bf04
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 23 1. De directeur kan een gedetineerde uitsluiten van deelname aan een of meer activiteiten: a. b. c. d.'
+  - index: 1
+    label: lid 2
+    sha256: bb81d9c2578ab097cd17cdc1d97ec5272803762d6bff792b43a1e6ae3ce619f8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De uitsluiting ingevolge het eerste lid, onder a of b, duurt ten hoogste twee weken. De directeur kan deze uitsluitin g telkens voor ten hoogste twee weken verlengen, indien hij tot het oordeel is gekomen dat de noodzaak tot uitsluiting n og bestaat.
+  - index: 2
+    label: lid 3
+    sha256: 65de86e6aacab61fb5964293d5877ce249b12aec4f7c5c9d0c2720a3c2fbc77e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien onverwijlde tenuitvoerlegging van de uitsluiting, bedoeld in het eerste lid, onder a of b, geboden is, kan een ambtenaar of medewerker de maatregel, bedoeld in het eerste lid, voor een periode van ten hoogste vijftien uren treffen .
+- number: '24'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 46c2dfe45402e71d5d0fdab84768936ad651bb57d33889936ee68ceccedc22e5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 24 1. De directeur is bevoegd een gedetineerde in afzondering te plaatsen op de gronden genoemd in artikel 23, e erste lid. De afzondering ingevolge artikel 23, eerste lid, onder a of b, duurt ten hoogste twee weken.
+  - index: 1
+    label: lid 2
+    sha256: 3d69ed4c923ef5f4a75fba869d4026771b140f0319d8db84c80ef712ca488b04
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De afzondering wordt ten uitvoer gelegd in een afzonderingscel of in een andere verblijfsruimte. Gedurende het verbli jf in afzondering neemt de gedetineerde niet deel aan activiteiten, voor zover de directeur niet anders bepaalt en behou dens het dagelijks verblijf in de buitenlucht, bedoeld in artikel 49, derde lid. De directeur kan het contact met de bui tenwereld gedurende het verblijf in de afzonderingscel beperken of uitsluiten.
+  - index: 2
+    label: lid 3
+    sha256: 6a079af951f031e4e03ddfaf411846492c09485cef6295bf4dd5de9d84345ce0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur kan de afzondering, bedoeld in het eerste lid, op de grond van artikel 23, eerste lid, onder a of b, tel kens voor ten hoogste twee weken verlengen, indien hij tot het oordeel is gekomen dat de noodzaak tot afzondering nog be staat.
+  - index: 3
+    label: lid 4
+    sha256: 5a9b761fb97ec02cdb43506e966574751e811e3b6465c8fd48b90d0037dd8826
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Indien onverwijlde tenuitvoerlegging van de afzondering op de grond van artikel 23, eerste lid, onder a of b, geboden is, kan een ambtenaar of medewerker een gedetineerde voor een periode van ten hoogste vijftien uren in afzondering plaa tsen. De directeur wordt van deze plaatsing onverwijld op de hoogte gesteld.
+  - index: 4
+    label: lid 5
+    sha256: 778cb52f311af25ba28ed004f2da3b9ce4d769fc5bcfb1363b4abcbadddac37c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De directeur draagt zorg dat in geval van afzondering het nodige contact tussen ambtenaren en medewerkers van de inri chting en de gedetineerde wordt gewaarborgd en naar aard en frequentie op de situatie van de gedetineerde wordt afgestem d.
+  - index: 5
+    label: lid 6
+    sha256: b938ae56baa40786e0782c226501071e5e9cdced469afaa3a240146ba3b63781
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. De directeur draagt zorg dat, ingeval de afzondering langer dan vierentwintig uren duurt en ten uitvoer wordt gelegd in een afzonderingscel, de commissie van toezicht en de aan de inrichting verbonden arts of diens vervanger terstond hie rvan in kennis worden gesteld.
+  - index: 6
+    label: lid 7
+    sha256: 222857a9b69ec39f7f786327cd4a7dd5c7e0f80a75fc3a588098d5823d30d8c0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. Onze Minister stelt nadere regels omtrent het verblijf in en de inrichting van de afzonderingscel. Deze betreffen in elk geval de rechten die tijdens het verblijf in de afzonderingscel aan de gedetineerde toekomen.
+- number: '25'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 87134fdaf036295120d734c8c8f46a3e543cc256d3dba1a4d20b81bf5c8025b5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 25 1. Indien de tenuitvoerlegging van de afzondering in de inrichting of afdeling waarin zij is opgelegd op erns tige bezwaren stuit, kan zij in een andere inrichting of afdeling worden ondergaan.
+  - index: 1
+    label: lid 2
+    sha256: 327f823693cced3eb93e82b8c61956401a2adb2dafe9dfa4fa940d6b23bbf4e0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien de directeur van oordeel is dat van de in het eerste lid bedoelde omstandigheid sprake is, plaatst hij in over eenstemming met de selectiefunctionaris de gedetineerde over.
+  - index: 2
+    label: lid 3
+    sha256: 9581081e81e9dfaf89c18e291897b8de6cade334ed06569fdbef7d6f4e55e21a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Over de verlenging van de afzondering, waarvan de tenuitvoerlegging plaatsvindt in een andere inrichting of afdeling, beslist de directeur van de inrichting of afdeling waarin de afzondering was opgelegd, in overeenstemming met de select iefunctionaris en gehoord de directeur van de inrichting of afdeling waar de tenuitvoerlegging van de afzondering plaats vindt.
+  - index: 3
+    label: lid 4
+    sha256: fc04b12bff7946d4154c2e6da073f860df76da89374a2bfa6716470a056e55b5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Onze Minister stelt nadere regels omtrent de procedure van overplaatsing en van verlenging van de afzondering ingevol ge het tweede onderscheidenlijk het derde lid.
+- number: '26'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2c0406d9dddb3d00953b9a0ee1c3c93bb6c4444734946cc4090d345b5d508a3f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 26 1. Een gedetineerde kan, ingevolge het derde en het vierde lid, worden toegestaan de inrichting te verlaten.
+  - index: 1
+    label: lid 2
+    sha256: f4b6c0270e31b31d988786b3cfdcf1296a3b0919e41ad29dd0e23946f863e375
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het verlaten van de inrichting, bedoeld in het eerste lid, schort de tenuitvoerlegging van de vrijheidsstraf of vrijh eidsbenemende maatregel niet op.
+  - index: 2
+    label: lid 3
+    sha256: 7abdb79a64a0de4582ac459a2e1c30f8a4c11c33a028f6d634a07f4f5c042052
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Onze Minister stelt nadere regels aangaande het verlaten van de inrichting bij wijze van verlof. Deze betreffen in el k geval de criteria waaraan een gedetineerde moet voldoen om voor het verlof in aanmerking te komen, de bevoegdheid tot en de wijze van verlening, weigering, beperking en intrekking alsmede de duur en frequentie van het verlof en de voorwaa rden die aan het verlof kunnen worden verbonden.
+  - index: 3
+    label: lid 4
+    sha256: 4e00fefbf9fc41c19e27d15d2beedd11bc819f5082a2014e73251227b010b5f2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. De directeur stelt een gedetineerde in de gelegenheid onder door hem te stellen voorwaarden de inrichting te verlaten teneinde een gerechtelijke procedure bij te wonen: a. b. c.'
+  - index: 4
+    label: lid 5
+    sha256: e81cee75d616a39ee53125b4433e53c778e29601c2c91eb5d9bf5d4b9623652f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Met het oog op het verlaten van de inrichting, bedoeld in het vierde lid, kan de directeur aan daartoe door hem aange wezen ambtenaren of medewerkers bevelen dat de betrokken persoon naar de daartoe bestemde plaats wordt overgebracht.
+- number: '27'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: cc5fdd5aeee6ea5c8dc162dc758e14cd8238ea6062d66c8e1dda6a76ab68080d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 27 Het recht van de gedetineerde op onaantastbaarheid van zijn lichaam, zijn kleding en de van zijn lichaam afge scheiden stoffen en zijn verblijfsruimte kan overeenkomstig de bepalingen van dit hoofdstuk worden beperkt.
+- number: '28'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ca3486c561dde3ed25a28dd862c8550415b6bc89aa5c9b446fdf928b39b07624
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 28 1. De directeur kan de gedetineerde verplichten een legitimatiebewijs bij zich te dragen en dit op verzoek va n een ambtenaar of medewerker te tonen.
+  - index: 1
+    label: lid 2
+    sha256: ae106310d9b0d618cfb93c3cb4d4f8d5f74f1fc4366ac677ae511fd9302a133c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De gedetineerde is verplicht zijn medewerking te verlenen aan het vastleggen van zijn beeltenis, het nemen van een vi ngerafdruk of het afnemen van een handscan.
+- number: '29'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: f61c8f55aeaf2b81e0ce959e78e8ec5ade23f81c64c1940793b12bf7878946ae
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 29 1. De directeur is bevoegd een gedetineerde bij binnenkomst of bij het verlaten van de inrichting, voorafgaan d aan of na afloop van bezoek, dan wel indien dit anderszins noodzakelijk is in het belang van de handhaving van de orde of de veiligheid in de inrichting, aan zijn lichaam of aan zijn kleding te onderzoeken.
+  - index: 1
+    label: lid 2
+    sha256: 17420bc7da4a577f8b85ebb69ecbb391c2bfcdc4386ab6aabad753ec57b47db3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het onderzoek aan het lichaam van de gedetineerde omvat mede het uitwendig schouwen van de openingen en holten van he t lichaam van de gedetineerde. Het onderzoek aan de kleding van de gedetineerde omvat mede het onderzoek van de voorwerp en die de gedetineerde bij zich draagt of met zich meevoert.
+  - index: 2
+    label: lid 3
+    sha256: 5ee3645f96e2aa0220cee6f31439689426fc35c3c55b150a05f00e624926cb40
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het onderzoek aan het lichaam van de gedetineerde wordt op een besloten plaats en, voor zover mogelijk, door personen van hetzelfde geslacht als de gedetineerde verricht.
+  - index: 3
+    label: lid 4
+    sha256: 28b9ae83fb41cf816c661c401cb91eee3619a313180002a5bf64c4b2259e841f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Indien bij een onderzoek aan het lichaam of de kleding voorwerpen worden aangetroffen die niet in het bezit van de ge detineerde mogen zijn, en, voor zover het onderzoek betrekking heeft op de openingen of holten van het lichaam van de ge detineerde, deze voorwerpen zonder het gebruik van hulpmiddelen daaruit kunnen worden verwijderd, is de directeur bevoeg d deze in beslag te nemen. Hij draagt zorg dat deze voorwerpen, hetzij onder afgifte van een bewijs van ontvangst ten be hoeve van de gedetineerde op diens kosten worden bewaard, hetzij met toestemming van de gedetineerde worden vernietigd, hetzij aan een opsporingsambtenaar ter hand worden gesteld met het oog op de voorkoming of opsporing van strafbare feite n.
+- number: '30'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 227aef75e277375b06480554519b5fef4ae9aa8d7d9bbac049acab4dde58e15f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 30 1. De directeur kan, indien dit noodzakelijk is in het belang van de handhaving van de orde of de veiligheid in de inrichting dan wel in verband met de beslissing tot plaatsing of overplaatsing dan wel in verband met de verlening van verlof, een gedetineerde verplichten urine af te staan ten behoeve van een onderzoek van die urine op aanwezigheid van gedragsbeïnvloedende middelen.
+  - index: 1
+    label: lid 2
+    sha256: 912723ff83963812af8b484bb2d47c23a5ed2b78aa85514d05dd3dba07bfd63f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister stelt nadere regels omtrent de wijze van uitvoering van het urineonderzoek. Deze regels betreffen in el k geval het recht van de gedetineerde om de uitslag te vernemen en om voor eigen rekening een hernieuwd onderzoek van de afgestane urine te laten plaatsvinden. Artikel 29, derde lid, is van overeenkomstige toepassing.
+- number: '31'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 92abcc88353097037fe04a582638fc08c714d093d7dc621d0018465628a298bb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 31 1. De directeur kan bepalen dat een gedetineerde in het lichaam wordt onderzocht, indien dit noodzakelijk is ter afwending van ernstig gevaar voor de handhaving van de orde of de veiligheid in de inrichting dan wel voor de gezond heid van de gedetineerde. Het onderzoek in het lichaam wordt verricht door een arts of, in diens opdracht, door een verp leegkundige.
+  - index: 1
+    label: lid 2
+    sha256: d8cfc6f783a00c41e4df7040172c1dfcb1aca172f48e885941d8d182b7b364ce
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Een ambtenaar of medewerker van de inrichting waar de gedetineerde verblijft kan indien onverwijlde tenuitvoerlegging geboden is, een beslissing als bedoeld in het eerste lid nemen.
+  - index: 2
+    label: lid 3
+    sha256: 934ae7799624979598105e1964e917b741d3fa6bcac0cea9327369f43e7db4ca
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien bij het onderzoek in het lichaam voorwerpen worden aangetroffen die niet in het bezit van de gedetineerde moge n zijn, en deze voorwerpen door de arts of verpleegkundige uit het lichaam kunnen worden verwijderd, is de directeur bev oegd deze in beslag te nemen. Artikel 29, vierde lid, laatste volzin, is van overeenkomstige toepassing.
+- number: '32'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ea888960155408824155faabef11b7e58e8f362c288f593f1f05224bf192ed04
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 32 1. De directeur kan een gedetineerde verplichten te gedogen dat ten aanzien van hem een bepaalde geneeskundig e handeling wordt verricht, indien die handeling naar het oordeel van een arts noodzakelijk is ter afwending van ernstig gevaar voor de gezondheid of veiligheid van de gedetineerde of van anderen. De handeling wordt verricht door een arts o f, in diens opdracht, door een verpleegkundige.
+  - index: 1
+    label: lid 2
+    sha256: 7fe8917a4b97508e0b58a3e4fa7848e491dd9ce7da57fb67138cfe47125515f0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij algemene maatregel van bestuur worden nadere regels gesteld omtrent de toepassing van het eerste lid. Deze regels betreffen in ieder geval de melding en registratie van de geneeskundige handeling, alsmede de taak van de verantwoordel ijke arts indien de geneeskundige handeling noodzakelijk is ter afwending van ernstig gevaar, voortvloeiend uit de stoor nis van de geestvermogens van de gedetineerde. De algemene maatregel van bestuur treedt niet eerder in werking dan acht weken na de datum van uitgifte van het Staatsblad waarin hij is geplaatst. Van de plaatsing wordt onverwijld mededeling gedaan aan de beide kamers der Staten-Generaal.
+- number: '33'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 70be0382721c4a77843b889fb00234c2325945a3c521234061f46d360a27c8c9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 33 1. De directeur kan bepalen dat een gedetineerde tijdens de afzondering door bevestiging van mechanische midd elen aan zijn lichaam voor een periode van ten hoogste vierentwintig uren in zijn bewegingsvrijheid wordt beperkt, indie n die beperking noodzakelijk is ter afwending van een van de gedetineerde uitgaand ernstig gevaar voor diens gezondheid of de veiligheid van anderen dan de gedetineerde. De directeur stelt de arts of diens vervanger en de commissie van toez icht van de bevestiging onverwijld in kennis.
+  - index: 1
+    label: lid 2
+    sha256: 2a9547e7bba8083b234e337cc3426644a027bcfe621e454a0d96741d88706e08
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien onverwijlde tenuitvoerlegging van de maatregel, bedoeld in het eerste lid, geboden is, kan een ambtenaar of me dewerker hiertoe beslissen en deze voor een periode van ten hoogste vier uren ten uitvoer leggen. De directeur, de arts of diens vervanger en de commissie van toezicht worden hiervan onverwijld in kennis gesteld.
+  - index: 2
+    label: lid 3
+    sha256: 5c8b64ec46b97178f59ddef30fc2b84f2e7df1eedffe5cf987cca230b09ad9ef
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur kan de beslissing tot bevestiging van mechanische middelen aan het lichaam van de gedetineerde telkens m et ten hoogste vierentwintig uren verlengen. De beslissing tot verlenging wordt genomen na overleg met de aan de inricht ing verbonden arts of diens vervanger.
+  - index: 3
+    label: lid 4
+    sha256: 193742a191343c73309c9505f5f69ae74255491f128c92fdfc5dc2bd07ad49aa
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Onze Minister stelt nadere regels omtrent de bevestiging van mechanische middelen aan het lichaam.
+- number: '34'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 286faa81d53eca979e38d54111e4b74f94f8fa92180dba589cb2b2d24cae3262
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 34 1. De directeur is bevoegd de verblijfsruimte van een gedetineerde op de aanwezigheid van voorwerpen die niet in zijn bezit mogen zijn te onderzoeken: a. b.'
+  - index: 1
+    label: lid 2
+    sha256: ba234c0cc41e386a10d365a4a15724c2f79d3c79217dbcfc9291e285807ae25e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Artikel 29, vierde lid, is van overeenkomstige toepassing.
+- number: '35'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 971d1190477994be27a321f2c5349b5f96ccd03d3d0758c6100ca4fc091c034d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 35 1. De directeur is bevoegd jegens een gedetineerde geweld te gebruiken dan wel vrijheidsbeperkende middelen a an te wenden, voor zover dit noodzakelijk is met het oog op een van de volgende belangen: a. b. c.'
+  - index: 1
+    label: lid 2
+    sha256: 22d4741cca1ca5ab1de9fc2370c31387b8ce9a0dd92c33dec86de9758b887c29
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. De selectiefunctionaris of een daartoe door hem aangewezen ambtenaar of medewerker is bevoegd jegens een gedetineerde geweld te gebruiken of vrijheidsbeperkende middelen aan te wenden met het oog op een van de volgende belangen: a. b.'
+  - index: 2
+    label: lid 3
+    sha256: aa86b2d6aa169d0df5900dafaa70cfd419bc929e882fd9f5c769f55ed3e540ac
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Aan het gebruik van geweld gaat zo mogelijk een waarschuwing vooraf. Degene die geweld heeft gebruikt maakt hiervan o nverwijld een schriftelijk verslag en doet dit verslag onverwijld aan de directeur dan wel de selectiefunctionaris toeko men.
+  - index: 3
+    label: lid 4
+    sha256: 4ac35b4c7b007b5ee0641c701e68efd0636e5fd8e021ae215e0eb88f3f77dd04
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Onze Minister stelt nadere regels omtrent het gebruik van geweld en de aanwending van vrijheidsbeperkende middelen.
+- number: '36'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 15089f00e6c83aa430b32566141da8f8eebf96530a2338a24f62c0e29b0000e3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 36 1. De gedetineerde heeft, behoudens de overeenkomstig het tweede tot en met het vierde lid te stellen beperki ngen, het recht brieven en stukken per post te verzenden en te ontvangen. De hieraan verbonden kosten komen, tenzij de d irecteur anders bepaalt, voor rekening van de gedetineerde.
+  - index: 1
+    label: lid 2
+    sha256: 3cd4e6ec7d44fc7e5e35f487f96d9f989c2eda87ee7705619b683dc4b3c4afcf
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De directeur is bevoegd enveloppen of andere poststukken, afkomstig van of bestemd voor gedetineerden, op de aanwezig heid van bijgesloten voorwerpen te onderzoeken en deze hiertoe te openen. Indien de enveloppen of andere poststukken afk omstig zijn van of bestemd zijn voor de in artikel 37, eerste of tweede lid, genoemde personen of instanties, geschiedt dit onderzoek in aanwezigheid van de betrokken gedetineerde.
+  - index: 2
+    label: lid 3
+    sha256: 01f18d130157a37b95d5ae88e2a227284611da5b2f1f10a8dd6ca3b8ccd08fb1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur is bevoegd op de inhoud van brieven of andere poststukken afkomstig van of bestemd voor gedetineerden to ezicht uit te oefenen. Dit toezicht kan omvatten het kopiëren van brieven of andere poststukken. Van de wijze van uitoef enen van toezicht wordt aan de gedetineerden tevoren mededeling gedaan.
+  - index: 3
+    label: lid 4
+    sha256: 92e57128c9cdefb2b3e139e5a1921e1243e83a4be883e299086e033295c49f00
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. De directeur kan de verzending of uitreiking van bepaalde brieven of andere poststukken alsmede bijgesloten voorwerpe n weigeren, indien dit noodzakelijk is met het oog op een van de volgende belangen: a. b. c.'
+  - index: 4
+    label: lid 5
+    sha256: afde90700ca7a08547730dea6ccda78d44ea45622f04462e84f96656e7a8afba
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De directeur draagt zorg dat de niet uitgereikte brieven of andere poststukken dan wel bijgesloten voorwerpen, hetzij worden teruggegeven aan de gedetineerde of voor diens rekening worden gezonden aan de verzender of een door de gedetine erde op te geven adres, hetzij onder afgifte van een bewijs van ontvangst ten behoeve van de gedetineerde worden bewaard , hetzij met toestemming van de gedetineerde worden vernietigd, hetzij aan een opsporingsambtenaar ter hand worden geste ld met het oog op de voorkoming of opsporing van strafbare feiten.
+- number: '37'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 0265373aacc9d84738fe19900c352f5754ccea4a59a0cd51c47a55dae276df7b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 37 1. Artikel 36, derde en vierde lid, is niet van toepassing op brieven, door de gedetineerde gericht aan of af komstig van: a. b. c. d. e. f. g. h. i. j. k.'
+  - index: 1
+    label: lid 2
+    sha256: 436c195cef0a17e51f197e45a25029d1de98980b0c2f9067df78b93289d2db6d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Voor de toepassing van het eerste lid, onder d, wordt onder justitiële autoriteiten mede begrepen: organen die kracht ens een wettelijk voorschrift of een in Nederland geldend verdrag bevoegd zijn tot kennisneming van klachten of behandel ing van met een klacht aangevangen zaken.'
+  - index: 2
+    label: lid 3
+    sha256: b908c814e521e7e9431900587d8a3da4be4de892e746a761a42ad603470aa11e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Onze Minister kan nadere regels stellen omtrent de wijze van verzending van brieven aan en door de in het eerste lid genoemde personen en instanties.
+- number: '38'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: eb1aeeb59e14cd3d77014c19d4685bd785b0fa2b81afb81278549e71d700cbcc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 38 1. De gedetineerde heeft het recht gedurende ten minste één uur per week op in de huisregels vastgestelde tij den en plaatsen bezoek te ontvangen. In de huisregels worden regels gesteld omtrent het aanvragen van bezoek.
+  - index: 1
+    label: lid 2
+    sha256: 7fc7ff6982bb3c7fc638be0a2844fbb27ce91bd74baca3e96ece08f8324dfc8d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De directeur kan het aantal tegelijkertijd tot de gedetineerde toe te laten personen beperken, indien dit noodzakelij k is in het belang van de handhaving van de orde of de veiligheid in de inrichting.
+  - index: 2
+    label: lid 3
+    sha256: 044e3905b97ec789ab683b6c2bfabc33f193873b7fb7d164832bdeb2f27c7e94
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur kan de toelating tot de gedetineerde van een bepaald persoon of van bepaalde personen weigeren, indien d it noodzakelijk is met het oog op een belang als bedoeld in artikel 36, vierde lid. Deze weigering geldt voor ten hoogst e drie maanden.
+  - index: 3
+    label: lid 4
+    sha256: 509575c33fad5062ad3aaec9b1d60331d6bbed80cd8149296b426bb36a133de9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De directeur kan bepalen dat tijdens het bezoek toezicht wordt uitgeoefend, indien dit noodzakelijk is met het oog op een belang als bedoeld in artikel 36, vierde lid. Dit toezicht kan omvatten het beluisteren of opnemen van het gesprek tussen de bezoeker en de gedetineerde. Tevoren wordt aan betrokkenen mededeling gedaan van de aard en de reden van het t oezicht.
+  - index: 4
+    label: lid 5
+    sha256: ae07cecbbf20345a7845d5ffc909748e446c03e4c208021d25fd7814fdb72e92
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Iedere bezoeker dient zich bij binnenkomst op deugdelijke wijze te legitimeren. De directeur kan bepalen dat een bezo eker aan zijn kleding wordt onderzocht op de aanwezigheid van voorwerpen die een gevaar kunnen opleveren voor de orde of de veiligheid in de inrichting. Dit onderzoek kan ook betrekking hebben op door hem meegebrachte voorwerpen. De directe ur is bevoegd dergelijke voorwerpen gedurende de duur van het bezoek onder zich te nemen tegen afgifte van een bewijs va n ontvangst dan wel aan een opsporingsambtenaar ter hand te stellen met het oog op de voorkoming of opsporing van strafb are feiten.
+  - index: 5
+    label: lid 6
+    sha256: 2c5b839a3615b9c181090a216b8af8e926afd87ca1f8192ea8acdff4ffbcfb4b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. De directeur kan het bezoek binnen de daarvoor bestemde tijd beëindigen en de bezoeker uit de inrichting doen verwijd eren, indien dit noodzakelijk is met het oog op een belang als bedoeld in artikel 36, vierde lid.
+  - index: 6
+    label: lid 7
+    sha256: d768a7b3c5080f0881268b246dede6d50e1a2fc861e9cde90533ed0f88fd2521
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. De in artikel 37, eerste lid, onder g en h, genoemde personen en instanties hebben te allen tijde toegang tot de gede tineerde. De overige in dat lid genoemde personen en instanties hebben toegang tot de gedetineerde op in de huisregels v astgestelde tijden en plaatsen. Tijdens dit bezoek kunnen zij zich vrijelijk met de gedetineerde onderhouden, behoudens ingeval de directeur, na overleg met de desbetreffende bezoeker, van mening is dat van de gedetineerde een ernstig gevaa r uitgaat voor de veiligheid van de bezoeker. In dat geval laat de directeur voor het bezoek weten welke toezichthoudend e maatregelen genomen worden om het onderhoud zo ongestoord mogelijk te laten verlopen. De toezichthoudende maatregelen mogen er niet toe leiden dat vertrouwelijke mededelingen in het onderhoud tussen de gedetineerde en diens rechtsbijstand verlener bij derden bekend kunnen worden.
+- number: '39'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: fcf611fa4c576e8a79acbc72b38b8d433dea2a09112330a8e5d7159c6d3d7ebc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 39 1. De gedetineerde heeft, behoudens de overeenkomstig het tweede tot en met het vierde lid te stellen beperki ngen, het recht ten minste eenmaal per week op in de huisregels vastgestelde tijden en plaatsen en met behulp van een da artoe aangewezen toestel gedurende tien minuten een of meer telefoongesprekken te voeren met personen buiten de inrichti ng. De hieraan verbonden kosten komen, tenzij de directeur anders bepaalt, voor rekening van de gedetineerde.
+  - index: 1
+    label: lid 2
+    sha256: dcda509b4abd376884d8d57d26b56715b424256439d93b9396cc628fb8c4ea5f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De directeur kan bepalen dat op de door of met de gedetineerde gevoerde telefoongesprekken toezicht wordt uitgeoefend , indien dit noodzakelijk is om de identiteit van de persoon met wie de gedetineerde een gesprek voert vast te stellen d an wel met het oog op een belang als bedoeld in artikel 36, vierde lid. Dit toezicht kan omvatten het beluisteren of opn emen van het telefoongesprek. Tevoren wordt aan de betrokkene mededeling gedaan van de aard en de reden van het toezicht .
+  - index: 2
+    label: lid 3
+    sha256: 0d9539428236d20abd1244c4e9e676e607165629e637939998c800ed29163f1f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur kan de gelegenheid tot het voeren van een bepaald telefoongesprek of bepaalde telefoongesprekken weigere n of een telefoongesprek binnen de daarvoor bestemde tijd beëindigen, indien dit noodzakelijk is met het oog op een bela ng als bedoeld in artikel 36, vierde lid. De beslissing tot het weigeren van een bepaald telefoongesprek of bepaalde tel efoongesprekken geldt voor ten hoogste drie maanden.
+  - index: 3
+    label: lid 4
+    sha256: 25e45c0e1836f2785e438ea97dba0f80a8221191941456b2fe8aa900d18f5a6c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De gedetineerde wordt in staat gesteld met de in artikel 37, eerste lid, genoemde personen en instanties telefonisch contact te hebben, indien hiervoor de noodzaak en de gelegenheid bestaat. Op deze gesprekken wordt geen ander toezicht u itgeoefend dan noodzakelijk is om de identiteit van de personen of instantie met wie de gedetineerde een telefoongesprek voert of wenst te voeren vast te stellen.
+- number: '40'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 9d23875edd9937b95e2232a40235f12b403a80dfad1e43f9b9027724672bd845
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 40 1. De directeur kan toestemming geven voor het voeren van een gesprek tussen de gedetineerde en een vertegenw oordiger van de media, voor zover dit zich verdraagt met de volgende belangen: a. b. c. d.'
+  - index: 1
+    label: lid 2
+    sha256: 4928e1450c05cd033966b57215f6301c6b948058e8d2b410f8ac5c2ebc6204ab
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De directeur kan met het oog op de bescherming van de in het eerste lid genoemde belangen aan de toegang van een vert egenwoordiger van de media tot de inrichting voorwaarden verbinden. De directeur is bevoegd een vertegenwoordiger van de media uit de inrichting te doen verwijderen, indien hij de hem opgelegde voorwaarden niet nakomt.
+  - index: 2
+    label: lid 3
+    sha256: c8d21bc1d89ca7fc8e1df08a9ac81ec06a460b555757b18ba5b27cfd4d0e99e4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur kan op het contact met een vertegenwoordiger van de media toezicht uitoefenen, indien dit noodzakelijk i s met het oog op een belang als bedoeld in het eerste lid. Artikel 38, vierde lid, tweede en derde volzin, en vijfde lid , is van overeenkomstige toepassing.
+- number: '41'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2bd338920f1415828e0608d0d53f18cc1665de31673e8f3a03abae9e6c63b6c9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 41 1. De gedetineerde heeft het recht zijn godsdienst of levensovertuiging, individueel of in gemeenschap met an deren, vrij te belijden en te beleven.
+  - index: 1
+    label: lid 2
+    sha256: d1844834dc9f7403a6d482568099244a937aad17b6d5ea2893d94e711b5e14bd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De directeur draagt zorg dat in de inrichting voldoende geestelijke verzorging, die zoveel mogelijk aansluit bij de g odsdienst of levensovertuiging van de gedetineerden, beschikbaar is.
+  - index: 2
+    label: lid 3
+    sha256: 86d797ac3195ffd75ca990a60dbcb173ad4eb195b75ab91bfe9f0a542ebae86b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. De directeur stelt de gedetineerde in de gelegenheid op in de huisregels vastgestelde tijden en plaatsen: a. b. c.'
+  - index: 3
+    label: lid 4
+    sha256: 12f8ced57d0245d925ec7b0bf83e4901b0cc5ce775ec49e30a950fd087b9cf3f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij of krachtens algemene maatregel van bestuur worden nadere regels gesteld ten aanzien van de beschikbaarheid van d e geestelijke verzorging. Deze regels hebben betrekking op de verlening van geestelijke verzorging door of vanwege versc hillende richtingen van godsdienst of levensovertuiging, op de organisatie en de bekostiging van de geestelijke verzorgi ng en op de aanstelling van geestelijke verzorgers bij een inrichting.
+- number: '42'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c8f1739610bcaa055198a8a0130a4d72dcaa23b8b8e42277651efc36c0742237
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 42 1. De gedetineerde heeft recht op verzorging door een aan de inrichting verbonden arts of diens vervanger.
+  - index: 1
+    label: lid 2
+    sha256: b2ae872a518b12bb313b8332ab3480185b9dc4172516d00d319be73e5c512eeb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De gedetineerde heeft recht op raadpleging, voor eigen rekening, van een arts van zijn keuze. De directeur stelt in o verleg met de gekozen arts de plaats en het tijdstip van de raadpleging vast.
+  - index: 2
+    label: lid 3
+    sha256: a01ae48067596d9d5812416aa62958f4707980bc91945448334342cad802355b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. De directeur draagt zorg dat de aan de inrichting verbonden arts of diens vervanger: a. b. c.'
+  - index: 3
+    label: lid 4
+    sha256: 3b46aae3a1b976463b2812d86e673c453518b222f4569afb4f7e0fab084b020c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. De directeur draagt zorg voor: a. b. c.'
+  - index: 4
+    label: lid 5
+    sha256: 1494aecea2def6d1237ca3f54c466479aacdf9f9339e43013e88cd21fb86a441
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Bij algemene maatregel van bestuur worden regels gesteld inzake het klagen over beslissingen die ten aanzien van gede tineerden zijn genomen door de aan de inrichting verbonden arts of diens plaatsvervanger.
+- number: '43'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d411a0fe047f4434d040746b4eebc0b4c359e783f0c2bcba03a6f7b9366ad802
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 43 1. De gedetineerde heeft recht op sociale verzorging en hulpverlening.
+  - index: 1
+    label: lid 2
+    sha256: 6dd72158c5457078b6a1e603797e98c23be90a3b6f3f4894d700028de6bfc243
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De directeur draagt zorg dat reclasseringswerkers en andere daarvoor in aanmerking komende gedragsdeskundigen de in h et eerste lid omschreven zorg en hulp in de inrichting kunnen verlenen.
+  - index: 2
+    label: lid 3
+    sha256: 349f5ba33225b779cd8bccfddd5be9f5e4d47b0076929a6d3edf4ffc743b92ec
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur draagt zorg voor overbrenging van de gedetineerde naar de daartoe bestemde plaats, indien de in het eers te lid omschreven zorg en hulp dit noodzakelijk maken en een dergelijke overbrenging zich verdraagt met de ongestoorde t enuitvoerlegging van de vrijheidsbeneming.
+- number: '44'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6f59f19ccbe50fc7a1e23d96727ecacf4f02ca9e16c8b4af86f1ab5568d12106
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 44 1. De directeur draagt zorg dat aan de gedetineerde voeding, noodzakelijke kleding en schoeisel worden verstr ekt dan wel dat hem voldoende geldmiddelen ter beschikking worden gesteld om hierin naar behoren te voorzien.
+  - index: 1
+    label: lid 2
+    sha256: 0c48de7d37c2109a4ce647bb8c9c661aa14cba2c500559e24bac19d9ea381681
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De gedetineerde heeft recht op het dragen van eigen kleding en schoeisel, tenzij die een gevaar kunnen opleveren voor de orde of de veiligheid in de inrichting. Hij kan worden verplicht tijdens de arbeid of sport aangepaste kleding of sc hoeisel te dragen. In de huisregels kunnen regels worden gesteld omtrent de wijze van gebruik en onderhoud van kleding e n schoeisel.
+  - index: 2
+    label: lid 3
+    sha256: 4e77556868277a81e04e69b129e9e1b25c3257910d2b710e12421c9f3a282e29
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur draagt zorg dat bij de verstrekking van voeding zoveel mogelijk rekening wordt gehouden met de godsdiens t of levensovertuiging van de gedetineerden.
+  - index: 3
+    label: lid 4
+    sha256: aeba14e8b96c6a60925863a1e0d27f1d707c2d039e037431e99f9c13f88a2081
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De directeur draagt zorg dat de gedetineerde in staat gesteld wordt zijn uiterlijk en lichamelijke hygiëne naar behor en te verzorgen.
+  - index: 4
+    label: lid 5
+    sha256: 9a326582e69d6f1e033750ca6f0dc51c34d806fd9fa95ef0f29b5ce6c568d8ba
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. In de huisregels worden regels gesteld omtrent de aankoop door gedetineerden van andere gebruiksartikelen dan die wel ke door de directeur ter beschikking worden gesteld.
+- number: '45'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 5d57a72ad3da851801c94f8050b569be07c9700a527d62319829230ec1a28201
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 45 1. In de huisregels kan worden bepaald dat het bezit van bepaalde soorten voorwerpen binnen de inrichting of een bepaalde afdeling daarvan verboden is, indien dit noodzakelijk is in het belang van de handhaving van de orde of de veiligheid in de inrichting, dan wel de beperking van de aansprakelijkheid van de directeur voor de voorwerpen.
+  - index: 1
+    label: lid 2
+    sha256: a64d32f06b5c6e2c7cbb845e0e792666aaf7203bab07f485249169d3544514d4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. De directeur kan een gedetineerde toestemming geven hem toebehorende voorwerpen, waarvan het bezit niet is verboden i ngevolge het eerste lid, in zijn verblijfsruimte te plaatsen dan wel bij zich te hebben voor zover dit zich verdraagt me t de volgende belangen: a. b.'
+  - index: 2
+    label: lid 3
+    sha256: 3ef772d6ab2b126c393767facc646ef7a22a429886aa8e4ef2e80da4426fd964
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur kan aan de toestemming, bedoeld in het tweede lid, voorwaarden verbinden die kunnen betreffen het gebrui k van en de aansprakelijkheid voor deze voorwerpen. Bij of krachtens algemene maatregel van bestuur kunnen regels worden gesteld krachtens welke de aansprakelijkheid van de directeur voor voorwerpen die een gedetineerde ingevolge het tweede lid onder zich heeft wordt beperkt tot een bepaald bedrag.
+  - index: 3
+    label: lid 4
+    sha256: 623531b5507da5aa41fc6962d0053e3debc7298d39a910673ec263719cf9905c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De directeur is bevoegd aan de gedetineerde toebehorende voorwerpen voor diens rekening te laten onderzoeken, teneind e vast te stellen of de toelating of het bezit daarvan kan worden toegestaan dan wel is verboden, ingevolge het eerste o nderscheidenlijk het tweede lid.
+  - index: 4
+    label: lid 5
+    sha256: bcf31af79443ef7374fda4fee47f47af9e8e6c8d62e927b03a75c7e5ba860162
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De directeur is bevoegd voorwerpen ten aanzien waarvan geen toestemming is verleend dan wel die zijn verboden, ingevo lge het eerste onderscheidenlijk het tweede lid, in beslag te nemen. Hij draagt zorg dat deze voorwerpen hetzij onder af gifte van een bewijs van ontvangst ten behoeve van de gedetineerde op diens kosten worden bewaard, hetzij voor diens rek ening worden gezonden aan de verzender of een door de gedetineerde op te geven adres, hetzij met toestemming van de gede tineerde worden vernietigd, hetzij aan een opsporingsambtenaar ter hand worden gesteld met het oog op de voorkoming of o psporing van strafbare feiten.
+- number: '46'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d042ad261859165661ec4e826bbe1b6520dd46952ceef1425198a8f49fd2cc7f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 46 1. Het bezit van contant geld door de gedetineerden in de inrichting of een afdeling is verboden, tenzij in d e huisregels anders is bepaald.
+  - index: 1
+    label: lid 2
+    sha256: 4b2ea50bc4fb79538f36e323c38bcdafca1e2a93edc4a0cc96e7f3315945cdab
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In inrichtingen of afdelingen waar het bezit van contant geld door de gedetineerden verboden is, heeft de gedetineerd e de beschikking over een rekening-courant bij de inrichting.
+  - index: 2
+    label: lid 3
+    sha256: 4df379c99ced82c73c090d44d3ff993b0947724992c28376df5976b4fb1722c3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. In de huisregels kunnen nadere regels worden gesteld omtrent het bezit van contant geld en het gebruik van de rekenin g-courant. Deze regels kunnen een beperking betreffen van het bedrag waarover de gedetineerde ten hoogste in contanten o f door middel van zijn rekeningcourant mag beschikken.
+- number: '47'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: dd3a21b8e5119d2e2ba1db7601ce97671f35d9028b5ccd256bfd2aacdacbbaef
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 47 1. De gedetineerde heeft recht op deelname aan de in de inrichting beschikbare arbeid.
+  - index: 1
+    label: lid 2
+    sha256: 2cfa38b31875d10bd403f0d00c1613891d84f4fd821f02e4dd5305ec8d042c05
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De directeur draagt zorg voor de beschikbaarheid van arbeid voor de gedetineerden, voor zover de aard van de detentie zich daar niet tegen verzet.
+  - index: 2
+    label: lid 3
+    sha256: d7713e2cb7d6fea17802e792382009bc30fef2073621ffc28178378011ea7520
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Gedetineerden die tot een vrijheidsstraf zijn veroordeeld zijn verplicht de aan hen door de directeur opgedragen arbe id, zowel binnen als buiten de inrichting of afdeling, te verrichten.
+  - index: 3
+    label: lid 4
+    sha256: f8e2a24e66cd7d7d5d2bb465eeba7febf1a01dd098a1a69dc6a118adedbe738a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De arbeidstijd wordt in de huisregels vastgesteld binnen de grenzen van hetgeen buiten de inrichting gebruikelijk is.
+  - index: 4
+    label: lid 5
+    sha256: 6b500431e0a330404d676ab24ed556b4eea07e6d69eb50c3232d14843dcbb1d5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Onze Minister stelt regels omtrent de samenstelling en de hoogte van het arbeidsloon. De directeur is belast met de v aststelling en uitbetaling van het arbeidsloon.
+- number: '48'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 14e5415fc71228130d7332a8079f0890d5e73bfa7fa7fac12a683d765143c559
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 48 1. De gedetineerde heeft recht op het kennis nemen van het nieuws, voor eigen rekening, en het wekelijks gebr uik maken van een bibliotheekvoorziening. De gedetineerde heeft het recht op het volgen van onderwijs en het deelnemen a an andere educatieve activiteiten voor zover deze zich verdragen met de aard en de duur van de detentie en de persoon va n de gedetineerde.
+  - index: 1
+    label: lid 2
+    sha256: 4bf5212fe13f5c18f30661c3ba725e89e6ff2294d5af2193b437d25653759419
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De gedetineerde heeft recht op lichamelijke oefening en het beoefenen van sport gedurende ten minste tweemaal drie kw artier per week, voor zover zijn gezondheid zich daar niet tegen verzet.
+  - index: 2
+    label: lid 3
+    sha256: 479cae863f00c696a712d6a63d2ca0e09cb39a2d256196d01af20373f0986a55
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur draagt zorg dat daarvoor in aanmerking komende functionarissen in de in het eerste lid, tweede volzin, e n tweede lid bedoelde activiteiten kunnen voorzien.
+  - index: 3
+    label: lid 4
+    sha256: c929b2175e89e40a9cf2f03156b1f115243b5070987dc0eb3b4a01220cad2833
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Onze Minister stelt regels omtrent de voorwaarden waaronder een tegemoetkoming kan worden verleend in de kosten die v oor de gedetineerde aan het volgen van onderwijs en het deelnemen aan andere educatieve activiteiten voor zover hierin n iet in de inrichting wordt voorzien, kunnen zijn verbonden. Deze voorwaarden kunnen betreffen de aard, de duur en de kos ten van deze activiteiten alsmede de vooropleiding van de gedetineerde en diens vorderingen.
+- number: '49'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 279d3a32962c2861f8cbae78a1813a0c7135d6e70f79d17422295d1b24d6c02c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 49 1. De gedetineerde heeft recht op recreatie en dagelijks verblijf in de buitenlucht, voor zover zijn gezondhe id zich daar niet tegen verzet.
+  - index: 1
+    label: lid 2
+    sha256: 44532a1d2e2353445140d3724fa5a4694c70b68a3f2b0459674bc16167753c20
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De directeur draagt zorg dat de gedetineerde in de gelegenheid wordt gesteld tot deelname aan recreatieve activiteite n, gedurende ten minste zes uren per week.
+  - index: 2
+    label: lid 3
+    sha256: 638637d63e3bde8772d49f2fa506234b886aa8b46755f310f3160f5b03946fde
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur draagt zorg dat de gedetineerde in de gelegenheid wordt gesteld dagelijks ten minste een uur in de buite nlucht te verblijven.
+- number: '50'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 54a2a3455ac0edd36188c15919b0628d93ff01a672f9a83a44cd5a5434b810b6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 50 1. Indien een ambtenaar of medewerker constateert dat een gedetineerde betrokken is bij feiten die onverenigb aar zijn met de orde of de veiligheid in de inrichting dan wel met de ongestoorde tenuitvoerlegging van de vrijheidsbene ming en hij voornemens is daarover aan de directeur schriftelijk verslag te doen, deelt hij dit de gedetineerde mede.
+  - index: 1
+    label: lid 2
+    sha256: ec9124432ee21baed32a7d0f6704500ec3360b0b6affe61606ddb19a3865728a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De directeur beslist over het opleggen van een disciplinaire straf zo spoedig mogelijk nadat hem dit verslag is gedaa n.
+  - index: 2
+    label: lid 3
+    sha256: 36700bb3d721b2523c27abe6d593e7dd85ab643e29a87ba135efc7f693e2a7d9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien de directeur of zijn plaatsvervanger feiten als bedoeld in het eerste lid constateert, blijft het eerste lid b uiten toepassing.
+  - index: 3
+    label: lid 4
+    sha256: c94277d427040854aada979828c298a5a26caaf4bd23b60f6d988c4691fe922a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Een straf kan worden opgelegd dan wel ten uitvoer gelegd in een andere inrichting of afdeling dan waarin het verslag, bedoeld in het eerste lid, is opgemaakt.
+- number: '51'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b047173b9939a536630e51acb8afd506964d4579f5fd705a99825040e432caa6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 51 1. De directeur kan wegens het begaan van feiten als bedoeld in artikel 50, eerste lid, de navolgende discipl inaire straffen opleggen: a. b. c. d. e.'
+  - index: 1
+    label: lid 2
+    sha256: 487e792d8be07c0b4c47aa94531b217e91ddd12fcd6fde084a17a63c51c8c02f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De directeur bepaalt bij de oplegging van een geldboete tevens door welke andere straf deze zal worden vervangen, ing eval de boete niet binnen de daartoe door hem gestelde termijn is betaald.
+  - index: 2
+    label: lid 3
+    sha256: 67c8498d9ff79485599223ea1ae2b100025c38320267dea594ad05d62f9686fa
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur kan voor feiten als bedoeld in artikel 50, eerste lid, meer dan één straf opleggen, met dien verstande d at de in het eerste lid onder a en c genoemde straffen slechts kunnen worden opgelegd voor zover zij tezamen niet langer duren dan twee weken;
+  - index: 3
+    label: lid 4
+    sha256: 60c9c34a9936de140dcfc021bf7e45d0e06db33bb26aca006f469432e904bbe9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De oplegging van een straf laat onverlet de mogelijkheid voor de directeur om terzake van de door de gedetineerde toe gebrachte schade met hem een regeling te treffen.
+  - index: 4
+    label: lid 5
+    sha256: 115cd53f332affcc44ba2309c62c9f19426d1ef740efa69dec9e48c541e7d557
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Geen straf kan worden opgelegd, indien de gedetineerde voor het begaan van een feit als bedoeld in artikel 50, eerste lid, niet verantwoordelijk kan worden gesteld.
+  - index: 5
+    label: lid 6
+    sha256: a0f68cccb7cdcb3eb687a3611b1a74b13b9be46d22aef28556304c43b2625b2a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Indien een straf is opgelegd wordt deze onverwijld ten uitvoer gelegd. De directeur kan bepalen dat een straf niet of slechts ten dele ten uitvoer wordt gelegd.
+- number: '52'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 5623a7692997ac6366f10e54f9bb007bfc7170a6886609bba90802fbdf55dc3f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 52 1. Indien de tenuitvoerlegging van de opsluiting in een strafcel in de inrichting of afdeling waarin zij is o pgelegd niet mogelijk is of op ernstige bezwaren stuit, kan zij in een andere inrichting of afdeling worden ondergaan.
+  - index: 1
+    label: lid 2
+    sha256: 8b98b862eaedcdc91630aa703ed6c84242f3346e6f9d5d5f93cc26caf36a47e0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien de directeur van oordeel is dat de in het eerste lid bedoelde omstandigheid zich voordoet, plaatst hij in over eenstemming met de selectiefunctionaris de gedetineerde hiertoe over.
+  - index: 2
+    label: lid 3
+    sha256: f35a8f385178efa4cb124a23a5b0e46ae068e4bec1a65c06e81e4fcb4f90ceb7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Onze Minister stelt nadere regels omtrent de procedure van overplaatsing ingevolge het tweede lid.
+- number: '53'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8a03fc897aa707d5defa1b045fc36d04c987a62e1f28fe1aa2893b236e251ee4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 53 1. Een straf kan geheel of ten dele voorwaardelijk worden opgelegd. De proeftijd bedraagt ten hoogste drie ma anden.
+  - index: 1
+    label: lid 2
+    sha256: 9481ebe7b64bf41cdffa79eb305e01b3bc07e56da8f3b05c9aa4dd5408bbd8ef
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De directeur stelt in elk geval als voorwaarde dat de gedetineerde zich onthoudt van het plegen van feiten die onvere nigbaar zijn met de orde of de veiligheid in de inrichting dan wel met de ongestoorde tenuitvoerlegging van de vrijheids beneming. De directeur kan andere voorwaarden aan het gedrag van de gedetineerde stellen. De opgelegde voorwaarden worde n vermeld in de mededeling, bedoeld in artikel 58, eerste lid.
+  - index: 2
+    label: lid 3
+    sha256: 8ba54334603fd54722e4c4900b7b3044fb630b5db1b0dd4d4f07d8d7ddb71264
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij het overtreden van een voorwaarde binnen de proeftijd kan de directeur bepalen dat de opgelegde voorwaardelijke s traf geheel of ten dele ten uitvoer wordt gelegd.
+  - index: 3
+    label: lid 4
+    sha256: 0b4bd80255611c57a005073e5a2710bb5c8a22d7ac4e5f3a021d3b7e0a6e0e0b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De directeur kan een onvoorwaardelijke straf geheel of ten dele omzetten in een voorwaardelijke straf.
+- number: '54'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 65cfa3600c7538b96fa293e5c1e105fdf274b55e79892ee371c9588ddde15cde
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 54 1. Van elke strafoplegging dan wel wijziging daarvan houdt de directeur aantekening.
+  - index: 1
+    label: lid 2
+    sha256: 30a0881d41829930b47b0d205d2481363c6b006576ebdc36dd3633c1a25f68a5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien een straf ingevolge de hoofdstukken XI of XII geheel of ten dele wordt herzien, houdt de directeur hiervan aan tekening.
+- number: '55'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c2d9c176bb684c939989eec8e761d1fd5529ab64d934e536c06c32ec77c5ec4e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 55 1. De gedetineerde aan wie de disciplinaire straf van opsluiting, bedoeld in artikel 51, eerste lid, onder a, is opgelegd is uitgesloten van het deelnemen aan activiteiten, voor zover de directeur niet anders bepaalt en behoudens het dagelijks verblijf in de buitenlucht, bedoeld in artikel 49, derde lid. De directeur kan het contact met de buitenw ereld gedurende het verblijf in de strafcel beperken of uitsluiten.
+  - index: 1
+    label: lid 2
+    sha256: dc8db6f35dc5fcf2d07c53a9de49a0b4e379f57a3dcc1dd3bcb8dc4c97028ad9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De directeur draagt zorg dat, ingeval de opsluiting in een strafcel ten uitvoer wordt gelegd en langer dan vierentwin tig uren duurt, de commissie van toezicht en de aan de inrichting verbonden arts of diens vervanger terstond hiervan in kennis worden gesteld.
+  - index: 2
+    label: lid 3
+    sha256: 5bed020af522f4a700e0e386ff547cb39bfcfaf6d9c332b689217d7dc917b7a1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Onze Minister stelt nadere regels omtrent het verblijf in en de inrichting van de strafcel. Deze betreffen in elk gev al de rechten die tijdens het verblijf in de strafcel aan de gedetineerde toekomen.
+- number: '56'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 83082ac00476c46ca543dae38b5985735ab72aede51d6fc5dbd6026571493cc2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 56 1. De directeur draagt zorg dat de gedetineerde bij binnenkomst in de inrichting, schriftelijk en zoveel moge lijk in een voor hem begrijpelijke taal, op de hoogte wordt gesteld van zijn bij of krachtens deze wet gestelde rechten en plichten.
+  - index: 1
+    label: lid 2
+    sha256: 699fe785f47f6e0f35b776113d1973d6a38057bca5de411c451b71432567f49a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. De gedetineerde wordt hierbij in het bijzonder gewezen op diens bevoegdheid: a. b. c.'
+  - index: 2
+    label: lid 3
+    sha256: c76642a11d2dae3142e570bef402839991a659e6d5219ff48208ff4988c222cc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Een gedetineerde vreemdeling wordt bij binnenkomst in de inrichting geïnformeerd over zijn recht de consulaire verteg enwoordiger van zijn land van zijn detentie op de hoogte te laten stellen.
+- number: '57'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: e147d8d574a19ea4f4e961aa520bea2c7fa6869c3da517442cae7150f05f7ad9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 57 1. De directeur stelt de gedetineerde in de gelegenheid te worden gehoord, zoveel mogelijk in een voor hem be grijpelijke taal, alvorens hij beslist omtrent: a. b. c. d. e. f. g. h.'
+  - index: 1
+    label: lid 2
+    sha256: ce6e2166fe53bc8a43a3abd0cf6f94d0b20490b5c15e9004240ad0a51ad56e4a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Zo nodig geschiedt het horen van de gedetineerde met bijstand van een tolk. Van het horen van de gedetineerde wordt a antekening gehouden.
+  - index: 2
+    label: lid 3
+    sha256: 0b886625782ea6193663b43582af80454b128f61c5efd43ae7e47928cefb14ac
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Toepassing van het eerste lid, onder b, c, d, e, f en g, kan achterwege blijven indien: a. b.'
+- number: '58'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8a1440f71db8d2a3a83cede15b615191a00605af4521854a5f0557daba0c31e0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 58 1. De directeur geeft de gedetineerde van elke beslissing als bedoeld in artikel 57, eerste lid, onverwijld s chriftelijk en zoveel mogelijk in een voor hem begrijpelijke taal een met redenen omklede, gedagtekende en ondertekende mededeling.
+  - index: 1
+    label: lid 2
+    sha256: 829d58bb5f4b7253f503677e84fab3ba1da73d9eb70d35bdf73000cadccf8417
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. De directeur geeft de gedetineerde op de in het eerste lid omschreven wijze een mededeling omtrent: a. b. c. d.'
+  - index: 2
+    label: lid 3
+    sha256: c34a6f776b3278f9a4ae36a67260a221ee54809d81d2e048515b7cd3025f6333
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. In de gevallen, genoemd in het tweede lid, kan de mededeling achterwege blijven, indien de beslissing van de directeu r strekt ter uitvoering van een beperking die aan de gedetineerde is opgelegd ingevolge de [artikelen 222](jci1.3:c:BWBR 0001926&artikel=222) en [225 van de lnvoeringswet van het Wetboek van Strafvordering](jci1.3:c:BWBR0001926&artikel=225).
+  - index: 3
+    label: lid 4
+    sha256: 385291079e43ca57978ec7e634a3a6b3e372096967f1a7e2f5f1215c5c7de246
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De gedetineerde wordt in de mededeling, bedoeld in het eerste en tweede lid, gewezen op de mogelijkheid van het inste llen van beklag, bedoeld in hoofdstuk Xl, de wijze waarop en de termijn waarbinnen zulks dient te geschieden, alsmede op de mogelijkheid tot het doen van een verzoek aan de voorzitter van de beroepscommissie om hangende de uitspraak op het klaagschrift de tenuitvoerlegging van de beslissing geheel of gedeeltelijk te schorsen.
+- number: '59'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a8132b46662bbbb8242b4e56445eceea2ae727843c7d351d1c6a48512dcb903e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 59 Bij of krachtens algemene maatregel van bestuur worden regels gesteld omtrent de aanleg van dossiers. In elk geval betreffen deze de omschrijving van gedetineerden over wie een dossier moet worden aangelegd, de aard van de daarin vervatte informatie, het recht op inzage of afschrift van het dossier door de betrokken gedetineerde en de beperkingen daarop en de termijn gedurende welke alsmede de wijze waarop het dossier bewaard blijft.
+- number: '60'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: f7ae23e489bfddde39ed28e3fb8a9b18c3d4aa53216b6ba609487dcb31fe19a0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 60 1. Een gedetineerde kan bij de beklagcommissie beklag doen over een hem betreffende door of namens de directe ur genomen beslissing.
+  - index: 1
+    label: lid 2
+    sha256: 907cab163475bb3f839b298d1fb54301c897def3da1148cf21ff2b2106b71af6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Met een beslissing als bedoeld in het eerste lid wordt gelijkgesteld een verzuim of weigering om te beslissen. Het ne men van een beslissing wordt geacht te zijn verzuimd of geweigerd, indien niet binnen de wettelijke of, bij het ontbreke n daarvan, binnen een redelijke termijn een beslissing is genomen.
+  - index: 2
+    label: lid 3
+    sha256: d0ff38d3bfcbbd9c335f1c8faadabf7cd7efad0af1fad5ef25d2712b38c63e0e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De directeur draagt zorg dat een gedetineerde die beklag wenst te doen daartoe zo spoedig mogelijk in de gelegenheid wordt gesteld.
+- number: '61'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 50cbdf8ad039a5f03a22ab06a5667a1cb51940cdaf5a3c2d15b203c6d167cbfd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 61 1. De gedetineerde doet beklag door de indiening van een klaagschrift bij de beklagcommissie bij de inrichtin g waar de beslissing waarover hij klaagt is genomen.
+  - index: 1
+    label: lid 2
+    sha256: 5696bf3913c99c617b4380d95568b0ecd0bc132d72a1359b37923c0061cf5841
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De indiening van het klaagschrift kan door tussenkomst van de directeur van de inrichting waar de gedetineerde verbli jft geschieden. De directeur draagt in dat geval zorg dat het klaagschrift of, indien het klaagschrift zich in een envel op bevindt, de envelop van een dagtekening wordt voorzien, welke geldt als dag van indiening.
+  - index: 2
+    label: lid 3
+    sha256: 501bb8d94dbd684a9c5053b30afe0e0c9138583bac637ae24d8985bbffb7a8d8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het klaagschrift vermeldt zo nauwkeurig mogelijk de beslissing waarover wordt geklaagd en de redenen van het beklag.
+  - index: 3
+    label: lid 4
+    sha256: b34cec66dc7098da1766af69507fc90ba8ad98371a621c4cea49b4c953829fd0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Indien de gedetineerde de Nederlandse taal niet voldoende beheerst kan hij het klaagschrift in een andere taal indien en. De voorzitter van de beklagcommissie kan bepalen dat het klaagschrift in de Nederlandse taal wordt vertaald. De verg oeding van de voor de vertaling gemaakte kosten geschiedt volgens regelen te stellen bij algemene maatregel van bestuur.
+  - index: 4
+    label: lid 5
+    sha256: dbea47e828860629115b7c2fe38b72154b9c89b767cfed580816467a8eeeee1a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Het klaagschrift wordt uiterlijk op de zevende dag na die waarop de gedetineerde kennis heeft gekregen van de besliss ing waarover hij zich wenst te beklagen ingediend. Een na afloop van deze termijn ingediend klaagschrift is niettemin on tvankelijk, indien redelijkerwijs niet kan worden geoordeeld dat de gedetineerde in verzuim is geweest.
+- number: '62'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d8bb2476eb4855512abb3ef9ba89d6dc406cf8eeeb75f38814f102c448110d7b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 62 1. Het klaagschrift wordt behandeld door een door de commissie van toezicht benoemde beklagcommissie, bestaan de uit drie leden, die wordt bijgestaan door een secretaris.
+  - index: 1
+    label: lid 2
+    sha256: 403b086b50ddf25bcc377c130a6e1150afcc96dce0765549bae2931818f2aefa
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De voorzitter dan wel een door hem aangewezen lid van de beklagcommissie kan, indien hij het beklag van eenvoudige aa rd, dan wel kennelijk niet-ontvankelijk, kennelijk ongegrond of kennelijk gegrond acht, het klaagschrift enkelvoudig afd oen, met dien verstande dat hij tevens de bevoegdheden bezit die aan de voorzitter van de voltallige beklagcommissie toe komen.
+  - index: 2
+    label: lid 3
+    sha256: 164852a1a6d477f2a2eba950151a66b996f4bc27eca848404ad5274aa2343fab
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De voorzitter, dan wel het door hem aangewezen lid, bedoeld in het tweede lid, kan de behandeling te allen tijde verw ijzen naar de voltallige beklagcommissie.
+  - index: 3
+    label: lid 4
+    sha256: 9be303f0d3b1908a407abe43e9215f58719cc7c6cdfa0d9f0b4f02b676883b38
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De behandeling van het klaagschrift vindt niet in het openbaar plaats, behoudens ingeval de beklagcommissie van oorde el is dat de niet openbare behandeling niet verenigbaar is met enige een ieder verbindende bepaling van een in Nederland geldend verdrag.
+- number: '63'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6c6c733798f1d7574fe82a9695d086cbd9a3c478c4ca644475081d0cbdd747eb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 63 1. De secretaris van de beklagcommissie zendt de directeur een afschrift van het klaagschrift toe.
+  - index: 1
+    label: lid 2
+    sha256: e1f49a3a834c5230b90646daf367091108341060c97002f4cd0e4956f9ea5388
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De directeur geeft dienaangaande zo spoedig mogelijk schriftelijk de nodige inlichtingen aan de beklagcommissie, tenz ij hij van oordeel is dat het klaagschrift kennelijk niet-ontvankelijk of kennelijk ongegrond is of tenzij het vierde li d toepassing vindt. Hij voegt daaraan de opmerkingen toe, waartoe het klaagschrift hem overigens aanleiding geeft.
+  - index: 2
+    label: lid 3
+    sha256: 430de68b67a426344de068bb0c53c4ac8e0063b668f68901c9ac20527781a592
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Aan de klager geeft de secretaris van de beklagcommissie schriftelijk kennis van de inhoud van deze inlichtingen en o pmerkingen.
+  - index: 3
+    label: lid 4
+    sha256: d122f4adda91a3d518a582ea1a3ec99dd68d2c21208c51163aeabcf0506a23cf
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De beklagcommissie kan het klaagschrift in handen stellen van het lid van de commissie van toezicht, bedoeld in artik el 7, derde lid, teneinde deze in de gelegenheid te stellen terzake te bemiddelen. De secretaris doet hiervan mededeling aan de directeur.
+- number: '64'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 11b9b52e406a5b1639131275401208c12538040ca7e146cc60de6af96855f83a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 64 1. De beklagcommissie stelt de klager en de directeur in de gelegenheid omtrent het klaagschrift mondeling op merkingen te maken, tenzij zij het beklag aanstonds kennelijk niet-ontvankelijk, kennelijk ongegrond of kennelijk gegron d acht.
+  - index: 1
+    label: lid 2
+    sha256: c21130e54da6bdf7e4710a2fe7a9f0357c9bfefadff2e16610531f79016f40c6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De klager en de directeur kunnen de voorzitter van de beklagcommissie de vragen opgeven die zij aan elkaar gesteld we nsen te zien.
+  - index: 2
+    label: lid 3
+    sha256: ee87aa8f6040ad6d5128c5014d96a1075bddac6d2115ff8d97de44d2f1e97891
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De beklagcommissie kan de directeur en de klager buiten elkaars aanwezigheid horen. In dat geval worden zij in de gel egenheid gesteld vooraf de vragen op te geven die zij gesteld wensen te zien en wordt de zakelijke inhoud van de aldus a fgelegde verklaring door de voorzitter van de beklagcommissie aan de klager onderscheidenlijk de directeur mondeling med egedeeld.
+  - index: 3
+    label: lid 4
+    sha256: 20f7997b0dea5d38ab2e4f7bddd694922a7068eafcfe98dc44a34e78b784e754
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De beklagcommissie kan ook bij andere personen mondeling of schriftelijk inlichtingen inwinnen. Indien mondeling inli chtingen worden ingewonnen, zijn het tweede en derde lid, tweede volzin, van overeenkomstige toepassing.
+- number: '65'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4e80a9e274a6dfe3741afc6f573eaa34fec6dc125b55e2a692f505390d945f68
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 65 1. De klager heeft het recht zich te doen bijstaan door een rechtsbijstandverlener of een andere vertrouwensp ersoon, die daartoe van de beklagcommissie toestemming heeft gekregen. Indien aan de klager een advocaat is toegevoegd, geschieden diens beloning en de vergoeding van de door hem gemaakte kosten volgens regelen te stellen bij algemene maatr egel van bestuur.
+  - index: 1
+    label: lid 2
+    sha256: 47cb4fa5130150d4195f18a49fb5c2632a53e95f41e110bed18b3b64897a9c1b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien de klager de Nederlandse taal niet voldoende beheerst, draagt de voorzitter zorg voor de bijstand van een tolk . De beloning van de tolk en de vergoeding van de door de tolk gemaakte kosten geschieden volgens regelen te stellen bij algemene maatregel van bestuur.
+  - index: 2
+    label: lid 3
+    sha256: df022d56dda2f53ec4d8d54be8e4d218ed23c88e76d2668489e5e214e25a9c83
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Tijdens de beklagprocedure staat de beklagcommissie aan de klager op diens verzoek toe van de gedingstukken kennis te nemen.
+  - index: 3
+    label: lid 4
+    sha256: a4a356dc50c718aa3bc8be586939cb046bdad15c7b85866d1a628548e4ced2ce
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Indien de klager elders verblijft kunnen de opmerkingen, bedoeld in artikel 64, eerste lid, op verzoek van de beklagc ommissie ten overstaan van een lid van een andere beklagcommissie worden gemaakt.
+  - index: 4
+    label: lid 5
+    sha256: c9e50f97da528583fcdbdd2dabee6cd66d9e6536b713bd1cfa1055f3de3544c2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Van het horen van de betrokkenen maakt de secretaris een schriftelijk verslag, dat door de voorzitter en de secretari s wordt ondertekend. Bij verhindering van een van hen wordt de reden daarvan in het verslag vermeld.
+- number: '66'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b6f4c574fed8b7a43e134df6e2ede0c41496210294a0be51c3a926447c60dcf9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 66 1. Hangende de uitspraak op het klaagschrift kan de voorzitter van de beroepscommissie op verzoek van de klag er, na de directeur te hebben gehoord, de tenuitvoerlegging van de beslissing waarop het klaagschrift betrekking heeft g eheel of gedeeltelijk schorsen.
+  - index: 1
+    label: lid 2
+    sha256: 6695903aaa3050fb78c430768a8fd1f1f4b10cac206a587b0f7c567899cfd10f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De voorzitter doet hiervan onverwijld mededeling aan de directeur en de klager.
+- number: '67'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 245cee6bf2d6623a3dfca2cb744abbf2a8b03326acd3392ed5d25c7a9e3a2528
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 67 1. De beklagcommissie doet zo spoedig mogelijk, doch in ieder geval binnen een termijn van vier weken te reke nen vanaf de datum waarop het klaagschrift is ontvangen, uitspraak. In bijzondere omstandigheden kan de beklagcommissie deze termijn met ten hoogste vier weken verlengen. Van deze verlenging wordt aan de directeur en de klager mededeling ge daan.
+  - index: 1
+    label: lid 2
+    sha256: 0487ba7cf7bbb03d4033c918c5901e51b6fdc8e48e4ff45c0325e45764bed3ef
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De uitspraak is met redenen omkleed en gedagtekend. Zij bevat een verslag van het horen van personen door de beklagco mmissie. Zij wordt door de voorzitter, alsmede door de secretaris ondertekend. Bij verhindering van één van hen wordt de reden daarvan in de uitspraak vermeld. Aan de klager en de directeur wordt onverwijld en kosteloos een afschrift van de beslissing van de beklagcommissie toegezonden of uitgereikt. De datum van die toezending of uitreiking wordt op dit afs chrift aangetekend.
+  - index: 2
+    label: lid 3
+    sha256: 7b8413fc9baa1f5bd94e01b266697a178180f570b97c2d6bbbd9a7daefa3f4c7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De uitspraak vermeldt de mogelijkheid van het instellen van beroep bij de beroepscommissie, de wijze waarop en de ter mijn waarbinnen dit moet worden gedaan alsmede de mogelijkheid tot schorsing van de tenuitvoerlegging van de uitspraak, bedoeld in artikel 70, tweede lid.
+  - index: 3
+    label: lid 4
+    sha256: a36cbcbd172afd4281f23769884dec9276501d061dc3a70e8b20462281340e35
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Indien de klager de Nederlandse taal niet voldoende beheerst en in de inrichting niet op andere wijze in een vertalin g kan worden voorzien, draagt de voorzitter van de beklagcommissie zorg voor een vertaling van de uitspraak en de medede ling, bedoeld in het tweede, onderscheidenlijk derde lid. De vergoeding van de voor de vertaling gemaakte kosten geschie dt volgens regelen te stellen bij algemene maatregel van bestuur.
+  - index: 4
+    label: lid 5
+    sha256: 14fee237e9d95b285a1fc134692b7883cd26c8b31d9bdc619b8a7cf830a9c5a4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De voorzitter van de beklagcommissie kan de uitspraak ook mondeling mededelen aan de klager en de directeur. Zij word en daarbij gewezen op de mogelijkheid tot het instellen van beroep bij de beroepscommissie, de wijze waarop en de termij n waarbinnen dit moet worden gedaan, alsmede op de mogelijkheid tot schorsing van de tenuitvoerlegging van de uitspraak, bedoeld in artikel 70, tweede lid. Als dag van de uitspraak geldt de dag van het doen van deze mededeling. Indien monde ling uitspraak wordt gedaan, wordt deze uitspraak op het klaagschrift aangetekend.
+  - index: 5
+    label: lid 6
+    sha256: 2e9a2f58a9fa00e5358f8cb9a036e343d8f6ce43e076be560e8ec8fcfd6ed842
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Indien het vijfde lid toepassing heeft gevonden en beroep wordt ingesteld als voorzien in artikel 69, eerste lid, vin dt uitwerking van de beslissing van de beklagcommissie plaats op de wijze, bedoeld in het tweede lid. De secretaris van de beklagcommissie zendt een afschrift van deze uitspraak toe aan de directeur, de klager en de beroepscommissie.
+  - index: 6
+    label: lid 7
+    sha256: a1afeb3b202a2e018ca8c5d28961433c85630a8443bddb1bcb4a945c4e88bbb4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. De secretaris zendt van alle uitspraken van de beklagcommissie een afschrift naar Onze Minister. Een ieder heeft rech t op kennisneming van deze uitspraken en het ontvangen van een afschrift daarvan. Onze Minister draagt zorg dat dit afsc hrift geen gegevens bevat waaruit de identiteit van de gedetineerde kan worden afgeleid. Met betrekking tot de kosten va n het ontvangen van een afschrift is het bij of krachtens de [Wet tarieven in strafzaken](jci1.3:c:BWBR0002406) bepaalde van overeenkomstige toepassing.
+- number: '68'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d20f08a01b01641e7c71c929d3be6df0f0e52851ed3dfa5814dbc7762cf02f3c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 68 1. De uitspraak van de beklagcommissie strekt tot gehele of gedeeltelijke: a. b. c.'
+  - index: 1
+    label: lid 2
+    sha256: d719890199593b620021e8e7953b45d24481be2396c247b2035ad5d474f12765
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Indien de beklagcommissie van oordeel is dat de beslissing waarover is geklaagd: a. b.'
+  - index: 2
+    label: lid 3
+    sha256: 349bb6eebeaea743a9800b9c79cca675200dd475220c8c7ed191c43b24c91888
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Bij toepassing van het tweede lid kan de beklagcommissie: a. b. c.'
+  - index: 3
+    label: lid 4
+    sha256: f6342fa884810c82a53f274d1c2319664f21c9021c7af9c68634d96a4201149f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij toepassing van het derde lid, onder a, kan de beklagcommissie in haar uitspraak een termijn stellen.
+  - index: 4
+    label: lid 5
+    sha256: 30b9060fe582b81428daf58bd6dff45316c0cbe3c8cd73aab08ed9ba95b22e7f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De beklagcommissie kan bepalen dat de uitspraak buiten werking blijft totdat deze onherroepelijk is geworden.
+  - index: 5
+    label: lid 6
+    sha256: eba5cecd9fd6949fd187a67d5479f3379c0aff1eaeb4aafc8dc959b124acded5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Indien het tweede lid toepassing vindt, worden de rechtsgevolgen van de vernietigde beslissing, voor zover mogelijk, door de directeur ongedaan gemaakt, dan wel in overeenstemming gebracht met de uitspraak van de beklagcommissie.
+  - index: 6
+    label: lid 7
+    sha256: 94c2bb97f1c45b585a9cd9761a48450f0849c6f9dbef473d67764e07a9a527c6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. Voor zover de in het zesde lid bedoelde gevolgen niet meer ongedaan te maken zijn, bepaalt de beklagcommissie dan wel de voorzitter, na de directeur te hebben gehoord, of enige tegemoetkoming aan de klager geboden is. Zij stelt de tegemo etkoming, die geldelijk van aard kan zijn, vast.
+- number: '69'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: e80e18ff1d3b7c8f2553d18fe806accd9d5a1a3e75dbcff0a3afe645f9271848
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 69 1. Tegen de uitspraak van de beklagcommissie kunnen de directeur en de klager beroep instellen door het indie nen van een beroepschrift. Het met redenen omklede beroepschrift moet uiterlijk op de zevende dag na die van de ontvangs t van het afschrift van de uitspraak onderscheidenlijk na die van de mondelinge mededeling van de uitspraak worden inged iend.
+  - index: 1
+    label: lid 2
+    sha256: 365d77e0f600253cc3921e2a53edf76cd9e6397c3ac4294df5f6be607b66735e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het beroepschrift wordt ingediend bij en behandeld door een door de Raad benoemde beroepscommissie van drie leden, di e wordt bijgestaan door een secretaris.
+  - index: 2
+    label: lid 3
+    sha256: ad39ef9e38ecf3bc26c144244fff4f20ca453dcd441912bed94b62baacf35004
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Ten aanzien van de behandeling van het beroepschrift zijn de artikelen 60, derde lid, 61, vierde lid, 62, vierde lid, 63, eerste, tweede en derde lid, 64, en 65, eerste, tweede en derde lid, van overeenkomstige toepassing, met dien verst ande dat de beroepscommissie kan bepalen dat: a. b. c.'
+- number: '70'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ee12e7b0d284f17c06ee808d1f504d2106903ea82ba8c4e8fd8c24bcf33f355f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 70 1. Het indienen van een beroepschrift schorst de tenuitvoerlegging van de uitspraak van de beklagcommissie ni et, behalve voor zover deze de toekenning van een tegemoetkoming als bedoeld in artikel 68, zevende lid, inhoudt.
+  - index: 1
+    label: lid 2
+    sha256: ea8d97bbb1a9d202f1b2159e1db8f9da6331494779a8f297f3ba34e52b746dfa
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Hangende de uitspraak op het beroepschrift kan de voorzitter van de beroepscommissie op verzoek van degene die het be roep heeft ingesteld en gehoord de andere betrokkene in de procedure de tenuitvoerlegging van de uitspraak van de beklag commissie geheel of gedeeltelijk schorsen. Hij doet hiervan onverwijld mededeling aan de directeur en de klager.
+- number: '71'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 5f533e71965a7381d5303884a5ea16d61316011b52fcf4e01719201b86970b32
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 71 1. De beroepscommissie doet zo spoedig mogelijk uitspraak.
+  - index: 1
+    label: lid 2
+    sha256: 8ad5a03759e9c6dd6d2c1c9db05db902cdb74ec9ee9dd4e111d83a2275c3379a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. De uitspraak van de beroepscommissie strekt tot gehele of gedeeltelijke: a. b. c.'
+  - index: 2
+    label: lid 3
+    sha256: c0b665c6d9fd71cb24170f9824d5a23f9510333d6b992390f95df8af33d12a48
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien het tweede lid, onder c, toepassing vindt, doet de beroepscommissie hetgeen de beklagcommissie had behoren te doen.
+  - index: 3
+    label: lid 4
+    sha256: 345c5dd1c57c522ef67c4ea6e06d861aa95e5f6239762980dc526f0ad8c0545f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Ten aanzien van de uitspraak van de beroepscommissie zijn de artikelen 66 en 67, tweede lid, eerste en derde tot en m et vijfde volzin, vierde en zevende lid, van overeenkomstige toepassing.
+- number: '72'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4d0a5a5f329a01f9aedb911437c39269729de957bc687d43a11742a5b513bf4e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 72 1. De betrokkene heeft het recht tegen de beslissing van de selectiefunctionaris op het bezwaar- of verzoeksc hrift voor zover dit betreft een gehele of gedeeltelijke ongegrondverklaring, onderscheidenlijk afwijzing als bedoeld in de artikelen 17 en 18 een met redenen omkleed beroepschrift in te dienen bij de commissie, bedoeld in artikel 73, eerst e lid. De betrokkene heeft ook het recht een beroepschrift in te dienen in het geval dat het indienen van een bezwaarsch rift op de grond als vermeld in artikel 17, vijfde lid, achterwege is gebleven.
+  - index: 1
+    label: lid 2
+    sha256: 69ccc66bb56543452eaafd0a8d6b8a2db4197fd3fe3294a80626bc73b9cc0747
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De gedetineerde heeft het recht tegen een hem betreffende beslissing aangaande verlof, voor zover hiertegen geen bekl ag ingevolge artikel 60, eerste en tweede lid, openstaat, een met redenen omkleed beroepschrift in te dienen bij de comm issie, bedoeld in artikel 73, eerste lid.
+- number: '73'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 88c619966354f662069248eb7be6f1e15e124b51ee7fe144a03d0597e1aff4dd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 73 1. Het beroepschrift wordt behandeld door een door de Raad benoemde commissie van drie leden, die wordt bijge staan door een secretaris.
+  - index: 1
+    label: lid 2
+    sha256: 6aebb52d151f0c28351455ab89de207af8639705f863cd331906db51f8de2da6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het beroepschrift wordt ingediend uiterlijk op de zevende dag na die waarop de betrokkene kennis heeft gekregen van d e beslissing waartegen hij beroep instelt. Een na afloop van deze termijn ingediend beroepschrift is niettemin ontvankel ijk, indien redelijkerwijs niet kan worden geoordeeld dat de gedetineerde in verzuim is geweest.
+  - index: 2
+    label: lid 3
+    sha256: c1fac6acb530934516736be9f42654c61f3e106eb6b92edde1a38d856c098334
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien de betrokkene gedetineerd is, kan de indiening van het beroepschrift geschieden door tussenkomst van de direct eur van de inrichting of afdeling waar hij verblijft. De directeur draagt zorg dat het beroepschrift onverwijld van een dagtekening wordt voorzien. Als dag waarop het beroepschrift is ingediend geldt die van de dagtekening.
+  - index: 3
+    label: lid 4
+    sha256: e783353426a6bec8fc34fb39c3f3014a9410f34d4dba4058b3e7d7bb4946c71d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. De artikelen 60, derde lid, 61, vierde lid, 63, 64, 65, 66, 67, tweede lid, eerste en derde tot en met vijfde volzin, vierde en zevende lid, met uitzondering van de eerste volzin, 68, eerste, tweede, derde, vierde, zesde en zevende lid, zijn van overeenkomstige toepassing, met dien verstande dat de commissie, bedoeld in het eerste lid, kan bepalen dat: a. b. c.'
+- number: '74'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d5abca13bc12547c1dc15af1060453ef7c3ba7f1834be39be9be38ef0a9dcc8a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 74 De directeur draagt zorg voor een regelmatig overleg met gedetineerden over zaken die rechtstreeks de detenti e raken.
+- number: '75'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b91f85e432be2515446387a65dc44074b3aef47f28a8f7fbbb4ea8d41ff2bc34
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 75 1. De in de artikelen 17 en 18, alsmede in de hoofdstukken XI tot en met XIII aan de gedetineerde toegekende rechten kunnen, behoudens ingeval de selectiefunctionaris of beklag- of beroepscommissie van oordeel is dat zwaarwegende belangen van de gedetineerde zich daartegen verzetten, mede worden uitgeoefend door: a. b. c.'
+  - index: 1
+    label: lid 2
+    sha256: 38aafd54b1f9e49c4a2c923e24ee4530ff63436beabfa06e61444d3698960704
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De directeur draagt zorg dat de in het eerste lid genoemde personen op deze rechten opmerkzaam worden gemaakt.
+- number: '76'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a27f9c787108435cdea6f8c00d2caff838dc0f80ea2a9755e1c2957baa67fa08
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 76 1. De plaatsing van een tot vrijheidsstraf veroordeelde in een justitiële inrichting voor verpleging van ter beschikking gestelden geschiedt voordat zes maanden sedert de beslissing, bedoeld in [artikel 13, eerste lid, van het We tboek van Strafrecht](jci1.3:c:BWBR0001854&artikel=13) is genomen, in een gevangenis of huis van bewaring zijn doorgebra cht.
+  - index: 1
+    label: lid 2
+    sha256: 87fafae887a858f7f39300bb11145fbfcd20df0674bc4f77cfbf5a8b47315d00
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien Onze Minister, rekening houdende met de in [artikel 11, tweede lid, van de Beginselenwet verpleging ter beschi kking gestelden](jci1.3:c:BWBR0008765&artikel=11) genoemde eisen, van oordeel is dat de plaatsing niet binnen de in het eerste lid gestelde termijn mogelijk is, kan hij deze termijn telkens met drie maanden verlengen.
+  - index: 2
+    label: lid 3
+    sha256: cdd1263801045f5200c7d58370ada2b12638cd2df4b17d2ed6de393f4aa87a42
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Tegen de beslissing tot verlenging, bedoeld in het tweede lid, kan de tot vrijheidsstraf veroordeelde beroep instelle n bij de Raad. Het bepaalde in [Hoofdstuk XVI van de Beginselenwet verpleging ter beschikking gestelden](jci1.3:c:BWBR00 08765&hoofdstuk=XVI) is van overeenkomstige toepassing.
+- number: '77'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 17a09c33aedca7a488292df021b6116388138d01bb6d8724c43b2547501e6f60
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 77 1. Een onveroordeelde die met toepassing van [artikel 196](jci1.3:c:BWBR0001903&artikel=196), [317](jci1.3:c: BWBR0001903&artikel=317) of [509g van het Wetboek van Strafvordering](jci1.3:c:BWBR0001903&artikel=509g) in een inrichti ng tot klinische observatie bestemd is opgenomen, wordt voor wat betreft zijn rechtspositie gelijkgesteld met een onvero ordeelde die in een huis van bewaring verblijft, indien de inrichting tot klinische observatie bestemd tevens een huis v an bewaring is.'
+  - index: 1
+    label: lid 2
+    sha256: fc78d36c0dc9aa846d71bd1059c1a481ea5c6bf3e873ffb4e72cabecbefc54ee
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Een ter beschikking gestelde die met toepassing van [artikel 509g](jci1.3:c:BWBR0001903&artikel=509g) of [509o, vijfd e lid, van het Wetboek van Strafvordering](jci1.3:c:BWBR0001903&artikel=509o) in een inrichting tot klinische observatie bestemd is opgenomen, wordt voor wat betreft zijn rechtspositie gelijkgesteld met een ter beschikking gestelde die in e en huis van bewaring verblijft, indien de inrichting tot klinische observatie bestemd tevens huis van bewaring is.
+- number: '78'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: fa59e5669ef404fc50f987caf6071ef813accba41ea0aee5c57038d44ec92e00
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 78 Voor zover de regels van de krijgsmacht daartoe aanleiding geven kan bij militaire gedetineerden van de bepal ingen in deze wet worden afgeweken.
+- number: '79'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 15eb4e65b7056395260436e933f08400bea8067814d07295646b5a6df39d4f53
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 79 Wijzigt het Wetboek van Strafrecht.
+- number: '80'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ba3099e5499b69514a81d198a1aa391ce155b3e4c5a5a0427883f35f6a29ddfb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 80 Wijzigt het Wetboek van Strafvordering.
+- number: '81'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 04c6b5e437b3ec7832bc77808f1d9b9eb117d45803cf6a6f6781401bdbc483eb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 81 Wijzigt de Wet op de rechterlijke organisatie.
+- number: '82'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2062d1017947c80e7e02d4b2d3099449a94bb1b1cfbe2faa44bd687080ad8fda
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 82 Wijzigt de Wet op de economische delicten.
+- number: '83'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 1e2d6042643cbd1d3f40a1da6fff69d7d9ca9fc60721315c04bdff80b65ddc81
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 83 Wijzigt de Wet bijzondere opnemingen in psychiatrische ziekenhuizen.
+- number: '84'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 9d17603b4977baccdfa11c299a050e65df5f6c7f2d3537131ad3f580c88be290
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 84 Wijzigt de Invoeringswet Wetboek van Strafvordering.
+- number: '85'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b3a8c8647967919d9e9d3f83d12b8ebdcc95dbb859aa8dcd9faf52707785b88c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 85 Wijzigt de Wet op de rechtsbijstand.
+- number: '86'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2296aa54a293c3087609b939f5103c73e805e3c57e913fad57a72457564a6ae4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 86 Wijzigt de Arbeidsomstandighedenwet.
+- number: '87'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a5859f4b5d16f8251b8e4ebc773eeabf58b875112371088ced0ba05b85316517
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 87 Wijzigt de Wet ziekenhuisvoorzieningen.
+- number: '88'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 7a911ee6d1337ba037864c1812e30d4b62800e67e211977c9bb75232b1906b23
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 88 Wijzigt de Wet op het voortgezet onderwijs.
+- number: '89'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6b6d67539a81c6431251af085d0eef66d32b36cd3ee9a98d5b79550b0f14154d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 89 Wijzigt de Oorlogswet voor Nederland.
+- number: '90'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 7792766fa73d2320826014a936a1f12d9609c20281d0a6716540064167a97564
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 90 Wijzigt de Beginselenwet verpleging ter beschikking gestelden.
+- number: '91'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a0a4be8aa00bba4eff007b7d83ecd61a6aa32e8e268a9aa5e67c7ff4d1f8f2fd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 91 De Beginselenwet gevangeniswezen wordt ingetrokken, met uitzondering van de artikelen 2 tot en met 5.
+- number: '92'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 5e3b72466991ba8e9c5b9e81f7f0e210d268e44b4bc3859664c45cb34bb349b2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 92 De regels en de bestemmingen van gevangenissen en huizen van bewaring vastgesteld krachtens [artikel 22 van h et Wetboek van Strafrecht](jci1.3:c:BWBR0001854&artikel=22), zoals dit artikel gold vóór de inwerkingtreding van deze we t, worden geacht te zijn vastgesteld krachtens de toepasselijke bepalingen van deze wet.
+- number: '93'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b6f6a5de38e3bd30c07f720ab30506132ec1553e9e3f9528168a964edf8504f3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 93 Deze wet heeft geen gevolgen voor klaagschriften of beroepschriften die zijn ingediend voor de inwerkingtredi ng van deze wet.
+- number: '94'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 991eefbdedf934127606da879a35cfd4a798312f2508493e42ef1cc5c1097477
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 94 Deze wet treedt in werking op een bij koninklijk besluit te bepalen tijdstip. Bij koninklijk besluit kan een ander tijdstip worden vastgesteld waarop artikel 76 in werking treedt.
+- number: '95'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 28d2eb1d9de5296e1612fde09a333508b4573798f79616586dbc65e03cc712c0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 95 Deze wet wordt aangehaald als: Penitentiaire beginselenwet.'

--- a/textguard/nl/wet/test_untranslatables/2025-01-01.yaml
+++ b/textguard/nl/wet/test_untranslatables/2025-01-01.yaml
@@ -1,0 +1,36 @@
+$id: test_untranslatables
+valid_from: '2025-01-01'
+source: corpus/regulation/nl/wet/test_untranslatables/2025-01-01.yaml
+articles:
+- number: '1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 0b1b314e49b5af3e607b02b5e58d4557e4d208179da8e629200e98a31aa2a229
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: De basistoeslag bedraagt 1000 eurocent.
+- number: '2'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 47a1bccf1cbec52d4eb10fbac6bb50e7685fea6c91a4cac6e4cfbfdc8624204a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Het bedrag wordt naar boven afgerond op hele euro's.
+- number: '3'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6ee656c66dcd61d93811c42e653cdf8901cd4c488075389e2701a73556cf358c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: De toegekende toeslag bedraagt tweemaal de basistoeslag.
+- number: '4'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: eb5b38fd78ccfe30acb6d834317e389d836c0379826f51e0b9e4d4ca84cfdbde
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: De som van alle deeltoeslagen wordt berekend. Dit artikel is geaccepteerd als onvertaalbaar.

--- a/textguard/nl/wet/vreemdelingenwet_2000/2000-11-23.yaml
+++ b/textguard/nl/wet/vreemdelingenwet_2000/2000-11-23.yaml
@@ -1,0 +1,28 @@
+$id: vreemdelingenwet_2000
+valid_from: '2000-11-23'
+source: corpus/regulation/nl/wet/vreemdelingenwet_2000/2000-11-23.yaml
+articles:
+- number: '14'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 97ae2e46bdbdd8ad7229079c9c6b7749e56e5d6bb628435b2de84a5b9e88d434
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. Onze Minister is bevoegd: a. de aanvraag tot het verlenen van een verblijfsvergunning voor bepaalde tijd in te willigen, af te wijzen dan wel niet in behandeling te nemen.'
+- number: '16'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 8f4fd7fa1084a2290b1a460da0277d2487ebe4ac94654e98ea8b52faa6374522
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. Een aanvraag tot het verlenen van een verblijfsvergunning voor bepaalde tijd als bedoeld in artikel 14 kan worden afgewezen indien: a. de vreemdeling niet beschikt over een geldige machtiging tot voorlopig verblijf die overeenkomt met het verblijfsdoel; b. de vreemdeling niet beschikt over een geldig document voor grensoverschrijding.'
+- number: '69'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 1e76973696129c8f36a5916e99ac8d60e7a0b08712e379822823867c3881156b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. In afwijking van artikel 6:7 van de Algemene wet bestuursrecht bedraagt de termijn voor het indienen van een bezwaar- of beroepschrift vier weken.

--- a/textguard/nl/wet/wet_basisregistratie_personen/2025-02-12.yaml
+++ b/textguard/nl/wet/wet_basisregistratie_personen/2025-02-12.yaml
@@ -1,0 +1,3160 @@
+$id: wet_basisregistratie_personen
+valid_from: null
+source: corpus/regulation/nl/wet/wet_basisregistratie_personen/2025-02-12.yaml
+articles:
+- number: '1.1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 25f4ecb29fea5ffd67f7be4721a12e39a10658e8b5b2a27c46a888e725303bba
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 1.1 In deze wet en de daarop berustende bepalingen wordt verstaan onder:'
+  - index: 1
+    label: onderdeel a
+    sha256: 3841e14fb62835264d744bb4bad80dfa5a55b1a7b5354696183393385da7dc29
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. *Onze Minister:* Onze Minister van Binnenlandse Zaken en Koninkrijksrelaties;
+  - index: 2
+    label: onderdeel b
+    sha256: 25c35e135fb0459eacb7ecf2ed00579c68122e079b9527de36246f1ff5861380
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. *de basisregistratie:* de basisregistratie personen, bedoeld in artikel 1.2 ;
+  - index: 3
+    label: onderdeel c
+    sha256: 6a51ea3838ff8326fd19fcd258df2af84e634447f414bece168b80e18408292a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. *de persoonslijst:* het geheel van gegevens, bedoeld in artikel 2.7, eerste lid , en 2.69, eerste lid , over één persoon in de basisregistratie;
+  - index: 4
+    label: onderdeel d
+    sha256: a93f01eab739dae971e84c90da9cbd39b298f22db1e5fd4b9c7587cfc9add4ac
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. *de inschrijving:* de opneming van een persoonslijst in de basisregistratie;
+  - index: 5
+    label: onderdeel e
+    sha256: 9afec959e2c5b9c75b76e480cf9dce9825a1e2a02e03c8155c69a7ad762c3c74
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: e. *de ingeschrevene:* degene ten aanzien van wie een persoonslijst in de basisregistratie is opgenomen;
+  - index: 6
+    label: onderdeel f
+    sha256: ca916c25774e9218ca0eebd2c71bd925f0325a3ef1eeb0c5cedd9f4f309469ca
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: f. *de ingezetene:* de ingeschrevene, die zijn adres heeft in een gemeente in Nederland, en op wiens persoonslijst niet het gegeven van zijn overlijden of van vertrek uit Nederland als actueel gegeven is opgenomen;
+  - index: 7
+    label: onderdeel g
+    sha256: ff9c13a3ab4b35d6b3141fe9e77dbcca13da1069b683d793547887be60e3c880
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: g. *de systematische verstrekking van gegevens of het systematisch verstrekken van gegevens:* de verstrekking of het verstrekken van gegevens uit de basisregistratie, bedoeld in artikel 3.1, tweede lid ;
+  - index: 8
+    label: onderdeel h
+    sha256: 85345b6d758b6507fb975081bf55063aa0304ef9a604a0c3e029c5c3344fa54e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: h. *de bijhoudingsgemeente:* de gemeente waarvan het college van burgemeester en wethouders op grond van artikel 1.4 verantwoordelijk is voor de bijhouding van de persoonslijst;
+  - index: 9
+    label: onderdeel i
+    sha256: 1aa9e6a5398658dcc554f6a40cca84ecfc717462f710f9944ae87f2fb87c4b1b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: i. *een vreemdeling:* degene die de Nederlandse nationaliteit niet bezit en niet op grond van een wettelijke bepaling als Nederlander wordt behandeld;
+  - index: 10
+    label: onderdeel j
+    sha256: c535fcb1a126b8bdcc56a4f1eed582f17075dbb3bd0802e4aacdee7876597efc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: j. *de aangifte van verblijf en adres:* de aangifte, bedoeld in artikel 2.38 ;
+  - index: 11
+    label: onderdeel k
+    sha256: 3d4fb87bac62289bbaca4792ccf89ac8348a15a86e0e7e11e4decd77550ed31f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: k. *een beëdigde vertaler:* een vertaler als bedoeld in [artikel 1, onder d, van de Wet beëdigde tolken en vertalers](jci1.3:c:BWBR0022704&artikel=1) ;
+  - index: 12
+    label: onderdeel l
+    sha256: b222565a63f628a5c2b6f25b9e186c44456457536fd80066877171599d6fd4a0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: l. *de aangifte van adreswijziging:* de aangifte, bedoeld in artikel 2.39 ;
+  - index: 13
+    label: onderdeel m
+    sha256: 6187546ca86b4fe244eaa66eb8de7adb253e4676c007ce06fa0027fe303148ba
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: m. *de aangifte van vertrek:* de aangifte, bedoeld in artikel 2.43 ;
+  - index: 14
+    label: onderdeel n
+    sha256: 719c365b0e5d05ca99f874069e62ce5e3134c89e717931b3210e57394b8ffb48
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: n. *een authentiek gegeven:* een in de basisregistratie opgenomen gegeven dat op grond van artikel 1.6 als authentiek wordt aangemerkt;
+  - index: 15
+    label: onderdeel o
+    sha256: 88173c3f858cab464801d4e6d125e3b19603a2acb393f24b98c1f13a73c6edbb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: o. *het woonadres:* - - 1° het adres waar betrokkene woont, waaronder begrepen het adres van een woning die zich in een voertuig of vaartuig bevindt, indien het voertuig of vaartuig een vaste stand- of ligplaats heeft, of, indien betrokkene op meer dan één adres woont, het adres waar hij naar redelijke verwachting gedurende een half jaar de meeste malen zal overnachten; - 2° het adres waar, bij het ontbreken van een adres als bedoeld onder 1, betrokkene naar redelijke verwachting gedurende drie maanden ten minste twee derde van de tijd zal overnachten; - 1° het adres waar betrokkene woont, waaronder begrepen het adres van een woning die zich in een voertuig of vaartuig bevindt, indien het voertuig of vaartuig een vaste stand- of ligplaats heeft, of, indien betrokkene op meer dan één adres woont, het adres waar hij naar redelijke verwachting gedurende een half jaar de meeste malen zal overnachten; - 2° het adres waar, bij het ontbreken van een adres als bedoeld onder 1, betrokkene naar redelijke verwachting gedurende drie maanden ten minste twee derde van de tijd zal overnachten;
+  - index: 16
+    label: onderdeel p
+    sha256: 629eb88f623dcbc40d51902a51bc06da464738b2f6fed8cd0dbac6e5f800784a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: p. *het briefadres:* het adres waar voor betrokkene bestemde geschriften in ontvangst worden genomen;
+  - index: 17
+    label: onderdeel q
+    sha256: 931221aff3f5bf778c261e2c03435b94e030c6e1b1206c791d477f2e86353117
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: q. *het adres:* het woonadres, dan wel bij het ontbreken hiervan of bij toepassing van artikel 2.40 of 2.41 , het briefadres;
+  - index: 18
+    label: onderdeel r
+    sha256: 7d9c4ec14e70b5668733dc88e0fa1f2fff6f8cb00ef27f265314b11029aa0b05
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: r. *de briefadresgever:* de natuurlijke persoon of rechtspersoon, bedoeld in artikel 2.42 , die een briefadres ter beschikking stelt;
+  - index: 19
+    label: onderdeel s
+    sha256: 04e85a836170d8d9bd586d38e2c4749602fe57dfadefac17a0548a120c7b2df6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: s. *het burgerservicenummer:* het nummer, bedoeld in [artikel 1, onder b, van de Wet algemene bepalingen burgerservicenummer](jci1.3:c:BWBR0022428&artikel=1) ;
+  - index: 20
+    label: onderdeel t
+    sha256: a461eaf767ff48a888fc6266bdc929b6d92bb00313c5b52a06cebb6399400f4b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: t. *een overheidsorgaan:* - - 1° een orgaan van een rechtspersoon die krachtens publiekrecht is ingesteld, of - 2° een ander persoon of college, met enig openbaar gezag bekleed; - 1° een orgaan van een rechtspersoon die krachtens publiekrecht is ingesteld, of - 2° een ander persoon of college, met enig openbaar gezag bekleed;
+  - index: 21
+    label: onderdeel u
+    sha256: 120f3ad1151b28851efe28c02c867cc1b47b86bf15c54c967f40c4c3fcf83622
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: u. *een derde:* elke natuurlijke persoon niet zijnde een overheidsorgaan of een ingeschrevene en elke rechtspersoon die niet krachtens publiekrecht is ingesteld, noch met enig openbaar gezag is bekleed;
+  - index: 22
+    label: onderdeel v
+    sha256: a2b1cd4264e32ef269d57414a1e17e68ddabc11491929c041009c7b90d3a097e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: v. *openbare lichamen:* de openbare lichamen Bonaire, Sint Eustatius en Saba;
+  - index: 23
+    label: onderdeel w
+    sha256: dfedb09ddad21d13793cbe9bcc8f266d515aa1f5ec95e6deaae0667017dfef3e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: w. *een inschrijfvoorziening:* een voorziening als bedoeld in artikel 2.64 ;
+  - index: 24
+    label: onderdeel x
+    sha256: 8677fb7861a007f972cfa5ef63bb229e11dc1ef5f32d87e6e6fae6e32b23d46d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: x. *het Besluit bevolkingsboekhouding:* het Besluit bevolkingsboekhouding zoals dat gold op de laatste dag voor de intrekking van de Wet bevolkings- en verblijfsregisters.
+- number: '1.2'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4961f6f73ab0b5982ec341e71e4ac012efa59e070a05c9f50c16d7697f82d4de
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 1.2 Er is een basisregistratie personen. De basisregistratie bevat persoonsgegevens over de ingezetenen van Nederland. De basisregistratie bevat persoonsgegevens over niet-ingezetenen voor zover deze wet daarin voorziet.
+- number: '1.3'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: bde6fda4ed47e52156e69214c044907b7081549c476f46196aa8647cf0b10e9e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 1.3 1 De basisregistratie heeft tot doel overheidsorganen te voorzien van de in de registratie opgenomen gegevens, voor zover deze gegevens noodzakelijk zijn voor de vervulling van hun taak.
+  - index: 1
+    label: lid 2
+    sha256: 94b1501870570468d186087435dd28af676607a27ec7a520a540b0ea5a070fc6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De basisregistratie heeft mede tot doel derden te voorzien van de in de registratie opgenomen gegevens, in bij of krachtens deze wet aangewezen gevallen.
+- number: '1.4'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 7397286dd78cb6c25fe5173b5a9bd74246d91be5f956de62935a8354680bc652
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 1.4 1 Het college van burgemeester en wethouders is verantwoordelijk voor het bijhouden van persoonsgegevens in de basisregistratie overeenkomstig afdeling 1 van hoofdstuk 2 .
+  - index: 1
+    label: lid 2
+    sha256: af22a05adfd09bfb7c9e515a0c44d01c27c3bff0e17cad1913c006325000a214
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister is verantwoordelijk voor het bijhouden van persoonsgegevens in de basisregistratie overeenkomstig afdeling 2 van hoofdstuk 2 .
+- number: '1.5'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b6fc476f208efbbc4cec159fa56fdd424168966137e7bcf3312cbcf263201147
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 1.5 1 Onze Minister is verantwoordelijk voor de verstrekking van gegevens uit de basisregistratie die hij doet bij of krachtens hoofdstuk 3 .
+  - index: 1
+    label: lid 2
+    sha256: 9f6fd9a3658c48924e64ce87add33d7e8071acce8d5688c04ae1dbde2760cb69
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het college van burgemeester en wethouders is verantwoordelijk voor de verstrekking van gegevens uit de basisregistratie die hij doet bij of krachtens hoofdstuk 3 .
+- number: '1.6'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 38645b590ee2b5dadba6deb62ba5460fea935ee0d68ae969ae768d9437deb0f6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 1.6 Bij algemene maatregel van bestuur wordt bepaald welke van de algemene gegevens, bedoeld in de artikelen 2.7 en 2.69 , worden aangemerkt als authentieke gegevens.
+- number: '1.7'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 679aaa18012a6dfde160567e5c05884f0984d86e8802f3255c7863a87a0599e0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 1.7 1 Het bestuursorgaan dat bij de vervulling van zijn taak informatie over een ingeschrevene nodig heeft die in de vorm van een authentiek gegeven beschikbaar is in de basisregistratie, gebruikt voor die informatie dat gegeven.
+  - index: 1
+    label: lid 2
+    sha256: 047250b2101ff9a2a11f588f0766311ac02088170bff0d4080b443ad50d7735f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Het eerste lid is niet van toepassing indien:'
+  - index: 2
+    label: onderdeel a
+    sha256: 4b9d67834e2b764c80d8d8f1f1e8486a0c04de11a2d9fa896efa196844fbecd0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. bij het gegeven een aantekening als bedoeld in artikel 2.26 of 2.76 is geplaatst;
+  - index: 3
+    label: onderdeel b
+    sha256: d658da7b391ac9e5562ad90f30926c5ecb639a044e0f04c446e120e828e23b99
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. het bestuursorgaan ten aanzien van het gegeven een mededeling als bedoeld in artikel 2.34, eerste lid , doet;
+  - index: 4
+    label: onderdeel c
+    sha256: 8e1e0c90f5a698997869cdff7825622c17eb3c6cfb10553a8a71dd013ee655b8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. bij wettelijk voorschrift anders is bepaald;
+  - index: 5
+    label: onderdeel d
+    sha256: 82b6947a458b081ceb2d37c932d374ab940e16a55ad5fbd3aac44f6aca6c9f4d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. een goede vervulling van de taak van het bestuursorgaan door de onverkorte toepassing van het eerste lid wordt belet.
+- number: '1.8'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ee86339039e602435993fc30f607d9a0d5599d2d8d9bd6a2b1aa697093406a63
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 1.8 Een ingeschrevene aan wie door een bestuursorgaan een gegeven wordt gevraagd, waarop artikel 1.7, eerste lid , van toepassing is, behoeft dat gegeven niet mede te delen, behoudens voor zover het gegeven naar het oordeel van het bestuursorgaan noodzakelijk is voor een deugdelijke vaststelling van de identiteit van betrokkene.
+- number: '1.9'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: fe5b89e9a1736878d61f50be943840f94255e5d94da5b48d0d90e30dff7d7256
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 1.9 1 De basisregistratie bestaat uit gemeentelijke en centrale voorzieningen.
+  - index: 1
+    label: lid 2
+    sha256: 68d247132355305107279acc440525ee16657776d3c36b546a8e04f58d1e98c0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het college van burgemeester en wethouders is verantwoordelijk voor de gemeentelijke voorziening.
+  - index: 2
+    label: lid 3
+    sha256: fd9351aa87985947df5e644eed45a63dfd534832e292d1501699121b4002b063
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Onze Minister is verantwoordelijk voor de centrale voorzieningen.
+  - index: 3
+    label: lid 4
+    sha256: 64c980cabe1bfabf686b20390c47881816536a22aaf363cbae096738725e722b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Onze Minister draagt zorg voor een stelsel van berichtuitwisseling ten behoeve van de bijhouding en de raadpleging van de basisregistratie en de systematische verstrekking van gegevens.
+- number: '1.10'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 3844864a9360284288cd602de4f465140ff27e16f3254d0b27c13387d869926c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 1.10 1 Bij of krachtens algemene maatregel van bestuur worden regels gesteld omtrent:'
+  - index: 1
+    label: onderdeel a
+    sha256: 04dcf7b37c4ccf5a59bb1a61395a4af833adef98fcf7a3456dbdfa2ac7f8fc01
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de technische en administratieve inrichting en werking en de beveiliging van de basisregistratie;
+  - index: 2
+    label: onderdeel b
+    sha256: ce42468694372d258d4ca97d853e3d32e1c5515ee7c2697aae1b08db437154cb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de uitwisseling van berichten tussen de centrale voorzieningen en de gemeentelijke voorzieningen en tussen de centrale voorzieningen en de overheidsorganen waaraan en derden aan wie systematisch gegevens worden verstrekt.
+  - index: 3
+    label: lid 2
+    sha256: d0ba8fa0bd3c4640469fe7041758495389e0b753687037ec2d1be99297d3349f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De in het eerste lid bedoelde regels omvatten mede eisen omtrent de deugdelijke uitvoering van werkzaamheden, de beveiliging van gegevens en de bescherming van de persoonlijke levenssfeer, die een bewerker in acht moet nemen als hij in opdracht van het college van burgemeester en wethouders technische of administratieve werkzaamheden verricht.
+- number: '1.11'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: e94887e2c135fe50aab17b5c321a7db1537f46c257fe21f42b8522b50301cc26
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 1.11 1 Het college van burgemeester en wethouders draagt zorg dat de gemeentelijke voorziening functioneert overeenkomstig de regels, bedoeld in artikel 1.10 .
+  - index: 1
+    label: lid 2
+    sha256: 669320cdc4686e636f1201b7635c543a5b5816ace3d8c64106a255ed6c31846a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister draagt zorg dat de centrale voorzieningen functioneren overeenkomstig de regels, bedoeld in artikel 1.10 .
+  - index: 2
+    label: lid 3
+    sha256: baad618d7e8089fac217efc73a437cbbc1610b8d5363b3c3dee156741d5e3339
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het overheidsorgaan waaraan of de derde aan wie systematisch gegevens worden verstrekt draagt zorg dat de uitwisseling van berichten in verband met de systematische verstrekking van gegevens van zijn kant geschiedt overeenkomstig de regels, bedoeld in artikel 1.10 .
+- number: '1.12'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a59446502f8acfcee46702724b024447a793061e81c034d713ff74b7401bbbea
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 1.12 1 Onze Minister kan een onderzoek verrichten om vast te stellen of een overheidsorgaan waaraan systematisch gegevens worden verstrekt, voldoet aan de regels, bedoeld in artikel 1.10 .
+  - index: 1
+    label: lid 2
+    sha256: 7e04d24a8ee0df00694db500bc68349e17a243b32b049deeb2f74234fcd9fb5c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het eerste lid is niet van toepassing op organen van gemeenten, provincies of gemeenschappelijke regelingen waaraan zij deelnemen.
+  - index: 2
+    label: lid 3
+    sha256: f4fd2dceabd4f5263209c0e744fa3479facf345633eb939ae3c3c8d129a5d2f1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij regeling van Onze Minister kan worden bepaald op welke wijze het overheidsorgaan medewerking verleent aan het onderzoek.
+  - index: 3
+    label: lid 4
+    sha256: fd58ea2d41b5f8b0877b6498b661d595a5df942d70c0f0343263c533c239749e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het eerste en derde lid zijn van overeenkomstige toepassing op een derde aan wie systematisch gegevens worden verstrekt.
+- number: '1.13'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 7914b08e758c4b9ff7918387e6a98288c845031c7ef240cca4a524c2ccf42e83
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 1.13 De [artikelen 49](jci1.3:c:BWBR0011468&artikel=49) en [50 van de Wet bescherming persoonsgegevens](jci1.3:c:BWBR0011468&artikel=50) zijn van overeenkomstige toepassing.
+- number: '1.14'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: da10979dfcc4c9d6e059779981a6db2f023cf693cd17b0dc343c87aeaf417520
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 1.14 1 De gemeenten en de overheidsorganen waaraan en derden aan wie op grond van artikel 3.2 , 3.3 , 3.13 of 3.14 gegevens worden verstrekt of informatie ter beschikking wordt gesteld, dragen bij in de kosten in verband met de uitvoering van deze wet. Indien een van deze betrokkenen geen rechtspersoonlijkheid bezit, komt de bijdrage ten laste van de rechtspersoon waartoe de betrokkene behoort.
+  - index: 1
+    label: lid 2
+    sha256: ae35aa8a856f0e89b277374fcc97270002574a8c1e2ec8ca8812af5266bf78aa
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij algemene maatregel van bestuur wordt bepaald welke categorieën van kosten het betreft en worden de grondslagen bepaald van de bijdragen van de betrokkenen.
+  - index: 2
+    label: lid 3
+    sha256: a7886739c39802d963e1708d5a564b768c4284cb7a38c0d98e25fc4d38f5e246
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij of krachtens algemene maatregel van bestuur worden nadere regels gesteld omtrent de vaststelling en de betaling van de bijdragen. Daarbij kan worden bepaald dat Onze Minister het in rekening te brengen bedrag op nul vaststelt, voor zover een voorziening is getroffen in de begroting van het ministerie van Binnenlandse Zaken en Koninkrijksrelaties die in de plaats treedt van de bijdrage van de betrokkene.
+- number: '1.15'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 32ca6337756069a4d3da5b8d853d792e8d47cd51cf21982129969b50b601a1b3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 1.15 1 Onze Minister overlegt periodiek met representatieve vertegenwoordigingen van de gemeenten, van de aangewezen bestuursorganen als bedoeld in artikel 2.65 en van de overheidsorganen en derden aan wie op grond van artikel 3.2 , 3.3 of 3.13 gegevens uit de basisregistratie worden verstrekt.
+  - index: 1
+    label: lid 2
+    sha256: 30d0973e8f35e42daba7c768cdc3ad6488bad48ffc428de2cf9a42091249c5af
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Alle onderwerpen die bij of krachtens deze wet worden geregeld, lenen zich voor overleg. In ieder geval wordt overleg gepleegd over:'
+  - index: 2
+    label: onderdeel a
+    sha256: 8154267a968ff5c68bb69de8a468150fe147125912ad3fa0af5fc0b3143454e0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. wijzigingen in het bepaalde bij of krachtens deze wet;
+  - index: 3
+    label: onderdeel b
+    sha256: 9cffbb1de154db4b831b8072c23258ac7321ecaaf72da4d64b6d64658752db94
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de uitgangspunten van het te voeren kwaliteitsbeleid;
+  - index: 4
+    label: onderdeel c
+    sha256: 078a9ebafbed4c679d9713813cda945cb43ba8aa43fd9fccf0daff2c260a74a3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. de uitgangspunten van het uitvoeren van artikel 1.14 .
+  - index: 5
+    label: lid 3
+    sha256: cba6cedc9f99222b673cf64e218930901e512d9a6a9a14d3d6506f19a24c57ce
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Onze Minister kan met betrekking tot het overleg nadere regels stellen.
+- number: '2.1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 467ad8e6f37e92ed95b09c9183f8a791f0022d1ee72323b7a06c69b8d4f2e401
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.1 1 Deze afdeling is van toepassing op personen die als ingezetene in de basisregistratie zijn of worden ingeschreven en op ingeschrevenen die op het moment van hun overlijden ingezetene waren.
+  - index: 1
+    label: lid 2
+    sha256: de29f8c140ac2365e06a0d4ab344511a5ae92183dd35e41f71ed6ec6a12291bf
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Met betrekking tot de ingeschrevene die geen ingezetene meer is, worden krachtens deze afdeling geen nieuwe algemene gegevens opgenomen.
+  - index: 2
+    label: lid 3
+    sha256: bf30d4353837caf9cac0750a1c8ac9b21e1dba59dc887c6bf88880df77ffd2af
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. In afwijking van het eerste of tweede lid worden gegevens opgenomen krachtens deze afdeling, voor zover:'
+  - index: 3
+    label: onderdeel a
+    sha256: dbe8b674f17fbec5680dbdfae1c706bfee38a5f408efae2d84bb7b0b04fc698c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. het feiten betreft die zich hebben voorgedaan in de tijd dat de ingeschrevene nog ingezetene was, of
+  - index: 4
+    label: onderdeel b
+    sha256: 99e30280e2a6e6334bae513b4c22ccdc4da1963040a0a6a5146a91e7aebd4893
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. dit bij algemene maatregel van bestuur is bepaald.
+- number: '2.2'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 21cd9091566c8af0b315e08ab2bd7137a4cd3fd61e9dbda8b76a8963ab1f4729
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.2 De inschrijving in de basisregistratie geschiedt op grond van de geboorteakte, de aangifte van de betrokkene of ambtshalve.
+- number: '2.3'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 68e4b9a9795ee094d93f163af316415b60ee0f761c102baf7462bbf282c2fb7e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.3 Op grond van de geboorteakte, opgemaakt door een ambtenaar van de burgerlijke stand in Nederland, waarop als geboorteplaats een plaats in Nederland is vermeld, geschiedt de inschrijving van het kind dat niet reeds is ingeschreven en waarvan de moeder op de geboortedatum van het kind als ingezetene is ingeschreven. De inschrijving geschiedt door het college van burgemeester en wethouders van de gemeente waar de moeder als ingezetene is ingeschreven.
+- number: '2.4'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 3344f448b808a0004651e71faddff3d7b874f23fccbd32f45d40c0f09ac7ea07
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.4 1 Op grond van zijn aangifte van verblijf en adres wordt degene die rechtmatig verblijf geniet, niet in de basisregistratie is ingeschreven en naar redelijke verwachting gedurende een half jaar ten minste twee derde van de tijd in Nederland verblijf zal houden, ingeschreven in de basisregistratie door het college van burgemeester en wethouders van de gemeente waar hij zijn adres heeft.
+  - index: 1
+    label: lid 2
+    sha256: c9a0eb99651b56228813532865377be6d0e8f48b0f37c5e69be3d06eaaf0b3a0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien een persoon als bedoeld in het eerste lid in gebreke is met het doen van aangifte, draagt het college ambtshalve zorg voor de inschrijving. Het college van burgemeester en wethouders is bevoegd de betrokkene alsnog op grond van zijn aangifte in te schrijven, indien de aangifte na afloop van de aangiftetermijn geschiedt.
+  - index: 2
+    label: lid 3
+    sha256: dfe506a3cfe9fbf447941c0704fcd1919f45e4857c7a87f49cf80fddf58eea36
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Inschrijving geschiedt niet dan nadat de identiteit van de betrokkene deugdelijk is vastgesteld.
+- number: '2.5'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2884df2e930b3433d795c6d195f2f704f22d5da55f73aa8d3e538d554d3b7d0c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.5 1 Inschrijving op grond van artikel 2.4 van een persoon die komt vanuit Aruba, Curaçao, Sint Maarten, of een van de openbare lichamen, vindt niet plaats, dan nadat hij een hem betreffend verhuisbericht, verstrekt door de verantwoordelijke voor de verwerking van gegevens in de basisadministratie in Aruba, Curaçao, Sint Maarten of een van de openbare lichamen waar hij laatstelijk als ingezetene was ingeschreven, heeft overgelegd.
+  - index: 1
+    label: lid 2
+    sha256: 1ba25ca2f27d4d0b0e4642027378f182e65256b77232302d0d89b1b32455e26d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In het geval dat anderszins blijkt dat het vertrek van de betrokken persoon is verwerkt in de basisadministratie in Aruba, Curaçao, Sint Maarten of een van de openbare lichamen waar hij laatstelijk als ingezetene was ingeschreven, of blijkt dat betrokkene daarin niet als ingezetene was ingeschreven, kan het college van burgemeester en wethouders afwijken van het bepaalde in het eerste lid.
+- number: '2.6'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 54d100d676c503c9b80655e0962233b4f4b00a6470ff746e8cd0c16d1fe9840a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.6 1 Bij algemene maatregel van bestuur worden categorieën bepaald van personen, die in verband met hun bijzondere verblijfsrechtelijke positie niet in aanmerking komen voor inschrijving.
+  - index: 1
+    label: lid 2
+    sha256: 3b301f5298d1c076e63205c258123298c97948e6d58ba3ab815b4a03dfd1a7c8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Bij of krachtens de maatregel kunnen regels worden gesteld ten aanzien van een persoon die behoort tot een categorie als bedoeld in het eerste lid, omtrent:'
+  - index: 2
+    label: onderdeel a
+    sha256: 3be6cc6476d9dc31736510f4a5ba953faf722f4e8f7d3195403ffa1550ed0e4c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. het niet-inschrijven van de persoon;
+  - index: 3
+    label: onderdeel b
+    sha256: e51f5a81979dd01c75c84c5d6353f7f52fbe07a72347eb4989628605ac01dadd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. het aanmerken van de persoon die reeds is ingeschreven als een ingeschrevene die wegens zijn vertrek uit Nederland niet als ingezetene is ingeschreven.
+- number: '2.7'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 3244d62393c783a429bf4e246fa21210f751549fcf06b9c3b5e801b00084280d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 2.7 1 In de basisregistratie worden over de ingeschrevene uitsluitend de volgende gegevens opgenomen:'
+  - index: 1
+    label: onderdeel a
+    sha256: 577ac29cb7f106fdf24470bebdb7c2952e5254f0a75b468a45a4c9ff4f69c8f5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'a. algemene gegevens: - 1° gegevens over de burgerlijke staat waar het betreft de naam, de geboorte, het geslacht, de ouders, het huwelijk, dan wel geregistreerd partnerschap en eerdere huwelijken of eerder geregistreerde partnerschappen, de echtgenoot dan wel geregistreerd partner en eerdere echtgenoten of geregistreerde partners, de kinderen en het overlijden; - 2° gegevens over curatele; - 3° gegevens over het gezag dat over de minderjarige wordt uitgeoefend; - 4° gegevens over de nationaliteit, met dien verstande dat geen gegevens over een vreemde nationaliteit worden opgenomen naast gegevens over het Nederlanderschap of het feit dat de betrokkene als Nederlander wordt behandeld; - 5° gegevens in verband met het verblijfsrecht van de vreemdeling; - 6° gegevens over de bijhoudingsgemeente en het adres in die gemeente, alsmede over het verblijf in Nederland en het vorige verblijf buiten Nederland en over het vertrek uit Nederland en het volgende verblijf buiten Nederland; - 7° gegevens over het burgerservicenummer van de ingeschrevene; - 8° gegevens over de burgerservicenummers van de ouders, de echtgenoot, de eerdere echtgenoten, de geregistreerde partner, de eerdere geregistreerde partners en de kinderen; - 9° gegevens over het gebruik door de ingeschrevene van de geslachtsnaam van de echtgenoot, de eerdere echtgenoot, de geregistreerde partner of de eerdere geregistreerde partner; - 10° gegevens, noodzakelijk in verband met de uitvoering van de [Kieswet](jci1.3:c:BWBR0004627) ; - 11° gegevens, noodzakelijk in verband met de uitvoering van de [Paspoortwet](jci1.3:c:BWBR0005212) . - 1° gegevens over de burgerlijke staat waar het betreft de naam, de geboorte, het geslacht, de ouders, het huwelijk, dan wel geregistreerd partnerschap en eerdere huwelijken of eerder geregistreerde partnerschappen, de echtgenoot dan wel geregistreerd partner en eerdere echtgenoten of geregistreerde partners, de kinderen en het overlijden; - 2° gegevens over curatele; - 3° gegevens over het gezag dat over de minderjarige wordt uitgeoefend; - 4° gegevens over de nationaliteit, met dien verstande dat geen gegevens over een vreemde nationaliteit worden opgenomen naast gegevens over het Nederlanderschap of het feit dat de betrokkene als Nederlander wordt behandeld; - 5° gegevens in verband met het verblijfsrecht van de vreemdeling; - 6° gegevens over de bijhoudingsgemeente en het adres in die gemeente, alsmede over het verblijf in Nederland en het vorige verblijf buiten Nederland en over het vertrek uit Nederland en het volgende verblijf buiten Nederland; - 7° gegevens over het burgerservicenummer van de ingeschrevene; - 8° gegevens over de burgerservicenummers van de ouders, de echtgenoot, de eerdere echtgenoten, de geregistreerde partner, de eerdere geregistreerde partners en de kinderen; - 9° gegevens over het gebruik door de ingeschrevene van de geslachtsnaam van de echtgenoot, de eerdere echtgenoot, de geregistreerde partner of de eerdere geregistreerde partner; - 10° gegevens, noodzakelijk in verband met de uitvoering van de [Kieswet](jci1.3:c:BWBR0004627) ; - 11° gegevens, noodzakelijk in verband met de uitvoering van de [Paspoortwet](jci1.3:c:BWBR0005212) .'
+  - index: 2
+    label: onderdeel b
+    sha256: fb20abd21505f696715b4985a10545fe442e96adcf0911dd7655b01f984f74ad
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'b. administratieve gegevens: - 1° gegevens in verband met de inschrijving en de wijziging van de bijhoudingsgemeente; - 2° gegevens ter aanduiding van akten en andere geschriften waaruit algemene gegevens zijn verkregen, dan wel van de rechtsgrond krachtens welke gegevens over het Nederlanderschap zijn opgenomen; - 3° gegevens ter aanduiding van de onjuistheid van een opgenomen algemeen gegeven of van strijd met de Nederlandse openbare orde van een opgenomen gegeven over de burgerlijke staat dan wel over een onderzoek naar die onjuistheid of strijdigheid, alsmede andere gegevens, noodzakelijk in verband met de bijhouding van de basisregistratie; - 4° gegevens over de beperking van de verstrekking van gegevens aan derden. - 1° gegevens in verband met de inschrijving en de wijziging van de bijhoudingsgemeente; - 2° gegevens ter aanduiding van akten en andere geschriften waaruit algemene gegevens zijn verkregen, dan wel van de rechtsgrond krachtens welke gegevens over het Nederlanderschap zijn opgenomen; - 3° gegevens ter aanduiding van de onjuistheid van een opgenomen algemeen gegeven of van strijd met de Nederlandse openbare orde van een opgenomen gegeven over de burgerlijke staat dan wel over een onderzoek naar die onjuistheid of strijdigheid, alsmede andere gegevens, noodzakelijk in verband met de bijhouding van de basisregistratie; - 4° gegevens over de beperking van de verstrekking van gegevens aan derden.'
+  - index: 3
+    label: lid 2
+    sha256: 49326eb55f79b2ce4a51aa7a786137712d1fc261021e13a76f023df036e7083e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De algemene en administratieve gegevens worden nader bepaald bij of krachtens algemene maatregel van bestuur.
+  - index: 4
+    label: lid 3
+    sha256: 55f73edecb77001f1d03609375ebb34062c4f9726d3c19e4197f72f5a80c1cfb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Een algemeen gegeven dat is opgenomen, blijft opgenomen, behoudens het bepaalde in artikel 2.57 en behoudens de gegevens, bedoeld in het eerste lid, onder a, onderdelen 10° en 11°.
+  - index: 5
+    label: lid 4
+    sha256: fb379cda53907470e91577f452f6c9d5d196beab5d8a5e8bc3c46eb5b5b1e58a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij of krachtens algemene maatregel van bestuur worden de verwijdering en de vernietiging van de algemene gegevens, bedoeld in het eerste lid, onder a, onderdelen 10° en 11°, en de administratieve gegevens, bedoeld in het eerste lid, onder b, geregeld.
+- number: '2.8'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6149126f0941aad9f249e811dc7cecbf2e2374bd99e88bcfd24767a97c633137
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 2.8 1 De gegevens over de burgerlijke staat worden, indien zij feiten betreffen die zich in Nederland hebben voorgedaan, ontleend aan een geschrift als bedoeld onder a en bij gebreke hiervan aan een geschrift als bedoeld onder b:'
+  - index: 1
+    label: onderdeel a
+    sha256: 2a4edcbf71da36ff113f6a6d154909e046c5f34c581b9fccc2750daa7351d1ec
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. een akte over het desbetreffende feit, die is opgenomen in de registers van de burgerlijke stand in Nederland;
+  - index: 2
+    label: onderdeel b
+    sha256: 196b5d02753650df4a9d65b8f143190fc00142a22ad9f653970a11a3a7cf495c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. een door de ambtenaar van de burgerlijke stand opgemaakte akte, een besluit, een in kracht van gewijsde gegane rechterlijke uitspraak of een notariële akte, over het desbetreffende feit.
+  - index: 3
+    label: lid 2
+    sha256: e80e8a39fa3382269bfac695f18e2bcb38e9923b778e4f79719c3c62d2152b10
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. De gegevens over de burgerlijke staat worden, indien zij feiten betreffen die zich buiten Nederland hebben voorgedaan, ontleend aan een geschrift als bedoeld onder a, bij gebreke hiervan aan een geschrift als bedoeld onder b of c, bij gebreke ook hiervan aan een geschrift als bedoeld onder d en bij gebreke ten slotte ook hiervan aan een geschrift als bedoeld onder e:'
+  - index: 4
+    label: onderdeel a
+    sha256: d58866cbd32360b1ad4f24c3942ee8c822893e363642150218b0cc2d1dc601b6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. een akte over het desbetreffende feit, die is opgenomen in de registers van de Nederlandse burgerlijke stand;
+  - index: 5
+    label: onderdeel b
+    sha256: 2e19412655777e0ab9e69065a4a97f664624e54f7145ad78dda73eaf25324422
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. een in Nederland gedane rechterlijke uitspraak over het desbetreffende feit die in kracht van gewijsde is gegaan;
+  - index: 6
+    label: onderdeel c
+    sha256: 6cc79869b7fea352caf182f04be9893939b6b1383de18f7115d88ee7d8bd90b5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. een buiten Nederland overeenkomstig de plaatselijke voorschriften door een bevoegde instantie opgemaakte akte die ten doel heeft tot bewijs te dienen van het desbetreffende feit, of een over dat feit gedane rechterlijke uitspraak, of bij gebreke daarvan een akte van bekendheid of beëdigde verklaring, bedoeld in [artikel 45 van Boek 1 van het Burgerlijk Wetboek](jci1.3:c:BWBR0002656&artikel=45) ;
+  - index: 7
+    label: onderdeel d
+    sha256: e6f4f8e8338e4f75652ea0a0fd198cf337b2220f957929fbcd9905ce33ec8e51
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. een geschrift dat overeenkomstig de plaatselijke voorschriften is opgemaakt door een bevoegde instantie, waarin het desbetreffende feit is vermeld;
+  - index: 8
+    label: onderdeel e
+    sha256: b9be3357c916dda1a00ad4d842b0db61288a677bcdb7610686849c93ecc170ce
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: e. een verklaring over het desbetreffende feit die betrokkene ten overstaan van een door het college van burgemeester en wethouders aangewezen ambtenaar onder eed of belofte heeft afgelegd, die op schrift is gesteld en door betrokkene is ondertekend.
+  - index: 9
+    label: lid 3
+    sha256: 442fffd77e581687c25ea47237a55bb957227d44aacb214ddda79807f704497e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De gegevens over de burgerlijke staat worden, indien zij feiten betreffen die zich in Nederland hebben voorgedaan en waarvan een in Nederland geaccrediteerde consulaire ambtenaar van een ander land bevoegd een akte heeft opgemaakt die ten doel heeft tot bewijs te dienen van het desbetreffende feit, ontleend aan die akte.
+- number: '2.9'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: cd2a69b86c336f41c008e8377e290f5a3425e38b85c6d8d266e42af4deece229
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.9 1 Aan een geschrift als bedoeld in artikel 2.8, tweede lid, onder c, d, of e , dan wel artikel 2.8, derde lid, worden geen gegevens ontleend over het huwelijk of het geregistreerd partnerschap dat is gesloten tussen echtgenoten dan wel geregistreerde partners van wie ten minste één vreemdeling is, voordat het college van burgemeester en wethouders zich een door de korpschef in de zin van de [Vreemdelingenwet 2000](jci1.3:c:BWBR0011823) afgegeven verklaring heeft doen overleggen.
+  - index: 1
+    label: lid 2
+    sha256: 8d21d7cc922837847b71ffcc76237aa18485d9582192f72ae02fbe202badf811
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De verklaring is niet vereist indien voldaan is aan de eisen genoemd in [artikel 25, vierde lid, onder b, c of d, van Boek 1 van het Burgerlijk Wetboek](jci1.3:c:BWBR0002656&artikel=25) .
+  - index: 2
+    label: lid 3
+    sha256: 482540201d116db9d52c7b90414c9452099c54704a7776e988ac5abd53d2287f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Op de verklaring zijn de regels in en krachtens [artikel 44, eerste lid, onder k, en derde lid, van Boek 1 van het Burgerlijk Wetboek](jci1.3:c:BWBR0002656&artikel=44) van overeenkomstige toepassing.
+- number: '2.10'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 1d188434f8e5a9dcfa2d0889558cfb7644ce4dbdee7b43b4667ccb1b42f89f66
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.10 1 Indien aannemelijk is dat omtrent een gegeven over de familierechtelijke betrekkingen tot de ouders of de kinderen, over het huwelijk en de eerdere huwelijken, over de echtgenoot en de eerdere echtgenoten, over het geregistreerd partnerschap en de eerdere geregistreerde partnerschappen of over de geregistreerde partner en de eerdere geregistreerde partners een geschrift als bedoeld in artikel 2.8, tweede lid, onder c of d , kan worden verschaft, mogen deze gegevens niet worden ontleend aan een geschrift als bedoeld in artikel 2.8, tweede lid, onder e.
+  - index: 1
+    label: lid 2
+    sha256: ceca58e3dec1ed99ccba575d1fa351bd09d7ba51e216a80586e856640d5279d2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Aan een geschrift als bedoeld in artikel 2.8, tweede lid, onder c, d of e , alsmede artikel 2.8, derde lid, worden geen gegevens ontleend, voor zover de Nederlandse openbare orde zich verzet tegen de erkenning van de rechtsgeldigheid van de in deze geschriften vermelde feiten.
+  - index: 2
+    label: lid 3
+    sha256: 437a9242dc04b3b79a79f51d755ba1b8d48905140837a2c5eae2a63144c642f6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Aan een geschrift als bedoeld in artikel 2.8, tweede lid, onder d en e , worden geen gegevens ontleend, indien aannemelijk is dat de gegevens onjuist zijn.
+  - index: 3
+    label: lid 4
+    sha256: 8fb50dd11328d9d2919edbe0bdab3c0edbf0e116c3afab847dbb6885ad163e2b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Aan een geschrift als bedoeld in artikel 2.8, tweede lid, onder e , worden geen gegevens ontleend, dan nadat de gegevens voor zover mogelijk zijn geverifieerd door raadpleging van de basisregistratie en zo nodig van andere registers of van geschriften die door de betrokkene zijn overgelegd.
+- number: '2.11'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 0c360fa063cf86d4f9500377f38ee66cb9e3a1d8868b9961bbc1c7aec922c056
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.11 Op de persoonslijst van een persoon worden geen gegevens over zijn kind opgenomen indien het kind ten tijde van de inschrijving van de persoon reeds is overleden en het kind zelf geen ingeschrevene is.
+- number: '2.12'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b580af42428b5c42722b223ce3d6ded507a2c765fc28fc0bae39397efa56251d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.12 1 Bij gerede twijfel over de toepassing van artikel 2.8, tweede en derde lid , en artikel 2.10, eerste en tweede lid , wordt advies ingewonnen van de ambtenaar van de burgerlijke stand in de gemeente.
+  - index: 1
+    label: lid 2
+    sha256: 15628814bf171e0c7351bc49ffa38c1ecc2b1aac4b978ee93bbebd84e9056475
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien bij de ontlening van gegevens over een huwelijk dat is gesloten tussen echtgenoten van wie ten minste één vreemdeling is, aan een geschrift als bedoeld in artikel 2.8, tweede lid, onder c, d, of e , dan wel artikel 2.8, derde lid, op grond van de verklaring van de korpschef in de zin van de [Vreemdelingenwet 2000](jci1.3:c:BWBR0011823) of anderszins het redelijke vermoeden bestaat dat het oogmerk van de echtgenoten, of een van beiden, niet was gericht op de vervulling van de door de wet aan de huwelijkse staat verbonden plichten, doch op het verkrijgen van toelating tot Nederland, wordt in afwijking van het eerste lid, over de ontlening van de gegevens over het huwelijk advies van de ambtenaar van de burgerlijke stand van de gemeente 's-Gravenhage ingewonnen.
+  - index: 2
+    label: lid 3
+    sha256: 457ecf89574683a6aceb293de54cd24452e74d88cad7f9d24d495b6c3c439604
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien na het advies, bedoeld in het eerste lid, gerede twijfel blijft bestaan of het voornemen bestaat van het advies af te wijken, wordt het advies van de Commissie van advies voor de zaken betreffende de burgerlijke staat en de nationaliteit ingewonnen.
+- number: '2.13'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 93438daeb9b38bb6524419e5168e8b1df1dd72d60302568d70405409cb620f08
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.13 1 De gegevens over curatele worden ontleend aan het curatele- en bewindregister.
+  - index: 1
+    label: lid 2
+    sha256: 0c49a3e80a6410103c7cc9150ad43ebb54f6504d198136b4209e20ea078274c1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De gegevens over het gezag dat over de minderjarige wordt uitgeoefend, worden ontleend aan het gezagsregister.
+- number: '2.14'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ff0a11c047ef2de138dc2761c77bb2ea28b8535292cec8bdc45eb6f9b3cbfce3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.14 1 Gegevens over het Nederlanderschap worden opgenomen met toepassing van de [Rijkswet op het Nederlanderschap](jci1.3:c:BWBR0003738) , van andere op het Nederlanderschap betrekking hebbende wettelijke bepalingen en van verdragen waaruit het Nederlanderschap voortvloeit.
+  - index: 1
+    label: lid 2
+    sha256: b9ca5580cd681cb3d44a4c2b079ba8b6fc2008cbb6fdec7a608fe080af873380
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien omtrent een ingeschrevene akten als bedoeld in [artikel 22, eerste lid, onder b, c en d, van de Rijkswet op het Nederlanderschap](jci1.3:c:BWBR0003738&artikel=22) zijn opgenomen in het in dat lid bedoelde register, wordt aan deze akten het gegeven over het Nederlanderschap ontleend. Indien omtrent een ingeschrevene een afschrift wordt overgelegd van de in de eerste volzin bedoelde akten uit het register, bedoeld in artikel 22, tweede lid, van de genoemde wet, wordt het gegeven over het Nederlanderschap aan dit afschrift ontleend.
+  - index: 2
+    label: lid 3
+    sha256: 5b5f02d0735e8b26d01ca16965eff333a2bd00beb446c9e6b366cb1887311dc0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Een gegeven over het Nederlanderschap wordt ontleend aan de bevestiging van de verklaring tot verkrijging van het Nederlanderschap of het uittreksel van het besluit tot verlening van het Nederlanderschap, waarvan de uitreiking of bekendmaking op andere wijze heeft plaatsgevonden in de gemeente waar de betrokkene is ingeschreven, onderscheidenlijk aan de door de betrokkene in die gemeente afgelegde verklaring van afstand van het Nederlanderschap, dan wel aan de mededeling van de burgemeester van een andere gemeente omtrent de verkrijging, de verlening of de afstand van het Nederlanderschap die betrekking heeft op de ingeschrevene, indien de uitreiking of bekendmaking van de bevestiging van de verklaring tot verkrijging van het Nederlanderschap of van het uittreksel van het besluit tot verlening van het Nederlanderschap op andere wijze, heeft plaatsgevonden, onderscheidenlijk de verklaring van afstand is afgelegd, in een andere gemeente dan de gemeente waar de betrokkene is ingeschreven. Voor zover het in deze gevallen gaat om verkrijging of verlening van het Nederlanderschap wordt daarbij afgeweken van het tweede lid.
+  - index: 3
+    label: lid 4
+    sha256: 4072012b8553f6f9a1fd26810ffd0e3d8f41d5580b98c924f502e0579affb4e4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. In de gevallen bedoeld in [artikel 17 van de Rijkswet op het Nederlanderschap](jci1.3:c:BWBR0003738&artikel=17) , worden de gegevens over het Nederlanderschap ontleend aan een afschrift van een in kracht van gewijsde gegane uitspraak van een rechterlijke instantie in Nederland.
+  - index: 4
+    label: lid 5
+    sha256: e097203538830fa589846269fbc0f62cba607af07053c11ccc90aa343de0cc86
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Indien een afschrift wordt overgelegd van een uitspraak van het Gemeenschappelijk Hof van Justitie van Aruba, Curaçao, Sint Maarten en van Bonaire, Sint Eustatius en Saba krachtens [artikel 17 van de Rijkswet op het Nederlanderschap](jci1.3:c:BWBR0003738&artikel=17) , worden de gegevens over het Nederlanderschap aan dit afschrift ontleend.
+  - index: 5
+    label: lid 6
+    sha256: e7fe6cb070d0ee7c7f4c441353fceecd66c66454e134d8746267533d18438663
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Gegevens over de behandeling als Nederlander van een persoon die niet het Nederlanderschap bezit, worden opgenomen met toepassing van de [Wet betreffende de positie van Molukkers](jci1.3:c:BWBR0003052) .
+- number: '2.15'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 65514bd3dd7e89951e94eb3227b8912b711a0ad3295239dc918bd09be13e1ad6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.15 1 Gegevens over een vreemde nationaliteit worden ontleend aan een beschikking of uitspraak van een daartoe volgens het ter plaatse geldend recht bevoegde administratieve of rechterlijke instantie, die tot doel heeft tot bewijs te dienen van de betreffende nationaliteit, dan wel opgenomen met toepassing van het betreffende nationaliteitsrecht.
+  - index: 1
+    label: lid 2
+    sha256: ad1ec1b3308875a4cf8d539480c21046800f1e6c5ea11e427d69d95a443e45a2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien gegevens over een vreemde nationaliteit niet overeenkomstig het eerste lid kunnen worden verkregen, kunnen deze gegevens worden ontleend aan een geschrift van een volgens het ter plaatse geldend recht bevoegde autoriteit, dat gegevens vermeldt over die nationaliteit.
+  - index: 2
+    label: lid 3
+    sha256: e75597cf9d570919079a8f0a22a73a6bfce50e980d38e354f463b9d72d75f741
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien de betrokkene geen nationaliteit bezit of de nationaliteit niet kan worden vastgesteld, wordt dit gegeven opgenomen. Indien een rechterlijke uitspraak op grond van [artikel 17 van de Rijkswet op het Nederlanderschap](jci1.3:c:BWBR0003738&artikel=17) is gedaan, waarbij is vastgesteld dat de betrokkene niet de Nederlandse nationaliteit bezit, wordt daarvan melding gemaakt.
+- number: '2.16'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 3f1ae557807e127db2ae33377071de736aed43fb1f19a6a853bd8e684ac25f77
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.16 Gegevens in verband met het verblijfsrecht van de vreemdeling worden ontleend aan mededelingen daarover van Onze Minister van Veiligheid en Justitie aan het college van burgemeester en wethouders.
+- number: '2.17'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 44ae79f78b7c71dab61432571baf6b9fd0d14443e61229b862ce08d85c290fdf
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.17 Bij de inschrijving van een vreemdeling op grond van artikel 2.4 , worden gegevens inzake de geboortedatum en de nationaliteit die niet als zodanig kunnen worden opgenomen overeenkomstig de artikelen 2.8 en 2.15 , ontleend aan een mededeling daarover van Onze Minister van Veiligheid en Justitie voor zover deze gegevens door hem zijn vastgesteld in het kader van de toelating van de betrokkene tot Nederland.
+- number: '2.18'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c8b2a3b9d9e00bd75c7b2848ad0d385e1a7099fc73dd3680834622e5b438131a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.18 Bij de inschrijving op grond van artikel 2.3 worden de gegevens omtrent het adres ontleend aan de persoonslijst van de moeder. Als datum van inschrijving wordt de geboortedatum opgenomen.
+- number: '2.19'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8661fbe93137fef15cef7eec683b314838ce328b8b0b9421868dd06f95fcb4ab
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.19 1 Aan de aangifte van verblijf en adres van degene die rechtmatig verblijf geniet, naar redelijke verwachting gedurende een half jaar ten minste twee derde van de tijd in Nederland verblijf zal houden en die zijn adres heeft in de betrokken gemeente, worden gegevens betreffende het verblijf in Nederland, het adres en het vorige verblijf buiten Nederland ontleend.
+  - index: 1
+    label: lid 2
+    sha256: a0e13d01977b3cfc59c18238eba85f09428dbb7b0bcf9a59dd4242851eb0d5c6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien aannemelijk is dat een gegeven betreffende het vorige verblijf buiten Nederland onjuist is, wordt dit gegeven niet opgenomen.
+  - index: 2
+    label: lid 3
+    sha256: dba464ffdb91b77a1aca058b4ce2817258d61f22b813f7d019875565daaba027
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien een persoon als bedoeld in het eerste lid in gebreke is met het doen van aangifte, draagt het college van burgemeester en wethouders van de gemeente waar betrokkene zijn adres heeft, ambtshalve zorg voor opneming van gegevens betreffende het verblijf, het adres en het vorige verblijf buiten Nederland. Het college van burgemeester en wethouders is bevoegd de gegevens alsnog aan de aangifte van de betrokkene te ontlenen, indien de aangifte na afloop van de aangiftetermijn geschiedt.
+  - index: 3
+    label: lid 4
+    sha256: d35729619fd87a4f7496a6a79f43f92069fcbafa41ccf5324716f3da9b59b7b5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Als datum van aanvang van het verblijf in Nederland en van vestiging van het adres in de gemeente wordt de dag opgenomen waarop de aangifte is ontvangen, dan wel de dag waarop van het voornemen tot ambtshalve opneming van gegevens over het verblijf en adres aan betrokkene schriftelijk mededeling is gedaan.
+  - index: 4
+    label: lid 5
+    sha256: 740c3261bc6fc095be2d6d45e3d53d86f0adca1d7b342ce911543d1e286590fe
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De gegevens worden niet opgenomen dan nadat de identiteit van de betrokkene deugdelijk is vastgesteld.
+  - index: 5
+    label: lid 6
+    sha256: 8cfa557cb35d7acbbcf9a9a725b31f92ad4110e4d2ca83738dabec0305dded6a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Indien de betrokkene komt vanuit Aruba, Curaçao, Sint Maarten, of een van de openbare lichamen, is artikel 2.5 van overeenkomstige toepassing.
+- number: '2.20'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 988c2a562fe891b04c468a7774f29757fd0a5f0a623dea9664a180ab2547c6e6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.20 1 Aan de aangifte van een ingezetene die zijn adres heeft gewijzigd, worden gegevens betreffende het adres ontleend, tenzij aannemelijk is dat de gegevens onjuist zijn.
+  - index: 1
+    label: lid 2
+    sha256: 27af65c2e35e92bb51afd063f665c94a8ac92cb3c4dc02adaf6cc87d8d1f1c46
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien een ingezetene die zijn adres heeft gewijzigd, in gebreke is met het doen van aangifte, draagt het college van burgemeester en wethouders van de gemeente waar betrokkene zijn adres heeft, ambtshalve zorg voor opneming van gegevens betreffende het adres. Het college van burgemeester en wethouders is bevoegd de gegevens alsnog aan de aangifte van de betrokkene te ontlenen, indien de aangifte na afloop van de aangiftetermijn geschiedt.
+  - index: 2
+    label: lid 3
+    sha256: 6f3361cb8b73a229b102432e2656b35bf2fd0f9be41d755932f0bd884f7523d1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Als datum van adreswijziging wordt opgenomen:'
+  - index: 3
+    label: onderdeel a
+    sha256: 939608ff3b42cd592393ccfaba534134f4aa763a209e4aba4a0ce1fd717afe54
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de in de aangifte vermelde datum van adreswijziging, als tijdig aangifte is gedaan;
+  - index: 4
+    label: onderdeel b
+    sha256: 555510809df9aed178ca540f4f8df7b5caab2abbd723c66ec5ad107c4f7abdc6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de dag waarop de aangifte is ontvangen, in de overige gevallen waarin de gegevens aan de aangifte van de betrokkene worden ontleend;
+  - index: 5
+    label: onderdeel c
+    sha256: f4fb7e0213bfe7ce4c51e1379feea02466f40acb42f15f1f88400937d8162687
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. de dag waarop van het voornemen tot opneming aan betrokkene schriftelijk mededeling is gedaan, bij ambtshalve opneming van de gegevens.
+  - index: 6
+    label: lid 4
+    sha256: 8a5335cdecdb095cc6123606bf51965f0d0e17814f6235ce9cd74d7d0cbdccf0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De gewijzigde gegevens worden niet opgenomen dan nadat de identiteit van de betrokkene deugdelijk is vastgesteld.
+- number: '2.21'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 86dfb6b8ef2603c5016298f77396c1729b7e0685abc3eea137bbd5d4a8022548
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.21 1 Aan de aangifte van vertrek van de ingezetene die naar redelijke verwachting gedurende een jaar ten minste twee derde van de tijd buiten Nederland zal verblijven, worden gegevens betreffende het vertrek uit Nederland en het volgende verblijf buiten Nederland ontleend.
+  - index: 1
+    label: lid 2
+    sha256: bed0f844ce56c771d93d5c153c76900a2ca1fdd6c849bbaf0b092eb4b1202c1c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien de ingezetene in gebreke is met het doen van aangifte, draagt het college van burgemeester en wethouders van de bijhoudingsgemeente ambtshalve zorg voor opneming van gegevens betreffende het vertrek en het volgende verblijf buiten Nederland. Het college van burgemeester en wethouders is bevoegd de gegevens alsnog aan de aangifte van de ingezetene te ontlenen, indien de aangifte na afloop van de aangiftetermijn geschiedt.
+  - index: 2
+    label: lid 3
+    sha256: d3e3b89d2f7caadd2e47e633d0900a2cb38df6ccea64a521a4a5c33ec111a5db
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Als datum van vertrek uit Nederland en van opheffing van het adres wordt de dag opgenomen waarop de aangifte is ontvangen, dan wel de dag waarop van het voornemen tot ambtshalve opneming van gegevens over het vertrek aan de ingeschrevene schriftelijk mededeling is gedaan.
+  - index: 3
+    label: lid 4
+    sha256: 1f02e5e20fd6beda2dbaee2ac7189e17a78412ebc183c6b455ef96ab822abb5c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De gegevens worden niet opgenomen dan nadat de identiteit van de betrokkene deugdelijk is vastgesteld.
+  - index: 4
+    label: lid 5
+    sha256: 9286aa75e2ef3b0450658ff27233b292bea15e028194165e6d83a584707c5997
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Indien de ingezetene in de aangifte van vertrek meldt te gaan verblijven in Aruba, Curaçao, Sint Maarten of een van de openbare lichamen, verstrekt het college van burgemeester en wethouders aan hem kosteloos een verhuisbericht, volgens een door Onze Minister vast te stellen model.
+- number: '2.22'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: cecb57ac0b4a03435fb5fb8c7a34313a358d18294f87f4c94521bca89846a628
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.22 1 Indien een ingezetene niet kan worden bereikt, van hem geen aangifte van wijziging van zijn adres of van vertrek is ontvangen als bedoeld in artikel 2.20, eerste lid , of 2.21, eerste lid , en na gedegen onderzoek geen gegevens over hem kunnen worden achterhaald betreffende het verblijf in Nederland, het vertrek uit Nederland noch het volgende verblijf buiten Nederland, draagt het college van burgemeester en wethouders van de bijhoudingsgemeente ambtshalve zorg voor de opneming van het gegeven van het vertrek van de ingezetene uit Nederland.
+  - index: 1
+    label: lid 2
+    sha256: 0f319e021d6ae5315b1dce63242ce8b95b8060714af2503dd9448f7c7cbea2d5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Als datum van vertrek uit Nederland en van opheffing van het adres wordt de dag opgenomen waarop het voornemen tot ambtshalve opneming van gegevens over het vertrek is bekendgemaakt.
+- number: '2.23'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4d4817c1056d0b1c4cc8e715a1cbfd12414db84f2b8eace3ab3d0b13bd309547
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.23 1 Indien het woonadres ontbreekt dan wel artikel 2.40 of artikel 2.41 van toepassing is, wordt op aangifte een briefadres opgenomen.
+  - index: 1
+    label: lid 2
+    sha256: 1e057efd7ce4e4b1941476c4f67273c873194716caddc02109fe19c0788c2c06
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het college van burgemeester en wethouders is bevoegd ambtshalve een briefadres op te nemen indien het woonadres ontbreekt en geen aangifte wordt gedaan van een briefadres. Het college neemt ambtshalve geen briefadres op dan met instemming van de briefadresgever.
+- number: '2.24'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 171a127ab1d267256d7dc14ae4f84375070a0611410254f16fab49729ddd6367
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.24 1 Het burgerservicenummer dat aan een persoon is toegekend overeenkomstig [artikel 8 van de Wet algemene bepalingen burgerservicenummer](jci1.3:c:BWBR0022428&artikel=8) wordt opgenomen op zijn persoonslijst, voordat over de betrokken persoon voor de eerste keer gegevens worden verstrekt.
+  - index: 1
+    label: lid 2
+    sha256: 140d4ebe11a26d7759abd3952a16d5304592d752f9b90b0895559c1235e04a10
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De gegevens over het burgerservicenummer van de ouders, de echtgenoot, de eerdere echtgenoten, de geregistreerde partner, de eerdere geregistreerde partners en de kinderen worden ontleend aan de desbetreffende persoonslijsten.
+- number: '2.25'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8c6d9d9c6fb6b9e5f59a5c3ce8306baf849eef475d7899f43d5ceaaefa3e6bc5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.25 De gegevens over het gebruik van de geslachtsnaam van de echtgenoot, de eerdere echtgenoot, de geregistreerde partner of de eerdere geregistreerde partner worden opgenomen op schriftelijk verzoek van de daartoe krachtens [artikel 9 van Boek 1 van het Burgerlijk Wetboek](jci1.3:c:BWBR0002656&artikel=9) bevoegde ingeschrevene, dan wel op grond van een rechterlijke uitspraak als bedoeld in artikel 9 van Boek 1 van het Burgerlijk Wetboek.
+- number: '2.26'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 061bf1f393f857952aca9b307b94d08c72845e9d7b3d9c18071229a41d2ca790
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.26 Omtrent de beslissing dat een opgenomen algemeen gegeven onjuist is of, indien het een gegeven over de burgerlijke staat betreft, in strijd is met de Nederlandse openbare orde, omtrent een onderzoek naar die onjuistheid of strijdigheid, alsmede omtrent de omstandigheid dat de ingeschrevene geen ingezetene meer is, wordt een aantekening geplaatst bij de desbetreffende gegevens.
+- number: '2.27'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: f03912a50c440c8ed05c8d9317a6f1136e01e2899f0a401f54743a79089305e2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.27 1 De ambtenaar van de burgerlijke stand die in een van de onder hem berustende registers melding heeft gemaakt van een feit dat van belang is voor de bijhouding van de basisregistratie, brengt de gegevens ter zake terstond ter kennis van zijn college van burgemeester en wethouders.
+  - index: 1
+    label: lid 2
+    sha256: 9a22ef973f8d6cbf964a84afebdca588c148d7a7abf8da183a917cf5f8448fc1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Een hem ingevolge een verdrag inzake de internationale uitwisseling van gegevens op het gebied van de burgerlijke stand toegezonden kennisgeving doet hij terstond toekomen aan zijn college.
+  - index: 2
+    label: lid 3
+    sha256: 426f1ec0cce56a706e2a262db146dd3977d786cb14c1a26fb31202873db606d0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Hij verstrekt aan het college van burgemeester en wethouders dat daarom vraagt, zo spoedig mogelijk alle inlichtingen die dat college nodig heeft voor de bijhouding van de basisregistratie.
+  - index: 3
+    label: lid 4
+    sha256: 624dc3fe1fab53b0324d806a995221edd66c0d7441357d791fb15d37146aaff4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De ambtenaar van de burgerlijke stand van de gemeente 's-Gravenhage, die wegens het ontbreken van een akte in de onder hem berustende registers geen latere vermelding als bedoeld in [artikel 20 van Boek 1 van het Burgerlijk Wetboek](jci1.3:c:BWBR0002656&artikel=20) toevoegt van een hem op grond van [artikel 20e van Boek 1 van het Burgerlijk Wetboek](jci1.3:c:BWBR0002656&artikel=20e) toegezonden besluit, rechterlijke uitspraak of notariële akte, brengt een afschrift van dat besluit, die uitspraak of die akte ter kennis van zijn college van burgemeester en wethouders.
+- number: '2.28'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a65d80e0c3555b58f1f4d6c6ce296683dd0e79c0b674d41ecf757eeb3d5126c8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.28 1 De griffier van de rechtbank die in het curatele- en bewindregister melding heeft gemaakt van een rechterlijke uitspraak waarbij met betrekking tot een persoon een voorziening in de curatele is getroffen, doet daarvan mededeling aan het college van burgemeester en wethouders van de bijhoudingsgemeente, onder vermelding van de persoon die het betreft en de datum waarop de rechtsgeldigheid van de voorziening ingaat.
+  - index: 1
+    label: lid 2
+    sha256: 2eb0185eef7a463af0d078f0119effa826036eb9837c2e85ebb655f5ca6d18e2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De griffier doet overeenkomstige mededeling van elke beslissing, houdende vernietiging van een rechterlijke uitspraak als bedoeld in het eerste lid, en van beëindiging van de curatele.
+  - index: 2
+    label: lid 3
+    sha256: 175c99da4ef1b8f1aac7baaf7ea6e07398f5abc5e2ac5e2ad157c9365a5dcc2a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De griffier van de rechtbank die in het gezagsregister aantekening heeft gehouden van een wijziging in het gezag dat over een minderjarige wordt uitgeoefend, welke van belang is voor de bijhouding van de basisregistratie, met betrekking tot de in artikel 2.7, eerste lid, onder a, onder 3° , bedoelde gegevens, doet van de wijziging mededeling aan het college van burgemeester en wethouders van de bijhoudingsgemeente van de minderjarige.
+  - index: 3
+    label: lid 4
+    sha256: 6e60e40b249c8844a27a25d9caaf4f85c77ed232061826e563fac1cb5889884a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De in het derde lid bedoelde mededeling geeft uitsluitend aan welke minderjarige het betreft, welke wijziging in het gezag heeft plaatsgevonden alsmede de datum waarop de wijziging ingaat.
+- number: '2.29'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a8a54127f442663df30c0fe09c5da451816886c12eff0619f199c78452b903d3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.29 1 Indien Onze Minister van Veiligheid en Justitie in het openbaar register, bedoeld in [artikel 22, eerste lid, van de Rijkswet op het Nederlanderschap](jci1.3:c:BWBR0003738&artikel=22) , melding heeft gemaakt van het feit dat een persoon een verklaring tot verkrijging van het Nederlanderschap of een verklaring van afstand van het Nederlanderschap heeft afgelegd, dan wel dat een persoon door verlening het Nederlanderschap heeft verkregen of door intrekking het Nederlanderschap heeft verloren, doet hij daarvan mededeling aan het college van burgemeester en wethouders van de bijhoudingsgemeente. De mededeling bevat de datum waarop de verklaring in ontvangst is genomen of de datum waarop het Nederlanderschap is verkregen of verloren.
+  - index: 1
+    label: lid 2
+    sha256: 65e577abc6f1a32ca3d496e8e69c5f9018ed840f8cc2eee2463cede7a9cc0202
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Een mededeling als bedoeld in het eerste lid blijft achterwege indien artikel 2.14, derde lid , van toepassing is.
+  - index: 2
+    label: lid 3
+    sha256: 759d0d189f7e28d2a7f9c088570674be8ad63d9f81acaf20aecb5eeb63a0f67b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De griffier van de rechtbank Den Haag dan wel de griffier van de Hoge Raad zendt een afschrift van een in kracht van gewijsde gegane rechterlijke uitspraak houdende de vaststelling van het Nederlanderschap of de vaststelling van het niet-bezitten van het Nederlanderschap, aan het college van burgemeester en wethouders van de bijhoudingsgemeente.
+- number: '2.30'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: bc8cf84c19699dd046ea1c96a580c8e811c9d6ac02bdda0c9473dcb190b6d26e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.30 Onze Minister van Veiligheid en Justitie doet van de gegevens in verband met het verblijfsrecht van de vreemdeling die voor de bijhouding van de basisregistratie van belang zijn, mededeling aan het college van burgemeester en wethouders van de bijhoudingsgemeente.
+- number: '2.31'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 183e127170804ce03f48c99125ad6056ed21906f76c136816548d0578ddbc286
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.31 Bij algemene maatregel van bestuur worden gevallen bepaald waarin het college van burgemeester en wethouders aan een korpschef als bedoeld in de [Vreemdelingenwet 2000](jci1.3:c:BWBR0011823) een afschrift toezendt van een beslissing als bedoeld in artikel 2.60 om op grond van artikel 2.10, tweede lid , een gegeven betreffende een vreemdeling niet in de basisregistratie op te nemen.
+- number: '2.32'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c22045a48850d8ec3f7a7431e82329a75d40360e555100137dad6f2ae467c2ad
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.32 De griffier van het betrokken gerecht zendt een afschrift van een in kracht van gewijsde gegane uitspraak als bedoeld in [artikel 9 van Boek 1 van het Burgerlijk Wetboek](jci1.3:c:BWBR0002656&artikel=9) aan het college van burgemeester en wethouders van de bijhoudingsgemeente van de onbevoegd verklaarde.
+- number: '2.33'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8c7893e3e6dafe5b976b9491168d3a397b609b850192d01fdbac889a461056c5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.33 Bij algemene maatregel van bestuur kunnen aan overheidsorganen verplichtingen worden opgelegd tot het doen van mededeling aan het college van burgemeester en wethouders van de betrokken gemeente inzake het van toepassing zijn van artikel 2.6 .
+- number: '2.34'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b380d08aaa234f7102aa96995255c96431def226138b14a4a7f8f919cbadbdec
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.34 1 Een bestuursorgaan dat in verband met de verstrekking van een authentiek gegeven uit de basisregistratie gerede twijfel heeft over de juistheid van dat gegeven, doet hiervan mededeling aan het college van burgemeester en wethouders van de bijhoudingsgemeente.
+  - index: 1
+    label: lid 2
+    sha256: 12ef9e1b01ef31aa8aa4fba224ba43db56bd74273157fe3c888da8bd4ec958b3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister wijst de bestuursorganen aan die tevens mededeling doen in verband met de verstrekking van andere dan authentieke gegevens.
+  - index: 2
+    label: lid 3
+    sha256: 2cf4a9b336ac7f1dd770969c7f5e39135f340e2592240ae575778cbf416b4095
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij of krachtens algemene maatregel van bestuur worden de gevallen waarin en de wijze waarop de mededeling wordt gedaan, alsmede de kennisgeving van het college van burgemeester en wethouders aan het bestuursorgaan naar aanleiding van een mededeling, geregeld.
+  - index: 3
+    label: lid 4
+    sha256: bb675c9b1837b83938acb2688095a7cf9a2656a64143d991d841f0048300bf3b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het college van burgemeester en wethouders kan nadere regels stellen omtrent het doen van mededeling door en de kennisgeving aan bestuursorganen die een orgaan zijn van de desbetreffende gemeente en kan een of meer van deze bestuursorganen aanwijzen om tevens mededeling te doen in verband met de verstrekking van andere dan authentieke gegevens.
+  - index: 4
+    label: lid 5
+    sha256: cd6fec7d505c8a586743d3c23c402eca37de5411265dd28e147d5ff0f13aadc9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Voor zover een mededeling als bedoeld in het eerste lid betrekking heeft op een gegeven dat op grond van een andere wet is overgenomen uit een andere registratie, zendt het college van burgemeester en wethouders die mededeling door aan de verantwoordelijke voor de verwerking van dat gegeven in die andere registratie.
+- number: '2.35'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8c5aa480fef43d58d3f2f4c0947c9fa3e24a93c71cfda5644172da1c1502a792
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.35 1 Een college van burgemeester en wethouders dat van de ambtenaar van de burgerlijke stand in zijn gemeente gegevens heeft ontvangen die van belang zijn voor de bijhouding van de basisregistratie door een andere gemeente, doet terstond mededeling van die gegevens aan het college van burgemeester en wethouders van de andere gemeente.
+  - index: 1
+    label: lid 2
+    sha256: 30f82736142e41adfa3156759768933a7deeee0d3c495b82936c8c1a1a55f8d3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Een college dat van de ambtenaar van de burgerlijke stand in zijn gemeente een ingevolge een verdrag inzake de internationale uitwisseling van gegevens op het gebied van de burgerlijke stand toegezonden kennisgeving heeft ontvangen die van belang is voor de bijhouding van de basisregistratie door een andere gemeente, doet die kennisgeving terstond toekomen aan het college van burgemeester en wethouders van de andere gemeente.
+  - index: 2
+    label: lid 3
+    sha256: d60f81693fd7a3f8591f5b8ba69b2832c6cf54757b91e14c5b5c7c5c9bd395a8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Onze Minister, dan wel een college van burgemeester en wethouders, verstrekt aan een college van burgemeester en wethouders dat daar belang bij heeft spontaan of op verzoek zo spoedig mogelijk alle inlichtingen die van belang zijn voor een goede uitvoering van de taak met betrekking tot de basisregistratie.
+- number: '2.36'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: bf0b9a393dead5e60e5773519f6d60f74cfa83655bb7da28fd5453ec1bb3bca6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.36 Bij algemene maatregel van bestuur kunnen aan overheidsorganen verplichtingen worden opgelegd tot het verschaffen aan het college van burgemeester en wethouders van de gegevens, bedoeld in artikel 2.7, eerste lid, onder a, onderdelen 10° en 11° .
+- number: '2.37'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 47d3f1ff03dd551d197985c41c35017800485f18a8d1a3ffc6be5aa2b80860b0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.37 Bij of krachtens algemene maatregel van bestuur kunnen regels worden gesteld met betrekking tot de wijze waarop aan de verplichtingen bedoeld in deze paragraaf moet worden voldaan.
+- number: '2.38'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4667894278e50dcde0a396e9e4c22a4b422a655f02a3f60463f29bf009325a67
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.38 1 Degene die naar redelijke verwachting gedurende een half jaar ten minste twee derde van de tijd in Nederland verblijf zal houden, meldt zich uiterlijk op de vijfde dag na de aanvang van zijn verblijf in persoon bij het college van burgemeester en wethouders van de gemeente waar hij zijn woonadres heeft om daarbij schriftelijk aangifte van verblijf en adres te doen. Indien hij geen woonadres heeft, kiest hij een briefadres en meldt hij zich binnen de gestelde termijn bij het college van burgemeester en wethouders van de gemeente waar hij zijn briefadres heeft om de bedoelde aangifte te doen.
+  - index: 1
+    label: lid 2
+    sha256: 29e30bbae0bfd78f65597589fa46bdb900fd67e5ff8db61028fa387a576dcdca
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Hij doet in de aangifte mededeling van de gegevens over zijn toekomstig verblijf in Nederland, over zijn adres in de gemeente en over het vorige verblijf buiten Nederland.
+  - index: 2
+    label: lid 3
+    sha256: 5e13363e1d29b620500b804102e4afde0c802324bc9d363301c362ad61189521
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Hij geeft bij de aangifte de inlichtingen en overlegt de geschriften ter zake van feiten betreffende zijn burgerlijke staat, zijn nationaliteit en zijn eerder verblijf in Nederland, die noodzakelijk zijn voor de bijhouding met betrekking tot hem van de basisregistratie. Op verzoek van het college van burgemeester en wethouders legt hij van een geschrift een door een beëdigde vertaler vervaardigde Nederlandse vertaling over. Indien hij zich in Nederland vestigt, komende vanuit Aruba, Curaçao, Sint Maarten of een van de openbare lichamen, overlegt hij een hem betreffend verhuisbericht, verstrekt door de verantwoordelijke voor de verwerking van gegevens in de basisadministratie in Aruba, Curaçao, Sint Maarten of een van de openbare lichamen, waar hij laatstelijk als ingezetene was ingeschreven.
+  - index: 3
+    label: lid 4
+    sha256: c181159c565503a5290228238f7161ab482388fd3338c2ac8fd3997179493c84
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Degene die naar redelijke verwachting gedurende een half jaar ten minste twee derde van de tijd in Nederland verblijf zal houden, doet aangifte van verblijf en adres overeenkomstig het eerste tot en met het derde lid, op het moment dat hij ophoudt te behoren tot een categorie als bedoeld in artikel 2.6 .
+  - index: 4
+    label: lid 5
+    sha256: 6d83775f9727fb707859f208173fc7154864211e9ef33de25d77f25f9d0d0f64
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. In een geval als bedoeld in het vierde lid vangt de in het eerste lid bedoelde termijn van vijf dagen aan met ingang van de dag na die waarop een in dat lid bedoelde situatie is ingetreden.
+  - index: 5
+    label: lid 6
+    sha256: 8b39a2b7f0a0bccc65eaa504bf01a0cc5738177c50c34f829cb7e73fb556f70b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '6. Aangifte van verblijf en adres blijft achterwege indien:'
+  - index: 6
+    label: onderdeel a
+    sha256: 284d0c9505111959f78f451cf42e6294009387b14e535caf6e6100d79e280181
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. het verblijf aanvangt door geboorte en inschrijving plaatsvindt op grond van de geboorteakte,
+  - index: 7
+    label: onderdeel b
+    sha256: 94ca455a684de1da437feab78ea6cb03503f09a2801ede9e7cb4ba16e78a67ed
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de betrokkene behoort tot een categorie van personen als bedoeld in artikel 2.6 , of
+  - index: 8
+    label: onderdeel c
+    sha256: 4bd693ac0d6f6a2ab7b513b63fdefb45147e5c9539a1798d891d1d07c04e609c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. de betrokkene een vreemdeling is die geen rechtmatig verblijf geniet.
+- number: '2.39'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 5555e89b77ced971dc66e236e6a7858a899a9a4556eee708d0f4652a3b4987b2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.39 1 De ingezetene die zijn adres wijzigt doet hiervan schriftelijk aangifte bij het college van burgemeester en wethouders van de gemeente waar hij zijn nieuwe adres heeft.
+  - index: 1
+    label: lid 2
+    sha256: 1104028577b13507824743ab9b98c046ae25b47c6432c15338a26765c3b5636e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Hij doet niet eerder aangifte dan vier weken vóór de beoogde datum van adreswijziging en niet later dan de vijfde dag na de adreswijziging. Hij doet in de aangifte mededeling van de datum van adreswijziging en van de gegevens over het nieuwe en het vorige adres.
+  - index: 2
+    label: lid 3
+    sha256: fc15794e155e4ad93d9bc07b55937e71bae1b86f11885695f0926287a4889372
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien een ingezetene geen woonadres heeft, kiest hij een briefadres. Het eerste en tweede lid zijn van overeenkomstige toepassing.
+- number: '2.40'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2c2ee15a13a2d8a91b3b13d7193f7baa711884fd950da7662a8463f506f829b5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.40 1 Degene die zijn woonadres heeft in een instelling die is aangewezen op grond van het derde of het vierde lid kan, in afwijking van de artikelen 2.38, eerste lid , en 2.39, eerste lid , in plaats van zijn woonadres een briefadres kiezen en daarvan overeenkomstig de genoemde bepalingen aangifte doen.
+  - index: 1
+    label: lid 2
+    sha256: 6a067eeff6d0a42398cb6f50ca4337d9979d44324b03257311e93360204fa960
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Een instelling wordt slechts aangewezen indien de aard van de instelling meebrengt, dat door opneming van het adres daarvan in de basisregistratie de persoonlijke levenssfeer van de betrokkenen onevenredig zou kunnen worden geschaad.
+  - index: 2
+    label: lid 3
+    sha256: 13763dd4a23d238aa3092bb66a621cd0c9f54bd06e3cd6f3fc22ff77e3c6f90e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Onze Minister kan categorieën van instellingen dan wel instellingen afzonderlijk aanwijzen, voor zover het betreft:'
+  - index: 3
+    label: onderdeel a
+    sha256: 71e555ee61421c1b89653727cf89e04d562531e51b52c52674dea4da57f4b9bc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. instellingen voor gezondheidszorg;
+  - index: 4
+    label: onderdeel b
+    sha256: 9b3b65f33a8e076b3db97b00be47cd12f8c827bde2af44761fe48900e2e58b7f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. instellingen op het gebied van de kinderbescherming;
+  - index: 5
+    label: onderdeel c
+    sha256: f3c3e1de53c8dc2437f7d9500c96ddec0dc3329f7d66b6ed77dc3eececb4f14f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. penitentiaire instellingen.
+  - index: 6
+    label: lid 4
+    sha256: ab925e07b29d17edfd5e0105faaf4d82f7950da5ee85d21b3010abc82d9b71d4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het college van burgemeester en wethouders kan een in de gemeente gevestigde instelling aanwijzen indien het betreft een instelling op het terrein van maatschappelijke opvang, bedoeld in [artikel 1, eerste lid, onderdeel g, onder 7°, van de Wet maatschappelijke ondersteuning](jci1.3:c:BWBR0020031&artikel=1) .
+  - index: 7
+    label: lid 5
+    sha256: 3189645da2fb9e946602c0d9ed92cf4c805746027c7d161812af077d6d0220dc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Het hoofd van een aangewezen instelling doet aan de betrokken personen tijdig schriftelijk mededeling van de mogelijkheid tot aangifte van een briefadres.
+- number: '2.41'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: da6ef80913849404a1bd6d37a1fa4be9cc428fb05b2b59a19f6049f446909bde
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.41 1 Voor zover het opnemen van een woonadres naar het oordeel van de burgemeester om veiligheidsredenen niet wenselijk is, kan de betrokkene in afwijking van artikel 2.38, eerste lid , en 2.39, eerste lid , in plaats van zijn woonadres een briefadres kiezen en daarvan overeenkomstig de genoemde bepalingen aangifte doen.
+  - index: 1
+    label: lid 2
+    sha256: 4da0a6793b563e6d45cf4576b5051916facc9323d835d8010df25e7ef4b90ab9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij algemene maatregel van bestuur kunnen nadere regels worden gesteld omtrent de toepassing van het eerste lid.
+- number: '2.42'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b2840b1b513d83164872496bb8f680a78f1cc6a4169060a6a1b552f913173f26
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 2.42 Als briefadresgever kan worden gekozen:'
+  - index: 1
+    label: onderdeel a
+    sha256: 23b6768a5716b2d596ee9795db7a251ebdc21971cf688fe906b246887c5a8ca2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. een natuurlijke persoon die als ingezetene is ingeschreven;
+  - index: 2
+    label: onderdeel b
+    sha256: b43e49213c52f9926d7c0acfa799c9e2d4e995b59f189b87f21878daf71c0c5a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. een rechtspersoon die zijn zetel heeft in Nederland en die door het college van burgemeester en wethouders is aangewezen om als briefadresgever in zijn gemeente op te treden.
+- number: '2.43'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d8bbfca899afe62c6a298aa4ddc58afecf47133c66d65d0b8beed5f3a84c9d6e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.43 1 De ingezetene die naar redelijke verwachting gedurende een jaar ten minste twee derde van de tijd buiten Nederland zal verblijven, doet bij het college van burgemeester en wethouders van de bijhoudingsgemeente voor zijn vertrek uit Nederland schriftelijk aangifte van vertrek. De aangiftetermijn vangt aan op de vijfde dag voor de dag van vertrek.
+  - index: 1
+    label: lid 2
+    sha256: 075ea075410d7bfd09bf27ae1edf0cc96d195b02f5708ec32c293c82fe325ebb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De ingezetene doet in die aangifte mededeling van de gegevens over zijn vertrek en het volgende verblijf buiten Nederland.
+  - index: 2
+    label: lid 3
+    sha256: 379028a5cc48f86831584210f8019441c4a01933d0a76b7568b304ce5576989d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Ter uitvoering van het eerste lid verschijnt de ingezetene in persoon bij het college, indien:'
+  - index: 3
+    label: onderdeel a
+    sha256: 733aefd273347c69fa931a9f2175123da7f4097f0d925f58af729bf3b199d19b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. niet alle ingezetenen met hetzelfde woonadres de verplichting, bedoeld in het eerste lid, vervullen, of
+  - index: 4
+    label: onderdeel b
+    sha256: 15174b4251bf41314f3ca0979214db0ce4ae6e1fa669f5dcd4de059fd5ea8404
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. niet voor alle ingezetenen met hetzelfde woonadres de verplichting, bedoeld in het eerste lid, wordt vervuld.
+  - index: 5
+    label: lid 4
+    sha256: c77585b7ceaac6cd639353896d67611d9ef6357f19e8fb3e046e696aaa2ff745
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Een minderjarige verschijnt in persoon, tenzij alle ingezetenen met hetzelfde woonadres aangifte van vertrek doen of aangifte van vertrek voor hen wordt gedaan.
+  - index: 6
+    label: lid 5
+    sha256: 0b08ba6f1521f34818405a8a7802ba31ac1f720d2d10492b238cb969108fa334
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Bij algemene maatregel van bestuur kunnen regels worden gesteld omtrent bijzondere gevallen waarin het eerste lid niet van toepassing is.
+- number: '2.44'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2e8cdae34ae8126707a15d574b0165f75a9695158910d0bf7d493cd34bc12002
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.44 De ingezetene brengt alle feiten betreffende zijn burgerlijke staat en nationaliteit die zich buiten Nederland hebben voorgedaan, zo spoedig mogelijk ter kennis aan het college van burgemeester en wethouders. Hij verstrekt aan het college, desgevraagd in persoon, de inlichtingen en overlegt de geschriften die noodzakelijk zijn voor de bijhouding met betrekking tot hem van de basisregistratie. Op verzoek van het college legt hij van een geschrift een door een beëdigde vertaler vervaardigde Nederlandse vertaling over.
+- number: '2.45'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 24ccae0bde9589f94147546950c7fb6d894ca32f54a91de5d3e202a3107b3380
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.45 1 Degene die aangifte heeft gedaan als bedoeld in de artikelen 2.38 tot en met 2.40 en artikel 2.43 , geeft op verzoek van het college van burgemeester en wethouders de inlichtingen ter zake van zijn aangifte die van belang zijn voor de bijhouding met betrekking tot hem van de basisregistratie. Deze verplichting is van overeenkomstige toepassing ten aanzien van het overleggen van geschriften. De betrokkene verschijnt hierbij desgevraagd in persoon.
+  - index: 1
+    label: lid 2
+    sha256: fd47fe7c04621f9d9588976da383542458456f08ec9d61a5252b85363adc4ce7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In de aangifte van een briefadres worden de redenen voor de aangifte van een briefadres medegedeeld. Bij de aangifte wordt een schriftelijke verklaring van instemming gevoegd van de briefadresgever.
+  - index: 2
+    label: lid 3
+    sha256: 26bc58c3867937a65f00b911c75c34170aac1d7ed94e95b92415dee86f535dde
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De briefadresgever draagt zorg dat voor de houder van het briefadres bestemde geschriften of inlichtingen daarover, aan hem worden doorgegeven of medegedeeld.
+  - index: 3
+    label: lid 4
+    sha256: cc22afc11d39d70c15047c8a049138aceee82e456cf2f66389446e535f649e28
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De briefadresgever verstrekt op verzoek van het college van burgemeester en wethouders, desgevraagd in persoon, ter zake van dat briefadres de inlichtingen en overlegt de geschriften die noodzakelijk zijn voor de bijhouding van de basisregistratie.
+  - index: 4
+    label: lid 5
+    sha256: f9d71a9a800d4ca332a948dd6734a80c216e709a82c014570efb0eba7af745a9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Bij algemene maatregel van bestuur kunnen nadere regels worden gesteld omtrent de toepassing van het eerste tot en met vierde lid.
+- number: '2.46'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a62198d811b5ee132eaa1e8b25b7d5f40462449539e0aee8754ebf4a0eedf5ea
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.46 De ingezetene verstrekt op verzoek van het college van burgemeester en wethouders over feiten betreffende zijn burgerlijke staat en nationaliteit, desgevraagd in persoon, de inlichtingen en overlegt de geschriften die noodzakelijk zijn voor de bijhouding van de basisregistratie. Op verzoek van het college van burgemeester en wethouders legt hij van een geschrift een door een beëdigde vertaler vervaardigde Nederlandse vertaling over.
+- number: '2.47'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a8c673c23cb85565e76d5ac426c4d7ea2539f78754620051ec5a738357588e33
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.47 Degene ten aanzien van wie het college van burgemeester en wethouders het redelijke vermoeden heeft dat hij in gebreke is met het doen van een aangifte als bedoeld in de artikelen 2.38 tot en met 2.43 , verstrekt op verzoek van het college van burgemeester en wethouders, desgevraagd in persoon, binnen een door het college in het verzoek te noemen termijn, ter zake de inlichtingen en overlegt de geschriften die noodzakelijk zijn voor de bijhouding met betrekking tot hem van de basisregistratie.
+- number: '2.48'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 7643a46050f67c579a4a63504fc269d27f6bfb5bc20f87d9df760d64d21e2297
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 2.48 De verplichtingen, vermeld in de artikelen 2.38 , 2.39 en 2.43 tot en met 2.47 , rusten op:'
+  - index: 1
+    label: onderdeel a
+    sha256: 8b1e186541b4d7613b2aa420d2cdbdcfd8d86b1d7c4653e93336bcf5a49faa5f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. ouders, voogden en verzorgers voor minderjarigen jonger dan 16 jaar;
+  - index: 2
+    label: onderdeel b
+    sha256: 91b1f74fd2ea2aab0a7b8e9baca98df24cdcab3d1b2453d8a8b7515622b49ee2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. ouders, voogden en verzorgers voor inwonende minderjarigen van 16 jaar of ouder, tenzij de minderjarige zelf de verplichting vervult;
+  - index: 3
+    label: onderdeel c
+    sha256: b71d7890565c0e0da1bb1d2a89aad27c40b77006d7e95c1cf148a66349b17250
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. curatoren voor onder curatele gestelden.
+- number: '2.49'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ea4f23bb9787c3d07f29b8e8adf21fa71577988c43efffb18de1c26ffc2a9b37
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 2.49 1 De verplichtingen, vermeld in de artikelen 2.39 en 2.44 tot en met 2.46 , kunnen worden vervuld door:'
+  - index: 1
+    label: onderdeel a
+    sha256: 46570bda6cc50240fe297ca22bdd5e7a23732198d781aa9aa750e066e91c1bf5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de ouder en zijn meerderjarige kind, indien beiden hetzelfde woonadres hebben, voor elkaar;
+  - index: 2
+    label: onderdeel b
+    sha256: 8e2e96da5bdaaaba5fe58ca306801e9291a5f7bd86b106ff82875a3b6dd396a8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. echtgenoten dan wel geregistreerde partners die hetzelfde woonadres hebben, voor elkaar;
+  - index: 3
+    label: onderdeel c
+    sha256: f6d9a1b5a2b516d7421127acaf3161df4ecb66f6b6676665ac3f802a7f02d14d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. elke meerderjarige voor een persoon die hem daartoe schriftelijk gemachtigd heeft;
+  - index: 4
+    label: onderdeel d
+    sha256: fb258b95b06bd6d448b5bbb82c11c39adfd612c699aa21f6391cf1516d9dcd59
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. het hoofd van een instelling voor gezondheidszorg voor een in die instelling verblijvende persoon die wegens de toestand van zijn gezondheid niet in staat kan worden geacht aan zijn verplichtingen te voldoen of een machtiging daartoe te geven, dan wel de echtgenoot, de geregistreerde partner of andere levensgezel of de bloed- of aanverwanten tot en met de tweede graad van een zodanig persoon, onder overlegging van een schriftelijke verklaring ter zake van het hoofd van de desbetreffende instelling.
+  - index: 5
+    label: lid 2
+    sha256: e78b67f2ecc7d6a7a7dc55b183a53a8cf929c9404798ec853f4eea6c85e044e7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In de gevallen, bedoeld in het eerste lid, kan het college van burgemeester en wethouders de vertegenwoordigde overeenkomstig de genoemde artikelen oproepen om in persoon te verschijnen tot het verstrekken van inlichtingen.
+  - index: 6
+    label: lid 3
+    sha256: 4ae9538704377677af490a629db6893624996492a23a98b765dc852b545fd717
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het eerste en tweede lid zijn van overeenkomstige toepassing op de in artikel 2.38 vermelde verplichtingen voor zover het bij algemene maatregel van bestuur bepaalde gevallen betreft. De maatregel bepaalt tevens de gevallen waarin kan worden afgeweken van de in dat artikel vermelde verplichting om zich in persoon te melden bij het college van burgemeester en wethouders. De maatregel bepaalt slechts gevallen waarin er om zwaarwegende redenen van kan worden afgezien dat de betrokkene zelf de verplichtingen vervult en zich daartoe in persoon meldt bij het college.
+  - index: 7
+    label: lid 4
+    sha256: 294822d88b7b2a7267b40b28f0f9abda276b2bdd79a895c35d69b29f7e1fed4d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. Het eerste lid, onderdelen a, b en d, en het tweede lid zijn van overeenkomstige toepassing op de in artikel 2.43 vermelde verplichting, met dien verstande dat, behoudens bij algemene maatregel van bestuur te bepalen gevallen, een ouder en zijn meerderjarige kind en echtgenoten dan wel geregistreerde partners voor elkaar slechts de aangifteplicht kunnen vervullen, indien:'
+  - index: 8
+    label: onderdeel a
+    sha256: c1c38acb55b01474c321d403cd88f03352b8b88fffaba26a07ed73d4e07fc70b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. zij die verplichting ook voor zichzelf vervullen, en
+  - index: 9
+    label: onderdeel b
+    sha256: 63bfa7546d10226f174932e8c8ddef5c55e16abeb1d5279539a5d1e8a8aaf98e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. alle andere ingezetenen met hetzelfde woonadres die verplichting vervullen of die verplichting voor hen wordt vervuld. De tweede en derde volzin van het derde lid zijn van overeenkomstige toepassing.
+  - index: 10
+    label: lid 5
+    sha256: de449d010410e61b40134f566a45bd163a47ccab8526514c45e0b96835b70a1a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Voor de toepassing van het eerste lid wordt met betrekking tot de verplichtingen, vermeld in artikel 2.39 , onder woonadres het nieuwe woonadres verstaan.
+- number: '2.50'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4405cffe08f1d693b1abaa0695ae4b3ce352b6edd9109383e190aa443eee4a12
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.50 Het hoofd van een instelling of bedrijf waar personen verblijf plegen te houden, de instellingen, bedoeld in artikel 2.40 daaronder begrepen, verstrekt, indien de instelling of het bedrijf ter zake door het college van burgemeester en wethouders is aangewezen, op door het college te bepalen tijdstippen aan het college de door het college gevraagde inlichtingen over de personen die naar redelijke verwachting in de instelling of het bedrijf voor onbepaalde tijd verblijf zullen houden dan wel gedurende drie maanden ten minste twee derde van de tijd zullen overnachten.
+- number: '2.51'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 467f3724a194da13a8b2e70d6d0786ced9286bf93c906fe54f9c2e8762cc4806
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.51 De echtgenoot, de geregistreerde partner en andere nabestaanden tot en met de tweede graad van een ingezetene die in het buitenland is overleden, verstrekken op verzoek van het college van burgemeester en wethouders van de gemeente waar betrokkene is ingeschreven, aan het college, voor zover mogelijk, de inlichtingen over dat overlijden en overleggen de geschriften die noodzakelijk zijn voor de bijhouding van de basisregistratie.
+- number: '2.52'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 79cb33940faa14486f2cfffccc4dcc4f4a991a4280a9791a7a3d1e418e04fa16
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.52 1 Degene die ter uitvoering van ingevolge deze paragraaf op hem rustende verplichtingen in persoon bij het college van burgemeester en wethouders verschijnt, overlegt desgevraagd met het oog op de vaststelling van zijn identiteit een op hem betrekking hebbend document als bedoeld in [artikel 1 van de Wet op de identificatieplicht](jci1.3:c:BWBR0006297&artikel=1) .
+  - index: 1
+    label: lid 2
+    sha256: 6984cfa3661411b370be4a9a293aeaba502b6f8188036db5db2e41c9a8fedb12
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De in artikel 2.48 bedoelde ouders, voogden, verzorgers en curatoren van minderjarigen of onder curatele gestelden, laten desgevraagd de minderjarige of de onder curatele gestelde met het oog op de vaststelling van de identiteit verschijnen bij het college van burgemeester en wethouders en overleggen desgevraagd een op hem betrekking hebbend document als bedoeld in het eerste lid.
+- number: '2.53'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b79ee0dba621a512600499e2015c8e684cc7f1e9734d476da230ab8bc575b679
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.53 1 Een verzoek als bedoeld in deze paragraaf wordt gericht aan het college van burgemeester en wethouders van de bijhoudingsgemeente.
+  - index: 1
+    label: lid 2
+    sha256: 3d253d46045d67a6358272dbb66efb397bf7613d5fb4896d345a8d0ba352bb07
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Een verzoek als bedoeld in artikel 2.55 kan ook worden gericht aan het college van enige andere gemeente in Nederland.
+  - index: 2
+    label: lid 3
+    sha256: 1c8fd2dab7915f36a9c4cedb2a6380181ddf971dcc7b18a5864ca9d98a51893d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Een verzoek als bedoeld in artikel 2.55 kan ook worden gericht aan Onze Minister. In dat geval treedt Onze Minister voor de toepassing van artikel 2.55 in de plaats van het college van burgemeester en wethouders en wordt het verzoek gedaan door tussenkomst van een inschrijfvoorziening.
+- number: '2.54'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: cefcacd53185f775e789226818b1d0eec019a6c5ea49a3ccf9638c5c938df28e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.54 1 Het college van burgemeester en wethouders zendt binnen vier weken na een inschrijving als bedoeld in de artikelen 2.3 en 2.4 , alsmede binnen vier weken nadat een ingeschrevene die geen ingezetene was ingezetene is geworden, aan de ingeschrevene in begrijpelijke vorm een volledig overzicht van zijn persoonslijst.
+  - index: 1
+    label: lid 2
+    sha256: 33a3dedc24acc3d7ebcd4ef054c375721b06750f12e024404acaafa92a694ca4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij minderjarigen jonger dan 16 jaar en bij onder curatele gestelden geschiedt de toezending aan de ouders, voogden of verzorgers, onderscheidenlijk aan de curator.
+  - index: 2
+    label: lid 3
+    sha256: b76f7f3627416b4023ffe69cb0573dd33c6af388c265dd00737c8c1bb7b33ccb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij de toezending wordt schriftelijk mededeling gedaan van de hoofdlijnen van de ter zake van de basisregistratie geldende regels, waaronder ten minste de hoofdlijnen van de regels betreffende de identiteit van de voor de verwerking verantwoordelijke, de doeleinden van de basisregistratie, de opgenomen gegevenscategorieën, de categorieën van ontvangers van gegevens en de rechten van de ingeschrevene.
+  - index: 3
+    label: lid 4
+    sha256: aee9f4473b428a02c52b30271c1628b04db3fc41a6b1b63b6930353e80928d12
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Degene die aangifte van verblijf en adres doet, wordt bij die gelegenheid schriftelijk op de hoogte gesteld van het recht, bedoeld in artikel 2.59 .
+- number: '2.55'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: cbca47db923fff7e319639a61486c8ee5975413b31594d4c482e2dc3f90472d9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.55 1 Het college van burgemeester en wethouders deelt een ieder op diens verzoek schriftelijk binnen vier weken kosteloos mede of hem betreffende persoonsgegevens in de basisregistratie worden verwerkt. Indien zodanige gegevens worden verwerkt, wordt de verzoeker met betrekking tot de basisregistratie de in artikel 2.54, derde lid , bedoelde schriftelijke mededeling gedaan.
+  - index: 1
+    label: lid 2
+    sha256: 390a7619ec912485a15d4a69ef11148dba73e3fafdaef5d56aa0c1856a9204d2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het college verleent een ieder op diens verzoek binnen vier weken kosteloos inzage in hem betreffende gegevens in de basisregistratie.
+  - index: 2
+    label: lid 3
+    sha256: e3f046dcbfea2088d360234807bfae8e5dddf5f888f4fc4c0991c8e4d2a0f956
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het college verstrekt een ieder op diens verzoek binnen vier weken een, desgevraagd gewaarmerkt, afschrift in begrijpelijke vorm van de hem betreffende persoonsgegevens die in de basisregistratie worden verwerkt, alsmede de beschikbare informatie over de oorsprong van die gegevens voor zover die niet van de verzoeker zelf afkomstig zijn.
+  - index: 3
+    label: lid 4
+    sha256: 62555c889d9bfcabe98992280480eaabda11a3142bfabc706db432216d60b115
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het college draagt zorg voor een deugdelijke vaststelling van de identiteit van de verzoeker.
+  - index: 4
+    label: lid 5
+    sha256: 3dcb0a91dfa1330ebd1e87da6b82e0fb0c16e1a28f81e1ab4bada20d4f4aca39
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '5. De verzoeken, bedoeld in het eerste tot en met derde lid, worden gedaan door:'
+  - index: 5
+    label: onderdeel a
+    sha256: 359205f5716415f5f940e7cd3a9c6d567c2d2c41b2c388d1a108bd1b60c567bc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. ouders, voogden of verzorgers voor minderjarigen jonger dan 16 jaar;
+  - index: 6
+    label: onderdeel b
+    sha256: e8f3d904c5f10582a82421ec9f09b090ec017303ce7ec4c28b3a0765633b6654
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. curatoren voor onder curatele gestelden.
+  - index: 7
+    label: lid 6
+    sha256: 67fc8fdd0d183ca93b65f4e28bef712bf2baad9bdefb9d180174e581bb0d22ac
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Aan het verzoek wordt geen gevolg gegeven indien dat niet met een redelijke tussenpoos is gedaan ten opzichte van een eerder verzoek.
+- number: '2.56'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4de758905f57e530c8a00a23683eed477650084d955ded673299da64ff1596a6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.56 1 Het college van burgemeester en wethouders neemt op schriftelijk verzoek van de daartoe krachtens [artikel 9 van Boek 1 van het Burgerlijk Wetboek](jci1.3:c:BWBR0002656&artikel=9) bevoegde ingeschrevene binnen vier weken kosteloos op zijn persoonslijst de gegevens op over het gebruik van de geslachtsnaam van de echtgenoot, de eerdere echtgenoot, de geregistreerde partner of de eerdere geregistreerde partner.
+  - index: 1
+    label: lid 2
+    sha256: 3cb7fb93a8538bbded0b70ec40ba5e32885495e8e060348f1e351ad46004f0ba
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het college doet van de opneming van de gegevens terstond schriftelijk mededeling aan de verzoeker.
+- number: '2.57'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 1af38caf762c28b000e7337ebd7eb4d4af5b994b3af1922c9e68a52c69687914
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 2.57 1 Het college van burgemeester en wethouders verwijdert op schriftelijk verzoek van de adoptiefouders van een minderjarige jonger dan 16 jaar, of op schriftelijk verzoek van een adoptiefkind van 16 jaar of ouder, binnen vier weken kosteloos van de persoonslijst van het adoptiefkind, de vóór de adoptie geldende algemene gegevens voor zover het betreft:'
+  - index: 1
+    label: onderdeel a
+    sha256: 959caa2c39d35ce32bba7ede65fa7bae0b446062e185cf4cfcb54ebcaa33b89b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. gegevens over de naam;
+  - index: 2
+    label: onderdeel b
+    sha256: d5fe22f5ed593c650e3169e07baa6ed30d2bd094f1283bb9e71149b216ed8341
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. gegevens over één of beide ouders;
+  - index: 3
+    label: onderdeel c
+    sha256: 53f381e7edb09203a5f7dad42f9c277ca41f65d4fd5d77e0bd466eb91d34ac38
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. gegevens over de bij de adoptie verloren nationaliteit;
+  - index: 4
+    label: onderdeel d
+    sha256: 4ba1637c3e335d431aacd878e0c3454032270e99166752d367d84ef829df8f41
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. gegevens over de bijhoudingsgemeente en het adres in die gemeente alsmede over het verblijf in Nederland en het vertrek uit Nederland.
+  - index: 5
+    label: lid 2
+    sha256: bb83b9d2b62c23aeef4b16daf4e339c6afec4b4d960bea5ffb83d8a830e64428
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het college verwijdert op schriftelijk verzoek van de ouder met wie door een uitspraak van adoptie de familierechtelijke betrekkingen tot een kind zijn verbroken, binnen vier weken kosteloos van de persoonslijst van die ouder de algemene gegevens over dat kind.
+  - index: 6
+    label: lid 3
+    sha256: ebf0e799b7d0fbb700e76b61a27771306618801a37198c43890533d31b78786c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Het college verwijdert op schriftelijk verzoek van de ingeschrevene binnen vier weken kosteloos van zijn persoonslijst de algemene gegevens die zijn gewijzigd in verband met een rechterlijke last tot wijziging van de vermelding van het geslacht in de geboorteakte van de ingeschrevene, voor zover deze gegevens golden vóór de wijziging en het betreft:'
+  - index: 7
+    label: onderdeel a
+    sha256: 959caa2c39d35ce32bba7ede65fa7bae0b446062e185cf4cfcb54ebcaa33b89b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. gegevens over de naam;
+  - index: 8
+    label: onderdeel b
+    sha256: 5e9a880b0666602a284ff48adde5f379dc3d9f1261dfbe40d0cc9fba0114f09a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. gegevens over het geslacht;
+  - index: 9
+    label: onderdeel c
+    sha256: 6dff68ba62ff59e42d46a306b854909497cd573fb07a524096756ae9e76fb30a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. gegevens over het gebruik van de geslachtsnaam van de echtgenoot, de eerdere echtgenoot, de geregistreerde partner of de eerdere geregistreerde partner.
+  - index: 10
+    label: lid 4
+    sha256: 484cb349e05c24824936a3a4c4635ed8f65f9fc08ffdcb26e7c699f95affe5b0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het college verwijdert op schriftelijk verzoek van de ingeschrevene die de leeftijd van 16 jaar heeft bereikt, binnen vier weken kosteloos van zijn persoonslijst de algemene gegevens over de naam en het geslacht van een ouder, een eerdere echtgenoot of een eerdere geregistreerde partner of het algemeen gegeven over de naam van het kind van de ingeschrevene, die zijn gewijzigd in verband met een rechterlijke last tot wijziging van de vermelding van het geslacht in de geboorteakte van de ouder, eerdere echtgenoot, eerdere geregistreerde partner of het kind.
+  - index: 11
+    label: lid 5
+    sha256: e711af5a2b62482aba88a6f3c9424719ba5ae3ec641f4f072ae05f96e3e70bf1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Artikel 2.55, vierde lid , is van toepassing op een verzoek als bedoeld in het eerste tot en met vierde lid. Op een verzoek als bedoeld in het derde of vierde lid is bovendien artikel 2.55, vijfde lid, van overeenkomstige toepassing.
+  - index: 12
+    label: lid 6
+    sha256: 3a88d21f2b7a34433b18e94235d91322f50459309183e75f63c0b41fd43f38fb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Het college doet van de verwijdering terstond schriftelijk mededeling aan de verzoeker.
+- number: '2.58'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 9bc5cacd65f4fe83becffb1ece99b1cec3085bb2f2ef85e756cf1938ba1f1cac
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.58 1 Het college van burgemeester en wethouders voldoet binnen vier weken kosteloos aan het verzoek van betrokkene hem betreffende gegevens in de basisregistratie te verbeteren, aan te vullen of te verwijderen, indien deze feitelijk onjuist dan wel onvolledig zijn of in strijd met een wettelijk voorschrift worden verwerkt. Het verzoek bevat de aan te brengen wijzigingen.
+  - index: 1
+    label: lid 2
+    sha256: d785b062cfaf810149eba163d6ac161fae5adc0592a2b51dff1204dd68fde5b8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het college geeft aan het verzoek uitvoering met inachtneming van het bepaalde bij of krachtens deze afdeling.
+  - index: 2
+    label: lid 3
+    sha256: 2df8ab3463a18a3a6dc3fc620532f3ff907eefa97abf6f85baf52a764d0c5775
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het college kan de termijn, bedoeld in het eerste lid, voor zover noodzakelijk, met telkens acht weken verlengen, indien het verzoek gegevens over de burgerlijke staat of de nationaliteit betreft. Het college doet terstond schriftelijk mededeling van de verlening aan de verzoeker.
+  - index: 3
+    label: lid 4
+    sha256: 6f490eccccee365d59d5db3b76251984caeba0039adf459e11ed5a47886b599e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Artikel 2.55, vierde en vijfde lid , is van overeenkomstige toepassing.
+  - index: 4
+    label: lid 5
+    sha256: 903e765fcf0055bdcf97bdd27c84cedb15b270d8075da0a9db31be524eaee932
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Het college van burgemeester en wethouders doet van de uitvoering van het verzoek terstond schriftelijk mededeling aan de verzoeker.
+- number: '2.59'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 829be653d1d323ce9ae272aebc79817b24cf7ca6d198fcaff4dd737125ac2bda
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.59 Het college van burgemeester en wethouders vermeldt op schriftelijk verzoek van de betrokkene kosteloos op zijn persoonslijst een aantekening omtrent beperking van de verstrekking van gegevens aan derden. Het college geeft binnen vier weken gevolg aan het verzoek en doet daarvan terstond schriftelijk mededeling aan de verzoeker, onder vermelding van de geldende regels ter zake. Indien het verzoek bij gelegenheid van een aangifte van verblijf en adres wordt gedaan, wordt aan dat verzoek bij die gelegenheid gevolg gegeven. Artikel 2.55, vierde en vijfde lid , is van overeenkomstige toepassing.
+- number: '2.60'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a9b92a28200921aba193a8a5c0bcba7181f187797a843b57d9e65b28100c35fc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 2.60 Een beslissing van het college van burgemeester en wethouders om:'
+  - index: 1
+    label: onderdeel a
+    sha256: 37a213e4bb8d17037b5f6199a5da5eb32168c8e6b1ca2d16e93dad952d6264b4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. aan een aangifte geen of slechts ten dele gevolg te geven;
+  - index: 2
+    label: onderdeel b
+    sha256: 396afb25816b9386d17ce4939a44cc93731cffbeae054a97d830e3c198b58878
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. een gegeven over de burgerlijke staat niet op te nemen, dan wel een geschrift daarover dat als akte is aangeboden niet als zodanig aan te merken;
+  - index: 3
+    label: onderdeel c
+    sha256: a19624844d60705811809a91cdfb3aa10d1a279ca662eee9d24f09a56fe215d2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. een gegeven over de nationaliteit niet op te nemen;
+  - index: 4
+    label: onderdeel d
+    sha256: 70e66c23b73f2a223bc0df8ca278a09b5703e2751dba3c55e1f3ff3643b378f3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. ambtshalve over te gaan tot inschrijving, of tot opneming van gegevens in het geval dat inschrijving of opneming op grond van een aangifte had moeten geschieden;
+  - index: 5
+    label: onderdeel e
+    sha256: a3b1c7e82038a18df57a7b6a19681acca8a3f0059f26e855b05e058b2d065956
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: e. ambtshalve over te gaan tot verbetering, aanvulling of verwijdering van een algemeen gegeven;
+  - index: 6
+    label: onderdeel f
+    sha256: cccc62fa3c42ded96df4d10f99fecb6eea7e56504685bcfc59495f1d6973f2c3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: f. bij een opgenomen algemeen gegeven een aantekening over de onjuistheid van dat gegeven of over de strijdigheid daarvan met de Nederlandse openbare orde te plaatsen;
+  - index: 7
+    label: onderdeel g
+    sha256: 8a93aec40021fea40348704c0ec72f332411fb89e51f9b4e421c5a1bd7b04d38
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: g. niet te voldoen aan een verzoek als bedoeld in de artikelen 2.55 tot en met 2.59 , wordt gelijkgesteld met een besluit in de zin van de [Algemene wet bestuursrecht](jci1.3:c:BWBR0005537) .
+- number: '2.61'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c7ccaa0e6a8d08f903b062c939fc1904de9412851e3e73c4dc18aaf0be737851
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.61 1 Indien de rechter het beroep, ingesteld tegen een besluit als bedoeld in artikel 2.60 , gegrond verklaart met toepassing van [artikel 8:72, derde lid, onderdeel b, of vierde lid, van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&artikel=8:72) , doet hij dat met inachtneming van het bepaalde bij of krachtens deze afdeling.
+  - index: 1
+    label: lid 2
+    sha256: 6f3f80e6805b08cc4e857953f7dc6c75c901ca1cbeb7998f4e742cf6729e5115
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Voor zover een besluit als bedoeld in artikel 2.60 het Nederlanderschap betreft, kan de betrokkene zich uitsluitend wenden tot de rechtbank Den Haag met een verzoek als bedoeld in [artikel 17 van de Rijkswet op het Nederlanderschap](jci1.3:c:BWBR0003738&artikel=17) .
+- number: '2.62'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 194fb3704bb5bdfab44f5e75b1922c5d6bad3250a56ea7ef5e0275cabc317711
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 2.62 In deze afdeling en de daarop berustende bepalingen wordt verstaan onder een aangewezen bestuursorgaan: een bestuursorgaan als bedoeld in artikel 2.65 , voor zover het betreft de taken en gevallen waar de in dat artikel bedoelde aanwijzing betrekking op heeft.'
+- number: '2.63'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 079b71061ebfa2725ab9150b2fea1f93973b2047195310ef80c2543cbd0ef11c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.63 1 Deze afdeling is van toepassing op personen die niet als ingezetene in de basisregistratie zijn ingeschreven, met uitzondering van personen die op het moment van hun overlijden ingezetene waren.
+  - index: 1
+    label: lid 2
+    sha256: bc0e321c524013da9455b34e26e37dd7cd5f9069bf16b3b4756f5dae7f65b15f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In afwijking van het eerste lid worden geen gegevens opgenomen krachtens deze afdeling in een geval als bedoeld in artikel 2.1, derde lid .
+  - index: 2
+    label: lid 3
+    sha256: 854af3be9cabc4f315760438138c1942e8b551cabc1bae60cc28c0fb663f07a2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De krachtens deze afdeling over een ingeschrevene opgenomen gegevens worden zodra hij ingezetene wordt opnieuw vastgesteld met inachtneming van de eerste afdeling van dit hoofdstuk .
+- number: '2.64'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: caea833021764fffb60da2d4c9660a9d331fd3bd9d527642c54b327abfe413f8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 2.64 Onze Minister houdt in Nederland voorzieningen in stand ten behoeve van de uitvoering van deze wet inzake:'
+  - index: 1
+    label: onderdeel a
+    sha256: 92f29b47609604b2a374a302c1fb32f0075cf95e50839e8e27ad50b90f8533c9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. het inschrijven van niet-ingezetenen;
+  - index: 2
+    label: onderdeel b
+    sha256: 7c3cf7d3754717d560b8abc81bbd18c47e6e6cf0cdaa6f3b00ab5e9f7e79ab8c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. het indienen van verzoeken van niet-ingezetenen aan Onze Minister.
+- number: '2.65'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c80f2eb863376eb1c3203df6bacbeb8579d0b4449792fc2bf72331a6d252c76a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.65 Bij algemene maatregel van bestuur kunnen bestuursorganen worden aangewezen die bevoegd zijn om Onze Minister een verzoek te doen als bedoeld in artikel 2.68, eerste lid , of een opgave als bedoeld in artikel 2.70, derde lid, onderdeel a . Bij de maatregel wordt bepaald op welke taken van het bestuursorgaan de aanwijzing betrekking heeft. Daarbij kan tevens bepaald worden op welke gevallen de aanwijzing betrekking heeft.
+- number: '2.66'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4d3825a900e98e208cdce116bddcbfdebe0ff7d7c0919abc8508031dbe0a4aba
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.66 1 Onze Minister schrijft een persoon in de basisregistratie in op grond van een verzoek als bedoeld in artikel 2.67 of artikel 2.68 .
+  - index: 1
+    label: lid 2
+    sha256: d5336f2f72522d82fbb838f624d2babc9d84b1782eca0b621b52acf9b3f0e74d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Inschrijving geschiedt niet als de betrokkene reeds in de basisregistratie is ingeschreven.
+- number: '2.67'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 9880d984d3c4c9cebf80664d7d94fe9b6d064e68d41bb25ce701a4faae6e448c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.67 1 Eenieder kan Onze Minister verzoeken hem in te schrijven in de basisregistratie.
+  - index: 1
+    label: lid 2
+    sha256: 73082d8df67c4ec6cc814495f812e650b570f4238f70608c22e577a19c0d502f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij zijn verzoek overlegt de betrokkene ten minste de bij of krachtens algemene maatregel van bestuur aangewezen bescheiden ten behoeve van een juiste inschrijving.
+  - index: 2
+    label: lid 3
+    sha256: dff903fc6333f5b90c3304e3fd09ef8b9159929d58c47ea5fa21cb717e2f3ca1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Onze Minister gaat niet over tot inschrijving dan nadat de betrokkene ten behoeve van de vaststelling van zijn identiteit in persoon bij de inschrijfvoorziening is verschenen. Bij of krachtens algemene maatregel van bestuur kan worden bepaald in welke gevallen van de verschijning in persoon kan worden afgezien.
+  - index: 3
+    label: lid 4
+    sha256: 9e0468540e3bf4e8eda19a9d6b6af90eb0d416569553cb5d89d4bee0f1ddf3f7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Onze Minister gaat niet over tot inschrijving dan nadat de identiteit van de betrokkene deugdelijk is vastgesteld.
+  - index: 4
+    label: lid 5
+    sha256: 18518723ab591ad32972ecff486ce419328f330e763d26431c08f9f354e97e35
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Onze Minister gaat niet over tot inschrijving als de betrokkene op grond van de eerste afdeling van dit hoofdstuk voor inschrijving in aanmerking komt.
+- number: '2.68'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 5f04d6c2af378289107e1e59fc7aec826016e5bdcd4c025e0b477ded667566a8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.68 1 Een aangewezen bestuursorgaan kan Onze Minister verzoeken om een persoon in te schrijven in de basisregistratie.
+  - index: 1
+    label: lid 2
+    sha256: e07cd5d8886b89ad915c5b16b9ff5d502bdcf26a6b1b0fe2f2f8bd8d5fd73d61
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het bestuursorgaan verzoekt alleen om inschrijving als het zelf gegevens over de betrokkene verwerkt in verband met de uitoefening van zijn taak.
+  - index: 2
+    label: lid 3
+    sha256: 63b735c2abd5b9d8584eee6ec4ef3a580b529be1b71241796cb60513e32ef974
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het bestuursorgaan verzoekt niet om inschrijving dan nadat de identiteit van de betrokkene deugdelijk is vastgesteld.
+  - index: 3
+    label: lid 4
+    sha256: cfdfd2139ed701cf3af3aa5b58a59901942875aa62d75ae1318fc44d2289c57d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het bestuursorgaan verzoekt niet om inschrijving als de betrokkene op grond van de eerste afdeling van dit hoofdstuk voor inschrijving in aanmerking komt.
+- number: '2.69'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b1d8c37cfa17dffff4f6483f0b84b74bdf2aabd8804b9270737525243f327e01
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 2.69 1 In de basisregistratie worden over de ingeschrevene uitsluitend de volgende gegevens opgenomen:'
+  - index: 1
+    label: onderdeel a
+    sha256: 478bbf673c080dcd4d87f89ccac8989599368f9d7a947870cc52c463315097c4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'a. algemene gegevens: - 1° gegevens over de burgerlijke staat waar het betreft de naam, de geboorte, het geslacht en het overlijden; - 2° gegevens over de nationaliteit, met dien verstande dat geen gegevens over een vreemde nationaliteit worden opgenomen naast gegevens over het Nederlanderschap of het feit dat de betrokkene als Nederlander wordt behandeld; - 3° gegevens in verband met het verblijfsrecht van de vreemdeling; - 4° gegevens over het woonadres; - 5° gegevens over het burgerservicenummer van de ingeschrevene; - 1° gegevens over de burgerlijke staat waar het betreft de naam, de geboorte, het geslacht en het overlijden; - 2° gegevens over de nationaliteit, met dien verstande dat geen gegevens over een vreemde nationaliteit worden opgenomen naast gegevens over het Nederlanderschap of het feit dat de betrokkene als Nederlander wordt behandeld; - 3° gegevens in verband met het verblijfsrecht van de vreemdeling; - 4° gegevens over het woonadres; - 5° gegevens over het burgerservicenummer van de ingeschrevene;'
+  - index: 2
+    label: onderdeel b
+    sha256: fd637cd87b6134fe74eac4a90b4ef2ab1f1f633a11590c916fccf7942ae4d499
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'b. administratieve gegevens: - 1° gegevens in verband met de inschrijving; - 2° gegevens over het niet-ingezetenschap; - 3° gegevens over de opgave van algemene gegevens die het aangewezen bestuursorgaan heeft gedaan of over het verzoek van de ingeschrevene om opneming van algemene gegevens; - 4° gegevens ter aanduiding van de bron waaruit algemene gegevens zijn verkregen, dan wel van de rechtsgrond krachtens welke algemene gegevens zijn opgenomen; - 5° gegevens ter aanduiding van de onjuistheid van een opgenomen algemeen gegeven of van strijd met de Nederlandse openbare orde van een opgenomen gegeven over de burgerlijke staat dan wel over een onderzoek naar die onjuistheid of strijdigheid, alsmede andere gegevens, noodzakelijk in verband met de bijhouding van de basisregistratie; - 6° gegevens over de beperking van de verstrekking van gegevens aan derden. - 1° gegevens in verband met de inschrijving; - 2° gegevens over het niet-ingezetenschap; - 3° gegevens over de opgave van algemene gegevens die het aangewezen bestuursorgaan heeft gedaan of over het verzoek van de ingeschrevene om opneming van algemene gegevens; - 4° gegevens ter aanduiding van de bron waaruit algemene gegevens zijn verkregen, dan wel van de rechtsgrond krachtens welke algemene gegevens zijn opgenomen; - 5° gegevens ter aanduiding van de onjuistheid van een opgenomen algemeen gegeven of van strijd met de Nederlandse openbare orde van een opgenomen gegeven over de burgerlijke staat dan wel over een onderzoek naar die onjuistheid of strijdigheid, alsmede andere gegevens, noodzakelijk in verband met de bijhouding van de basisregistratie; - 6° gegevens over de beperking van de verstrekking van gegevens aan derden.'
+  - index: 3
+    label: lid 2
+    sha256: c307915e65a4a50c2909189fd7514340df9b204f3802951ff36e68ae043fc171
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Artikel 2.7, tweede tot en met vierde lid , is van overeenkomstige toepassing.
+- number: '2.70'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a17b658fe572ea51684bb278c82055989058ccd37c71306dcba3da434e607596
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.70 1 Onze Minister neemt de gegevens over de burgerservicenummers op, overeenkomstig artikel 2.24 .
+  - index: 1
+    label: lid 2
+    sha256: 221de82064b4df18706166e37a1ce2a928eca09e153577e11100426e4f039a8e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister neemt bij een inschrijving als bedoeld in artikel 2.67 de bij algemene maatregel van bestuur aangewezen algemene gegevens op.
+  - index: 2
+    label: lid 3
+    sha256: 7f079fd2cd0a53c422d6597a0dc1cc59daba49d838403fd350bce91d64f72c71
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Onze Minister neemt in de overige gevallen algemene gegevens op:'
+  - index: 3
+    label: onderdeel a
+    sha256: c10a7b3ea2ffc22cb78386c5be0154368befa028fc9fc99b094ac40ad01fbd79
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. door ontlening aan een opgave van een aangewezen bestuursorgaan;
+  - index: 4
+    label: onderdeel b
+    sha256: e265305560937c6891fe22de5dd7e3fd969fd7030ee8713da5ef73cdfdf51cfe
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. op verzoek van de ingeschrevene.
+  - index: 5
+    label: lid 4
+    sha256: 01fb70b6eea6cd081d115df31ccec81f5d7b1af267a5271afec74a3d4a9f1954
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Onze Minister draagt zorg voor het opnemen van de administratieve gegevens die betrekking hebben op de algemene gegevens.
+- number: '2.71'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8f9e4160082cc4aa5160f8bc36e468c8c9c8c78c665a9de091485794f436a729
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.71 1 Het aangewezen bestuursorgaan dat een opgave doet als bedoeld in artikel 2.70, derde lid, onder a , geeft daarbij toepassing aan de artikelen 2.72 tot en met 2.75 .
+  - index: 1
+    label: lid 2
+    sha256: 8b705ffa35710fc04a04e3cd3f12fbffc7922d712d20ccd7ae9dfba961f8d10d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien het bestuursorgaan op grond van een wet, een verdrag of een besluit van een volkenrechtelijke organisatie gehouden is de desbetreffende gegevens te ontlenen aan een opgave van een buitenlands orgaan, ontleent het bestuursorgaan deze gegevens aan die opgave.
+  - index: 2
+    label: lid 3
+    sha256: bc4808d8a9f5316f0e0e98279ce8221e08e68ebbfd5603f8107c666eac7295bf
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien Onze Minister gegevens opneemt, anders dan door ontlening aan een opgave van een aangewezen bestuursorgaan, geeft hij daarbij toepassing aan de artikelen 2.72 tot en met 2.75 .
+- number: '2.72'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: fc6de000cae6b22696e9914e959e88ddc88ff4c78cc41f84822cfd6937785a13
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.72 De gegevens over de burgerlijke staat worden vastgesteld overeenkomstig de artikelen 2.8 en 2.10 .
+- number: '2.73'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 81d6f7b4e7d711d41f94e230ff5fac06ec33b817926e15867baf29b2eac5aff0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.73 De gegevens over de nationaliteit worden vastgesteld overeenkomstig de artikelen 2.14 en 2.15 .
+- number: '2.74'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 34ae5c28c0c58689b8716cf4d74cc409180ebba7a52d14bc114664156c070045
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.74 De gegevens in verband met het verblijfsrecht van de vreemdeling worden ontleend aan de gegevens die Onze Minister van Veiligheid en Justitie daarover tot zijn beschikking heeft.
+- number: '2.75'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b2ac13ca60ca57f778df5a3902a0a1d11147ea34febfffb0d09e50ef24198c5c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.75 1 De gegevens over het woonadres worden ontleend aan een opgave van de ingeschrevene.
+  - index: 1
+    label: lid 2
+    sha256: b8b2e5f2f709cf7593a51a2d6cec14421af25a20d9ddd1b098d5f88359160b48
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien aannemelijk is dat een gegeven in de opgave onjuist is, wordt het gegeven niet aan de opgave ontleend.
+  - index: 2
+    label: lid 3
+    sha256: 4a93a44efc107438d4e53344a68add5fd2dc476fb164b9855bc2bc87bf504629
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Als de ingeschrevene geen opgave heeft gedaan of aannemelijk is dat de opgave onjuiste gegevens bevat, kunnen de gegevens ambtshalve worden vastgesteld.
+- number: '2.76'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6a44618688c45413dc447cc1de87b4cc43e56e8be90aaefe845f48478cf942ce
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.76 Omtrent de vaststelling dat een opgenomen algemeen gegeven onjuist is of, indien het een gegeven over de burgerlijke staat betreft, in strijd is met de Nederlandse openbare orde, omtrent een onderzoek naar die onjuistheid of strijdigheid, alsmede omtrent de omstandigheid dat de ingeschrevene geen ingezetene is, wordt een aantekening geplaatst bij de desbetreffende gegevens.
+- number: '2.77'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4bba84a9382c320efb080d91394e93ef12ed556de091f25929cc73dbfe5c159b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.77 Bij of krachtens algemene maatregel van bestuur worden regels gesteld omtrent de wijze waarop een verzoek als bedoeld in artikel 2.68 en een opgave als bedoeld in artikel 2.70, derde lid , worden gedaan en omtrent de informatie die daarbij wordt overgelegd.
+- number: '2.78'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: fa1e91f4cbe3e765410480a5de183753b92ed374a9cca5507b85488d87eee657
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.78 1 Een aangewezen bestuursorgaan doet alleen een opgave als bedoeld in artikel 2.70, derde lid, onder a , voor zover het zelf de desbetreffende gegevens verwerkt in verband met de uitoefening van zijn taak. Als het bestuursorgaan bij die uitoefening de beschikking krijgt over gegevens over een ingeschrevene, die door middel van een dergelijke opgave kunnen leiden tot bijhouding van de basisregistratie, doet het bestuursorgaan opgave aan Onze Minister.
+  - index: 1
+    label: lid 2
+    sha256: bd3f8428a615e2cbd5492805c2f3f709dd4a5d3f211cafcb8810990b1c50ce16
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien bij een algemeen gegeven een aantekening is geplaatst omtrent een onderzoek naar de onjuistheid of strijdigheid met de openbare orde, bevordert een aangewezen bestuursorgaan de goede vaststelling van het gegeven, voor zover het bestuursorgaan zelf het gegeven verwerkt in verband met de uitoefening van zijn taak.
+  - index: 2
+    label: lid 3
+    sha256: 413001cb49141e7ce1bfc67c6e174b336c368ba0574411ea5a221fba5feac06f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij of krachtens algemene maatregel van bestuur kunnen nadere regels worden gesteld omtrent de uitvoering van het eerste en tweede lid.
+- number: '2.79'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 52cbe0d25aae94185b511bc5010beb203f6e982a50a5ebee376c70beb0ce55cd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.79 1 De persoon die aan Onze Minister een verzoek als bedoeld in deze afdeling richt, doet dit door tussenkomst van een inschrijfvoorziening.
+  - index: 1
+    label: lid 2
+    sha256: 9ced17b2a61381a3980f556a3054306daa9c9113e4c5cfee511fe632f14452ee
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij of krachtens algemene maatregel van bestuur kunnen nadere regels worden gesteld omtrent de indiening van een verzoek als bedoeld in het eerste lid en de informatie die daarbij wordt overgelegd.
+  - index: 2
+    label: lid 3
+    sha256: 3a9bee60e63fd8744428fe02d8994265205d59ec86659ae173eb7e73418cffdc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij algemene maatregel van bestuur worden regels gesteld omtrent de door de verzoeker verschuldigde rechten wegens handelingen ter uitvoering van het verzoek. Rechten kunnen slechts worden geheven voor zover de handelingen niet kosteloos moeten worden verricht.
+- number: '2.80'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: e1dd7984ffe515580546efeaa0c79f1fe110df3287a7b2324fcb06aec9ee0a42
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.80 Indien Onze Minister in verband met het opnemen van gegevens in de basisregistratie over een persoon aan de betrokkene verzoekt om een document als bedoeld in [artikel 1 van de Wet op de identificatieplicht](jci1.3:c:BWBR0006297&artikel=1) met het oog op de vaststelling van diens identiteit, is de betrokkene verplicht een dergelijk op hem betrekking hebbend document over te leggen.
+- number: '2.81'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 14e683da950c3bd56b58d14acc5d0fd74823f075cc6a416e66bff49a1740381b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.81 1 Onze Minister stelt binnen vier weken na een inschrijving als bedoeld in artikel 2.66 aan de ingeschrevene in begrijpelijke vorm een volledig overzicht ter beschikking van zijn persoonslijst.
+  - index: 1
+    label: lid 2
+    sha256: f5bc868d5fc4d78f5354faf10d21db7924166a27c7d27f1c16d5b6f94eed792e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister vermeldt op schriftelijk verzoek van de betrokkene op zijn persoonslijst kosteloos een aantekening omtrent beperking van de verstrekking van gegevens aan derden. Onze Minister geeft binnen vier weken gevolg aan het verzoek en doet daarvan terstond schriftelijk mededeling aan de verzoeker, onder vermelding van de geldende regels ter zake.
+  - index: 2
+    label: lid 3
+    sha256: 10c914f1b95864842db04652c656ffbc0ccc17d7fb1122f9720c9afe841d679d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. De artikelen 2.54, tweede en derde lid , 2.55 , 2.57 , 2.58 , 2.60 en 2.61 zijn van overeenkomstige toepassing ten aanzien van niet-ingezetenen met dien verstande dat Onze Minister in de plaats treedt van het college van burgemeester en wethouders en dat voor de toepassing van artikel 2.60, onderdeel a, voor «aangifte» wordt gelezen: verzoek.'
+  - index: 3
+    label: lid 4
+    sha256: 8f0f1fdf749debaeee59d3b0328ea3ac9da7c110e3228a4a4df2382318316918
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Een verzoek als bedoeld in artikel 2.55 kan ook worden gericht aan het college van burgemeester en wethouders van enige gemeente in Nederland.
+- number: '3.1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 303d6b125d4abb679ae2261b23e2a7d9bc19a6647a0447fa0d957ff4b7431174
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.1 1 Deze paragraaf is van toepassing op de systematische verstrekking van gegevens uit de basisregistratie.
+  - index: 1
+    label: lid 2
+    sha256: d06d73f57779dfb1790ca5e3fed0c8d4a8372601d06876c6c0a798d7aa9fef4c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij of krachtens algemene maatregel van bestuur wordt geregeld welke verstrekkingen systematische verstrekkingen zijn en worden nadere regels gesteld over deze verstrekkingen.
+- number: '3.2'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 9e89f2fefea032240a4966b11355d0a71386c40a1e553a80d565c51ba5f1efac
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.2 1 Onze Minister verstrekt gegevens aan een overheidsorgaan, voor zover dit is bepaald in een besluit van Onze Minister.
+  - index: 1
+    label: lid 2
+    sha256: 41a93bab82d7ddf2edc0505116416e3b1ade18f7e587d057c7c5e8993f2bc13c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister neemt het besluit op verzoek van het overheidsorgaan. Het verzoek bevat de gronden voor de verstrekking en de gegevens waarop het verzoek betrekking heeft.
+  - index: 2
+    label: lid 3
+    sha256: 2eb7080209d90d4e39dec85ab5e62c5736c418a9febdf25aba634d9e9e235751
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij de bepaling van de gegevens die worden verstrekt, worden de gegevens opgenomen die in het verzoek zijn vermeld voor zover het overheidsorgaan aantoont dat deze gegevens noodzakelijk zijn voor de goede vervulling van zijn taak.
+  - index: 3
+    label: lid 4
+    sha256: 057e0fe763ae586b8bed6d7b60efc8cccd5482d3a0ef97b63c66821f8c4dd35e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij het besluit wordt in ieder geval bepaald over welke categorieën van personen gegevens worden verstrekt, welke gegevens het betreft en in welke gevallen gegevens worden verstrekt.
+  - index: 4
+    label: lid 5
+    sha256: 4054e09bf968fdb6bedba014767ab512023da5d893751413c3488be1f6a282f4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Aan het besluit kunnen voorschriften en beperkingen worden verbonden in het belang van een zorgvuldige en doelmatige gegevensverstrekking.
+  - index: 5
+    label: lid 6
+    sha256: b3c190a624d0a618668ec20a9e3953892af63ce0d4543df122581b7b00fbbfd0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Onze Minister draagt zorg voor onverwijlde publicatie van het besluit in de Staatscourant.
+  - index: 6
+    label: lid 7
+    sha256: cda73271515d9d387cc1c4fcebf59b69e6bcf5b0d9f5b8a5c0de78f43f72c8ec
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. Bij of krachtens algemene maatregel van bestuur kunnen nadere regels worden gesteld omtrent de indiening van het verzoek en de bekendmaking van het besluit.
+  - index: 7
+    label: lid 8
+    sha256: 9f95078270a34b7f199b4343ca63e75f2b9d0464f191a1b7755a7195b1fbb312
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 8. Onze Minister kan een besluit als bedoeld in het eerste lid weigeren te nemen of het besluit intrekken, indien de gevraagde gegevensverstrekking zodanig is dat verstrekking op grond van paragraaf 2 aangewezen is.
+  - index: 8
+    label: lid 9
+    sha256: 736b28447d173c19757c597e1b98aae43147f1219a7fc2ec473128c6d39ba7a4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 9. Indien een overheidsorgaan verschillende taken uitoefent waarvoor gegevens worden gevraagd, kan Onze Minister bij het besluit de verschillende taken in aanmerking nemen.
+- number: '3.3'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 240ed4210865fb215fc738bc0faad956c575cbb264e3b90a5ff6b6fdae501174
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.3 1 Bij algemene maatregel van bestuur worden door derden verrichte werkzaamheden met een gewichtig maatschappelijk belang aangewezen, ten behoeve waarvan gegevens uit de basisregistratie kunnen worden verstrekt. De maatregel bepaalt tevens de categorieën van derden die voor de verstrekking in aanmerking komen en bepaalt of artikel 3.21 op de verstrekking van toepassing is. De maatregel kan beperkingen bevatten ten aanzien van de gegevens die kunnen worden verstrekt.
+  - index: 1
+    label: lid 2
+    sha256: 17cb9c77be3edf8778f5eef3ee5cbcb6e9141ac07ccde1856f1df44ba6138125
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij de maatregel worden slechts werkzaamheden aangewezen die samenhangen met een overheidstaak, strekken tot het in stand houden van een voorziening voor burgers die onderwerp is van overheidszorg, of waarbij anderszins gelet op de overheidsbemoeienis met die werkzaamheden, ondersteuning daarvan door gegevensverstrekking uit de basisregistratie gerechtvaardigd is.
+  - index: 2
+    label: lid 3
+    sha256: 5f09828ef98e2f42c815f52824de735502020a556abc49ffd2a2322b4d6350d6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Artikel 3.2 is van overeenkomstige toepassing.
+  - index: 3
+    label: lid 4
+    sha256: a46aa5a93dc8ef524449fba3db87a08421300270cd3a7ad3a53cf4dcaed27d33
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Op een verstrekking als bedoeld in het eerste lid is [artikel 76 van de Wet bescherming persoonsgegevens](jci1.3:c:BWBR0011468&artikel=76) van overeenkomstige toepassing.
+  - index: 4
+    label: lid 5
+    sha256: 8092ff76c72c191df850510dadfaa093eb0c3ac20419db2515c4696eae0f393e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De voordracht voor een krachtens het eerste lid vast te stellen algemene maatregel van bestuur wordt niet eerder gedaan dan vier weken nadat het ontwerp aan beide kamers der Staten-Generaal is overgelegd.
+- number: '3.4'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 88ec913280c74d988b212b107050a74a5ef1c5fa32d8914d2cad2d710e445a87
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.4 1 Deze paragraaf is van toepassing op de verstrekking van gegevens uit de basisregistratie, anders dan de systematische verstrekking, bedoeld in paragraaf 1 .
+  - index: 1
+    label: lid 2
+    sha256: 28cc9affe10c4425bb418f64e865fbe6e94385c18520c91f850af59258437f35
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Krachtens deze paragraaf kunnen gegevens worden verstrekt over alle ingeschrevenen.
+- number: '3.5'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 90c9b57d553bc51e64d95c0fdbf41b2f246023e3db6deba68fc3f0cca2aedfa1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.5 1 Het college van burgemeester en wethouders verstrekt op verzoek van een overheidsorgaan aan hem gegevens, voor zover deze gegevens noodzakelijk zijn voor de goede vervulling van zijn taak.
+  - index: 1
+    label: lid 2
+    sha256: a2d24b911fbf70c1e127a0e9a34d9f71f53bce3eab0d570503428ca9badc89de
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het verzoek bevat de gronden voor de verstrekking.
+  - index: 2
+    label: lid 3
+    sha256: b1426564530eaea23dbe208cd32c4e984d58d01777d17f86d7799298adaf6a49
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Voor zover krachtens het bepaalde in deze paragraaf gegevens kunnen worden verstrekt, wordt op verzoek een gewaarmerkt afschrift van de in het verzoek aangewezen gegevens verstrekt.
+  - index: 3
+    label: lid 4
+    sha256: 324c3f6dc59afa2231b03c5316949fb858cd819f6ddad00316faf4c0eb0d9b14
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het college weigert het verzoek indien de gevraagde gegevensverstrekking zodanig is dat verstrekking op grond van paragraaf 1 aangewezen is. Bij algemene maatregel van bestuur worden nadere regels gesteld omtrent gevallen waarin het college het verzoek moet weigeren.
+- number: '3.6'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: fa6a23af5926e5a8e8188df808c27edabbceaa2bd043601fe53d958098c210fc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 3.6 1 Het college van burgemeester en wethouders verstrekt op verzoek van een derde aan hem gegevens voor zover:'
+  - index: 1
+    label: onderdeel a
+    sha256: 8740dbc920006d7e2a864949544c381522dbc53f436ce57feb05995edefc7d4a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. het gebruik van die gegevens is voorgeschreven in een algemeen verbindend voorschrift,
+  - index: 2
+    label: onderdeel b
+    sha256: 74c9dcd177cb53895267825d820f7aadaf960fd8698e5241d929cd4d238ff669
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de derde voorafgaande schriftelijke toestemming heeft van de ingeschrevene over wie gegevens worden verstrekt, of
+  - index: 3
+    label: onderdeel c
+    sha256: 86ba5ce0c93a52b5f60b5cb6e497e03a8c3ae4afd6dd1ec754f7ffe1cf63088a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. de verstrekking in overeenstemming is met het tweede lid.
+  - index: 4
+    label: lid 2
+    sha256: 8c1042e4cf281b351d73eaec27765a1b8a6fbc3555312267ae193825efc1297d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij algemene maatregel van bestuur worden door derden verrichte werkzaamheden met een gewichtig maatschappelijk belang aangewezen, ten behoeve waarvan gegevens uit de basisregistratie kunnen worden verstrekt. De maatregel bepaalt tevens de categorieën van derden die voor de verstrekking in aanmerking komen en bepaalt of artikel 3.21 op de verstrekking van toepassing is. De maatregel kan beperkingen bevatten ten aanzien van de gegevens die kunnen worden verstrekt.
+  - index: 5
+    label: lid 3
+    sha256: 082952ff85c1187b55a989466beb16548687266691a42ea6fa06cf441883f5a6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Artikel 3.3, tweede en vierde lid , en artikel 3.5, tweede, derde en vierde lid , zijn van overeenkomstige toepassing.
+  - index: 6
+    label: lid 4
+    sha256: 0cabbe28ccde58cc3498c7fc8462bb68f4a57cc38c86ed927a8b5231a9fd37c0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De voordracht voor een krachtens het tweede lid vast te stellen algemene maatregel van bestuur wordt niet eerder gedaan dan vier weken nadat het ontwerp aan beide kamers der Staten-Generaal is overgelegd.
+- number: '3.7'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ab807708ca8a9a4c988bf29992b64694177d0f5f10c7d16be085a820d6694cf5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.7 1 Deze paragraaf is van toepassing op de verstrekking van gegevens uit de basisregistratie door het college van burgemeester van wethouders, anders dan de verstrekking, bedoeld in paragraaf 2 .
+  - index: 1
+    label: lid 2
+    sha256: e5191f7cc6f3c267c1b7495f09b88dfcd136a461ef5361727278533f45e67f94
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Krachtens deze paragraaf worden uitsluitend gegevens verstrekt over ingeschrevenen ten aanzien van wie het college op grond van artikel 1.4 verantwoordelijk is voor de bijhouding van de persoonslijst.
+- number: '3.8'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 35db6fac7ac4d014637c1479b86de47e3d66f0b87ab51417ce0bb958b08ba37d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.8 1 Bij of krachtens gemeentelijke verordening kunnen regels gesteld worden omtrent de verstrekking van gegevens aan overheidsorganen die een orgaan zijn van de gemeente.
+  - index: 1
+    label: lid 2
+    sha256: 97fd9916a0f1385ab9ee7ce8d6333167fb3cfd8c8e78df9019414ad8a6751b2a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Aan een overheidsorgaan worden slechts gegevens verstrekt voor zover deze gegevens noodzakelijk zijn voor de goede vervulling van zijn taak.
+- number: '3.9'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 09da044d91d20d6484aaaafd1b4bf959183a3727a4ed46d77df6a39be9079c6b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 3.9 1 Op verzoek van een derde kunnen aan hem gegevens worden verstrekt voor zover daarin is voorzien bij gemeentelijke verordening en voor zover:'
+  - index: 1
+    label: onderdeel a
+    sha256: f8c43255348cca20d8668f8e17a01a11e3fb24fd1de48d7dd3beebc77bbbdfcd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de derde voorafgaande schriftelijke toestemming heeft van de ingeschrevene over wie gegevens worden verstrekt, of
+  - index: 2
+    label: onderdeel b
+    sha256: 544b7843d3ae09fb68b465fd2dcac1e7c2b65b04b625050852e881ee1e633b96
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de verstrekking in overeenstemming is met het tweede lid.
+  - index: 3
+    label: lid 2
+    sha256: 689d6d6bc72ddb5f667fdf7e649276ea3e4b63d801bafa1f78b3b1aa88a06b72
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij gemeentelijke verordening kunnen door derden verrichte werkzaamheden met een gewichtig maatschappelijk belang voor de gemeente worden aangewezen, ten behoeve waarvan gegevens uit de basisregistratie kunnen worden verstrekt. De verordening bepaalt tevens de categorieën van derden die voor de verstrekking in aanmerking komen. De verordening staat slechts verstrekking toe voor zover deze noodzakelijk is voor de behartiging van het gerechtvaardigde belang van de derde en het belang of de fundamentele rechten en vrijheden van de ingeschrevene niet aan de verstrekking in de weg staan.
+  - index: 4
+    label: lid 3
+    sha256: 2179ab1c9df26124c96fb54c0b3335615c760d5f332541d5de436281b2c74593
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Aan een overheidsorgaan van, dan wel een persoon of organisatie gevestigd in een land buiten de Europese Unie worden slechts gegevens verstrekt overeenkomstig het eerste lid, onderdeel b, indien een verdrag of een besluit van een volkenrechtelijke organisatie in de verstrekking van die gegevens voorziet.
+  - index: 5
+    label: lid 4
+    sha256: cb514d2bec21c21aeef6cb8df3cdd5cc1fd4db2651a7d69d6589ab760998628c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De verstrekking kan uitsluitend betrekking hebben op algemene gegevens over de naam, het geslacht, de geslachtsnaam van de echtgenoot dan wel geregistreerde partner, de eerdere echtgenoot of eerdere geregistreerde partner, het gebruik door de ingeschrevene van de geslachtsnaam van de echtgenoot dan wel geregistreerde partner, de eerdere echtgenoot of eerdere geregistreerde partner, het adres, de bijhoudingsgemeente, de geboortedatum en de datum van overlijden.
+  - index: 6
+    label: lid 5
+    sha256: 501cd113129c9e093a6ebacfef6bd2a53de53ac2ba8cff9ac94a3d461cb10a67
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Artikel 3.3, tweede en vierde lid , en artikel 3.5, derde lid , zijn van overeenkomstige toepassing.
+- number: '3.10'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b1043cefce17bb2fee902ae6cb4ce5bac93a6795c92c576a53837e915265b3ad
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.10 1 Voor zover een algemeen gegeven wordt verstrekt waarbij een aantekening is geplaatst als bedoeld in artikel 2.26 , 2.59 , 2.76 of 2.81, tweede lid , wordt dat gegeven uitsluitend verstrekt onder mededeling van die aantekening.
+  - index: 1
+    label: lid 2
+    sha256: 2f2c3c09b33de656fa518a95a3a52417a8c0a0583c87fc8c849367f518cf70e8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De verstrekking van algemene gegevens die zijn opgenomen krachtens artikel 2.70, tweede of derde lid , geschiedt met de mededeling van de bron waaruit de gegevens zijn verkregen, dan wel van de rechtsgrond krachtens welke de gegevens zijn opgenomen. Indien de gegevens zijn opgenomen krachtens artikel 2.70, derde lid, onder a, wordt tevens medegedeeld welk bestuursorgaan de opgave heeft gedaan.
+- number: '3.11'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: fcd7eeb4f3efe981d84742e9556a1fc05603d85051d29b4de29e7370d537f6a0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.11 1 Het bestuursorgaan dat verantwoordelijk is voor de verstrekking van gegevens houdt gedurende twintig jaren volgend op de verstrekking aantekening van de verstrekking.
+  - index: 1
+    label: lid 2
+    sha256: f2ec6020e2294a5c21b9bcd5832f0a8c3af25247e3c20728da280cf9838faf1d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij of krachtens algemene maatregel van bestuur wordt bepaald van welke verstrekkingen geen aantekening wordt gehouden in verband met de veiligheid van de staat of de voorkoming, opsporing of vervolging van strafbare feiten.
+- number: '3.12'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b51fe7a94813e125a858861c49c0f830200eb9c66c2e47376956bf6184bc1f8c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.12 Bij of krachtens algemene maatregel van bestuur kan een regeling worden getroffen omtrent de verstrekking van algemene en administratieve gegevens aan een verantwoordelijke voor de verwerking van gegevens in een basisadministratie in Aruba, Curaçao, Sint Maarten of een van de openbare lichamen.
+- number: '3.13'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 49cb2e7a8f295582ebb572213a611ed99463b0d8c090b6e6e9ed68c683e8fb4b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 3.13 1 Een andere verstrekking uit de basisregistratie dan die bedoeld in de paragrafen 1 , 2 of 3 of in artikel 3.12 is slechts toegestaan voor zover daarin is voorzien bij algemene maatregel van bestuur en voor zover:'
+  - index: 1
+    label: onderdeel a
+    sha256: 1e39c0f08424d3f9e35cf356769f1609eb0c16575e462c87bd2613d5dd3aa181
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de verstrekking plaats vindt voor historische, statistische of wetenschappelijke doeleinden;
+  - index: 2
+    label: onderdeel b
+    sha256: 3c5372aa9e9e2287b2cd39c989da10d082261adc9c5ed67c8342ba94dd13b6cc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de persoonlijke levenssfeer niet onevenredig wordt geschaad;
+  - index: 3
+    label: onderdeel c
+    sha256: 2dc02ee7b756dec9a08d6a4cac6a2ef9c732843f0c908bdb8259511b0ca16e2b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. door de ontvanger van de gegevens de nodige voorzieningen zijn getroffen ten einde te verzekeren dat de verdere verwerking uitsluitend geschiedt ten behoeve van de onder a genoemde doeleinden.
+  - index: 4
+    label: lid 2
+    sha256: 012d970cdac3690d36f1efb52ad7948c3ecc7ab9b7947c71e1dc95dacb3f35d4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij of krachtens de in het eerste lid bedoelde maatregel kunnen nadere regels worden gesteld omtrent de verstrekking en de wijze waarop deze plaatsvindt.
+- number: '3.14'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d567e68627b251c7fcec10eb1d352995b0906b2967dcd77b655ebf6210ffde40
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.14 1 Onze Minister kan aan een overheidsorgaan of aan een derde informatie ter beschikking stellen die is verkregen door bewerking van gegevens uit de basisregistratie. Het betreft uitsluitend informatie die niet herleidbaar is tot gegevens betreffende een geïdentificeerde of identificeerbare ingeschrevene.
+  - index: 1
+    label: lid 2
+    sha256: 5cdc25aeda990caee46fa519e53a75aa38e9b2dcb19d5065674e097be48814f2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij of krachtens algemene maatregel van bestuur kunnen nadere regels worden gesteld omtrent het ter beschikking stellen van informatie, bedoeld in het eerste lid.
+- number: '3.15'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 82526da6e71b117c70fb7d47eca7eaede070e7c65f92f02aea879238c1df8243
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.15 Indien op grond van de artikelen 2.55, derde lid , 3.5, derde lid , 3.6, derde lid , of 3.9, vijfde lid , een gewaarmerkt afschrift wordt verstrekt van gegevens ten aanzien van een vreemdeling op wiens persoonslijst geen actuele gegevens zijn opgenomen in verband met het verblijfsrecht, wordt hiervan mededeling gedaan op dat afschrift.
+- number: '3.16'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6b66ea014420ba2f09ba65b749f40d8226aed85c2a99eb0d4afad2b240cfd409
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.16 Een derde kan bij het verwerken van persoonsgegevens gebruik maken van het burgerservicenummer voor zover dit noodzakelijk is in verband met de juiste verstrekking van gegevens aan hem uit de basisregistratie.
+- number: '3.17'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c07ab68126fadf878aba93f22badef66becc10128c194bbba6b5f46040a125e0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.17 1 De verstrekking van gegevens op grond van de artikelen 3.2 , 3.3 en 3.13 geschiedt kosteloos, onverminderd het bepaalde in artikel 1.14 .
+  - index: 1
+    label: lid 2
+    sha256: 176341214e60b1c86e7d07a931f700e7ee3035725361efc23fb72b0853d5eb30
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het eerste lid is van overeenkomstige toepassing op het ter beschikking stellen van informatie, bedoeld in artikel 3.14 .
+  - index: 2
+    label: lid 3
+    sha256: 8f609e252c4eb54b03c8e0bc0e769d493470e7bee3b3303f30f6464b787b2820
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Andere verstrekkingen aan een overheidsorgaan en verstrekkingen op grond van artikel 3.12 geschieden kosteloos.
+- number: '3.18'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: f13d8fa9182e2750b01c6a4b0e9d32eb5af2e5cd208f1e2813a4e184b712a74f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.18 Een beslissing op grond van deze afdeling omtrent het verstrekken van gegevens of het ter beschikking stellen van informatie wordt gelijkgesteld met een besluit in de zin van de [Algemene wet bestuursrecht](jci1.3:c:BWBR0005537) .
+- number: '3.19'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a207933a0269dd07c7b92a85311e28a770f76e53cf03058d284e2cdd0100e316
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.19 1 Een verzoek als bedoeld in de artikelen 3.22 en 3.23 kan worden gericht aan het college van burgemeester en wethouders van enige gemeente.
+  - index: 1
+    label: lid 2
+    sha256: 3eafcf97c8e05c03c1996c60327501587a66c5ed2d25dd9139d3ce9e0d6a7def
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het verzoek kan ook worden gericht aan Onze Minister. In dat geval treedt Onze Minister voor de toepassing van de artikelen 3.22 en 3.23 in de plaats van het college en wordt het verzoek gedaan door tussenkomst van een inschrijfvoorziening.
+- number: '3.20'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 9df72449e02938d6116d07ea31ea25fed41cea0eefbe033d4ae641eb7b1d9486
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.20 De verstrekking aan de betrokkene van hem betreffende gegevens geschiedt ingevolge artikel 2.55 of ingevolge artikel 2.81 in samenhang met artikel 2.55.
+- number: '3.21'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ce9bf73836174cc23ee90ea34cce7a6c174be54d0d805af118200d710297a5b0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 3.21 1 Indien op de persoonslijst een aantekening omtrent beperking van de verstrekking van gegevens aan derden is vermeld, worden geen gegevens van de persoonslijst verstrekt op grond van:'
+  - index: 1
+    label: onderdeel a
+    sha256: 49a04e47d0a8188fc29b7ac462863cc5251041d7e95b70d6018c178215b9914f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de artikelen 3.3 en 3.6 , voor zover de beperking van de verstrekking van toepassing is;
+  - index: 2
+    label: onderdeel b
+    sha256: 9f2e58ca14f1860e7858cb7f5d46ac98e947c7a04cb374b72c73cb9a0408d33d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. artikel 3.9 .
+  - index: 3
+    label: lid 2
+    sha256: 36d901131dc27b3df9f4242212057f4a7a43df797d2bbdb82f2702c63239eab8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In afwijking van het eerste lid verstrekt het college van burgemeester en wethouders gegevens op grond van artikel 3.6, eerste lid, onderdelen a en c , indien de persoonlijke levenssfeer daardoor niet onevenredig wordt geschaad.
+  - index: 4
+    label: lid 3
+    sha256: 37ba5dea2b979b054cb58e556f77a80182fe6cb451b1fa1b1ad7bceba41c2c61
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het college maakt een beschikking, waarmee het toepassing geeft aan het tweede lid, terstond bekend aan de betrokkene. Het geeft geen uitvoering aan de beschikking binnen een bij die beschikking gestelde termijn.
+  - index: 5
+    label: lid 4
+    sha256: 6f490eccccee365d59d5db3b76251984caeba0039adf459e11ed5a47886b599e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Artikel 2.55, vierde en vijfde lid , is van overeenkomstige toepassing.
+  - index: 6
+    label: lid 5
+    sha256: 26244f21ab09e62be8876c219499a47ef5362287489f13d7851306d385de4189
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Het college neemt passende maatregelen om ten minste eens per jaar aan de ingezetenen het recht, bedoeld in het eerste lid, bekend te maken. De bekendmaking vindt plaats via één of meer dag-, nieuws-, of huis-aan-huisbladen of op een andere geschikte wijze.
+- number: '3.22'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: f9e7cfdae9e7ddad5728214532a69a88044e04257fb3558b28202e284794eeac
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.22 1 Het college van burgemeester en wethouders deelt aan de betrokkene op diens verzoek kosteloos en schriftelijk binnen vier weken mede of hem betreffende gegevens gedurende twintig jaren voorafgaande aan het verzoek uit de basisregistratie zijn verstrekt aan een overheidsorgaan of een derde.
+  - index: 1
+    label: lid 2
+    sha256: 41ede9a7db5c4ab6825e46ce20001b13357922605e42857bf39a36bba19e405e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien zodanige verstrekking is geschied, doet het college daarvan desgevraagd binnen vier weken na ontvangst van het verzoek kosteloos en schriftelijk mededeling aan verzoeker. Het college kan volstaan met een in algemene termen gestelde mededeling omtrent de verstrekking, tenzij het belang van de verzoeker daardoor onevenredig wordt geschaad.
+  - index: 2
+    label: lid 3
+    sha256: 22084fec1770f20c2aeb7ec5e9e3e333275b270268bc228c0caff9534eef2b8c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Het college voldoet niet aan het in het eerste en tweede lid bedoelde verzoek voor zover:'
+  - index: 3
+    label: onderdeel a
+    sha256: 8dea9c027c4baef5cdb24ae2e5d7b528d370242bf4f0502f337f1ab404da0c5a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. van de verstrekking geen aantekening is gehouden krachtens artikel 3.11, tweede lid ;
+  - index: 4
+    label: onderdeel b
+    sha256: c2cae0bc6e3dd3f4311238fd9bbc419ca84d037c43b10caec8677818c9682587
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. dit noodzakelijk is in het belang van de veiligheid van de staat of de voorkoming, opsporing en vervolging van strafbare feiten.
+  - index: 5
+    label: lid 4
+    sha256: 4c51e454b26e7a9522a5e56fae95008ce891dce639e3fbd4b939b4b4807a929b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij of krachtens algemene maatregel van bestuur kan nader geregeld worden in welke gevallen toepassing gegeven moet worden aan het derde lid, onderdeel b.
+  - index: 6
+    label: lid 5
+    sha256: 04a541abd5974078196055bf578fd7850da61d4112a55f299a55d795b6909982
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Artikel 2.55, vierde en vijfde lid , is van overeenkomstige toepassing.
+- number: '3.23'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a3b35bdbed49483a6b93329ce44a93455d8063b1172ed5ea607f7500b2370f7b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.23 1 Het college van burgemeester en wethouders doet op schriftelijk verzoek van de betrokkene, indien op grond van het verzoek, bedoeld in de artikelen 2.57 en 2.58 , een besluit als bedoeld in artikel 2.60 , dan wel de uitspraak van de rechter, bedoeld in artikel 2.61 , ten aanzien van hem gegevens zijn verbeterd, aangevuld of verwijderd, van de wijziging mededeling aan overheidsorganen en derden aan wie gedurende twintig jaren voorafgaand aan het verzoek en in de sedert dat verzoek verstreken tijd, de desbetreffende gegevens zijn verstrekt, tenzij dit onmogelijk blijkt of een onevenredige inspanning kost.
+  - index: 1
+    label: lid 2
+    sha256: e1f07244dec543fae971dde7c7ae2294439d6d8f568215e78d7edce980849aeb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het verzoek, bedoeld in het eerste lid, kan de betrokkene aan het college richten tot uiterlijk acht weken nadat hij van de wijziging kennis heeft kunnen nemen.
+  - index: 2
+    label: lid 3
+    sha256: d50fbccdd23dfeba4eb5da42ddd8ee55c710eff1b168c8038b27ad27d48336ac
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het college doet aan de verzoeker desgevraagd opgave van degenen aan wie de mededeling, bedoeld in het eerste lid, is gedaan. Artikel 3.22, derde lid , is van overeenkomstige toepassing.
+  - index: 3
+    label: lid 4
+    sha256: 6f490eccccee365d59d5db3b76251984caeba0039adf459e11ed5a47886b599e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Artikel 2.55, vierde en vijfde lid , is van overeenkomstige toepassing.
+  - index: 4
+    label: lid 5
+    sha256: 10e304104f5946a46bba2282010fc22416deb52aa80aa8a2cdccbd16a6f62d2a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Dit artikel is van overeenkomstige toepassing indien gegevens ten aanzien van de betrokkene zijn verbeterd, aangevuld of verwijderd op grond van een verzoek ingevolge artikel 2.81 in samenhang met de artikelen 2.57 , 2.58, 2.60 en 2.61 .
+- number: '3.24'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8f0f2532f9bcc44daec2dc77aad5d70bac5f84d19ab11aa9a3921b26b4c163e8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3.24 Een beslissing op een verzoek als bedoeld in deze afdeling wordt gelijkgesteld met een besluit in de zin van de [Algemene wet bestuursrecht](jci1.3:c:BWBR0005537) .
+- number: '4.1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 5062b96b24525f2dd9c4af259ffffd5535a8aa1e9030a8a5062fa1cda0d4b00a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.1 1 Het College bescherming persoonsgegevens ziet in het belang van de bescherming van de persoonlijke levenssfeer toe op de uitvoering van deze wet.
+  - index: 1
+    label: lid 2
+    sha256: 4583bb494a873ca77211cd7572e6a8933e6609c389500fbc720950eef260ae22
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De [artikelen 60](jci1.3:c:BWBR0011468&artikel=60) , [61](jci1.3:c:BWBR0011468&artikel=61) en [65 van de Wet bescherming persoonsgegevens](jci1.3:c:BWBR0011468&artikel=65) zijn van overeenkomstige toepassing.
+  - index: 2
+    label: lid 3
+    sha256: 01df9785a184e72dd6e5b7ac1242a201f42c025e80077f51b7552b5d86d10c7a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De [artikelen 124](jci1.3:c:BWBR0005416&artikel=124) en [268 van de Gemeentewet](jci1.3:c:BWBR0005416&artikel=268) blijven buiten toepassing ten aanzien van het toezicht op het college van burgemeester en wethouders inzake de uitvoering van de hoofdstukken 2 en 3 .
+  - index: 3
+    label: lid 4
+    sha256: 374f28ea570d6e1595f5144b6185ade1022f4d9b7c62aed1303d2badcc617904
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het College wordt om advies gevraagd over voorstellen van wet tot wijziging van deze wet en ontwerpen van algemene maatregelen van bestuur op grond van deze wet die geheel of voor een belangrijk deel betrekking hebben op de verwerking van persoonsgegevens.
+- number: '4.2'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 57346523400df85d08477bb620d90ba6ac25ee2df166f5db9319a3d97fb60d93
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.2 Het college van burgemeester en wethouders wijst ambtenaren aan die zijn belast met het toezicht op de naleving van de verplichtingen van de burger ingevolge hoofdstuk 2, afdeling 1, paragraaf 5 .
+- number: '4.3'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 578bc7e652684be3f59a7eed8442b115ce3a746ad6be3822b0ab781bebf0c216
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.3 1 Het college van burgemeester en wethouders verricht periodiek een onderzoek naar de inrichting, de werking en de beveiliging van de basisregistratie, alsmede naar de verwerking van gegevens in de basisregistratie, voor zover het de gemeentelijke voorziening betreft of het college verantwoordelijk is voor de bijhouding.
+  - index: 1
+    label: lid 2
+    sha256: f282fc05661614eea670a2c912b145ed2863c8aae8ec7177d5e67796551a3812
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het college van burgemeester en wethouders zendt periodiek een uittreksel van de resultaten van het onderzoek aan het College bescherming persoonsgegevens.
+  - index: 2
+    label: lid 3
+    sha256: babbc922f54e9932c1487fb9518802ba42ccec4915134bb09c69c73f66545b84
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het eerste en tweede lid zijn van overeenkomstige toepassing op Onze Minister met dien verstande dat het onderzoek betrekking heeft op de centrale voorzieningen.
+  - index: 3
+    label: lid 4
+    sha256: 74b25a82e2c1c1d19540b4fed1b37543a916e4918c4e1e16327196e2b964c68c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het college van burgemeester en wethouders zendt periodiek een uittreksel van de resultaten van het onderzoek aan Onze Minister ten behoeve van een landelijk beeld van de in het eerste lid bedoelde aspecten.
+  - index: 4
+    label: lid 5
+    sha256: 10719a2f5e3c14fac78749564a75605479120ef5a6881a71b776f96693806592
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Bij of krachtens algemene maatregel van bestuur worden nadere regels gesteld met betrekking tot de periodiciteit en de uitvoering van de onderzoeken, bedoeld in het eerste lid, en de periodiciteit van de in het tweede en vierde lid bedoelde verzendingen en de inhoud van de in die leden bedoelde uittreksels.
+- number: '4.4'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a7ee2aafba8a801e8b610ec4d732c04ce149e4310f8f324752f5cbe0196cfa62
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.4 1 Het college van burgemeester en wethouders is ten behoeve van de uitvoering van deze wet tot een bij koninklijk besluit te bepalen datum verantwoordelijk voor de verwerking van persoonsgegevens in het persoonsregister, bedoeld in het Besluit bevolkingsboekhouding.
+  - index: 1
+    label: lid 2
+    sha256: 898094f5e9f07cd51113467656e5b74f544c7b0e9b2937cc7331a23682787adf
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij of krachtens algemene maatregel van bestuur kunnen regels worden gesteld omtrent de in het eerste lid bedoelde verwerking van persoonsgegevens. Daarbij kan worden bepaald dat het persoonsregister op een andere wijze dan in de vorm van persoonskaarten, bedoeld in het Besluit bevolkingsboekhouding, kan worden aangehouden en kan de vernietiging van de persoonskaarten worden geregeld.
+  - index: 2
+    label: lid 3
+    sha256: f6e08c1b6d3b5751f854d613944b0b64f57ab7098a163a5a3964bb4e24b394c4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Uit het persoonsregister worden geen andere gegevens verstrekt dan:'
+  - index: 3
+    label: onderdeel a
+    sha256: 706ea7091d13c705ecfbcc8af39a91d1b7de8fe321397a3d1c4ea8b7f4fbdc73
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. gegevens als bedoeld in artikel 2.7 ;
+  - index: 4
+    label: onderdeel b
+    sha256: 429e55a3cb9b86e9bba4d9a521edac3e5cbd4dba8714a8478e1a69b28059c7c6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. gegevens uit vak 23 van de persoonskaart.
+  - index: 5
+    label: lid 4
+    sha256: b51db010338dfdf2bf6c6b548c7a433054dfde7721d3963fbbb0a66183059b0f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Op de verstrekking, bedoeld in het derde lid, is hoofdstuk 3 , met uitzondering van de artikelen 3.1 tot en met 3.3 , van overeenkomstige toepassing.
+  - index: 6
+    label: lid 5
+    sha256: c4ec310445f9bf74c770f8ca880b4f59a3928ba4850e890840786b93a31b64e1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De artikelen 2.53, eerste lid , 2.55 en 2.57 tot en met 2.61 zijn van overeenkomstige toepassing.
+- number: '4.5'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: e50e730a935801043371c0e1afe3ce906eb4ab3fb5e9a8404362d0d01beb7967
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.5 1 Onze Minister is ten behoeve van de uitvoering van deze wet tot een bij koninklijk besluit te bepalen datum verantwoordelijk voor de verwerking van persoonsgegevens in het persoonskaartenarchief en het schakelregister, bedoeld in het Besluit bevolkingsboekhouding.
+  - index: 1
+    label: lid 2
+    sha256: ac3ea5d0a77060c7e80f8d34e02317edf4f0f60df666ba37a4f0bb07276f71b5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister kan de verantwoordelijkheid voor de verwerking, bedoeld in het eerste lid, overdragen aan het college van burgemeester en wethouders van een gemeente. De overdracht geschiedt slechts na instemming van dat college.
+  - index: 2
+    label: lid 3
+    sha256: 6cdd494058dc0a4a1ae3a79afb35c0ae040b06bd3e66c24a710d186ffea5704f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Ten aanzien van het persoonskaartenarchief is artikel 4.4, tweede tot en met vijfde lid , van overeenkomstige toepassing.
+  - index: 3
+    label: lid 4
+    sha256: 3521d0ad9b58e0d41b8c262cc32c8fd72fa22c50a9a6f522fe406eef29fc38c3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Ten aanzien van het schakelregister is artikel 4.4, tweede, vierde en vijfde lid , van overeenkomstige toepassing.
+- number: '4.6'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 61367c7e1638f9d685d8641abdf90500d840caa6269dadf3ffe46a2520c3dabc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.6 Onze Minister, of het in artikel 4.5, tweede lid , bedoelde college van burgemeester en wethouders, verstrekt op verzoek van het college dat een persoon inschrijft van wie in het persoonskaartenarchief een persoonskaart is opgenomen, de gegevens die zijn vermeld op de desbetreffende persoonskaart. Deze gegevens blijven berusten bij het college waaraan ze zijn verstrekt, waarbij artikel 4.4 van overeenkomstige toepassing is.
+- number: '4.7'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ad1adeb25eab9a55923f6e0a901c3ed104ca43ffbb4c7363cb169f9b7a7dda74
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.7 1 Er is een centraal archief van overledenen, bestaande uit de persoonskaarten, bedoeld in het Besluit bevolkingsboekhouding.
+  - index: 1
+    label: lid 2
+    sha256: a6ed37358345ee2a39ed968e1bca84f925c9d4976268b4771addcb16da42c031
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister is verantwoordelijk voor de verwerking van persoonsgegevens in het centraal archief van overledenen, bedoeld in het eerste lid. Hij treft een regeling ter bescherming van de persoonlijke levenssfeer.
+- number: '4.8'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c9051b00425666b36834c8ca7e3458e2be5b2393aac10a7a4bf00373938fa371
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 4.8 1 Bij of krachtens algemene maatregel van bestuur worden regels gesteld omtrent heffingen in verband met de verstrekking van gegevens uit de hierna genoemde registraties, voor zover Onze Minister verantwoordelijk is voor de verwerking van persoonsgegevens in deze registraties:'
+  - index: 1
+    label: onderdeel a
+    sha256: 378f7cc07635eb558312ee957f7d89936e7dec6d441344d99000853e511861d0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. het persoonskaartenarchief;
+  - index: 2
+    label: onderdeel b
+    sha256: ef542eb5c5ec870ac4b57a22a0674d95533b337d08a8e78039ab2046a91b7401
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. het schakelregister;
+  - index: 3
+    label: onderdeel c
+    sha256: 72c7b7087f30c113ea4e19455b71986878ddd98782b8618e5fecdd54b4e410cb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. het centraal archief van overledenen.
+  - index: 4
+    label: lid 2
+    sha256: ada7a118309114d37aab6416c0b61eeb4826578435020e2d114496b94cd8c76e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Op grond van de in het eerste lid bedoelde regels kunnen uitsluitend heffingen ingesteld worden in verband met de verstrekking van gegevens aan derden, anders dan de verstrekking overeenkomstig artikel 3.3 , en in verband met de verstrekking aan de betrokkene van hem betreffende gegevens.
+- number: '4.9'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b8a6ffcafa6d118fce4d493c0c6af41d17a8e28935b0bdf455bc4a0cd502a020
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 4.9 1 Naast de in artikel 2.7 bedoelde algemene gegevens worden tot een bij koninklijk besluit te bepalen datum over de op grond van hoofdstuk 1, afdeling 1, paragraaf 2 ingeschreven personen de volgende algemene gegevens opgenomen:'
+  - index: 1
+    label: onderdeel a
+    sha256: c41a6be3607bce445547d75a0b723765c48bc0edd6921f2cd85749c0ca971a92
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. het administratienummer van de ingeschrevene;
+  - index: 2
+    label: onderdeel b
+    sha256: 1f579993cf8a16ba8025ab946cadf97f55ee73a7884eb5acea0c2b7fe5694c1b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de administratienummers van de ouders, de echtgenoot, de eerdere echtgenoten, de geregistreerde partner, de eerdere geregistreerde partners en de kinderen;
+  - index: 3
+    label: onderdeel c
+    sha256: d592d0a6cd5c46e46c092eb53d9013f038d5f7e5b80d69e60dcccb16ab68bb2e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. de data waarop de onder a en b bedoelde nummers van kracht zijn geworden of beëindigd.
+  - index: 4
+    label: lid 2
+    sha256: fd48072418cad805b0269389aa8e1a7c7f9a4ed0d8d3ea6edcd6ebb31d244b96
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Naast de in artikel 2.69 bedoelde algemene gegevens worden tot een bij koninklijk besluit te bepalen datum over de op grond van hoofdstuk 1, afdeling 2, paragraaf 2 ingeschreven personen de volgende algemene gegevens opgenomen:'
+  - index: 5
+    label: onderdeel a
+    sha256: c41a6be3607bce445547d75a0b723765c48bc0edd6921f2cd85749c0ca971a92
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. het administratienummer van de ingeschrevene;
+  - index: 6
+    label: onderdeel b
+    sha256: 08350bb512d4f74382f98274af3eb997cfc0f5c3a5628562fc6e3db42b254fe9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de datum waarop het nummer van kracht is geworden of beëindigd.
+  - index: 7
+    label: lid 3
+    sha256: 821c348983a871567201cdb0b5a45d2443f22af5a932e9f91ee2d9eb15b6fb08
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Tot de laatste van de in de aanhef van het eerste en tweede lid bedoelde data blijft [artikel 50 van de Wet gemeentelijke basisadministratie persoonsgegevens](jci1.3:c:BWBR0006723&artikel=50) zoals dat luidde voor de inwerkingtreding van deze wet, van toepassing. Tot dat moment wordt aan een niet-ingezetene die wordt ingeschreven in de basisregistratie een administratienummer toegekend. Daarbij is het hiervoor bedoelde artikel 50, eerste, tweede, derde en zesde lid, van overeenkomstige toepassing, met dien verstande dat het nummer wordt toegekend door Onze Minister. Onze Minister neemt de gegevens, bedoeld in het tweede lid, op in de basisregistratie.
+  - index: 8
+    label: lid 4
+    sha256: 8c4c8d19155e089f726c1bacd59f871c7c4ac60847f2954b489b695ddae1ff3c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Een overheidsorgaan kan tot de in het derde lid bedoelde datum bij het verwerken van persoonsgegevens in het kader van de uitvoering van zijn taak gebruik maken van het administratienummer.
+  - index: 9
+    label: lid 5
+    sha256: 9fb22aefb59c16231d9ecb2e458be70122cf681959bfee9880fccbb25f6a2b52
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Een derde kan tot de in het derde lid bedoelde datum bij het verwerken van persoonsgegevens gebruik maken van het administratienummer voor zover dit noodzakelijk is in verband met de juiste verstrekking aan hem van gegevens uit de basisregistratie.
+  - index: 10
+    label: lid 6
+    sha256: 4f8065c1ebc18e777836853809e98fd98c7b4cacc7407426dedc155d3c3d1da3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Na de in het derde lid bedoelde datum wordt het administratienummer niet meer gebruikt.
+- number: '4.10'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ce0b0ab6c3ad3e92105093ed996048e70af8d47f36a5753fa5c706738415db10
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.10 1 Een besluit als bedoeld in [artikel 91, eerste lid, van de Wet gemeentelijke basisadministratie persoonsgegevens](jci1.3:c:BWBR0006723&artikel=91) geldt na de inwerkingtreding van deze wet als een besluit als bedoeld in artikel 3.2 .
+  - index: 1
+    label: lid 2
+    sha256: ef222631ec9af63e521cda7f9a8c935f74574a41a2cc9d6243661a0fd4484fae
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Een besluit als bedoeld in [artikel 99, zevende lid, van de Wet gemeentelijke basisadministratie persoonsgegevens](jci1.3:c:BWBR0006723&artikel=99) geldt na de inwerkingtreding van deze wet als een besluit als bedoeld in artikel 3.3 .
+- number: '4.11'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: dfdd0bd02f006ed7283c57de806525306712f15e10071ad1b8d3fa77de561516
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.11 Een persoonslijst als bedoeld in [artikel 1 van de Wet gemeentelijke basisadministratie persoonsgegevens](jci1.3:c:BWBR0006723&artikel=1) geldt na de inwerkingtreding van deze wet als een persoonslijst als bedoeld in artikel 1.1, onderdeel c , van deze wet.
+- number: '4.12'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a52494d77ab4ceb12162f6ce543c6a93e98aeb3a5eb27ca8762665207a34c646
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.12 Bij of krachtens algemene maatregel van bestuur worden regels gesteld omtrent het verwijderen en vernietigen van gegevens over een vreemde nationaliteit naast gegevens over het Nederlanderschap of het feit dat de betrokkene als Nederlander wordt behandeld. Daarbij kan worden afgeweken van de artikelen 2.7 en 2.69 .
+- number: '4.13'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 31a85a35fb786613c069a1da97a38aba17624fb877f118e9a853626354a059ab
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.13 1 Dit artikel is van toepassing op gevallen als bedoeld in artikel 2.1, derde lid , met uitzondering van het geval dat de betrokkene op het moment van zijn overlijden ingezetene was.
+  - index: 1
+    label: lid 2
+    sha256: ad4dd72e34ffb7f6550c3548f45136050c07e502d9f3378cd81d879b36f6055a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De voormalige bijhoudingsgemeente doet aan Onze Minister een opgave van de gegevens die in de basisregistratie moeten worden opgenomen.
+  - index: 2
+    label: lid 3
+    sha256: 33b2a29ccc8b81ff42860bd49eb5244596d5f525af7424a25c6b365718f83737
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Onze Minister neemt de gegevens op door deze te ontlenen aan de in het tweede lid bedoelde opgave.
+  - index: 3
+    label: lid 4
+    sha256: b4a8b55975514c9ca35d03f732767b08cb0770dfa97e3fa4c0fdee8bb9bbaae0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij of krachtens algemene maatregel van bestuur kunnen nadere regels worden gesteld omtrent de wijze waarop een opgave wordt gedaan en de informatie die daarbij wordt overgelegd.
+  - index: 4
+    label: lid 5
+    sha256: d60508c6957c86cac5cca6612c4edf9088a13c043240155781296ae0304b173e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Dit artikel is van toepassing tot een bij koninklijk besluit te bepalen tijdstip.
+- number: '4.14'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 7712fb9f2b9e02494bf11a8c3bf6a5e97a9b0e210d5d7dc4a03354f2b2214c85
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.14 De verplichting, bedoeld in artikel 2.81, eerste lid , is niet van toepassing na een inschrijving als bedoeld in artikel 2.66 , indien de inschrijving geschiedt op grond van een verzoek als bedoeld in artikel 2.68 en wordt gedaan ten aanzien van op het moment van inwerkingtreding van deze wet bij de aangewezen bestuursorganen bekende personen.
+- number: '4.15'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 68307e06cea331ab3c9b86a2e0b2295061ecdbf0719fb04cc6f08a0b7bc81848
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.15 1 Een college van burgemeester en wethouders geeft uitvoering aan deze wet met behulp van de gemeentelijke voorziening waarmee uitvoering werd gegeven aan de [Wet gemeentelijke basisadministratie persoonsgegevens](jci1.3:c:BWBR0006723&artikel=1) (de oude gemeentelijke voorziening) of met de gemeentelijke voorziening die is toegesneden op de basisregistratie personen (de nieuwe gemeentelijke voorziening).
+  - index: 1
+    label: lid 2
+    sha256: 2beff6cac9884fccb8a79a572c28bc955637b89e5cc6c320159c68ae2cc2d8f3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De overgang van gemeenten van de oude naar de nieuwe voorzieningen geschiedt per gemeente of groep van gemeenten.
+  - index: 2
+    label: lid 3
+    sha256: 6d5adf167a9b6ac306cc33d6d4ec27c2469e2c754549643a8309458dfe4cae9d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Bij of krachtens algemene maatregel van bestuur worden regels gesteld in verband met de overgang, waaronder regels omtrent het tijdstip van de overgang. Bij deze regels kan worden afgeweken van de hoofdstukken 2 en 3 van deze wet, voor zover het betreft:'
+  - index: 3
+    label: onderdeel a
+    sha256: f60a4b8aa1cc5e1db695773163fda7a1a398a1a81a3ca21367467f19ff437fa7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de conversie van gegevens, indien een gemeente met een oude voorziening de bijhoudingsgemeente wordt;
+  - index: 4
+    label: onderdeel b
+    sha256: 643110c38fe2397fea59541d855999c9cc9b07ef1e157e909ae554cf884805d7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. het doen van verzoeken als bedoeld in artikel 2.53 aan een ander dan de bijhoudingsgemeente;
+  - index: 5
+    label: onderdeel c
+    sha256: a45b683cb65ac4e2908c7bd81e563929a45ae21b34a3cf80b6f3b24c2d114027
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. het doen van een verzoek als bedoeld in artikel 2.59 ;
+  - index: 6
+    label: onderdeel d
+    sha256: cdd3c0315ebb66fcd4ae4c327d0a260301bf2941fff46ed97ccbeacbc87f02b8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. het verstrekken van gegevens op grond van de artikelen 3.5 en 3.6 over personen waarvoor de gemeente niet de bijhoudingsgemeente is;
+  - index: 7
+    label: onderdeel e
+    sha256: 0da39e6b8b4d404a31e1029727c6df6f24e6a14564f8c04a1629df9167d10a81
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: e. het doen van verzoeken als bedoeld in artikel 3.19 aan een ander dan de bijhoudingsgemeente, en
+  - index: 8
+    label: onderdeel f
+    sha256: b8172e3fae86b7d39e9a572c5779d0e51e1a9d599c28482d3cb2f8165dd680f0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: f. overige aspecten inzake de bijhouding en verstrekking van gegevens, voor zover de afwijking noodzakelijk is in verband met een goede bijhouding en verstrekking van de gegevens in de basisregistratie gedurende de overgang van de oude naar de nieuwe voorzieningen.
+- number: '4.16'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2f7f59bd9dce72d975652bbd8dea4635219a45d530df84bab9981c94fc145bfb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.16 1 Een overheidsorgaan waaraan of een derde aan wie systematisch gegevens worden verstrekt wisselt berichten uit met de centrale voorzieningen op de wijze waarop de berichtuitwisseling plaats vond onder de [Wet gemeentelijke basisadministratie persoonsgegevens](jci1.3:c:BWBR0006723) (de oude berichtuitwisseling) of op de wijze die is toegesneden op de basisregistratie personen (de nieuwe berichtuitwisseling).
+  - index: 1
+    label: lid 2
+    sha256: 4b7e9cfd55b07c2b02627d4aa408b9d192d23235fb72ff5b8b3a9660333f950c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De overgang van de in het eerste lid bedoelde overheidsorganen of derden van de oude naar de nieuwe berichtuitwisseling geschiedt per overheidsorgaan of derde, of per groep van organen of derden. De overgang kan betrekking hebben op delen van de organisatie van het overheidsorgaan of de derde en op verschillende wijzen van systematische verstrekking.
+  - index: 2
+    label: lid 3
+    sha256: 707dd1a4c6776d458ce719f5ae7801e360658ac26cc8b5e33cad79a1a9dbab13
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij of krachtens algemene maatregel van bestuur worden regels gesteld in verband met de overgang, waaronder regels omtrent het tijdstip van de overgang.
+- number: '4.17'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 0e54213bf868abd6cdf1fb03a893ad7504df3f804b7185405f2b60d8bd9badfe
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 4.17 Het college van burgemeester en wethouders kan een bestuurlijke boete van ten hoogste 325 euro opleggen:'
+  - index: 1
+    label: onderdeel a
+    sha256: 118eb718b530f0c3588ba9c3c5b719ff6335afe01ca76d2edd8939f1eaca053d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. ter zake van overtreding van de artikelen 2.38 , 2.39 , 2.40, vijfde lid , 2.43 tot en met 2.47 , 2.50 , 2.51 en 2.52 ;
+  - index: 2
+    label: onderdeel b
+    sha256: 4febdbfc0104176972c567b7e2afbb0ac6c5674041ad32717fa7e4b5f729d862
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. aan degene met een woonadres in de gemeente die bewust toelaat dat een andere persoon met datzelfde woonadres is ingeschreven, terwijl hij weet dat dit onjuist is.
+- number: '4.18'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: e1c3bfeaa21b72ef2c914ff29d92a83912e027c795cf5d47b1863d324a5ae438
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.18 De termijn, bedoeld in [artikel 12, eerste lid, van de Archiefwet 1995](jci1.3:c:BWBR0007376&artikel=12) vangt aan bij degene die op de dag van zijn overlijden ingezetene is, op die dag, en bij degene die na vertrek uit Nederland op de dag vallende honderd jaar na de geboorte niet ingezetene is, op die dag.
+- number: '4.19'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b2118728e6481def4f08d208a8b87e6ea7c8649f497f0bb558199e3d4bab58d6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.19 De [Wet gemeentelijke basisadministratie persoonsgegevens](jci1.3:c:BWBR0006723) wordt ingetrokken.
+- number: '4.20'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: e5f2301c51c2d9e4c0a2f7d2ae27244f4c29b43ccf1debe33dd8a9e55f289ecd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4.20 Deze wet treedt in werking op een bij koninklijk besluit te bepalen tijdstip.
+- number: '4.21'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: eb15a538359316193a426d421ac9ac8d5cd2060165ea8d5b56baf42aa9ac2013
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 4.21 Deze wet wordt aangehaald als: Wet basisregistratie personen.'

--- a/textguard/nl/wet/wet_forensische_zorg/2019-01-01.yaml
+++ b/textguard/nl/wet/wet_forensische_zorg/2019-01-01.yaml
@@ -1,0 +1,58 @@
+$id: wet_forensische_zorg
+valid_from: '2019-01-01'
+source: corpus/regulation/nl/wet/wet_forensische_zorg/2019-01-01.yaml
+articles:
+- number: '1.1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 27633576c80679c7fa6aa77f9b51ae44d1b47c5dc68676b838e8125508fc4634
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 1.1 1. In deze wet en de daarop berustende bepalingen wordt verstaan onder:'
+  - index: 1
+    label: tekst
+    sha256: 9994aa63f3ee1f0e4d2be79c78629916286700fdb481894bd695bc9048cd40fd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'forensische zorg: geestelijke gezondheidszorg, verslavingszorg en de zorg voor verstandelijk gehandicapten, die onderdeel is van, dan wel aansluit bij een (voorwaardelijke) straf of maatregel of die voortvloeit uit een last tot plaatsing als bedoeld in artikel 2.3.'
+  - index: 2
+    label: lid 2
+    sha256: 2341ee3e671e35d167c935974922232e037018b68956f0e074aad673c9185a78
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Onder forensische zorg als bedoeld in het eerste lid wordt verstaan:'
+  - index: 3
+    label: onderdeel a
+    sha256: 3cb6875972e735ba25ca32b429236aac8608860309480fd5e29bab5abb78b8cc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. geestelijke gezondheidszorg als omschreven bij of krachtens de Wet verplichte geestelijke gezondheidszorg;
+  - index: 4
+    label: onderdeel b
+    sha256: 41c6e29028d98fd7b51045a81190f3c876292f049a11b06ae007a852cc8719a2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. verslavingszorg;
+  - index: 5
+    label: onderdeel c
+    sha256: 9329171a5c21396873a8c9614d4e0e80f0393d93c8d35ca91b7b627f55db5df9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. zorg voor verstandelijk gehandicapten als omschreven bij of krachtens de Wet zorg en dwang psychogeriatrische en verstandelijk gehandicapte clienten.
+- number: '2.1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 3c6d9f5966bbba86cf3b5a90624355d3011b3a1266897b0591f2dc875c450161
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2.1 De tenuitvoerlegging van een vrijheidsbenemende straf of maatregel wordt zo veel mogelijk dienstbaar gemaakt aan de voorbereiding van de terugkeer van de forensische patient in de maatschappij en de vermindering van de kans op recidive, met inachtneming van de veiligheid van de samenleving.
+- number: '10.3'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a4eb79424a859e847056db42995d4bcff7b44216e9b8ef886b336ebef7f53196
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 10.3 Deze wet wordt aangehaald als: Wet forensische zorg.'

--- a/textguard/nl/wet/wet_inkomstenbelasting_2001/2024-01-01.yaml
+++ b/textguard/nl/wet/wet_inkomstenbelasting_2001/2024-01-01.yaml
@@ -1,0 +1,36 @@
+$id: wet_inkomstenbelasting_2001
+valid_from: '2024-01-01'
+source: corpus/regulation/nl/wet/wet_inkomstenbelasting_2001/2024-01-01.yaml
+articles:
+- number: '3.1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 0b3f9a6d52d4966c50ffbe247f25736d5f4179993d37f949211b50bd28c1b695
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Belastbaar inkomen uit werk en woning is het inkomen uit werk en woning verminderd met de te verrekenen verliezen uit werk en woning.
+- number: '4.12'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: df90168f9f365d04acda8a5083f5e3e21f939c74a95aff7bc62d4b361eae80a8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Inkomen uit aanmerkelijk belang is het gezamenlijke bedrag van de reguliere voordelen en de vervreemdingsvoordelen verminderd met de te verrekenen verliezen uit aanmerkelijk belang.
+- number: '5.2'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a7a0d38dad382e79adfe4b4a34fdde6ba04891a9dc2cdcdd7189884e049dfac3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Rendementsgrondslag is de waarde van de bezittingen verminderd met de waarde van de schulden. De rendementsgrondslag aan het begin van het kalenderjaar (peildatum 1 januari) wordt als uitgangspunt genomen.
+- number: '2.18'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b183a7c23de95422e3f327c47f9d05a04ac1410d5c57401cb7527cb5270bbae9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Verzamelinkomen is het gezamenlijke bedrag van het inkomen uit werk en woning, het inkomen uit aanmerkelijk belang en het belastbaar inkomen uit sparen en beleggen.

--- a/textguard/nl/wet/wet_inkomstenbelasting_2001/2025-01-01.yaml
+++ b/textguard/nl/wet/wet_inkomstenbelasting_2001/2025-01-01.yaml
@@ -1,0 +1,36 @@
+$id: wet_inkomstenbelasting_2001
+valid_from: '2025-01-01'
+source: corpus/regulation/nl/wet/wet_inkomstenbelasting_2001/2025-01-01.yaml
+articles:
+- number: '3.1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 0b3f9a6d52d4966c50ffbe247f25736d5f4179993d37f949211b50bd28c1b695
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Belastbaar inkomen uit werk en woning is het inkomen uit werk en woning verminderd met de te verrekenen verliezen uit werk en woning.
+- number: '4.12'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: df90168f9f365d04acda8a5083f5e3e21f939c74a95aff7bc62d4b361eae80a8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Inkomen uit aanmerkelijk belang is het gezamenlijke bedrag van de reguliere voordelen en de vervreemdingsvoordelen verminderd met de te verrekenen verliezen uit aanmerkelijk belang.
+- number: '5.2'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a7a0d38dad382e79adfe4b4a34fdde6ba04891a9dc2cdcdd7189884e049dfac3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Rendementsgrondslag is de waarde van de bezittingen verminderd met de waarde van de schulden. De rendementsgrondslag aan het begin van het kalenderjaar (peildatum 1 januari) wordt als uitgangspunt genomen.
+- number: '2.18'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b183a7c23de95422e3f327c47f9d05a04ac1410d5c57401cb7527cb5270bbae9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Verzamelinkomen is het gezamenlijke bedrag van het inkomen uit werk en woning, het inkomen uit aanmerkelijk belang en het belastbaar inkomen uit sparen en beleggen.

--- a/textguard/nl/wet/wet_langdurige_zorg/2025-07-05.yaml
+++ b/textguard/nl/wet/wet_langdurige_zorg/2025-07-05.yaml
@@ -1,0 +1,150 @@
+$id: wet_langdurige_zorg
+valid_from: '2025-07-05'
+source: corpus/regulation/nl/wet/wet_langdurige_zorg/2025-07-05.yaml
+articles:
+- number: 1.1.1
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a169b585b8a534d7baa8af944473d0ebc4925a4a62d654064da4350df29e1478
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'In deze wet en de daarop berustende bepalingen wordt verstaan onder: – ADL-woning: woning die deel uitmaakt van een aantal bij elkaar horende rolstoeldoorgankelijke sociale huurwoningen; – begeleiding: activiteiten waarmee een persoon wordt ondersteund bij het uitvoeren van algemene dagelijkse levensverrichtingen en bij het aanbrengen en behouden van structuur in en regie over het persoonlijk leven; – burgerservicenummer: het burgerservicenummer, bedoeld in artikel 1, onderdeel b, van de Wet algemene bepalingen burgerservicenummer; – CAK: het CAK, genoemd in artikel 6.1.1; – CIZ: het CIZ, genoemd in artikel 7.1.1; – cliëntondersteuning: onafhankelijke ondersteuning met informatie, advies, algemene ondersteuning en zorgbemiddeling die bijdraagt aan het tot gelding brengen van het recht op zorg in samenhang met dienstverlening op andere gebieden; – continentaal plat: de exclusieve economische zone van het Koninkrijk, bedoeld in artikel 1 van de rijkswet instelling exclusieve economische zone, voor zover deze grenst aan de territoriale zee van Nederland; – dossier: de schriftelijk of elektronisch vastgelegde gegevens met betrekking tot de verlening van zorg aan een cliënt; – Fonds langdurige zorg: fonds, genoemd in artikel 89 van de Wet financiering sociale verzekeringen; – indicatiebesluit: besluit van het CIZ waarbij beoordeeld wordt of en in welke omvang de verzekerde in aanmerking komt voor zorg; – inspecteur of ontvanger: de functionaris, bedoeld in artikel 2, derde lid, onder b, van de Algemene wet inzake rijksbelastingen; – instelling: 1°. een instelling in de zin van de Wet toelating zorginstellingen; 2°. een organisatorisch verband dat gevestigd is buiten het grondgebied van het Europese deel van Nederland en overeenkomstig de daar geldende wetgeving rechtmatig gezondheidszorg verstrekt als bedoeld bij of krachtens artikel 3.1.1; – mantelzorger: natuurlijke persoon die rechtstreeks voortvloeiend uit een tussen personen bestaande sociale relatie zorg verleent zonder dat dit beroeps- of bedrijfsmatig geschiedt; – Onze Minister: Onze Minister van Volksgezondheid, Welzijn en Sport; – persoonsgebonden budget: een subsidie waarmee de verzekerde onder de bij of krachtens artikel 3.3.3 en titel 4.2 van de Algemene wet bestuursrecht gestelde voorwaarden aan hem te verlenen zorg kan inkopen; – persoonlijke verzorging: het ondersteunen bij of het overnemen van activiteiten op het gebied van de persoonlijke verzorging, gericht op het opheffen van een tekort aan zelfredzaamheid; – Nederland: het Europese deel van Nederland; – solistisch werkende zorgverlener: een zorgverlener die, anders dan in dienst of onmiddellijk of middellijk in opdracht van een instelling beroepsmatig zorg verleent; – Sociale verzekeringsbank: de Sociale verzekeringsbank, genoemd in artikel 3 van de Wet structuur uitvoeringsorganisatie werk en inkomen; – verblijf: verblijf als bedoeld in artikel 3.1.1, eerste lid, onder a; – verpleging: handelingen, gericht op herstel of voorkoming van verergering van de aandoening, beperking of handicap; – verzekeraar: verzekeringsonderneming als bedoeld in richtlijn nr. 73/239/EEG van de Raad van de Europese Gemeenschappen van 24 juli 1973 tot coördinatie van de wettelijke en bestuursrechtelijke bepalingen betreffende de toegang tot het directe verzekeringsbedrijf, met uitzondering van de levensverzekeringbranche en de uitoefening daarvan (PbEG L 228); – vreemdeling: vreemdeling als bedoeld in de Vreemdelingenwet 2000; – Wlz-uitvoerder: rechtspersoon die geen zorgverzekeraar is, die zich overeenkomstig artikel 4.1.1 heeft aangemeld voor de uitvoering van deze wet, het zorgkantoor daaronder begrepen; – woningaanpassing: bouwkundige of woontechnische ingreep in of aan een woonruimte; – zorg: zorg en overige diensten als bedoeld in artikel 3.1.1; – zorg in natura: zorg, geleverd door zorgaanbieders op grond van schriftelijke overeenkomsten tussen zorgaanbieders en Wlz-uitvoerders als bedoeld in artikel 4.2.2; – zorgaanbieder: een instelling dan wel een solistisch werkende zorgverlener; – zorgautoriteit: de zorgautoriteit,
+      genoemd in artikel 3 van de Wet marktordening gezondheidszorg; – Zorginstituut: het Zorginstituut Nederland, genoemd in artikel 58, eerste lid, van de Zorgverzekeringswet; – zorgkantoor: een ingevolge artikel 4.2.4, tweede lid, voor een bepaalde regio aangewezen Wlz-uitvoerder; – zorgplan: schriftelijk of elektronisch als zodanig vastgelegde uitkomsten van hetgeen met de verzekerde dan wel een vertegenwoordiger van de verzekerde is besproken met betrekking tot de in artikel 8.1.1 genoemde onderwerpen; – zorgverlener: een natuurlijke persoon die in persoon beroepsmatig zorg verleent; – zorgverzekeraar: een zorgverzekeraar als bedoeld in artikel 1, onderdeel b, van de Zorgverzekeringswet; – zorgverzekering: een zorgverzekering als bedoeld in artikel 1, onderdeel d, van de Zorgverzekeringswet.'
+- number: 2.1.1
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 4a363ea82f72efa0f23b2efa60b868cf180bfe491cd707ce9a4d2233412c3d94
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. Verzekerd overeenkomstig de bepalingen van deze wet is degene, die: a. ingezetene is; b. geen ingezetene is, doch ter zake van in Nederland of op het continentaal plat in dienstbetrekking verrichte arbeid aan de loonbelasting is onderworpen.'
+  - index: 1
+    label: lid 2
+    sha256: 202d14b807c3df9e0f133945cf3ac5c022034ffe7a77f231cc9413db54eccf80
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In afwijking van het eerste lid zijn vreemdelingen die niet rechtmatig in Nederland verblijf genieten als bedoeld in artikel 8, onder a tot en met e en l, van de Vreemdelingenwet 2000, niet verzekerd.
+  - index: 2
+    label: lid 3
+    sha256: d7776f20368c00823255bd32d414af03c43dbb24b10690d8a939b543ac62bc3b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. In afwijking van het tweede lid zijn verzekerd: a. kinderen in Nederland geboren uit een in Nederland wonende vreemdeling die rechtmatig verblijf geniet als bedoeld in artikel 8, onder a tot en met e of l, van de Vreemdelingenwet 2000, dan wel in het buitenland geboren uit in Nederland wonende ouders die rechtmatig verblijf genieten als bedoeld in artikel 8, onder a tot en met e of l, van de Vreemdelingenwet 2000; b. kinderen die door in Nederland wonende personen met de Nederlandse nationaliteit dan wel met rechtmatig verblijf als bedoeld in artikel 8, onder a tot en met e of l, van de Vreemdelingenwet 2000, worden geadopteerd en voor wie met het oog op adoptie beginseltoestemming is verleend op grond van artikel 2 van de Wet opneming buitenlandse kinderen ter adoptie.'
+  - index: 3
+    label: lid 4
+    sha256: 0fca50bc2b50a7615e4f38e1526ec3b647aede7fb1bffb3fe24abe8a9c89bc74
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij of krachtens algemene maatregel van bestuur kan, in afwijking van het eerste lid, uitbreiding dan wel beperking worden gegeven aan de kring der verzekerden.
+  - index: 4
+    label: lid 5
+    sha256: ffca0bb88bdeb93a11175d8f5e94c05b15f65087aca9d03fdc57acd27899bca2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '5. Bij of krachtens algemene maatregel van bestuur kan, in afwijking van het eerste en tweede lid, uitbreiding worden gegeven aan de kring der verzekerden voor zover het betreft: a. vreemdelingen die rechtmatig in Nederland arbeid verrichten dan wel hebben verricht; b. vreemdelingen die, na in Nederland rechtmatig verblijf te hebben genoten als bedoeld in artikel 8, onder a tot en met e en l, van de Vreemdelingenwet 2000, tijdig toelating in aansluiting op dat verblijf hebben aangevraagd, dan wel bezwaar hebben gemaakt of beroep hebben ingesteld tegen de intrekking van het besluit tot toelating, totdat op die aanvraag, dat bezwaar of dat beroep is beslist.'
+- number: 2.1.2
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c1485dc599cc5f12bb8b830ce7443062d1e78ebbaa4f0dbd676f2d960fd6c56c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Zo nodig in afwijking van artikel 2.1.1 en de daarop berustende bepalingen: a. wordt als verzekerde aangemerkt de persoon van wie de verzekering op grond van deze wet voortvloeit uit de toepassing van bepalingen van een verdrag of van een besluit van een volkenrechtelijke organisatie; b. wordt niet als verzekerde aangemerkt de persoon op wie op grond van een verdrag of een besluit van een volkenrechtelijke organisatie de wetgeving van een andere mogendheid van toepassing is.'
+- number: 2.1.3
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 747e13ae7fb71583d33236d262605429ea574568fa27aec2e3aa23c3465c2167
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: De Sociale verzekeringsbank stelt ambtshalve en, desgevraagd, op aanvraag vast of een natuurlijke persoon voldoet aan de bij of krachtens de artikelen 2.1.1 of 2.1.2 vastgestelde voorwaarden voor het verzekerd zijn ingevolge deze wet.
+- number: 3.1.1
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 20cb50cd5377158ba83e591b4ee78291bfc3c7fb60fd6982b1ae5d990eddae24
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. Het op grond van deze wet verzekerde pakket omvat de volgende vormen van zorg: a. verblijf in een instelling, met inbegrip van voorzieningen die niet ten laste van de verzekerde kunnen komen, waaronder in elk geval: 1°. het verstrekken van eten en drinken, 2°. het schoonhouden van de woonruimte van de verzekerde, en 3°. voor meerdere verzekerden te gebruiken of te hergebruiken roerende voorzieningen die noodzakelijk zijn voor de zorgverlening of in verband met het opheffen of verminderen van belemmeringen die de verzekerde als gevolg van een aandoening, beperking, stoornis of handicap ondervindt bij het normale gebruik van zijn woonruimte; b. persoonlijke verzorging, begeleiding en verpleging; c. behandeling, omvattende geneeskundige zorg van specifiek medische, specifiek gedragswetenschappelijke of specifiek paramedische aard die noodzakelijk is in verband met de aandoening, beperking, stoornis of handicap van de verzekerde; d. door of namens een instelling waarvan de verzekerde verblijf alsmede behandeling als bedoeld in onderdeel c ontvangt te verlenen: 1°. geneeskundige zorg van algemeen medische aard, niet zijnde paramedische zorg, 2°. behandeling van een psychische stoornis indien de behandeling integraal onderdeel uitmaakt van de behandeling van een van de in artikel 3.2.1 genoemde aandoeningen of beperkingen; 3°. farmaceutische zorg; 4°. het gebruik van hulpmiddelen, noodzakelijk in verband met de in de instelling gegeven zorg; 5°. tandheelkundige zorg; 6°. kleding, verband houdende met het karakter en de doelstelling van de instelling; e. het individueel gebruik van mobiliteitshulpmiddelen; f. vervoer naar een plaats waar de verzekerde gedurende een dagdeel begeleiding of behandeling ontvangt; g. logeeropvang in een instelling, met inbegrip van de voorzieningen, bedoeld in onderdeel a, mits dit geschiedt ter ontlasting van een of meer mantelzorgers. 2. Bij of krachtens algemene maatregel van bestuur kunnen aard, inhoud en omvang van de verzekerde zorg nader worden geregeld.'
+- number: 3.2.1
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: a2c88ec1bdd67a89a98f36ca11fdb04f70e41dd79fe386de7a6c60c59e5c462a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. Een verzekerde heeft recht op zorg die op zijn behoeften, persoonskenmerken en mogelijkheden is afgestemd voor zover hij naar aard, inhoud en omvang en uit een oogpunt van doelmatige zorgverlening redelijkerwijs op die zorg is aangewezen omdat hij, vanwege een somatische of psychogeriatrische aandoening of beperking of een verstandelijke, lichamelijke of zintuiglijke handicap, een blijvende behoefte heeft aan: a. permanent toezicht ter voorkoming van escalatie of ernstig nadeel voor de verzekerde, of b. 24 uur per dag zorg in de nabijheid, omdat hij zelf niet in staat is om op relevante momenten hulp in te roepen en hij, om ernstig nadeel voor hem zelf te voorkomen, 1°. door fysieke problemen voortdurend begeleiding, verpleging of overname van zelfzorg nodig heeft, of 2°. door zware regieproblemen voortdurend begeleiding of overname van taken nodig heeft. 2. In het eerste lid wordt verstaan onder: a. blijvend: van niet voorbijgaande aard; b. permanent toezicht: onafgebroken toezicht en actieve observatie gedurende het gehele etmaal, waardoor tijdig kan worden ingegrepen; c. ernstig nadeel voor de verzekerde: een situatie waarin de verzekerde: 1°. zich maatschappelijk te gronde richt of dreigt te richten; 2°. zichzelf in ernstige mate verwaarloost of dreigt te verwaarlozen; 3°. ernstig lichamelijk letsel oploopt of dreigt op te lopen dan wel zichzelf ernstig lichamelijk letsel toebrengt of dreigt toe te brengen; 4°. ernstig in zijn ontwikkeling wordt geschaad of dreigt te worden geschaad of dat zijn veiligheid ernstig wordt bedreigd, al dan niet doordat hij onder de invloed van een ander raakt; d. zelfzorg: de uitvoering van algemene dagelijkse levensverrichtingen waaronder de persoonlijke verzorging en hygiëne en, zo nodig, de verpleegkundige zorg; e. regieproblemen: beperkingen in het vermogen om een adequaat oordeel te vormen over dagelijks voorkomende situaties op het gebied van sociale redzaamheid, probleemgedrag, psychisch functioneren of geheugen en oriëntatie. 3. In afwijking van het eerste lid heeft een meerderjarige verzekerde recht op zorg voor zover hij vanwege een combinatie van een licht verstandelijke handicap en gedragsproblemen: a. tijdelijk behoefte heeft aan permanent toezicht of 24 uur per dag zorg in de nabijheid als bedoeld in het eerste lid, onder a of b, of b. volgens zijn behandelaar is aangewezen op het afmaken van een onder de Jeugdwet aangevangen behandeling met verblijf. 4. Bij of krachtens algemene maatregel van bestuur wordt bepaald in welke gevallen een verzekerde, in afwijking van het eerste lid, geen recht heeft op vormen van zorg voor zover hij krachtens een zorgverzekering of een andere wettelijke regeling recht heeft of kan doen gelden op die zorg. 5. Bij of krachtens algemene maatregel van bestuur kunnen regels worden gesteld met betrekking tot het eerste tot en met derde lid.'
+- number: 3.2.3
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 41c589b67ca3ea544033a62bd3a72fc71a4345813017c0bd0151017aae858595
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Het recht op zorg wordt op aanvraag van de verzekerde in een indicatiebesluit vastgesteld door het CIZ. Het recht op zorg dat wordt vastgesteld in het indicatiebesluit sluit aan bij de behoefte van de verzekerde. 2. De verzekerde vermeldt bij de aanvraag zijn burgerservicenummer. 3. De verzekerde verstrekt op verzoek of uit eigen beweging alle informatie, waarvan het hem redelijkerwijs duidelijk moet zijn dat die van belang kan zijn voor de beoordeling van het recht op zorg, en is verplicht mee te werken door zich te laten onderzoeken door het CIZ of door daartoe door het CIZ aangewezen personen. 4. Het CIZ wijst de verzekerde bij de aanvraag op het recht op cliëntondersteuning, bedoeld in artikel 2.2.4, eerste lid, onder a, van de Wet maatschappelijke ondersteuning 2015. 5. Bij of krachtens algemene maatregel van bestuur kunnen regels worden gesteld over de wijze waarop de indicatie tot stand komt en over de inrichting en geldigheidsduur van het indicatiebesluit.
+- number: 3.3.3
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 9eaa47d6e47b698503cee479c0188708839c67d4fe1d203d1e76488a678c3476
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. Het zorgkantoor verleent op aanvraag van de verzekerde en onverminderd het vierde en vijfde lid alsmede andere bij wettelijk voorschrift gestelde voorwaarden of beperkingen, volgens bij of krachtens algemene maatregel van bestuur te stellen regels, een persoonsgebonden budget waarmee de verzekerde, in plaats van zorg in natura te ontvangen, zelf betalingen doet voor zorg als bedoeld in artikel 3.1.1, eerste lid, onderdelen a, onder 2°, b, f of g. De verzekerde ziet af van het recht op verblijf en van de daarmee gepaard gaande voorziening, bedoeld in artikel 3.1.1, eerste lid, onderdeel a, onder 1°, alsmede van de behandeling, bedoeld in artikel 3.1.1, eerste lid, onderdeel d. 2. Voordat een besluit op een aanvraag als bedoeld in het eerste lid wordt genomen, kan de verzekerde of zijn vertegenwoordiger het zorgkantoor een persoonlijk plan overhandigen, waarin de verzekerde of zijn vertegenwoordiger de door hem beoogde samenstelling van het persoonsgebonden budget schetst. Het zorgkantoor brengt de verzekerde of zijn vertegenwoordiger van deze mogelijkheid op de hoogte en stelt hem gedurende zeven dagen na de aanvraag in de gelegenheid het plan te overhandigen. 3. Indien de verzekerde of zijn vertegenwoordiger een persoonlijk plan als bedoeld in het tweede lid aan het zorgkantoor heeft overhandigd, betrekt het zorgkantoor het persoonlijk plan bij het nemen van het besluit op de aanvraag, bedoeld in het eerste lid. 4. Het persoonsgebonden budget wordt, onverminderd het vijfde lid en andere bij wettelijk voorschrift gestelde voorwaarden of beperkingen, verleend, indien: a. naar het oordeel van het zorgkantoor met het persoonsgebonden budget op doelmatige wijze zal worden voorzien in toereikende zorg van goede kwaliteit; b. de verzekerde naar het oordeel van het zorgkantoor in staat is te achten op eigen kracht of met hulp van een vertegenwoordiger, de aan een budget verbonden taken en verplichtingen op verantwoorde wijze uit te voeren; c. de verzekerde naar het oordeel van de het zorgkantoor in staat is te achten op eigen kracht of met hulp van een vertegenwoordiger, de door hem verkozen zorgaanbieders en mantelzorgers op zodanige wijze aan te sturen en hun werkzaamheden op elkaar af te stemmen, dat sprake is of zal zijn van verantwoorde zorg; d. de verzekerde zich gemotiveerd op het standpunt stelt dat hij de zorg met een persoonsgebonden budget wenst geleverd te krijgen, en, e. de verzekerde bij de aanvraag een budgetplan voorlegt aan het zorgkantoor. 5. Het persoonsgebonden budget wordt in ieder geval geweigerd indien: a. de verzekerde zich bij de eerdere verstrekking van een persoonsgebonden budget niet heeft gehouden aan de opgelegde verplichtingen; b. de verzekerde blijkens de basisregistratie personen niet beschikt over een woonadres; c. de verzekerde rechtens zijn vrijheid is ontnomen; d. de vertegenwoordiger van de verzekerde niet voldoet aan regels inhoudende beperkingen of eisen die bij of krachtens algemene maatregel van bestuur aan de kring van vertegenwoordigers kunnen worden gesteld in het belang van de bescherming van de verzekerde of van het waarborgen van de hulp, bedoeld in de onderdelen b en c van het vierde lid. 6. Bij of krachtens algemene maatregel van bestuur worden regels gesteld over de wijze waarop de hoogte van een persoonsgebonden budget wordt vastgesteld waarbij geldt dat de hoogte toereikend moet zijn. 7. De Sociale verzekeringsbank voert namens de zorgkantoren de betalingen ten laste van verstrekte persoonsgebonden budgetten, alsmede het hiermee verbonden budgetbeheer, uit. 8. De regels, bedoeld in het eerste lid, hebben in ieder geval betrekking op: a. de gevallen waarin en de voorwaarden waaronder de verzekerde aan wie een persoonsgebonden budget wordt verleend, de mogelijkheid heeft om zorg te betrekken van een mantelzorger of een natuurlijke persoon die niet beroeps- of bedrijfsmatig zorg verleent, of die persoon vanuit het persoonsgebonden budget te betalen; b. verplichtingen die aan de verzekerde worden opgelegd met betrekking tot de overeenkomsten die de verzekerde sluit met
+      de personen van wie hij de zorg betrekt en daarvoor betaling ontvangen uit het persoonsgebonden budget; c. de gevallen waarin, onverminderd het vierde en vijfde lid, verzekerden worden uitgesloten van de verlening van een persoonsgebonden budget; d. de wijze waarop de Sociale verzekeringsbank de taak, bedoeld in het zevende lid, uitvoert, en e. de vorm en inhoud van het budgetplan, bedoeld in het eerste lid, onderdeel e. 9. De op grond van het eerste, vijfde, zesde en achtste lid gestelde regels kunnen voor verschillende categorieën van verzekerden verschillend worden vastgesteld.'
+- number: 4.2.1
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: f348bd22409753624082fe73f622321765326b10bb9a9d6024272020e1e38f94
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. De Wlz-uitvoerder heeft een zorgplicht, die inhoudt dat: a. hij de bij hem ingeschreven verzekerde informatie verschaft over de leveringsvormen, bedoeld in hoofdstuk 3, paragraaf 3, en deze verzekerde, indien hij in aanmerking kan komen voor meerdere leveringsvormen, in de gelegenheid stelt voor zorg met verblijf in een instelling, voor een volledig pakket thuis of voor een modulair pakket thuis te kiezen of hem wijst op de mogelijkheid om bij het zorgkantoor een persoonsgebonden budget aan te vragen, b. indien de verzekerde zorg in natura zal worden verstrekt: 1°. hij ervoor zorgt dat de zorg waarop de verzekerde aangewezen is binnen redelijke termijn en op redelijke afstand van waar deze wenst te gaan wonen dan wel bij hem thuis, wordt geleverd, 2°. hij de verzekerde de keuze laat uit alle geschikte, gecontraceerde zorgaanbieders die deze verzekerde de zorg op redelijke termijn kunnen verlenen, of 3°. hij de verzekerde desgewenst bemiddelt naar geschikte, gecontracteerde zorgaanbieders, c. hij ervoor zorgt dat voor de verzekerde cliëntondersteuning beschikbaar is waarop de verzekerde, al dan niet met behulp van zijn vertegenwoordiger of mantelzorger, een beroep kan doen. 2. Het zorgkantoor heeft een zorgplicht, die inhoudt dat: a. hij de verzekerden die wonen in de regio waarvoor hij als zorgkantoor is aangewezen, desgevraagd informatie verschaft over de voorwaarden waaronder zij in aanmerking kunnen komen voor een persoonsgebonden budget, b. hij, indien hij met toepassing van artikel 3.3.3 een persoonsgebonden budget heeft verleend, ervoor zorgt dat het budget binnen redelijke termijn beschikbaar wordt gesteld. 3. Dit lid is nog niet in werking getreden. 4. De voordracht voor een krachtens het derde lid vast te stellen algemene maatregel van bestuur wordt niet eerder gedaan dan vier weken nadat het ontwerp aan beide kamers der Staten-Generaal is overgelegd.'
+- number: 4.2.4
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: ebf27da3cd275d8c4875e28b374cab65e75aafb2849ff60ccc03a2c93e5e761c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. De Wlz-uitvoerder is verantwoordelijk voor de uitvoering van hetgeen bij en krachtens deze wet is geregeld voor de bij hem ingeschreven verzekerden. De eerste volzin geldt niet voor werkzaamheden die bij of krachtens de wet aan een andere rechtspersoon zijn opgedragen. 2. Bij of krachtens algemene maatregel van bestuur wordt Nederland ingedeeld in regio’s. Onze Minister wijst per regio een Wlz-uitvoerder aan als zorgkantoor. Het zorgkantoor is voor alle verzekerden die wonen in de regio waarvoor hij is aangewezen belast met de verstrekking van het persoonsgebonden budget, alsmede in een bij algemene maatregel van bestuur te bepalen mate met de administratie of controle van de aan die verzekerden verleende zorg. 3. Bij of krachtens de algemene maatregel van bestuur of de aanwijzing, bedoeld in het tweede lid, kunnen nadere voorwaarden aan de administratie of controle worden gesteld en kunnen, voor het geval voor een regio een ander zorgkantoor wordt aangewezen, regels worden gesteld om een goede taakoverdracht te bewerkstelligen. 4. Indien een Wlz-uitvoerder werkzaamheden ter vervulling van zijn zorgplicht of van zijn in het eerste lid bedoelde taak uitbesteedt, neemt hij daartoe bij algemene maatregel van bestuur te bepalen regels in acht alsmede, voor zover het verlenen van de verzekerde zorg wordt uitbesteed, de bij of krachtens artikel 4.2.2 gestelde regels. 5. Nadat Onze Minister een melding van de zorgautoriteit als bedoeld in artikel 79, vierde lid, van de Wet marktordening gezondheidszorg heeft ontvangen, kan hij bepalen dat de Wlz-uitvoerders geen werkzaamheden mogen uitbesteden aan het in de melding genoemde zorgkantoor en kan hij de in het tweede lid bedoelde aanwijzing van het zorgkantoor intrekken. 6. Overeenkomsten die in strijd met het bij en krachtens het vierde en vijfde lid of het bij of krachtens artikel 4.2.2 bepaalde zijn gesloten, zijn nietig.
+- number: 4.2.6
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 2e2b92b5daf5e91e4168b350a053106f50261378e874ac3b4e56cb45b385966a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. De Wlz-uitvoerder voert ter zake van de uitvoering van deze wet een administratie die gescheiden is van de overige activiteiten die plaatsvinden in de groep als bedoeld in artikel 24b van Boek 2 van het Burgerlijk Wetboek, waartoe de Wlz-uitvoerder behoort. 2. Buiten de werkzaamheden die uit deze wet voortvloeien, verricht de Wlz-uitvoerder slechts taken die hem bij of krachtens de wet zijn opgedragen.
+- number: 5.1.1
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: f31f789b69a7df6bc43273e16fd16e70309e9f2f9064737a04f5b8414df5a6d3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Het Zorginstituut bevordert de rechtmatige en doelmatige uitvoering van deze wet door de Wlz-uitvoerders en het CAK. 2. Het Zorginstituut kan met het oog op de rechtmatige en doelmatige uitvoering van deze wet beleidsregels stellen voor de Wlz-uitvoerders en voor het CAK.
+- number: 6.1.1
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 040a3ed8840d4ecc540d32ffb8bea0479fff6601538ea198b078daab33e4bdea
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Er is een CAK, dat rechtspersoonlijkheid bezit. 2. Het CAK is gevestigd in een door Onze Minister te bepalen plaats. 3. Het CAK bestaat uit ten hoogste drie leden, onder wie de voorzitter. 4. Het CAK wordt in en buiten rechte vertegenwoordigd door de voorzitter. 5. Benoeming vindt plaats op grond van de deskundigheid die nodig is voor de uitoefening van de taken van het CAK alsmede op grond van maatschappelijke kennis en ervaring. 6. De leden worden benoemd voor ten hoogste vier jaar. Herbenoeming kan twee maal en telkens voor ten hoogste vier jaar plaatsvinden. 7. In afwijking van artikel 15 van de Kaderwet zelfstandige bestuursorganen worden de personeelsleden van de in het eerste lid bedoelde rechtspersoon in dienst genomen op arbeidsovereenkomst naar burgerlijk recht. De bepalingen van titel 10 van Boek 7 van het Burgerlijk Wetboek zijn op deze overeenkomst van toepassing.
+- number: 7.1.1
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 06c937d8303ef6ef9581cf38d079b73f770fa004354afdbd9b61dd9d1e324213
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Er is een CIZ, dat rechtspersoonlijkheid bezit. 2. Het CIZ is gevestigd in een door Onze Minister te bepalen plaats. 3. Het CIZ bestaat uit ten hoogste drie leden, onder wie de voorzitter. 4. Het CIZ wordt in en buiten rechte vertegenwoordigd door de voorzitter. 5. Benoeming vindt plaats op grond van de deskundigheid die nodig is voor de uitoefening van de taken van het CIZ alsmede op grond van maatschappelijke kennis en ervaring. 6. De leden worden benoemd voor ten hoogste vier jaar. Herbenoeming kan twee maal en telkens voor ten hoogste vier jaar plaatsvinden. 7. In afwijking van artikel 15 van de Kaderwet zelfstandige bestuursorganen worden de personeelsleden van de in het eerste lid bedoelde rechtspersoon in dienst genomen op arbeidsovereenkomst naar burgerlijk recht. De bepalingen van titel 10 van Boek 7 van het Burgerlijk Wetboek zijn op deze overeenkomst van toepassing.
+- number: 14.1.1
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 7c1b755b39d7ec2edc2994cfe0741ff89d39a0b32114e2187a2d3e4af05ce715
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Deze wet wordt aangehaald als: Wet langdurige zorg.'

--- a/textguard/nl/wet/wet_op_de_zorgtoeslag/2024-01-01.yaml
+++ b/textguard/nl/wet/wet_op_de_zorgtoeslag/2024-01-01.yaml
@@ -1,0 +1,138 @@
+$id: zorgtoeslagwet
+valid_from: '2024-01-01'
+source: corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2024-01-01.yaml
+articles:
+- number: '1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: daee5d41ffbd2612d367a8e264ac7de2e6947b371a0b97effa6cc73416e609c4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'In deze wet en de daarop berustende bepalingen wordt verstaan onder:'
+  - index: 1
+    label: onderdeel a
+    sha256: 13bfc93f4b526c2c29d7b264d46de24f3ffb266c8309906a9a3ee909cdd1639c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'a. verzekerde: degene die ingevolge de Zorgverzekeringswet verzekerd is; b. toetsingsinkomen: het verzamelinkomen, bedoeld in artikel 2.18 van de Wet inkomstenbelasting 2001; c. drempelinkomen: het bedrag, bedoeld in artikel 2, tweede lid; d. normpremie: de premie, berekend overeenkomstig artikel 2; e. standaardpremie: de premie, bedoeld in artikel 4.'
+- number: 1a
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 15c925b2096e37151c82b3ea28c71add9af7174ed767582810516bc580d5e709
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'In deze wet en de daarop berustende bepalingen wordt verstaan onder Onze Minister: Onze Minister van Volksgezondheid, Welzijn en Sport.'
+- number: '2'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 4ac0f07cad7d0cfcbbb3f46b6185068ebae1bbe99ea274fb9588f6f7e4c880d0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Indien de normpremie voor een verzekerde in het berekeningsjaar minder bedraagt dan de standaardpremie in dat jaar, heeft de verzekerde aanspraak op een zorgtoeslag ter grootte van dat verschil. Voor een verzekerde met een toeslagpartner geldt het dubbele van de standaardpremie en worden de verzekerde en de toeslagpartner geacht gezamenlijk aanspraak te maken op zorgtoeslag.
+  - index: 1
+    label: lid 2
+    sha256: 5f06152ee0d57229db31f3585ff3ccc4d43f3fe9b4f71513c78a2a54a39c9968
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De normpremie bedraagt een percentage van het drempelinkomen in het berekeningsjaar, vermeerderd met een percentage van het toetsingsinkomen van de verzekerde. Ingeval de verzekerde een toeslagpartner heeft, wordt het gezamenlijk toetsingsinkomen van de verzekerde en de toeslagpartner in aanmerking genomen.
+  - index: 2
+    label: lid 3
+    sha256: f3380a37924a9b8b1c16b34de30052b0858bf3f64c5db11d0c97b35c0e7db43d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De percentages, bedoeld in het tweede lid, bedragen voor een verzekerde met een toeslagpartner 4,256 procent van het drempelinkomen, vermeerderd met 13,670 procent van het toetsingsinkomen, en voor een verzekerde zonder toeslagpartner 1,879 procent van het drempelinkomen, vermeerderd met 13,670 procent van het toetsingsinkomen. Bij ministeriële regeling kunnen deze percentages worden gewijzigd.
+  - index: 3
+    label: lid 4
+    sha256: b0069189a55acb5f629377535b018f57b7b4f8a8dc41c5b34548a9dc256617af
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. In afwijking van het eerste lid bedraagt de aanspraak op een zorgtoeslag voor een verzekerde met een partner die geen verzekerde is, vijftig procent van het op grond van het eerste lid berekende bedrag.
+  - index: 4
+    label: lid 5
+    sha256: 972096518adbb9cd4185a5b7d584b63b0f245766af494786b556f533293c32e1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De aanspraak op een zorgtoeslag wordt voor iedere kalendermaand afzonderlijk bepaald.
+  - index: 5
+    label: lid 6
+    sha256: 2de52f7fc559548ccbf5b1fa91a86254a5410e30a6b3a0fcadd1d4e41fc50758
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Bij ministeriële regeling kunnen nadere regels worden gesteld.
+  - index: 6
+    label: lid 7
+    sha256: af51ada54f7df35e1bcc6d0a68f6e728e8de67376da09aded35f550a96801193
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. Onze Minister zendt een voornemen tot wijziging van de percentages, bedoeld in het derde lid, ten minste twee weken voor de vaststelling aan beide kamers der Staten-Generaal.
+- number: '3'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 894d41db855b31a911d295be58f24190253ee2e6ef45946fe7aaeec1764f01bb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Een verzekerde heeft geen aanspraak op zorgtoeslag indien de rendementsgrondslag, bedoeld in artikel 5.2 van de Wet inkomstenbelasting 2001, van de verzekerde of, ingeval de verzekerde een toeslagpartner heeft, de gezamenlijke rendementsgrondslag van de verzekerde en de toeslagpartner op de peildatum meer bedraagt dan € 127.582 voor een verzekerde zonder toeslagpartner, onderscheidenlijk € 161.329 voor een verzekerde met een toeslagpartner.
+- number: '4'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 424caeef334ded0ea6ef6b0ccec32dd29c0a6ac9f6d4e0efe51513708cfd1a8a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Onze Minister stelt uiterlijk 22 dagen voorafgaande aan het berekeningsjaar bij regeling de standaardpremie voor het berekeningsjaar vast.
+- number: 4a
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b9cea51038b7ebd05f04198adc5c78a895a8f18d621331c6a78ec39a69245372
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Voor de persoon, bedoeld in artikel 69 van de Zorgverzekeringswet, wordt de standaardpremie aangepast aan de hand van de verhouding tussen de zorguitgaven per verzekerde in het land waar de persoon woont en de zorguitgaven per verzekerde in Nederland.
+- number: '5'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 64c9fc5d1fef010140ca6f1b0df9c8ba3c8903da38784a630421e927fe0c1059
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. De Dienst Toeslagen is belast met de uitvoering van deze wet.
+  - index: 1
+    label: lid 2
+    sha256: 41e7c7227920575fa3af78418895e5cf2bb0e22225320849366e15ba43731efc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Tot en met 4. [Procedurele bepalingen over aanvraag en betaling]
+  - index: 2
+    label: lid 5
+    sha256: e1ea19f9367df0fbdfcabb7f8f986adece2e71f41b255b475c51073738be8288
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De zorgtoeslag komt ten laste van het Rijk.
+- number: '6'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ef562d3b744f0c932bbfe8e23f9f9ba38627f6ba17a9c69067ee1e26f78dfade
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Onze Minister zendt binnen vier jaar na de inwerkingtreding van deze wet, en vervolgens telkens na vier jaar, aan de Staten-Generaal een verslag over de doeltreffendheid en de effecten van deze wet in de praktijk.
+- number: '7'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: be07c42696d7b8fbfecfe7f1eabcad72cc15613150e2bbbd52f8150f298f494f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Deze wet treedt in werking op een bij koninklijk besluit te bepalen tijdstip.
+- number: '8'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b741e88afa677ea9c48778dedecfc79e1c396698286f2975a10856e8b5191bbb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Deze wet wordt aangehaald als: Wet op de zorgtoeslag.'

--- a/textguard/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml
+++ b/textguard/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml
@@ -1,0 +1,138 @@
+$id: zorgtoeslagwet
+valid_from: '2025-01-01'
+source: corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml
+articles:
+- number: '1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: daee5d41ffbd2612d367a8e264ac7de2e6947b371a0b97effa6cc73416e609c4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'In deze wet en de daarop berustende bepalingen wordt verstaan onder:'
+  - index: 1
+    label: onderdeel a
+    sha256: 13bfc93f4b526c2c29d7b264d46de24f3ffb266c8309906a9a3ee909cdd1639c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'a. verzekerde: degene die ingevolge de Zorgverzekeringswet verzekerd is; b. toetsingsinkomen: het verzamelinkomen, bedoeld in artikel 2.18 van de Wet inkomstenbelasting 2001; c. drempelinkomen: het bedrag, bedoeld in artikel 2, tweede lid; d. normpremie: de premie, berekend overeenkomstig artikel 2; e. standaardpremie: de premie, bedoeld in artikel 4.'
+- number: 1a
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 15c925b2096e37151c82b3ea28c71add9af7174ed767582810516bc580d5e709
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'In deze wet en de daarop berustende bepalingen wordt verstaan onder Onze Minister: Onze Minister van Volksgezondheid, Welzijn en Sport.'
+- number: '2'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 4ac0f07cad7d0cfcbbb3f46b6185068ebae1bbe99ea274fb9588f6f7e4c880d0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Indien de normpremie voor een verzekerde in het berekeningsjaar minder bedraagt dan de standaardpremie in dat jaar, heeft de verzekerde aanspraak op een zorgtoeslag ter grootte van dat verschil. Voor een verzekerde met een toeslagpartner geldt het dubbele van de standaardpremie en worden de verzekerde en de toeslagpartner geacht gezamenlijk aanspraak te maken op zorgtoeslag.
+  - index: 1
+    label: lid 2
+    sha256: 5f06152ee0d57229db31f3585ff3ccc4d43f3fe9b4f71513c78a2a54a39c9968
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De normpremie bedraagt een percentage van het drempelinkomen in het berekeningsjaar, vermeerderd met een percentage van het toetsingsinkomen van de verzekerde. Ingeval de verzekerde een toeslagpartner heeft, wordt het gezamenlijk toetsingsinkomen van de verzekerde en de toeslagpartner in aanmerking genomen.
+  - index: 2
+    label: lid 3
+    sha256: 290d2b8d58c710c91bca94c66f76bc654651bdaa82268589bab638a140f80c3b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De percentages, bedoeld in het tweede lid, bedragen voor een verzekerde met een toeslagpartner 4,273 procent van het drempelinkomen, vermeerderd met 13,700 procent van het toetsingsinkomen, en voor een verzekerde zonder toeslagpartner 1,896 procent van het drempelinkomen, vermeerderd met 13,700 procent van het toetsingsinkomen. Bij ministeriële regeling kunnen deze percentages worden gewijzigd.
+  - index: 3
+    label: lid 4
+    sha256: b0069189a55acb5f629377535b018f57b7b4f8a8dc41c5b34548a9dc256617af
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. In afwijking van het eerste lid bedraagt de aanspraak op een zorgtoeslag voor een verzekerde met een partner die geen verzekerde is, vijftig procent van het op grond van het eerste lid berekende bedrag.
+  - index: 4
+    label: lid 5
+    sha256: 972096518adbb9cd4185a5b7d584b63b0f245766af494786b556f533293c32e1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De aanspraak op een zorgtoeslag wordt voor iedere kalendermaand afzonderlijk bepaald.
+  - index: 5
+    label: lid 6
+    sha256: 2de52f7fc559548ccbf5b1fa91a86254a5410e30a6b3a0fcadd1d4e41fc50758
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Bij ministeriële regeling kunnen nadere regels worden gesteld.
+  - index: 6
+    label: lid 7
+    sha256: af51ada54f7df35e1bcc6d0a68f6e728e8de67376da09aded35f550a96801193
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. Onze Minister zendt een voornemen tot wijziging van de percentages, bedoeld in het derde lid, ten minste twee weken voor de vaststelling aan beide kamers der Staten-Generaal.
+- number: '3'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a2737382a91738c30e7f116a4b039395cdd62ba5134f1b9ec1c49743dde920af
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Een verzekerde heeft geen aanspraak op zorgtoeslag indien de rendementsgrondslag, bedoeld in artikel 5.2 van de Wet inkomstenbelasting 2001, van de verzekerde of, ingeval de verzekerde een toeslagpartner heeft, de gezamenlijke rendementsgrondslag van de verzekerde en de toeslagpartner op de peildatum meer bedraagt dan € 141.896 voor een verzekerde zonder toeslagpartner, onderscheidenlijk € 179.429 voor een verzekerde met een toeslagpartner.
+- number: '4'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 424caeef334ded0ea6ef6b0ccec32dd29c0a6ac9f6d4e0efe51513708cfd1a8a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Onze Minister stelt uiterlijk 22 dagen voorafgaande aan het berekeningsjaar bij regeling de standaardpremie voor het berekeningsjaar vast.
+- number: 4a
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b9cea51038b7ebd05f04198adc5c78a895a8f18d621331c6a78ec39a69245372
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Voor de persoon, bedoeld in artikel 69 van de Zorgverzekeringswet, wordt de standaardpremie aangepast aan de hand van de verhouding tussen de zorguitgaven per verzekerde in het land waar de persoon woont en de zorguitgaven per verzekerde in Nederland.
+- number: '5'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 64c9fc5d1fef010140ca6f1b0df9c8ba3c8903da38784a630421e927fe0c1059
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. De Dienst Toeslagen is belast met de uitvoering van deze wet.
+  - index: 1
+    label: lid 2
+    sha256: 41e7c7227920575fa3af78418895e5cf2bb0e22225320849366e15ba43731efc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Tot en met 4. [Procedurele bepalingen over aanvraag en betaling]
+  - index: 2
+    label: lid 5
+    sha256: e1ea19f9367df0fbdfcabb7f8f986adece2e71f41b255b475c51073738be8288
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De zorgtoeslag komt ten laste van het Rijk.
+- number: '6'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ef562d3b744f0c932bbfe8e23f9f9ba38627f6ba17a9c69067ee1e26f78dfade
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Onze Minister zendt binnen vier jaar na de inwerkingtreding van deze wet, en vervolgens telkens na vier jaar, aan de Staten-Generaal een verslag over de doeltreffendheid en de effecten van deze wet in de praktijk.
+- number: '7'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: be07c42696d7b8fbfecfe7f1eabcad72cc15613150e2bbbd52f8150f298f494f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Deze wet treedt in werking op een bij koninklijk besluit te bepalen tijdstip.
+- number: '8'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b741e88afa677ea9c48778dedecfc79e1c396698286f2975a10856e8b5191bbb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Deze wet wordt aangehaald als: Wet op de zorgtoeslag.'

--- a/textguard/nl/wet/wet_open_overheid/2025-02-12.yaml
+++ b/textguard/nl/wet/wet_open_overheid/2025-02-12.yaml
@@ -1,0 +1,914 @@
+$id: wet_open_overheid
+valid_from: '2025-02-12'
+source: corpus/regulation/nl/wet/wet_open_overheid/2025-02-12.yaml
+articles:
+- number: '1.1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a4c0e908de7ab500346ba593c2033f6677395e45955aa0febf11ac3016440c76
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Eenieder heeft recht op toegang tot publieke informatie zonder daartoe een belang te hoeven stellen, behoudens bij deze wet gestelde beperkingen.
+- number: '2.1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: daee5d41ffbd2612d367a8e264ac7de2e6947b371a0b97effa6cc73416e609c4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'In deze wet en de daarop berustende bepalingen wordt verstaan onder:'
+  - index: 1
+    label: onderdeel a
+    sha256: 4605a607ddf7b587285d0973a633ab984ae45355c2f6ce806187095c5a93039d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'a. document: een door een orgaan, persoon of college als bedoeld in artikel 2.2, eerste lid, opgemaakt of ontvangen schriftelijk stuk of ander geheel van vastgelegde gegevens dat naar zijn aard verband houdt met de publieke taak van dat orgaan, die persoon of dat college;'
+  - index: 2
+    label: onderdeel b
+    sha256: 1da2f45824a94166c2bc4263da4b58aa21b441a303cb9c4814cb74d5ff9a694d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'b. milieu-informatie: hetgeen daaronder wordt verstaan in artikel 19.1a van de Wet milieubeheer;'
+  - index: 3
+    label: onderdeel c
+    sha256: 76e568fc5ac33c23a5d786d37d4a5159c626483583bb33784cc8788bf7fe5fe2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'c. Onze Minister: Onze Minister van Binnenlandse Zaken en Koninkrijksrelaties;'
+  - index: 4
+    label: onderdeel d
+    sha256: 6f2919ec0e70892220fc0251b1d1037156bd4d89bffd5129ecaa81905790d268
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'd. publieke informatie: informatie neergelegd in documenten die berusten bij een orgaan, persoon of college als bedoeld in artikel 2.2, eerste lid, of informatie die krachtens artikel 2.3 door een bestuursorgaan kan worden gevorderd.'
+- number: '2.2'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: befed44811ee18e6a7ce2cb1917bde202d65be41510e4aa30f94ba09227b05ec
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. Deze wet is van toepassing op: a. bestuursorganen; b. de Kamers en de verenigde vergadering der Staten-Generaal; c. de Raad voor de rechtspraak en het College van afgevaardigden; d. de Raad van State, tenzij de Raad het koninklijk gezag uitoefent, en met uitzondering van de Afdeling bestuursrechtspraak; e. de Algemene Rekenkamer; f. de Nationale ombudsman en de substituut-ombudsmannen als bedoeld in artikel 9, eerste lid, van de Wet Nationale ombudsman, en ombudsmannen en ombudscommissies als bedoeld in artikel 9:17, onderdeel b, van de Algemene wet bestuursrecht.'
+  - index: 1
+    label: lid 2
+    sha256: 20c0b2aec5fe4aa9eb46fd57d503bf302c317650c447b93dd53ad13cddcc802c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Voor de toepassing van deze wet worden de organen, personen en colleges, bedoeld in het eerste lid, onderdelen b tot en met f, die op grond van de Algemene wet bestuursrecht geen bestuursorgaan zijn, gelijk gesteld met een bestuursorgaan.
+- number: '2.4'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 1213f47e003cd6ad9a33c4f25e60b04aeba057f428e42800fd3695a2df4b443c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Een bestuursorgaan draagt er zorg voor dat de documenten die het ontvangt, vervaardigt of anderszins onder zich heeft, zich in goede, geordende en toegankelijke staat bevinden.
+  - index: 1
+    label: lid 2
+    sha256: 98fe7920a0dda921d2a55e66ba63254d21d9fc961ddd18a14200b1f1fb7c0e23
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Een bestuursorgaan draagt er zoveel mogelijk zorg voor dat de informatie die het overeenkomstig deze wet verstrekt, actueel, nauwkeurig en vergelijkbaar is.
+  - index: 2
+    label: lid 3
+    sha256: 5d6533eecb7afc1b5853019774946973b3e4e76d41c605eaaed8f4573b45ecbc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Indien een bestuursorgaan overeenkomstig deze wet informatie openbaar maakt, geschiedt dat op zodanige wijze dat de belanghebbende en belangstellende burger zoveel mogelijk wordt bereikt en op de volgende algemeen toegankelijke wijze: a. in elektronische vorm, in een machinaal leesbaar open formaat, samen met de metadata, overeenkomstig artikel 5, eerste lid, van de Richtlijn 2003/98/EG van het Europees Parlement en de Raad van 17 november 2003 inzake het hergebruik van overheidsinformatie (PbEG 2003 L 345), zoals deze is gewijzigd bij Richtlijn 2013/37/EU van het Europees Parlement en de Raad van 26 juni 2013 tot wijziging van Richtlijn 2003/98/EG inzake het hergebruik van overheidsinformatie (PbEU 2013 L 175); b. of, indien verstrekking in een machinaal leesbaar open formaat redelijkerwijs niet gevergd kan worden, in andere elektronisch doorzoekbare vorm; c. of, indien elektronische verschaffing redelijkerwijs niet gevergd kan worden, door verstrekking van een kopie van de letterlijke inhoud ervan in andere vorm te verstrekken; d. of, indien verstrekking van een kopie of de letterlijke inhoud redelijkerwijs niet gevergd kan worden, door een uittreksel of een samenvatting van de inhoud te geven, inlichtingen daaruit te verschaffen of door terinzagelegging.'
+  - index: 3
+    label: lid 4
+    sha256: 859187065635f0f8bd45e9af5bc8794463d80f895bc0d6e42420d802f2702f92
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Een bestuursorgaan is niet verantwoordelijk voor de juistheid of de volledigheid van door derden opgestelde informatie.
+  - index: 4
+    label: lid 5
+    sha256: 3b4d4a579c1299530b96cb03088417fbd859fb2394bb3b2b1423f7a5dce036aa
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Indien het bestuursorgaan kennis draagt van de onjuistheid of onvolledigheid van de verstrekte informatie, doet het hiervan mededeling.
+  - index: 5
+    label: lid 6
+    sha256: 30320306fd28e386d8592bcae99825508d978ec75766bf606cd3845633f9d39f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Indien het bestuursorgaan informatie verstrekt, verstrekt het zo nodig, en voor zover deze informatie voorhanden is, tevens informatie over de methoden die zijn gebruikt bij het samenstellen van de informatie.
+- number: '2.5'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 59342b182c55e3d14f7a938e4e8053db3564f38c075292f1dbb3f3d2fc09fbae
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Bij de toepassing van deze wet wordt uitgegaan van het algemeen belang van openbaarheid van publieke informatie voor de democratische samenleving.
+- number: '3.1'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: d1b5066b5e795c0c31b61cc85a7371b0acd5f33e095d19176c908187de54eaeb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Het bestuursorgaan dat het rechtstreeks aangaat, maakt bij de uitvoering van zijn taak uit eigen beweging de bij het bestuursorgaan berustende informatie neergelegd in documenten voor eenieder openbaar, indien dit zonder onevenredige inspanning of kosten redelijkerwijs mogelijk is, behoudens voor zover de artikelen 5.1, eerste, tweede en vijfde lid, en 5.2 aan openbaarmaking in de weg staan of met de openbaarmaking geen redelijk belang wordt gediend. Deze informatie betreft in ieder geval informatie over het beleid, inclusief de voorbereiding, uitvoering, naleving, handhaving en evaluatie.
+  - index: 1
+    label: lid 2
+    sha256: f531cff113c10ca9a1e729a0282da8786558f118a1e236ae243549dccc879f00
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het bestuursorgaan doet bij een gedeeltelijke niet-openbaarmaking hiervan mededeling gelijktijdig met de openbaarmaking.
+  - index: 2
+    label: lid 3
+    sha256: db986f9b50fb5953a5cefb5145792443a1d55f33ed9278e15b69d2fb02b30291
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Documenten als bedoeld in het eerste lid worden niet openbaar gemaakt dan nadat belanghebbenden die naar verwachting bedenkingen zullen hebben tegen openbaarmaking, in de gelegenheid zijn gesteld binnen een door het bestuursorgaan gestelde termijn hun zienswijze naar voren te brengen.
+  - index: 3
+    label: lid 4
+    sha256: 28fdcc158f2e1bee719d7a0907e8e6368af6512c798aea4597eebd6cc0bc8b13
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het bestuursorgaan deelt een belanghebbende mede dat toepassing wordt gegeven aan het eerste lid, onder vermelding van het tijdstip van openbaarmaking en de openbaar te maken documenten. De mededeling wordt gelijkgesteld met een besluit.
+- number: '3.3'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: e836aafc9178a04b70abeb9ca1b9a120642f0925229cd1e946fad61b545cf5a3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. Een bestuursorgaan maakt in ieder geval uit eigen beweging openbaar: a. wetten en andere algemeen verbindende voorschriften; b. overige besluiten van algemene strekking; c. [dit onderdeel is nog niet in werking getreden]; d. inzicht in zijn organisatie en werkwijze, waaronder de taken en bevoegdheden van de organisatieonderdelen; e. de bereikbaarheid van het bestuursorgaan en zijn organisatieonderdelen en de wijze waarop een verzoek om informatie kan worden ingediend.'
+  - index: 1
+    label: lid 2
+    sha256: d42acc3c3cdaf51a5163a1dfac57be9e5c004640e8ad80a3b7485074c77b9209
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Behoudens voor zover de artikelen 5.1, eerste, tweede en vijfde lid, en 5.2 daaraan in de weg staan, maakt het bestuursorgaan voorts uit eigen beweging openbaar: a. [dit onderdeel is nog niet in werking getreden]; b. vergaderstukken en verslagen van de Kamers en de verenigde vergadering der Staten-Generaal en hun commissies, tenzij deze betrekking hebben op door de regering vertrouwelijk aan de Staten-Generaal verstrekte informatie; c. [dit onderdeel is nog niet in werking getreden]; d. [dit onderdeel is nog niet in werking getreden]; e. [dit onderdeel is nog niet in werking getreden]; f. [dit onderdeel is nog niet in werking getreden]; g. [dit onderdeel is nog niet in werking getreden]; h. [dit onderdeel is nog niet in werking getreden]; i. [dit onderdeel is nog niet in werking getreden]; j. [dit onderdeel is nog niet in werking getreden]; k. [dit onderdeel is nog niet in werking getreden]; l. [dit onderdeel is nog niet in werking getreden].'
+  - index: 2
+    label: lid 3
+    sha256: 9ae38818fea12fdda0f170118a4345571b17de5667d3b8f8e21f25d1d24c1a1a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Op voordracht van Onze Minister kan bij algemene maatregel van bestuur worden bepaald dat: a. het bestuursorgaan andere categorieen van informatie uit eigen beweging openbaar maakt overeenkomstig het eerste of tweede lid; en b. categorieen van beschikkingen worden aangewezen die in afwijking van het tweede lid, onderdeel k, uit eigen beweging openbaar gemaakt worden.'
+  - index: 3
+    label: lid 4
+    sha256: 42011a28a2f0bda891644a58f34bc2330625fc0c3a7250b147dfaf2c8f3658ab
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De openbaarmaking, bedoeld in het eerste en tweede lid, geschiedt zo spoedig mogelijk, doch uiterlijk binnen twee weken na vaststelling of ontvangst van de informatie.
+  - index: 4
+    label: lid 5
+    sha256: 06b4d51d8f4eb3c3accf8dfe201957988f3541124076406c6392602d12493d99
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '5. In afwijking van het vierde lid: a. worden de ontwerpen en de bijbehorende adviesaanvragen, bedoeld in het eerste lid, onderdeel c, alsmede de daarop betrekking hebbende adviezen, bedoeld in het tweede lid, onderdeel e, onder 1, door het bestuursorgaan dat het advies heeft gevraagd openbaar gemaakt uiterlijk gelijktijdig met de indiening van het voorstel van wet bij de Staten-Generaal dan wel de bekendmaking van het algemeen verbindend voorschrift of besluit, indien het bestuursorgaan in zijn adviesaanvraag heeft gemotiveerd dat eerdere openbaarmaking afbreuk zou doen aan een met de wet, het voorschrift of het besluit beoogde doel; b. worden in geval van voorstellen van algemene begrotingswetten en de stukken betreffende de verantwoording van de ontvangsten en de uitgaven van het Rijk als bedoeld in artikel 105, eerste, tweede en derde lid, van de Grondwet, de daarbij behorende toelichtende stukken, alsmede in geval van een op het in artikel 65 van de Grondwet bedoelde tijdstip ingediende voorstel van wet voor zover dat voorstel betrekking heeft op het heffen van belasting, de versies waarover een adviesaanvraag wordt gedaan, de op die versies betrekking hebbende adviezen als bedoeld in het tweede lid, onderdeel e, en de op die versies betrekking hebbende onderzoeken als bedoeld in het tweede lid, onderdeel j, openbaar gemaakt gelijktijdig met de indiening van het voorstel van wet of de stukken bij de Staten-Generaal; c. worden vergaderstukken als bedoeld in het tweede lid, onderdelen b en c, openbaar gemaakt, gelijktijdig met de verspreiding aan de deelnemers van de betreffende vergadering; d. worden agenda''s als bedoeld in het tweede lid, onderdeel d, openbaar gemaakt, uiterlijk bij aanvang van de betreffende vergadering; e. wordt de inhoud van een schriftelijk verzoek als bedoeld in het tweede lid, onderdeel i, openbaar gemaakt met de beslissing op dat verzoek; f. geschiedt de openbaarmaking van onderzoeken als bedoeld in het tweede lid, onderdeel j, onder 1, uiterlijk binnen vier weken na ontvangst van het onderzoek; g. geschiedt de openbaarmaking van een beschikking houdende een herstelsanctie die niet in het tweede lid, onderdeel k, onder 6, is uitgezonderd, uiterlijk twee weken nadat de beschikking onherroepelijk is geworden; h. worden ingekomen documenten als bedoeld in het tweede lid, niet openbaar gemaakt dan nadat belanghebbenden die naar verwachting bedenkingen zullen hebben tegen openbaarmaking, in de gelegenheid zijn gesteld binnen twee weken hun zienswijze naar voren te brengen; i. worden documenten als bedoeld in het tweede lid, waarbij gedurende de voorbereiding ervan of na toepassing van onderdeel h is gebleken dat een belanghebbende naar verwachting bezwaar heeft tegen een voorgeschreven openbaarmaking, openbaar gemaakt na twee weken na vaststelling, onderscheidenlijk het verstrijken van de op grond van onderdeel h gestelde termijn om een zienswijze naar voren te brengen.'
+  - index: 5
+    label: lid 6
+    sha256: c13fcc41459da57bb76bce4c61c73bfca2378c7125b941c2934b74870f620b00
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '6. De openbaarmaking, bedoeld in het tweede lid, onderdeel e, geschiedt: a. voor een adviesaanvraag aan een adviescollege of -commissie door het bestuursorgaan dat het advies heeft gevraagd; b. voor een advies van een adviescollege of -commissie door dat adviescollege of die commissie, behoudens de gevallen, bedoeld in het vijfde lid, onderdelen a en b; c. voor een advies van een andere externe partij door het bestuursorgaan dat het advies heeft ontvangen.'
+  - index: 6
+    label: lid 7
+    sha256: a6760049e34cd37cecdf74271b718cf1d2e869d74e52c71340a8d25d5d9fd947
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. Het bestuursorgaan deelt een belanghebbende mede dat toepassing wordt gegeven aan het vijfde lid, onderdeel i, onder vermelding van het tijdstip van openbaarmaking en de openbaar te maken documenten. De mededeling wordt gelijkgesteld met een besluit.
+  - index: 7
+    label: lid 8
+    sha256: ddbc33d1b27a10d835af33f63c103c9e7b712facec450f5bf507a4c106a210cb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 8. Het bestuursorgaan doet mededeling van een gedeeltelijke niet-openbaarmaking gelijktijdig met de openbaarmaking. Van een gehele niet-openbaarmaking doet het bestuursorgaan mededeling op de wijze en het tijdstip waarop het niet-openbaar gemaakte stuk openbaar zou zijn gemaakt.
+  - index: 8
+    label: lid 9
+    sha256: f2b8c5c8806efd440df558552d21354f5c928091ef6aec216abc16d6ab9d656b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 9. Onze Minister kan bij ministeriele regeling nadere regels stellen over de wijze waarop in dit artikel genoemde documenten actief openbaar worden gemaakt.
+- number: 3.3a
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: ab376bed5ca5d101fec0beb0db3c06141322552cf053bb1e0d5564aad84467ce
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. Een bestuursorgaan kan in plaats van door openbaarmaking overeenkomstig artikel 3.3, tweede lid, onderdeel k, de informatie over beschikkingen inzake subsidies aan anderen dan natuurlijke personen openbaar maken in een voor personen elektronisch raadpleegbaar overzicht, waarbij, voor zover de informatie in de beschikking is opgenomen en de artikelen 5.1, eerste, tweede en vijfde lid, en 5.2 niet aan openbaarmaking in de weg staan, in ieder geval openbaar wordt gemaakt: a. de grondslag van de subsidie; b. de ontvanger; c. de activiteiten waarvoor de subsidie wordt verstrekt, alsmede in de beschikking opgenomen doelvoorschriften; d. de hoogte van verleningen, vaststellingen en wijzigingen; e. de intrekkingen; f. de dagtekening van de beschikking.'
+  - index: 1
+    label: lid 2
+    sha256: 748a1e867abe60b11d5cbb385866a0b8f7eb6b39c096b9590ce0905ba2fdeb36
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Een bestuursorgaan kan in plaats van door openbaarmaking overeenkomstig artikel 3.3, tweede lid, onderdeel k, de informatie over andere beschikkingen dan beschikkingen inzake subsidies openbaar maken in een voor personen elektronisch raadpleegbaar overzicht, waarbij, voor zover de informatie in de beschikking is opgenomen en de artikelen 5.1, eerste, tweede en vijfde lid, en 5.2 niet aan openbaarmaking in de weg staan, in ieder geval openbaar wordt gemaakt: a. de grondslag van de beschikking; b. het rechtsgevolg van de beschikking, inclusief in de beschikking opgenomen voorschriften; c. de duur van de beschikking; d. de geadresseerde, voor zover de bescherming van de persoonlijke levenssfeer hieraan niet in de weg staat; e. de dagtekening van de beschikking.'
+  - index: 2
+    label: lid 3
+    sha256: 1a23dae1cd93d8bc05e8d58a04d5e12e6b96a710a0594c5d94d86eb9218535a9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Een bestuursorgaan kan in plaats van door openbaarmaking overeenkomstig artikel 3.3, tweede lid, onderdeel l, de informatie over schriftelijke oordelen in klachtprocedures openbaar maken in een voor personen elektronisch raadpleegbaar overzicht, waarbij, voor zover de informatie in het oordeel is opgenomen en de artikelen 5.1, eerste, tweede en vijfde lid, en 5.2 niet aan openbaarmaking in de weg staan, in ieder geval openbaar wordt gemaakt: a. de datum van ontvangst van de klacht; b. het betrokken organisatieonderdeel; c. de functiebenaming van de ambtenaar over wie is geklaagd; d. de omschrijving van de gedraging waartegen de klacht gericht is; e. de bevindingen; f. het oordeel; g. de conclusies; h. de dagtekening van het oordeel.'
+  - index: 3
+    label: lid 4
+    sha256: 6b9ecdd21ba42300e4907458aa493e10643c42283125027fe39b7e086e78d02a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Een bestuursorgaan kan in het overzicht, bedoeld in het derde lid, vergelijkbare klachten betreffende een organisatieonderdeel gecombineerd weergeven, indien ook het oordeel en de conclusies vergelijkbaar zijn. Voor iedere gecombineerde weergave wordt in plaats van de informatie, bedoeld in het derde lid, onderdelen a en h, het aantal verzonden oordelen per maand vermeld.
+  - index: 4
+    label: lid 5
+    sha256: 222781cca275db538bad42da14ae8a3bde4c788f7ee4fe8ad8dea6673afd9722
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Een overzicht als bedoeld in dit artikel wordt ten minste iedere twee weken bijgewerkt.
+  - index: 5
+    label: lid 6
+    sha256: ea3fc7dcf9f12fe5c9e246bb06493b6a206d249d19e2f3084e68e862c452a6e2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Onze Minister kan bij ministeriele regeling nadere regels stellen over de wijze waarop in dit artikel genoemde overzichten actief openbaar worden gemaakt.
+- number: 3.3b
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: e853659c77d23ee0428734fc1d5dfed6c79f23fd5b6c0c89d1866af2d414cd36
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: De openbaarmaking van de in de artikelen 3.3 en 3.3a genoemde documenten geschiedt elektronisch op een algemeen toegankelijke wijze door middel van een door Onze Minister in stand gehouden digitale infrastructuur. Deze infrastructuur is beschikbaar voor de openbaarmaking van andere documenten.
+- number: '3.4'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: e2617ad066b5c1ed481045b9f3565adb072b005b4144b9106e7407038588503b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: In afwijking van de artikelen 5.1 en 5.2 kan een bestuursorgaan informatie uit eigen beweging openbaar maken, wanneer een ander zwaarwegend algemeen belang, daaronder begrepen het belang van openbare veiligheid, de volksgezondheid of het milieu of de bescherming van de democratische rechtsorde, dat in een concreet geval vergt.
+- number: '3.5'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 9fcf3a53ea2e8a0957fd264225a9cb7415b4b864348dd0441c627cd5f6d46e55
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Een bestuursorgaan besteedt in de jaarlijkse begroting dan wel de jaarlijkse begroting van het openbaar lichaam of de rechtspersoon waarvan het bestuursorgaan deel uit maakt, aandacht aan de beleidsvoornemens inzake de uitvoering van deze wet en doet in de jaarlijkse verantwoording verslag van de uitvoering ervan, mede in relatie tot de beleidsvoornemens.
+- number: '4.1'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: eacdceab29ee777f29bb306cfe107acbcee571b1f750d39b742c4b84877ebd22
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Eenieder kan een verzoek om publieke informatie richten tot een bestuursorgaan of een onder verantwoordelijkheid van een bestuursorgaan werkzame instelling, dienst of bedrijf. In het laatste geval beslist het verantwoordelijke bestuursorgaan op het verzoek.
+  - index: 1
+    label: lid 2
+    sha256: a11d3b66844b44900446f9950001840edaa47632b152fe1bd2bbdb8e834cd50d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Een verzoek kan mondeling of schriftelijk worden ingediend en kan elektronisch worden verzonden op de door het bestuursorgaan aangegeven wijze.
+  - index: 2
+    label: lid 3
+    sha256: cd1466c3024c5f7accdd3c14a01e106f06cbd89feb14d5bb8679fb8ba25839af
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De verzoeker behoeft bij zijn verzoek geen belang te stellen.
+  - index: 3
+    label: lid 4
+    sha256: 2cb20d334848c8be176b1c026767b63e5cce30500028ee060c348a6cf042de1c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De verzoeker vermeldt bij zijn verzoek de aangelegenheid of het daarop betrekking hebbende document, waarover hij informatie wenst te ontvangen.
+  - index: 4
+    label: lid 5
+    sha256: 0167f0452dc98862931d981e6f9841ec08f66fe12af5499f8d81cc8eeed4036f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Indien een verzoek te algemeen geformuleerd is, verzoekt het bestuursorgaan binnen twee weken na ontvangst van het verzoek de verzoeker om het verzoek te preciseren en is het de verzoeker daarbij behulpzaam.
+  - index: 5
+    label: lid 6
+    sha256: 05f594b860fc2b3a56e49d0d35550eda0eff56f1d4cb499b864eeaae8a365dee
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Het bestuursorgaan kan besluiten een verzoek niet te behandelen, indien de verzoeker niet meewerkt aan een verzoek tot precisering als bedoeld het vijfde lid. In afwijking van artikel 4:5, vierde lid, van de Algemene wet bestuursrecht wordt het besluit om het verzoek niet te behandelen aan de verzoeker bekendgemaakt binnen twee weken nadat het verzoek is gepreciseerd of nadat de daarvoor gestelde termijn ongebruikt is verstreken.
+  - index: 6
+    label: lid 7
+    sha256: ccd9bd8057efe07e2ba63b049aacadb51ccc60fb34c9cce5d20a19994f7a0eb1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. Een verzoek om informatie wordt ingewilligd met inachtneming van het bepaalde in hoofdstuk 5.
+- number: 4.1a
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 09b2511ba26c2580b71ebf65c3aa88e47ca352778b494d2bcb476a4b570bf0f2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Het bestuursorgaan waarborgt het behoud van de documenten waarop een door hem ontvangen verzoek betrekking heeft.
+- number: '4.2'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: e1f86950a6b64b9b652619977dc01bcc2a5be0d1a3cf50ca2d8688c9d9b9fa02
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Voor zover het verzoek betrekking heeft op informatie die berust bij een ander bestuursorgaan dan dat waarbij het verzoek is ingediend, wordt de verzoeker zo nodig naar dat bestuursorgaan verwezen. Is het verzoek schriftelijk gedaan, dan wordt het voor zover betrekking hebbend op informatie die bij een ander bestuursorgaan berust, onverwijld doorgezonden aan dat bestuursorgaan, onder mededeling van de doorzending aan de verzoeker.
+  - index: 1
+    label: lid 2
+    sha256: 1f901bd2c847bffd7ad8719ed86a1b1c24d1b5c6461156287736e70ab25d24a4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien het verzoek betrekking heeft op informatie die op grond van enig wettelijk voorschrift bij het bestuursorgaan had behoren te berusten, vordert het bestuursorgaan de gevraagde informatie van degene die over de informatie beschikt. Degene die over de gevraagde informatie beschikt, verstrekt deze per omgaande aan het bestuursorgaan.
+  - index: 2
+    label: lid 3
+    sha256: cdfb9fbc9bd81c938d249551c202af4c9fe21e7fe2c82f2108a9cedad5ae626c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Voor zover een verzoek als bedoeld in artikel 4.1, eerste lid, dat is gericht aan een der Kamers of de verenigde vergadering der Staten-Generaal, betrekking heeft op informatie die door de regering vertrouwelijk aan de Staten-Generaal is verstrekt, zendt de Kamer of de verenigde vergadering het verzoek ter behandeling door aan Onze Minister of Onze Ministers die deze informatie vertrouwelijk heeft of hebben verstrekt.
+- number: 4.2a
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d6815c94f7471db3b3545fc2a7fc1f71dc3455ceb68aa0720831cc6ccf98ea83
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Indien een voldoende gespecificeerd verzoek zodanig omvangrijk is dat niet binnen de termijn van artikel 4.4, eerste lid, kan worden beslist, treedt het bestuursorgaan voor het einde van die termijn in overleg met de verzoeker over de prioritering van de afhandeling van het verzoek. Het bestuursorgaan verstrekt de gevraagde documenten zo veel mogelijk in de door de verzoeker gewenste volgorde.
+- number: '4.3'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 5ba6985371dd379c44dc15cef433d7fb63a5a263a9c33418a40239d62b077147
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. De beslissing op een verzoek om informatie wordt mondeling of schriftelijk genomen.
+  - index: 1
+    label: lid 2
+    sha256: 4839fb96e2f742bf396e8c9a18c9a2033dd810a72fd3874d92187e7f8311442a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Het bestuursorgaan besluit in ieder geval schriftelijk op een verzoek om informatie, indien: a. het schriftelijke verzoek geheel of gedeeltelijk wordt afgewezen; b. de verzoeker bij gehele of gedeeltelijke afwijzing van het mondelinge verzoek verzoekt om een schriftelijk besluit; c. de gevraagde informatie slechts wordt verstrekt aan de verzoeker overeenkomstig artikel 5.5, artikel 5.6 of artikel 5.7 en aan de verstrekking voorwaarden worden verbonden; of d. de gevraagde informatie betrekking heeft op of afkomstig is van derden, tenzij deze hebben verklaard aan een schriftelijk besluit geen behoefte te hebben.'
+  - index: 2
+    label: lid 3
+    sha256: e71100e02ea5f7302f3baaf89a0840a1f331e6e14a35abb5b6a03b8eada1cfe0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij de afwijzing van een mondeling verzoek, wordt de verzoeker gewezen op de mogelijkheid van een schriftelijk besluit.
+- number: '4.4'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: f028646b9c4bac860cd2bf66c499842ee9d85d2153e2bebcfa0122a83fb0a0a4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Het bestuursorgaan beslist op het verzoek om informatie zo spoedig mogelijk, doch uiterlijk binnen vier weken gerekend vanaf de dag na die waarop het verzoek is ontvangen.
+  - index: 1
+    label: lid 2
+    sha256: b10c7b699a20019b2b840aac91c2e4426d08629cf3cadcdd95e79cdbde93cc68
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het bestuursorgaan kan de beslissing voor ten hoogste twee weken verdagen, indien de omvang of de gecompliceerdheid van de informatie een verlenging rechtvaardigt. Van de verdaging wordt voor de afloop van de eerste termijn schriftelijk gemotiveerd mededeling gedaan aan de verzoeker.
+  - index: 2
+    label: lid 3
+    sha256: 6ab1570778b50f0189d3341ade9707cb7095010c8454300d7f0123655f3f53b8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Onverminderd artikel 4:15 van de Algemene wet bestuursrecht wordt de termijn voor het geven van een beschikking opgeschort gerekend vanaf de dag na die waarop het bestuursorgaan de verzoeker meedeelt dat toepassing is gegeven aan artikel 4:8 van de Algemene wet bestuursrecht, tot en met de dag waarop door de belanghebbende of belanghebbenden een zienswijze naar voren is gebracht of de daarvoor gestelde termijn ongebruikt is verstreken.
+  - index: 3
+    label: lid 4
+    sha256: 802cbb5f8e2608c9a48f612aa17113a9840e71e2e4e7cf3723bb19609402555d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Indien de opschorting, bedoeld in het derde lid, eindigt, doet het bestuursorgaan daarvan zo spoedig mogelijk mededeling aan de verzoeker, onder vermelding van de termijn binnen welke de beschikking alsnog moet worden gegeven.
+  - index: 4
+    label: lid 5
+    sha256: 5ab6ab04e1491f1f254862907d72ed61b1efc5d5d1fec93e8e28fc77335045d9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Indien het bestuursorgaan heeft besloten informatie te verstrekken, wordt de informatie verstrekt tegelijk met de bekendmaking van het besluit, tenzij naar verwachting een belanghebbende bezwaar daartegen heeft, in welk geval de informatie wordt verstrekt twee weken nadat de beslissing is bekendgemaakt. Indien wordt verzocht om een voorlopige voorziening als bedoeld in artikel 8:81 van de Algemene wet bestuursrecht, wordt de openbaarmaking opgeschort totdat de voorzieningenrechter uitspraak heeft gedaan of het verzoek is ingetrokken.
+  - index: 5
+    label: lid 6
+    sha256: 4ce8c77d08cb8fe5a2494629f73b9933d4e883b078641c280dd8ea8150d49ad8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Indien het bestuursorgaan heeft besloten informatie te verstrekken die rechtstreeks betrekking heeft op een derde of die van een derde afkomstig is, deelt het bestuursorgaan dit besluit gelijktijdig mede aan deze derde.
+- number: '4.5'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 84639955b21a056d113011566a9493eaa94eb25b415d41e37c5c0e0ac6b29a0a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Het bestuursorgaan verstrekt de informatie in de door verzoeker verzochte vorm of, indien dit redelijkerwijs niet gevergd kan worden, met inachtneming van het bepaalde in artikel 2.4, derde lid.
+  - index: 1
+    label: lid 2
+    sha256: 250a8dc5ff3044f4cb5d5d14b514c8006434d96e1df76374492b89566a65354c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien de informatie reeds in een voor de verzoeker gemakkelijk toegankelijke vorm voor het publiek beschikbaar is, wijst het bestuursorgaan de verzoeker daarop.
+- number: '4.6'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 5bae9a71bd23934fa7f7e5d42684f89c1054b57dd4bf01aa11fdba644d9243d1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Indien de verzoeker kennelijk een ander doel heeft dan het verkrijgen van publieke informatie of indien het verzoek evident geen bestuurlijke aangelegenheid betreft, kan het bestuursorgaan binnen twee weken na ontvangst van het verzoek, dan wel onverwijld nadat is gebleken dat de verzoeker kennelijk een ander doel heeft dan het verkrijgen van publieke informatie, besluiten het verzoek niet te behandelen.
+- number: '4.7'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d6865945463d04eff213905c5b49c29fbc3f6efa6a7d67cd892eec5ab8a21bec
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Ter beantwoording van vragen over de beschikbaarheid van publieke informatie wijst het bestuursorgaan een of meer contactpersonen aan.
+- number: '5.1'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 6bea39b4a9603da832f785bb9ad1e0f0679a0985489a212710687e5d3baf0631
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. Het openbaar maken van informatie ingevolge deze wet blijft achterwege voor zover dit: a. de eenheid van de Kroon in gevaar zou kunnen brengen; b. de veiligheid van de Staat zou kunnen schaden; c. bedrijfs- en fabricagegegevens betreft die door natuurlijke personen of rechtspersonen vertrouwelijk aan de overheid zijn meegedeeld; d. persoonsgegevens betreft als bedoeld in paragraaf 3.1 onderscheidenlijk paragraaf 3.2 van de Uitvoeringswet Algemene verordening gegevensbescherming, tenzij de betrokkene uitdrukkelijk toestemming heeft gegeven voor de openbaarmaking van deze persoonsgegevens of deze persoonsgegevens kennelijk door de betrokkene openbaar zijn gemaakt; e. nummers betreft die dienen ter identificatie van personen die bij wet of algemene maatregel van bestuur zijn voorgeschreven als bedoeld in artikel 46 van de Uitvoeringswet Algemene verordening gegevensbescherming, tenzij de verstrekking kennelijk geen inbreuk op de levenssfeer maakt.'
+  - index: 1
+    label: lid 2
+    sha256: 2abfbc77b2d4ab31a8b96b3176ce72d33cddc5fe35a1fd6d75cc85b13327410e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Het openbaar maken van informatie blijft eveneens achterwege voor zover het belang daarvan niet opweegt tegen de volgende belangen: a. de betrekkingen van Nederland met andere landen en staten en met internationale organisaties; b. de economische of financiele belangen van de Staat, andere publiekrechtelijke lichamen of bestuursorganen, in geval van milieu-informatie slechts voor zover de informatie betrekking heeft op handelingen met een vertrouwelijk karakter; c. de opsporing en vervolging van strafbare feiten; d. de inspectie, controle en toezicht door bestuursorganen; e. de eerbiediging van de persoonlijke levenssfeer; f. de bescherming van andere dan in het eerste lid, onderdeel c, genoemde concurrentiegevoelige bedrijfs- en fabricagegegevens; g. de bescherming van het milieu waarop deze informatie betrekking heeft; h. de beveiliging van personen en bedrijven en het voorkomen van sabotage; i. het goed functioneren van de Staat, andere publiekrechtelijke lichamen of bestuursorganen.'
+  - index: 2
+    label: lid 3
+    sha256: f72a5d25c64f7cf8445edf63ae1b01d450f71530ab9d7093b63153d9ba923b89
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien een verzoek tot openbaarmaking op een van de in het tweede lid genoemde gronden wordt afgewezen, bevat het besluit hiervoor een uitdrukkelijke motivering.
+  - index: 3
+    label: lid 4
+    sha256: de04e2996561ad19fa7d1c9ee6819d67ba52bf15726644670c166a3d62299e38
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Openbaarmaking kan tijdelijk achterwege blijven, indien het belang van de geadresseerde van de informatie om als eerste kennis te nemen van de informatie dit kennelijk vereist. Het bestuursorgaan doet mededeling aan de verzoeker van de termijn waarbinnen de openbaarmaking alsnog zal geschieden.
+  - index: 4
+    label: lid 5
+    sha256: a46c7a7417ea1f48e89a8d4c6bc7fda7d71abccab3c70bf95ff0896dca073911
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. In uitzonderlijke gevallen kan openbaarmaking van andere informatie dan milieu-informatie voorts achterwege blijven indien openbaarmaking onevenredige benadeling toebrengt aan een ander belang dan genoemd in het eerste of tweede lid en het algemeen belang van openbaarheid niet tegen deze benadeling opweegt. Het bestuursorgaan baseert een beslissing tot achterwege laten van de openbaarmaking van enige informatie op deze grond ten aanzien van dezelfde informatie niet tevens op een van de in het eerste of tweede lid genoemde gronden.
+  - index: 5
+    label: lid 6
+    sha256: 16980290bbaf75ac80a43a781a52cd92b70fddbe542133d1cf463aed9a445ab1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Het openbaar maken van informatie blijft in afwijking van het eerste lid, onderdeel c, in geval van milieu-informatie eveneens achterwege voor zover daardoor het in het eerste lid, onderdeel c, genoemde belang ernstig geschaad wordt en het algemeen belang van openbaarheid van informatie niet opweegt tegen deze schade.
+  - index: 6
+    label: lid 7
+    sha256: 38f9aab54597aba7c33d1da521d7f23d871f6ecddd096c1a7d422fb9d04e42cf
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. Het eerste en tweede lid zijn niet van toepassing op milieu-informatie die betrekking heeft op emissies in het milieu.
+- number: '5.2'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 536d55913a9f48b924648446bb42319f10851de6fc7c30d4b049da24b9ea8fb3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. In geval van een verzoek om informatie uit documenten, opgesteld ten behoeve van intern beraad, wordt geen informatie verstrekt over daarin opgenomen persoonlijke beleidsopvattingen. Onder persoonlijke beleidsopvattingen worden verstaan ambtelijke adviezen, visies, standpunten en overwegingen ten behoeve van intern beraad, niet zijnde feiten, prognoses, beleidsalternatieven, de gevolgen van een bepaald beleidsalternatief of andere onderdelen met een overwegend objectief karakter.
+  - index: 1
+    label: lid 2
+    sha256: 9dfbb91e13652f0d3e2abb46e8ddde851ed36aa41a53c7bbf20ca991ec8641bb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het bestuursorgaan kan over persoonlijke beleidsopvattingen met het oog op een goede en democratische bestuursvoering informatie verstrekken in niet tot personen herleidbare vorm. Indien degene die deze opvattingen heeft geuit of zich erachter heeft gesteld, daarmee heeft ingestemd, kan de informatie in tot personen herleidbare vorm worden verstrekt.
+  - index: 2
+    label: lid 3
+    sha256: ecb71e092eaeb2a8867f0c9213023b4a32111449b6e9b8cbce1815b320b60913
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Onverminderd het eerste en tweede lid wordt uit documenten opgesteld ten behoeve van formele bestuurlijke besluitvorming door een minister, een commissaris van de Koning, Gedeputeerde Staten, een gedeputeerde, het college van burgemeester en wethouders, een burgemeester, een wethouder, het dagelijks bestuur van een waterschap of een lid van dat bestuur, informatie verstrekt over persoonlijke beleidsopvattingen in niet tot personen herleidbare vorm, tenzij het kunnen voeren van intern beraad onevenredig wordt geschaad.
+  - index: 3
+    label: lid 4
+    sha256: 090cdd1735ccfd9e203291e030d825957814e9c5700e2cc343634ff39e75b5c1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. In afwijking van het eerste lid wordt bij milieu-informatie het belang van de bescherming van de persoonlijke beleidsopvattingen afgewogen tegen het belang van openbaarmaking. Informatie over persoonlijke beleidsopvattingen kan worden verstrekt in niet tot personen herleidbare vorm. Indien degene die deze opvattingen heeft geuit of zich erachter heeft gesteld, daarmee heeft ingestemd, kan de informatie in tot personen herleidbare vorm worden verstrekt.
+- number: '5.3'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 505da60c3dd9e509a06168f494182516e5f25b1306aa11fd40223b6af29b81e8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Bij een verzoek om informatie die ouder is dan vijf jaar motiveert het bestuursorgaan bij een weigering van die informatie waarom de in artikel 5.1, tweede of vijfde lid, of artikel 5.2 bedoelde belangen ondanks het tijdsverloop zwaarder wegen dan het algemeen belang van openbaarheid.
+- number: '5.4'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 3e6eb088663717e633365cd6f040cb948d48836aa493dd7f4a4cb4a2049e0439
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: In afwijking van de artikelen 5.1 en 5.2 is informatie die berust bij de formateur of de informateur, dan wel informatie die door een bestuursorgaan aan de formateur of de informateur is gezonden niet openbaar totdat de formatie is afgerond.
+- number: 5.4a
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: a754e35683b4dd574b688fbeddfc70f73abdf91b3db02b5505f9784e0c23eb78
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. In afwijking van de artikelen 5.1 en 5.2 is niet openbaar de informatie betreffende de ondersteuning van individuele leden van de Eerste Kamer of de Tweede Kamer der Staten-Generaal, provinciale staten of de gemeenteraad door ambtenaren werkzaam bij de Eerste Kamer of de Tweede Kamer, de griffie van provinciale staten of de griffie van de gemeenteraad.
+  - index: 1
+    label: lid 2
+    sha256: b7b4b0a63d38b5f18a0eb6157b871be200fc5239e8567cba99c0a80a190d1c2a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In afwijking van artikel 5.2, eerste lid, wordt met betrekking tot informatie die aan individuele Kamerleden wordt verstrekt onder persoonlijke beleidsopvattingen verstaan ambtelijke adviezen, visies, standpunten en overwegingen ten behoeve van intern beraad.
+- number: '5.5'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 3829e8e99ba116dfb81620e6435c4d6bcc54047b08e2b6000b7cd827c6c4366e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Onverminderd het elders bij wet bepaalde, verstrekt een bestuursorgaan iedere natuurlijke of rechtspersoon op diens verzoek de op de verzoeker betrekking hebbende in documenten neergelegde informatie, tenzij een in artikel 5.1, eerste lid, onderdelen a, b en c, alsmede d en e, voor zover betrekking hebbend op derden, genoemd belang aan de orde is of een in artikel 5.1, tweede of vijfde lid, of artikel 5.2 genoemd belang zwaarder weegt dan het belang van de verzoeker bij toegang tot op hem betrekking hebbende informatie. De verzoeker vermeldt bij zijn verzoek de aangelegenheid of het daarop betrekking hebbende document, waarover hij informatie wenst te ontvangen.
+  - index: 1
+    label: lid 2
+    sha256: c4dd0c3144ec15143300ed8c5776f0e85108f34770c5254fe614aae8c69acc9f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het eerste lid is van overeenkomstige toepassing op een verzoek met betrekking tot gegevens ten aanzien van een overleden echtgenoot, geregistreerd partner, kind of ouder van de verzoeker, tenzij een schriftelijke wilsverklaring van de overledene aan de verstrekking in de weg staat.
+  - index: 2
+    label: lid 3
+    sha256: 2f3bf93ed13ae01c4c866a85f0504de190a222a5e584830ef98a01ec40e1918b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het bestuursorgaan draagt zorg voor een deugdelijke vaststelling van de identiteit van de verzoeker.
+  - index: 3
+    label: lid 4
+    sha256: 864dd2fb67d8fac15da9cb42f5fa4e297917d195d826cb8cfa83297b15b80fe5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het bestuursorgaan kan aan de verstrekking voorwaarden verbinden ter bescherming van een van de belangen, genoemd in de artikelen 5.1 en 5.2, tenzij de gevraagde informatie met toepassing van de artikelen 5.1 en 5.2 openbaar voor eenieder zou zijn.
+- number: '5.6'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 7ce823deeccb81d7c0ebb4ae5577891f6cf7937146084e7eb139dcf765173b20
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Het bestuursorgaan kan, in geval informatie ingevolge de artikelen 5.1 en 5.2 niet openbaar gemaakt kan worden, besluiten de informatie uitsluitend aan de verzoeker te verstrekken, indien er klemmende redenen zijn om de verzoeker niettegenstaande de toepasselijke uitzonderingsgrond of -gronden de gevraagde informatie niet te onthouden.
+  - index: 1
+    label: lid 2
+    sha256: 066aab57298da1eda23be96ac9165289b20654e98a69406f395a3e21714755e1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het eerste lid vindt slechts toepassing voor zover dit niet in strijd is met een toepasselijke geheimhoudingsplicht.
+  - index: 2
+    label: lid 3
+    sha256: 2f15f76a991ab97d16f58e8b067b6aa48a01af3a1d7a9bd1ab478df4ac201bb4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het bestuursorgaan kan aan de verstrekking voorwaarden verbinden ter bescherming van een van de belangen, genoemd in de artikelen 5.1 en 5.2.
+- number: '5.7'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 5668b37f79da3485cd636f6c47a2f608a7817348a4660618ce9c2664f58ecf87
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1. Een bestuursorgaan kan ten behoeve van historisch, statistisch, wetenschappelijk of journalistiek onderzoek toegang bieden tot informatie: a. die ingevolge de artikelen 5.1 en 5.2 niet openbaar gemaakt kan worden; of b. waarvan de vaststelling of deze informatie ingevolge de artikelen 5.1 en 5.2 openbaar gemaakt kan worden een onevenredige inspanning vergt.'
+  - index: 1
+    label: lid 2
+    sha256: 1bf0cc75fb8c585748364f5051b67c6fd55ffb26ebb636649b9ec7213aa51fc1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het bestuursorgaan kan aan het verlenen van toegang voorwaarden verbinden.
+  - index: 2
+    label: lid 3
+    sha256: 77968f89ea80249071d20ba94f5932c9f12be291f5fbd79b8c7a1c17bb609504
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De toegang tot informatie overeenkomstig het eerste lid wordt in ieder geval verleend onder de voorwaarde dat degene aan wie toegang wordt verleend, de verkregen informatie niet verder verspreidt zonder voorafgaand besluit van het bestuursorgaan waarin de informatie met toepassing van de artikelen 5.1 en 5.2 openbaar gemaakt wordt.
+- number: '6.1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6823e27206b4e40b1a2b60f206663b75825ae3bc6118c077bef4f5384b1bbafa
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Het bestuursorgaan treft maatregelen ten behoeve van het duurzaam toegankelijk maken van de digitale documenten, bedoeld in artikel 2.4, eerste lid.
+- number: '6.2'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 5fb92d0874f1720997e411131da408a44b55cc6b69eadd6ec1a111a368a40cad
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Onze Minister, in overeenstemming met Onze Minister van Onderwijs, Cultuur en Wetenschap, zendt een meerjarenplan naar de Staten-Generaal over de wijze waarop bestuursorganen hun digitale overheidsinformatie duurzaam toegankelijk maken.
+  - index: 1
+    label: lid 2
+    sha256: 8a72d2138f2120189992c17c3385bc8f3798a4f146f0273aa66438830068015d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het meerjarenplan bevat langetermijndoelen voor de verbetering van de wijze waarop digitale documenten worden vervaardigd, geordend, bewaard, vernietigd en ontsloten alsmede de stappen die daartoe op korte termijn worden gezet.
+  - index: 2
+    label: lid 3
+    sha256: f74c20155f65edad768124c0ea7ab5a70cc0a5a62a3ee82f6500286f42c5d02b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het meerjarenplan voorziet in stappen waarmee wordt bereikt dat eenieder zo veel mogelijk inzicht kan hebben in de aanwezigheid van publieke informatie bij een orgaan, persoon of college als bedoeld in artikel 2.2, eerste lid.
+  - index: 3
+    label: lid 4
+    sha256: 447251cee5d4072a1fbf05f368a4c9ef61aac798735ed2c70fe9f6404f5f976d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Onze Minister, in overeenstemming met Onze Minister van Onderwijs, Cultuur en Wetenschap, vult het meerjarenplan aan met de nodige maatregelen tot de digitale overheidsinformatie voldoende duurzaam toegankelijk is.
+- number: '7.1'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: e86960da004cd4a4abdb13ba9d3d062fbfeb9d7c7c64058e7d72faf2aaf61a49
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Er is een Adviescollege openbaarheid en informatiehuishouding.
+  - index: 1
+    label: lid 2
+    sha256: 9fdff413ce4968118a7f7f9d45a365521e841fae77b11b82bc42876ef1f54789
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het college bestaat uit een voorzitter en ten hoogste vier andere leden.
+  - index: 2
+    label: lid 3
+    sha256: 8b42cf39df6b3d02bb27c62e454e645dee8c5a04d9158fd744417f35559e787c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De benoeming van de leden bij koninklijk besluit geschiedt op voordracht van Onze Minister, in overeenstemming met Onze Minister van Onderwijs, Cultuur en Wetenschap.
+  - index: 3
+    label: lid 4
+    sha256: bf244ce53d334f3553efcf7286ae4ac4c3934a9b5f5c49ee404df49226654acc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De artikelen 13, 16 en 19 van de Kaderwet zelfstandige bestuursorganen zijn van overeenkomstige toepassing.
+- number: '7.2'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 7349024153182f08fae266411f013593a7540989d8e267ab32d86a34e754e5fc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Het college adviseert de regering en de beide Kamers der Staten-Generaal gevraagd en ongevraagd over de uitvoering van de regels over openbaarmaking van publieke informatie.
+  - index: 1
+    label: lid 2
+    sha256: 6610496e110d16b20088103fb19a74352f508b642c0c8cfec5a1e9d8bbea1118
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het college adviseert Onze Minister periodiek over aanpassing van het meerjarenplan. Het college rapporteert in zijn advies in elk geval over de stand van de informatiehuishouding in het bestuur, de voortgang van de uitvoering van het meerjarenplan en de toegang tot de publieke informatie.
+  - index: 2
+    label: lid 3
+    sha256: 3bd75f06f2bf094eff97f55a1fe822f5d4ee0109a1da32f2398069b766f1238b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het college wordt om advies gevraagd over voorstellen van wet en ontwerpen van algemene maatregelen van bestuur die geheel of voor een belangrijk deel betrekking hebben op de openbaarmaking en de ontsluiting van publieke informatie.
+  - index: 3
+    label: lid 4
+    sha256: d48b7f768d8b027e1fdb63ce887c1a403de33d825ed7ddf9371e420c3114dde6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het college adviseert het betrokken bestuursorgaan naar aanleiding van bij het college ingediende klachten van journalisten, wetenschappers of andere naar het oordeel van het college in aanmerking komende groepen met een beroepsmatig belang bij het gebruik van publieke informatie over de wijze waarop dat bestuursorgaan publieke informatie openbaar maakt.
+  - index: 4
+    label: lid 5
+    sha256: eb481f5b75d59e02a362e665406ecfb82665088102126d84b5aef2633524e1b5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '5. Het college bevordert de toepassing van deze wet, onder meer door: a. het geven van voorlichting aan bestuursorganen en anderen; b. het opleiden van personen werkzaam bij organen belast met de uitvoering van openbaarmaking van publieke informatie; c. het monitoren en onderzoeken van en rapporteren over de openbaarmaking van publieke informatie in algemene zin of door specifieke organen in het bijzonder; d. het publiceren van richtsnoeren ter bevordering van de openbaarmaking uit eigen beweging en de ontsluiting van informatie.'
+- number: '7.3'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 3eba1f28e4f3b42339d35df7223e485287794653d1cc30d8f35562bfcee58028
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Alvorens een advies als bedoeld in artikel 7.2, vierde lid, uit te brengen, bemiddelt het college tussen het bestuursorgaan en de klager. Het bestuursorgaan werkt aan de bemiddeling mee.
+  - index: 1
+    label: lid 2
+    sha256: f2c3e54ec0a761960a69d8d77cf423d5a0fc679116c397dd69c8c210a119580f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien de klacht mede betrekking heeft op een besluit op grond van deze wet waartegen bezwaar open staat, wordt de termijn voor het indienen van bezwaar, bedoeld in artikel 6:7 van de Algemene wet bestuursrecht, opgeschort tot het college advies heeft uitgebracht, dan wel aan de klager en het bestuursorgaan heeft bericht dat geen advies zal worden uitgebracht. De opschorting van de bezwaartermijn vangt aan met ingang van de dag nadat de klager de klacht aan het college heeft gezonden.
+  - index: 2
+    label: lid 3
+    sha256: a33953f13d72f95c8445cc681f1deae74447961cbf313ce1c01b320957ae2d6c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien de klager bezwaar maakt tegen het besluit, bedoeld in het tweede lid, beslist het bestuursorgaan in afwijking van artikel 7:10, eerste lid, van de Algemene wet bestuursrecht binnen twee weken nadat het college advies heeft uitgebracht, dan wel aan de klager en het bestuursorgaan heeft bericht dat geen advies zal worden uitgebracht.
+  - index: 3
+    label: lid 4
+    sha256: 8a5c1c8a7f5d5b9632e62b7c38223b585e1d969c15ac2732d4af997641e583d4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij algemene maatregel van bestuur kunnen nadere regels worden gesteld over de wijze waarop klachten worden ingediend en het college tussen het bestuursorgaan en de klager bemiddelt als bedoeld in het eerste lid.
+- number: '7.4'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4ddec5162c492795b2511e4a5020b033accdf8d0010efa3dacefebbccbea2155
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Een bestuursorgaan verstrekt desgevraagd het college alle gegevens die het nodig heeft voor zijn taak.
+- number: '7.5'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 1e2eb6533e4d8f0b63951dc8842be2a285bb51f205bff9969acf7ffdb0ff18b3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. De leden van het college alsmede de ambtenaren van zijn bureau zijn tot geheimhouding verplicht voor zover zij krachtens deze wet beschikken over documenten die door het bestuursorgaan waarvan zij afkomstig zijn niet openbaar zijn gemaakt.
+  - index: 1
+    label: lid 2
+    sha256: ea885e377e6abbff6f2872b71595c156ea918c7b41586ecad181f4b18f4eaaf5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Voor zover een aan het college gericht verzoek op grond van deze wet betrekking heeft op door een bestuursorgaan aan het college verstrekte informatie, zendt het college het verzoek ter behandeling door aan het bestuursorgaan.
+- number: '8.1'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 12ec29be062fb6157e5ebfb87aebc95bc06757bb272ecf0feeb20e7e04436e1e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Overtreding van een voorwaarde die op grond van artikel 5.5, vierde lid, 5.6, derde lid, of artikel 5.7, tweede of derde lid, aan een verstrekking is verbonden, wordt gestraft met gevangenisstraf van ten hoogste een jaar of geldboete van de vierde categorie.
+  - index: 1
+    label: lid 2
+    sha256: 4e9df6b3f1b2df55f0972362087a0d109a99612126ff7b655d447f433c3a0a36
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het in het eerste lid strafbaar gestelde feit is een misdrijf.
+- number: '8.2'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: eab08efa43c294f249d4bc8e0cf263f6658922277b310694db24807b3cadf51b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Paragraaf 4.1.3.2 van de Algemene wet bestuursrecht is niet van toepassing op besluiten op grond van deze wet en op beslissingen op bezwaar tegen deze besluiten.
+- number: '8.4'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: e54ab6d7bba07ee37e645f20eb429444eaf4cf28dda3495c8571df85bd8e26c1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. In geval van een gegrond beroep tegen het niet tijdig nemen van een besluit op grond van deze wet of een beslissing op bezwaar tegen een dergelijk besluit, waarbij nog geen besluit is bekendgemaakt, bepaalt de bestuursrechter, indien de omvang van het verzoek hiertoe aanleiding geeft, in afwijking van artikel 8:55d, eerste lid, van de Algemene wet bestuursrecht de termijn waarbinnen het bestuursorgaan alsnog een besluit bekendmaakt.
+  - index: 1
+    label: lid 2
+    sha256: 0d3b132c3d79e7327885ca5bacd281aed9a8c08eadfcba42c442621a78f8438b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien de bestuursrechter oordeelt dat het niet tijdig nemen van een besluit kennelijk het gevolg is van de wijze van indiening van het verzoek en nog geen besluit is bekendgemaakt, bepaalt de bestuursrechter, indien het verzoek hiertoe aanleiding geeft, in afwijking van artikel 8:55d, eerste lid, van de Algemene wet bestuursrecht een langere termijn waarbinnen het bestuursorgaan alsnog een besluit bekendmaakt.
+  - index: 2
+    label: lid 3
+    sha256: 351872ce816138884e72d54ff11c9b7c14ae71ce73256443c28cdf606dda7746
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. De bestuursrechter kan artikel 8:74, eerste lid, van de Algemene wet bestuursrecht buiten toepassing laten en een proceskostenveroordeling op grond van artikel 8:75, eerste lid, van de Algemene wet bestuursrecht achterwege laten, indien de indiener van het beroepschrift, gelet op de omvang van het verzoek, onvoldoende heeft meegewerkt aan het bereiken van overeenstemming over: a. een opschorting van de beslistermijn als bedoeld in artikel 4:15, tweede lid, onderdeel a, van de Algemene wet bestuursrecht; of b. verder uitstel van de beslistermijn, bedoeld in artikel 7:10, vierde lid, onderdeel a of b, van de Algemene wet bestuursrecht.'
+  - index: 3
+    label: lid 4
+    sha256: d27197c0f22fd85f8328f3c83bf6d97755da1fe8a2c1259e4db424fec64c73f2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De bestuursrechter kan eveneens artikel 8:74, eerste lid, van de Algemene wet bestuursrecht buiten toepassing laten en een proceskostenveroordeling op grond van artikel 8:75, eerste lid, van de Algemene wet bestuursrecht achterwege laten, indien hij oordeelt dat het niet tijdig nemen van een besluit kennelijk het gevolg is van de wijze van indiening van het verzoek.
+- number: '8.5'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ca82a073c24358c61600e7ef14589cba56dbd7125be1b12a31d3d910bb46ed33
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Het bestuursorgaan is bevoegd tot oplegging van een last onder dwangsom ter handhaving van artikel 4.2, tweede lid.
+- number: '8.6'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: dafebc0bca9b4955e5a4e471c74370bf30f7359ed2809f3f0f19ec2083a04a73
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. De openbaarmaking van informatie op grond van deze wet is kosteloos.
+  - index: 1
+    label: lid 2
+    sha256: 6c04825d129ce1002d4ca8e93f6838b97d65140e5095a08fc62bdf39d21dc88d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Voor de vervaardiging van kopieen van documenten kan een bestuursorgaan een redelijke vergoeding vragen, die de kostprijs van de verstrekte informatiedragers niet overstijgt.
+  - index: 2
+    label: lid 3
+    sha256: 10ba7edcd833f35cc3463e60653de18f41dabba56ba87faaa4a043455bf1f728
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Op voordracht van Onze Minister kunnen bij of krachtens algemene maatregel van bestuur regels worden gesteld met betrekking tot het tweede lid.
+- number: '8.7'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a46434783e3280dc81b5e60195ce6d40485e4d43af29929b94bd3e2203412e39
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Op voordracht van Onze Minister kunnen bij of krachtens algemene maatregel van bestuur regels worden gesteld over de wijze waarop een bestuursorgaan de uitvoering van deze wet organiseert.
+- number: '8.8'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 34f04643697cac8cb618a9a0637b54573e3c9738c6212c3ec3159b6bdfb76aaf
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: De artikelen 3.1, 3.3, 4.1, 5.1, eerste, tweede en vijfde lid, en 5.2 zijn niet van toepassing op informatie waarvoor een bepaling geldt die is opgenomen in de bijlage bij deze wet.
+- number: '8.9'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: 0ee363f2b0cf5860cd3928ff8cb88cc21fa48cde489a86d5d3cfc4df729d7511
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Onze Minister zendt binnen vijf jaar na de inwerkingtreding van deze wet aan de Staten-Generaal een verslag over de doeltreffendheid en de effecten van deze wet in de praktijk.
+  - index: 1
+    label: lid 2
+    sha256: ba77b8666ed2f23610fb0de93e0081c8d03d74603dff0989ab2f68b196ce873d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In deze evaluatie wordt in ieder geval aandacht besteed aan de vraag of het noodzakelijk is om een Informatiecommissaris in te stellen.
+- number: '10.1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 328f1f836cd752d4e0771bf7e9f3509e7a141a3161606bbc1e92cafcce2ecdad
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: De Wet openbaarheid van bestuur wordt ingetrokken.
+- number: '10.2'
+  chunks:
+  - index: 0
+    label: lid 1
+    sha256: ea1f286ba4f51d228d510df04c98e8c589d6d748cb7a745db48e5bd153b0487f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1. Documenten die voor de inwerkingtreding van deze wet zijn opgesteld, worden niet openbaar gemaakt op grond van artikel 3.1, eerste lid, of artikel 3.3, eerste of tweede lid, tenzij het bestuursorgaan dat redelijkerwijs mogelijk acht.
+  - index: 1
+    label: lid 2
+    sha256: ea5e8cb8bf8568eb42599356a8bf23f46bc2050ff215e7e2ed69b7fc4e042084
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het eerste lid is niet van toepassing op documenten die voor de datum van inwerkingtreding van deze wet zijn opgesteld en waarvan de aktieve openbaarmaking reeds op grond van de Wet openbaarheid van bestuur plaatsvond.
+- number: 10.2a
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 75c660c12d9c281a87e177c8cc69583c157105261f6d0475053aed73bd1f181c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Voor documenten die voor de inwerkingtreding van deze wet zijn opgesteld en waarop een verzoek betrekking heeft, zijn de bepalingen van deze wet van toepassing, tenzij toepassing daarvan onredelijk bezwarend is voor het betrokken bestuursorgaan.
+- number: 10.2b
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 510212e64eadf3b5517a2bf89e2f2705e47c2ac878ebe6c73a32d3b234dcd2c7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: De bepalingen van deze wet zijn niet van toepassing op adviezen van de Afdeling advisering van de Raad van State die voor de inwerkingtreding van deze wet zijn uitgebracht.
+- number: 10.2c
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: efd6de43399adb257dbe8b30b4767fba2f9fe4280d45c7e29465a517eee1a331
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: De bepalingen van deze wet zijn niet van toepassing op documenten waarop artikel 8.8 van toepassing is die voor de inwerkingtreding van deze wet zijn opgesteld.
+- number: 10.2d
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 87aa774b888be4df01e52dd5d865837aa8f2ee18bb99e496be55962ead915c84
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 10.2b laat onverlet de bepalingen van de Rijkswet Koninkrijksgeschillen.
+- number: 10.2f
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 77f044f1b7421cd6a0f63d7f82338f9d461274294bd7d2a6aa3594d594bf0cc6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Hoofdstuk 6 van deze wet vervalt op een bij koninklijk besluit te bepalen tijdstip.
+- number: 10.2g
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 0d614bf744770b9a955dd4217b48cfecc782db03cfd965fd417c2d0a36ed130c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 10.2e vervalt.
+- number: '10.3'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: be07c42696d7b8fbfecfe7f1eabcad72cc15613150e2bbbd52f8150f298f494f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Deze wet treedt in werking op een bij koninklijk besluit te bepalen tijdstip.
+- number: '10.4'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8c0f178408210d6b2a91a20e2b5347e87ae3695e64828631baee5cd13b2345c0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Deze wet wordt aangehaald als: Wet open overheid.'

--- a/textguard/nl/wet/zorgverzekeringswet/2025-01-01.yaml
+++ b/textguard/nl/wet/zorgverzekeringswet/2025-01-01.yaml
@@ -1,0 +1,3946 @@
+$id: zorgverzekeringswet
+valid_from: null
+source: corpus/regulation/nl/wet/zorgverzekeringswet/2025-01-01.yaml
+articles:
+- number: '1'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c3ae68dd50b6519a48dcb6b52f717bef0be2740bea7144eeca300e998cdaade7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 1 In deze wet en de daarop berustende bepalingen wordt verstaan onder:'
+  - index: 1
+    label: onderdeel a
+    sha256: 5f20293b2aeaa0f7e91a6c73f9e46bf1989d7fe7dce84aeb1b6ebb4c5ac3a848
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'a. verzekeraar: een verzekeringsonderneming als bedoeld in de eerste richtlijn schadeverzekering;'
+  - index: 2
+    label: onderdeel b
+    sha256: 22f5060eeb01274e0d90d4001372164038c301fe8517294d7813fa3471ceb69c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'b. zorgverzekeraar: een verzekeraar, voor zover deze zorgverzekeringen aanbiedt of uitvoert;'
+  - index: 3
+    label: onderdeel c
+    sha256: 7c71a3968df45a75d1dd895a3026a289ad955c2d0c95a240331debf2a398e229
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'c. verzekeringnemer: een persoon die met een zorgverzekeraar een zorgverzekering heeft gesloten;'
+  - index: 4
+    label: onderdeel d
+    sha256: cf4f2e3fa167fff6a5825a06f6ea4c7914af520d91b37c848af65e097d80323a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'd. zorgverzekering: een tussen een zorgverzekeraar en een verzekeringnemer ten behoeve van een verzekeringsplichtige gesloten schadeverzekering, die voldoet aan hetgeen daarover bij of krachtens deze wet is geregeld, en waarvan de verzekerde prestaties het bij of krachtens deze wet geregelde niet te boven gaan;'
+  - index: 5
+    label: onderdeel e
+    sha256: 3c2b68d88913be5bc274c98b4529a5f0b0c21e435ad5bc6ad89e115ce23118b2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'e. verzekeringsplichtige: degene die op grond van artikel 2 verplicht is zich krachtens een zorgverzekering te verzekeren of te laten verzekeren;'
+  - index: 6
+    label: onderdeel f
+    sha256: 55f9868ee6388fbf19336ac79946d363ee9741c175e6784ca6d3adab56879599
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'f. verzekerde: degene wiens risico van behoefte aan zorg of overige diensten, als bedoeld in artikel 10 , door een zorgverzekering wordt gedekt;'
+  - index: 7
+    label: onderdeel g
+    sha256: ba4899bb500434fcf00b29400a901ea999f6405581374d38b25a5ae9dc1df98d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'g. eigen risico: een door de verzekeringnemer met de zorgverzekeraar als onderdeel van de zorgverzekering overeengekomen bedrag aan kosten van zorg of overige diensten, als bedoeld bij of krachtens artikel 11 , dat de verzekerde voor zijn rekening zal nemen;'
+  - index: 8
+    label: onderdeel h
+    sha256: cbb53a398940953d10ead5c6848e60d7dffd8e497597b519b4ea57c33df8cc1d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'h. zorgpolis: de akte waarin de tussen een verzekeringnemer en een zorgverzekeraar gesloten zorgverzekering is vastgelegd;'
+  - index: 9
+    label: onderdeel i
+    sha256: 11b86c7df2cc03b0d2fadc1059af4fa854727e419d46554ecd23e03b88d0fc4d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'i. modelovereenkomst: model van een zorgverzekering, waarin een overzicht wordt gegeven van de rechten en plichten die de verzekeringnemer, de verzekerde en de zorgverzekeraar jegens elkaar zullen hebben indien een overeenkomst volgens het desbetreffende model wordt gesloten;'
+  - index: 10
+    label: onderdeel j
+    sha256: 44ddd8d88e5ca9f4906e100bde34fe137cc0d39302def3ca139037b824439081
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'j. sociaal-fiscaalnummer: het nummer, bedoeld in [artikel 2, derde lid, onderdeel j, van de Algemene wet inzake rijksbelastingen](jci1.3:c:BWBR0002320&artikel=2) ;'
+  - index: 11
+    label: onderdeel k
+    sha256: 01d7e070a73be175746f219d22f3703d9acb436b3ca1a81d71d4e8fa503d40f0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'k. inhoudingsplichtige: de inhoudingsplichtige in de zin van de [Wet op de loonbelasting 1964](jci1.3:c:BWBR0002471) dan wel in de zin van de [Wet financiering sociale verzekeringen](jci1.3:c:BWBR0017745) ;'
+  - index: 12
+    label: onderdeel l
+    sha256: ea68c15662654a82e248a466a3d885f9065369ef94f9eb1d2ecb8f57d064d267
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'l. instelling:'
+  - index: 13
+    label: tekst
+    sha256: b80b8e47029536d811e62dc15900dd943cefca3650806985bf33597df85df121
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1°. een instelling in de zin van de [Wet toelating zorginstellingen](jci1.3:c:BWBR0018906) ;
+  - index: 14
+    label: tekst
+    sha256: 7ebedbe1907a93e5029c60c88ecc5a2c613794ae7cca0246a0f5800f9b66d612
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2°. een in het buitenland gevestigde rechtspersoon die in het desbetreffende land zorg verleent in het kader van het in dat land bestaande socialezekerheidsstelsel, dan wel zich richt op het verlenen van zorg aan specifieke groepen van publieke functionarissen;
+  - index: 15
+    label: tekst
+    sha256: b80b8e47029536d811e62dc15900dd943cefca3650806985bf33597df85df121
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1°. een instelling in de zin van de [Wet toelating zorginstellingen](jci1.3:c:BWBR0018906) ;
+  - index: 16
+    label: tekst
+    sha256: 7ebedbe1907a93e5029c60c88ecc5a2c613794ae7cca0246a0f5800f9b66d612
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2°. een in het buitenland gevestigde rechtspersoon die in het desbetreffende land zorg verleent in het kader van het in dat land bestaande socialezekerheidsstelsel, dan wel zich richt op het verlenen van zorg aan specifieke groepen van publieke functionarissen;
+  - index: 17
+    label: onderdeel m
+    sha256: 02d147f633da7de79a8e87117b234a1862903c6b13a0c91dda7b54b55ff3c8e6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'm. Onze Minister: Onze Minister van Volksgezondheid, Welzijn en Sport;'
+  - index: 18
+    label: onderdeel m
+    sha256: 6a704c75cdbc06a528420ee399d0c6d0acf14c613b644cc39202fd52b69dfc7f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'm. College toezicht: het College van toezicht op de zorgverzekeringen, genoemd in artikel 77, eerste lid ;'
+  - index: 19
+    label: onderdeel o
+    sha256: af8a98632b4f22273522cb0f60596953255c06f9365dd7856afe6dbf33884a47
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'o. College zorgverzekeringen: het College voor zorgverzekeringen, genoemd in artikel 58, eerste lid ;'
+  - index: 20
+    label: onderdeel p
+    sha256: 30113e63f65daa98a4c2171117cf15cd12918d59cb8edd787116ee04fa2bee61
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'p. Zorgverzekeringsfonds: het fonds, genoemd in artikel 39 ;'
+  - index: 21
+    label: onderdeel q
+    sha256: 69b2421514565892abea8442a8f855ce0ff4e130f91a718efc941b0356915677
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'q. eerste richtlijn schadeverzekering: [richtlijn nr. 73/239/EEG](31973L0239) van de Raad van de Europese Gemeenschappen van 24 juli 1973 tot coördinatie van de wettelijke en bestuursrechtelijke bepalingen betreffende de toegang tot het directe verzekeringsbedrijf, met uitzondering van de levensverzekeringsbranche en de uitoefening daarvan (PbEG L 228);'
+  - index: 22
+    label: onderdeel r
+    sha256: c164ff42317b81b2d7742d9edd8e142736eb6323331d50a1e68dddd1bbea0185
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'r. generieke verevening: bijstelling van het deelbedrag op basis van het verschil per zorgverzekeraar tussen de kosten en het deelbedrag in relatie met de verschillen tussen de kosten en het deelbedrag bij andere zorgverzekeraars, per onderscheiden categorie van prestaties;'
+  - index: 23
+    label: onderdeel s
+    sha256: a8852a6a072326f89e80cf97126be962f9f9cef72bb3bd6978bfae2b4ea20561
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 's. loontijdvak: het loontijdvak, bedoeld in [artikel 25, eerste en vierde lid, van de Wet op de loonbelasting 1964](jci1.3:c:BWBR0002471&artikel=25) ;'
+  - index: 24
+    label: onderdeel t
+    sha256: b6b95a70033299f8004735e70c23353d95234c81a1c57cfb9b602a6386ab0596
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 't. bijdragebetalingstijdvak: het kalenderjaar.'
+- number: '2'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: aee9e9b992d0e7b0a3f8bc6b7373790c77b5f48aa9d1e51f69d8db29f9fb01d1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 2 1 Degene die ingevolge de [Algemene Wet Bijzondere Ziektekosten](jci1.3:c:BWBR0002614) en de daarop gebaseerde regelgeving van rechtswege verzekerd is, is verplicht zich krachtens een zorgverzekering te verzekeren of te laten verzekeren tegen het in artikel 10 bedoelde risico.
+  - index: 1
+    label: lid 2
+    sha256: 5c282a49365e9e7d009ba6ce862e473767b225ca38fe22fa7b07ddbe8b457a1a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. In afwijking van het eerste lid is niet verzekeringsplichtig:'
+  - index: 2
+    label: onderdeel a
+    sha256: 7de273e6d5895a14af816d529ca77ea0613570cb2c99df213baa2f43dcd3c97f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de militaire ambtenaar in werkelijke dienst als bedoeld in [artikel 1, eerste lid juncto vierde lid, onderdeel a, van de Militaire ambtenarenwet 1931](jci1.3:c:BWBR0001952&artikel=1) , alsmede de militair aan wie buitengewoon verlof met behoud van militaire inkomsten is verleend;
+  - index: 3
+    label: onderdeel b
+    sha256: f700270fe368f549b3f439748fe1cabb440d56e328324f527172758e8438bf3c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de natuurlijke persoon die op grond van [artikel 64, eerste lid, van de Wet financiering sociale verzekeringen](jci1.3:c:BWBR0017745&artikel=64) is ontheven van de verplichtingen, opgelegd op grond van de [Algemene Wet Bijzondere Ziektekosten](jci1.3:c:BWBR0002614) .
+  - index: 4
+    label: lid 3
+    sha256: ec66194ead2ee8a3acea694a146f2acc7f5ae38a7a39872feb8edd1457083092
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Degene die het gezag over een minderjarige, jonger dan achttien jaar, uitoefent, een curator, een bewindvoerder of een mentor als bedoeld in de [titels 16](jci1.3:c:BWBR0002656&titeldeel=16) , [19](jci1.3:c:BWBR0002656&titeldeel=19) of [20 van Boek 1 van het Burgerlijk Wetboek](jci1.3:c:BWBR0002656&titeldeel=20) , zorgt ervoor dat de minderjarige verzekeringsplichtige, dan wel de onder curatele, bewind of mentorschap gestelde verzekeringsplichtige krachtens een zorgverzekering verzekerd is.
+- number: '3'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 14b3e0a061bb2d70e6001e0747f14ddc217cfba40d1e91cc0b11a55ef6b5276b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 3 1 Een zorgverzekeraar is verplicht met of ten behoeve van iedere verzekeringsplichtige die in zijn werkgebied woont alsmede met of ten behoeve van iedere verzekeringsplichtige die in het buitenland woont, desgevraagd een zorgverzekering te sluiten.
+  - index: 1
+    label: lid 2
+    sha256: 56b018dc2e995d2b2153da0f6418026f895a7d0489cea41728bbb2c048b69d94
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien een zorgverzekeraar in een provincie verschillende varianten van de zorgverzekering aanbiedt, kan voor iedere in die provincie wonende verzekeringsplichtige uit alle varianten worden gekozen.
+  - index: 2
+    label: lid 3
+    sha256: 7edbd053bd519e00065b8a01575233f9d571ea8d648ca2c78c401cc2803359d5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De zorgverzekeraar stelt alle varianten van de zorgverzekering die hij in een provincie aanbiedt, in de vorm van modelovereenkomsten ter beschikking aan personen die overwegen ten behoeve van een in die provincie wonende verzekeringsplichtige een zorgverzekering met die verzekeraar te sluiten, alsmede, indien de zorgverzekeraar varianten toevoegt of wijzigt, aan de verzekeringnemers die ten behoeve van een in die provincie wonende verzekeringsplichtige een zorgverzekering met hem hebben gesloten.
+  - index: 3
+    label: lid 4
+    sha256: 978775daf8ed32952fa6f0c8a8d3dcda2b9874c5c790dade9303121bcb02bdaa
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. In afwijking van het eerste lid is een zorgverzekeraar niet verplicht een zorgverzekering te sluiten met of ten behoeve van een verzekeringsplichtige wiens eerdere zorgverzekering hij of de verzekeringnemer binnen een periode van vijf jaar, gelegen onmiddellijk voorafgaande aan het verzoek tot het sluiten van de verzekering, heeft opgezegd of ontbonden wegens:'
+  - index: 4
+    label: onderdeel a
+    sha256: 619226aba69cabb47e4ddd56717ffab304ceec96b03bf1037c0b70842f8e3839
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. opzettelijke misleiding door de verzekeringnemer of de verzekerde, of
+  - index: 5
+    label: onderdeel b
+    sha256: c1ba3b6564be13d373d30cce3aac9721f4a1e6477bd590abec7624ae09567853
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. het niet betalen van de premie, bedoeld in artikel 17, vijfde lid .
+  - index: 6
+    label: lid 5
+    sha256: a4086e7d5558f286e84c42e0079bd862f81cc95986b5d481a8785b90e10e60a9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. In afwijking van het tweede lid kan ten behoeve van een in het buitenland wonende verzekeringsplichtige worden gekozen tussen alle varianten van de zorgverzekering die een zorgverzekeraar in Nederland aanbiedt.
+  - index: 7
+    label: lid 6
+    sha256: 8a05e0e54fc8f72e0304d64a67c627d0b79c74952ef450af40342e1a0c7c4e1a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. In afwijking van het derde lid worden degene die ten behoeve van een in het buitenland wonende verzekeringsplichtige een zorgverzekering wenst te sluiten alle modelovereenkomsten die de zorgverzekeraar in Nederland hanteert ter beschikking gesteld, en worden, indien eenmaal een zorgverzekering is gesloten, de verzekeringnemer alle toegevoegde of gewijzigde varianten die die zorgverzekeraar aanbiedt ter beschikking gesteld.
+- number: '4'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d6b4727e86d4949517dd5137700a9675f704b14564c19c58a2a76253c8e796d2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 4 1 Degene die een zorgverzekering wenst te sluiten, vermeldt bij het verzoek daartoe het sociaal-fiscaalnummer van de te verzekeren persoon.
+  - index: 1
+    label: lid 2
+    sha256: db7844340bd548e958db8ef957723ea09f17fa879da1cb8398a5e74da3964713
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De zorgverzekeraar stelt, voor zover dat redelijkerwijs nodig is voor de uitvoering van de zorgverzekering en van deze wet, de identiteit van de te verzekeren persoon vast.
+  - index: 2
+    label: lid 3
+    sha256: ccf1e6bc162411e03a6e01ef2c41c857cdd14e9a0d5f935f16b0451781364c84
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De in het tweede lid bedoelde vaststelling geschiedt aan de hand van documenten als bedoeld in [artikel 1 van de Wet op de identificatieplicht](jci1.3:c:BWBR0006297&artikel=1) , die de verzekeringnemer of de te verzekeren persoon hem desgevraagd ter inzage geeft.
+  - index: 3
+    label: lid 4
+    sha256: 9a6b492996b5da4e6bc7572a390cd18576707bf817b6be4132624cbb6f00c2ea
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De zorgverzekeraar neemt aard en nummer van de in het derde lid bedoelde documenten in zijn administratie op.
+  - index: 4
+    label: lid 5
+    sha256: 691b2debb62fd37343436eefe8d3e3477e2d3856cf1d75a6c7f411937b8c65a8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De zorgverzekeraar verlangt van de vreemdeling, bedoeld in de [Vreemdelingenwet 2000](jci1.3:c:BWBR0011823) , voor wie hem wordt verzocht een zorgverzekering te sluiten, een kopie van het document of de schriftelijke verklaring, bedoeld in [artikel 9, eerste lid, van die wet](jci1.3:c:BWBR0011823&artikel=9) , dat wordt aangemerkt als een bescheid als bedoeld in [artikel 4:3, tweede lid, van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&artikel=4:3) .
+- number: '5'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ab94a05b220bee3c913a1a679eff591d7356a04a5dbb5e2ab9c4938d07996b73
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 5 1 De zorgverzekering gaat in op de dag waarop de zorgverzekeraar het verzoek, bedoeld in artikel 3, eerste lid , en, indien het tweede of vijfde lid van dat artikel van toepassing is, de aanduiding van de variant waar de verzekeringnemer voor kiest, heeft ontvangen.
+  - index: 1
+    label: lid 2
+    sha256: a8a78dbc423aea44d7fc8d558678da88ba87520770002d3ac1425a5db1fc354d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien de zorgverzekeraar op basis van het in het eerste lid bedoelde verzoek niet vast kan stellen of hij verplicht is voor de te verzekeren persoon een zorgverzekering te sluiten, en hij de persoon die de verzekering wenst te sluiten in verband daarmee uitnodigt de voor deze vaststelling noodzakelijke gegevens te verschaffen, gaat de zorgverzekering, in afwijking van het eerste lid, in op de dag waarop laatstbedoelde persoon aan dit verzoek heeft voldaan.
+  - index: 2
+    label: lid 3
+    sha256: 1c78dac5913fd2c37a1c1d256292678bc8d243b33481521862c3b9018507cae9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. De zorgverzekeraar verstrekt degene die het verzoek, bedoeld in het eerste lid, doet en, indien dit een ander is dan degene ten behoeve van wiens verzekering het verzoek is gedaan, laatstbedoelde persoon onverwijld:'
+  - index: 3
+    label: onderdeel a
+    sha256: 7b57473a27a448008c63ce3ed13ed5e633e679f236025b558a4972db957cd66c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. een bewijs van het verzoek, bedoeld in het eerste lid, waarop de datum van ontvangst is vermeld;
+  - index: 4
+    label: onderdeel b
+    sha256: 6284cf75de7e95f023a8ee2ffc5b24cffdd5508911b7291b51416061f5e72ccb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. een bewijs van de ontvangst van gegevens, bedoeld in het tweede lid, waarop de datum van de ontvangst is vermeld.
+  - index: 5
+    label: lid 4
+    sha256: 5950756a8b379adbe9ce5a2833d67cb3573c781fe2bfb5faad55b9e1f0baf651
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Indien degene ten behoeve van wie de zorgverzekering wordt gesloten op de dag waarop de zorgverzekeraar het verzoek, bedoeld in het eerste lid, ontvangt reeds op grond van een zorgverzekering verzekerd is, en de verzekeringnemer aangeeft de zorgverzekering te willen laten ingaan op een door hem aangegeven, latere dag dan de dag, bedoeld in het eerste of tweede lid, gaat de verzekering op die latere dag in.
+  - index: 6
+    label: lid 5
+    sha256: 7f73c01704e568c820906d96509c5360d053cda55990d61a0a8bf2d69b9d56be
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Indien de zorgverzekering ingaat binnen vier maanden nadat de verzekeringsplicht is ontstaan, werkt deze, zonodig in afwijking van [artikel 925, eerste lid, van boek 7 van het Burgerlijk Wetboek](jci1.3:c:BWBR0005290&artikel=925) , terug tot en met de dag waarop die plicht ontstond.
+- number: '6'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2b30a306beb501922c60b9a4578830bf845119346bdf3c376ed9b7eaf49fef48
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 6 1 De zorgverzekering eindigt van rechtswege met ingang van de dag volgende op de dag waarop:'
+  - index: 1
+    label: onderdeel a
+    sha256: 5bf26b20fd1c610530505229c9cc3d2fdf8411cc6cf772c5dcef19207a807bd0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de verzekeraar ten gevolge van wijziging of intrekking van zijn vergunning tot uitoefening van het schadeverzekeringsbedrijf, geen zorgverzekeringen meer mag aanbieden;
+  - index: 2
+    label: onderdeel b
+    sha256: fb3e22d60ba41d6578d500c0dec916bf9106ef323982da9d1ea1286bb8f86838
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de verzekerde ten gevolge van wijziging van het werkgebied buiten het werkgebied van de zorgverzekeraar komt te wonen;
+  - index: 3
+    label: onderdeel c
+    sha256: 28cf1dc96efcac27a7a565646e4174ac17250ab48ab7be5e0343404780adf813
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. de verzekerde overlijdt;
+  - index: 4
+    label: onderdeel d
+    sha256: 057b6159997e7850b2c2cada12c1d6cda5d30812e1389474377604ccfd736c82
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. de verzekeringsplicht van de verzekerde eindigt.
+  - index: 5
+    label: lid 2
+    sha256: 4b81825373d4ec17208c0b4aaf0564de0b16f7ce6b3d9be1be9787b4f6eb2d48
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De zorgverzekering eindigt van rechtswege met ingang van de eerste dag van de tweede maand volgende op de dag waarop de verzekerde, zonder dat zijn verzekeringsplicht eindigt, ten gevolge van verhuizing komt te wonen buiten een provincie waarin zijn zorgverzekeraar de ten behoeve van hem gesloten variant van de zorgverzekering aanbiedt of uitvoert.
+  - index: 6
+    label: lid 3
+    sha256: 58e7a5aa02fb2eaee9f0e2e7a8a936af8d333b3e64a71457ad3eb4603a90af30
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De zorgverzekeraar stelt de verzekeringnemer uiterlijk twee maanden voordat een zorgverzekering op grond van het eerste lid, onderdeel a of b eindigt, van dit einde op de hoogte, onder vermelding van de reden daarvan en de datum waarop de verzekering eindigt.
+  - index: 7
+    label: lid 4
+    sha256: 519bee21a9d0d6627d795380541794b6dc108c0a0831ff56b4140c8a910b4667
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De verzekeringnemer stelt de zorgverzekeraar onverwijld op de hoogte van alle feiten en omstandigheden over de verzekerde die op grond van het eerste lid, onderdeel c of d, dan wel het tweede lid tot het einde van de zorgverzekering hebben geleid of kunnen leiden.
+  - index: 8
+    label: lid 5
+    sha256: 7dffdf3dbc311f4f1b2ef1c1c536bf4763eff3002fa7824d7653a37821babd1a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Indien de zorgverzekeraar op grond van de in het vierde lid bedoelde gegevens tot de conclusie komt dat de zorgverzekering zal eindigen of geëindigd is, deelt hij dit, onder vermelding van de reden daarvan en de datum waarop de verzekering eindigt of geëindigd is, onverwijld aan de verzekeringnemer mede.
+- number: '7'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 9ced7dadeed52e458a0b35d3672be39d8004a761f0e939f6a4a62a97a87f667c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 7 1 De verzekeringnemer kan de zorgverzekering voor 1 november van ieder jaar met ingang van 1 januari van het volgende kalenderjaar opzeggen.
+  - index: 1
+    label: lid 2
+    sha256: 5c2a44473f07ed753ff37550ed5cdbc9af22ceb9d4ec46e15b1c16f1583719f0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De verzekeringnemer die een ander dan zichzelf heeft verzekerd, kan de zorgverzekering opzeggen indien de verzekerde krachtens een andere zorgverzekering verzekerd wordt.
+  - index: 2
+    label: lid 3
+    sha256: ed69a8688a4d760fb44d97757af94f2a9103b04f94d19365043a67959de4440e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. In afwijking van [artikel 940, vierde lid, van Boek 7 van het Burgerlijk Wetboek](jci1.3:c:BWBR0005290&artikel=940) :'
+  - index: 3
+    label: onderdeel a
+    sha256: cfd69ad93754e10ab9eebec8557f93d77316d2161dd773e71fa04d4ed7fc2b41
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. kan de verzekeringnemer de zorgverzekering opzeggen in de periode gelegen tussen de datum waarop zijn zorgverzekeraar hem het voornemen tot verhoging van de grondslag van de premie heeft meegedeeld en de inwerkingtreding van die verhoging;
+  - index: 4
+    label: onderdeel b
+    sha256: f7f6a8543c0e702f035ed2eef962f05e228cddc22640f515c468300b83401178
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. kan de verzekeringnemer niet opzeggen indien een wijziging in de verzekerde prestaties ten nadele van de verzekeringnemer of de verzekerde rechtstreeks voortvloeit uit een wijziging van de bij of krachtens de artikelen 11 tot en met 14 gestelde regels.
+  - index: 5
+    label: lid 4
+    sha256: 878e7112381ec90bff40a3220468ffa82de22987d5e40af5899d1b9db1f3461e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De opzegging, bedoeld in het tweede lid, of in het derde lid, onderdeel a, gaat in op de eerste dag van de tweede kalendermaand volgende op de dag waarop de verzekeringnemer heeft opgezegd.
+  - index: 6
+    label: lid 5
+    sha256: 76858a1629888615e84bfa2e4f03df9062928fd047a2e5cf3be2f994a6b41590
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. In afwijking van het vierde lid gaat een opzegging, bedoeld in het tweede lid, in met ingang van de dag waarop de verzekerde krachtens de andere zorgverzekering verzekerd wordt, indien die opzegging voorafgaande aan laatstbedoelde dag door de zorgverzekeraar is ontvangen.
+- number: '8'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: be4018e6cb24f7afd79bd5d7b64e2874c8583e8cb311b09bb9660e47d1633eaf
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 8 1 Aan een opzegging of ontbinding van de zorgverzekering wegens het niet betalen van de verschuldigde premie, wordt geen terugwerkende kracht verleend, noch wordt daaraan een verplichting verbonden tot ongedaanmaking of vergoeding van hetgeen partijen reeds ter nakoming van de zorgverzekering jegens elkaar hebben verricht.
+  - index: 1
+    label: lid 2
+    sha256: 156cf82563bdba35acfa76969ff8ec29580bb4b3d85fdb49edaaca7bcc21a836
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Een zorgverzekeraar mag de zorgverzekering gedurende de periode, bedoeld in artikel 24 , niet opzeggen of ontbinden.
+- number: '9'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: e00b77fe5d369b94288d40a8535dac0871ec324e67d2d86ae9e528311c257932
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 9 1 De zorgverzekeraar verstrekt de verzekeringnemer en, indien deze een ander is dan de verzekeringnemer, de verzekerde zo spoedig mogelijk na het sluiten van de zorgverzekering en vervolgens voorafgaande aan ieder kalenderjaar een zorgpolis.
+  - index: 1
+    label: lid 2
+    sha256: 07fabed7ebdc64220a893d5f63e9d81895d511f0205c082f3767e2af570268e1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Indien de zorgverzekering eindigt, verstrekt de zorgverzekeraar de verzekeringnemer en, indien deze een ander is dan de verzekeringnemer, de verzekerde een bewijs van het einde van de zorgverzekering, waarop worden aangetekend:'
+  - index: 2
+    label: onderdeel a
+    sha256: 6bf89a3273e0c35fbb91864136d0666fc39fe520498d8ca3900922ca1b84550f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. naam, adres, woonplaats en sociaal-fiscaalnummer van de verzekerde;
+  - index: 3
+    label: onderdeel b
+    sha256: c79a0d76888f90ad3485dda6a2067d32e1ff90d15ee3d49b31200650dfd59767
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. naam, adres en woonplaats van de verzekeringnemer;
+  - index: 4
+    label: onderdeel c
+    sha256: 6b7a836850e69ccc6ae9cf55c0e62c5928bb9b5b773066508a720f2ce03125c1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. naam, adres en woonplaats van de zorgverzekeraar;
+  - index: 5
+    label: onderdeel d
+    sha256: bb15929a246e050114b62774a55064b566c0922eedd9323e505b1dadd556260b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. de dag waarop de zorgverzekering eindigt;
+  - index: 6
+    label: onderdeel e
+    sha256: a0280b1b8e8ae3e4e52350965d433b4d52f06e24670e5182eb6d4abd19f0cc3d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: e. of voor de verzekerde op die dag een eigen risico gold en zo ja, met welke ingangsdatum, voor welk bedrag en met welke in verband daarmee verleende korting.
+  - index: 7
+    label: lid 3
+    sha256: 2db873dddceb2a68fa3727c4c92a49fadbaff12c4e0a2cd1979dc6f3cdc9e97f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien de zorgverzekering eindigt om de in artikel 6, eerste lid, onderdeel d , genoemde reden, wordt dat op het in het tweede lid bedoelde bewijs aangetekend.
+- number: '10'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 916b766cef7e49f53d52566193a1b54c5f0fd89c9efc4ceb04776847a2878089
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 10 Het krachtens de zorgverzekering te verzekeren risico is de behoefte aan:'
+  - index: 1
+    label: onderdeel a
+    sha256: 7e3038667ad660c6d5022e0940e13c652783fc2c09d799567220106bc42ae159
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. geneeskundige zorg, waaronder de integrale eerstelijnszorg zoals die door huisartsen en verloskundigen pleegt te geschieden;
+  - index: 2
+    label: onderdeel b
+    sha256: 1bfd9d3e04fe693947caab38181bdb00a71611ab2a59c0dd6d1a6ad70326696f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. mondzorg;
+  - index: 3
+    label: onderdeel c
+    sha256: aa3e616a3a2d6b713d9eb210e5de27d53d469eb842dd0f3998136dc3cb96d170
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. farmaceutische zorg;
+  - index: 4
+    label: onderdeel d
+    sha256: 3d3993fc3f1fde6f0c9dfcb419bf07eb7d625f2d41138c0be4b4f32ce07bea88
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. hulpmiddelenzorg;
+  - index: 5
+    label: onderdeel e
+    sha256: 5b2cd08828009d96ec52ca58d941136e7be41a4cb495c7f546b89b40aeb2937c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: e. verpleging;
+  - index: 6
+    label: onderdeel f
+    sha256: 3fb5e3ee80a98fe3b87da0f56faffde33420b28ae749c764cf4e20e2a54329b3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: f. verzorging, waaronder de kraamzorg;
+  - index: 7
+    label: onderdeel g
+    sha256: ba93cbdf7cae390910a451adf78e90f18ba56e9109b0cc8f26dd35e0346255ab
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: g. verblijf in verband met geneeskundige zorg;
+  - index: 8
+    label: onderdeel h
+    sha256: 39933bbbae7126b195d15ddc37b69ae20db8c82660261a5d7a1e5bf6b85008b3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: h. vervoer in verband met het ontvangen van zorg of diensten als bedoeld in de onderdelen a tot en met g, dan wel in verband met een aanspraak op grond van de [Algemene Wet Bijzondere Ziektekosten](jci1.3:c:BWBR0002614) .
+- number: '11'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 82e36ffb2f409304b4f8a6a14d7e676964d0640673fca16504436dd2467ffc9e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 11 1 De zorgverzekeraar heeft jegens zijn verzekerden een zorgplicht die zodanig wordt vormgegeven, dat de verzekerde bij wie het verzekerde risico zich voordoet, krachtens de zorgverzekering recht heeft op prestaties bestaande uit:'
+  - index: 1
+    label: onderdeel a
+    sha256: 3da9483d36a3cd97a064c1c3baf96c79b7cf79be6e580b4f52149c4983724729
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de zorg of de overige diensten waaraan hij behoefte heeft, of
+  - index: 2
+    label: onderdeel b
+    sha256: dd3d42ac2a089d8f1a627241dcc73b731bddee72b5ae34ac88436761cc16bc14
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. vergoeding van de kosten van deze zorg of overige diensten alsmede, desgevraagd, activiteiten gericht op het verkrijgen van deze zorg of diensten.
+  - index: 3
+    label: lid 2
+    sha256: 018a1b014250f89e92b0bfb7b4843f805a8e14a5af3e127d436f1b3b2a4eb6a4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In de zorgverzekering kunnen combinaties van verzekerde prestaties als bedoeld in het eerste lid, onderdeel a of b, worden opgenomen.
+  - index: 4
+    label: lid 3
+    sha256: db67b88ede8f3946b8b02ab71df77f7bba23e4b4863b27787912a9f8a7865631
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij algemene maatregel van bestuur worden de inhoud en omvang van de in het eerste lid bedoelde prestaties nader geregeld en kan voor bij die maatregel aan te wijzen vormen van zorg of overige diensten worden bepaald dat een deel van de kosten voor rekening van de verzekerde komt.
+  - index: 5
+    label: lid 4
+    sha256: 9dba54d508405c4580d44f50a0426d323106ba3abb5fd57dfa11adaa7fb22b2e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. In de algemene maatregel van bestuur kan worden bepaald dat bij ministeriële regeling:'
+  - index: 6
+    label: onderdeel a
+    sha256: 590242272824b3a2bbc42636bb7b581a504c11710ce6b9685af42d5b340db20b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. vormen van zorg of overige diensten kunnen worden uitgezonderd van de in het eerste lid bedoelde of in de maatregel nader omschreven prestaties;
+  - index: 7
+    label: onderdeel b
+    sha256: 6b2a83c53e9e9d1cd80e5dccbab13900e67c4a813120f9ad95d4fdd28456a7b4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de inhoud en omvang van de prestaties bestaande uit zorg als bedoeld in artikel 10, onderdelen a, c en d , nader wordt geregeld;
+  - index: 8
+    label: onderdeel c
+    sha256: ecd8ec6b1144a218ab8faf6c590f4444ff30c3ae9bf02b4eed419c93e82700d1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. nadere regels kunnen worden gesteld over het deel van de kosten dat voor rekening van de verzekerde komt.
+  - index: 9
+    label: lid 5
+    sha256: 1b9a7c26e90bf13a7156d86bb00e4eb4e3eb009a7f21db9203073137d2e8a405
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Een zorgverzekeraar kan modelovereenkomsten aanbieden waarin, in geringe afwijking van het bepaalde bij of krachtens het eerste en derde lid, bepaalde om ethische of levensbeschouwelijke redenen controversiële prestaties buiten de dekking van de zorgverzekering blijven.
+- number: '12'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4b29e11e3f47dea7c2df4124fd5c4f555e2a6d04ba73dad14e65c9fb286b48a1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 12 1 Bij algemene maatregel van bestuur kunnen ter bescherming van het algemeen belang vormen van zorg of overige diensten worden aangewezen die de zorgverzekeraar slechts verstrekt of vergoedt indien tussen hem en de aanbieder van de desbetreffende zorg of dienst een overeenkomst over de te leveren zorg of dienst en de daarvoor in rekening te brengen prijs is gesloten, dan wel indien de aanbieder bij hem in dienst is.
+  - index: 1
+    label: lid 2
+    sha256: d96792757f6d85785b524191ebe2fe04df71baa4654249d2b17ccefcf565f1b9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij deze algemene maatregel van bestuur kunnen tevens vormen van zorg of overige diensten worden aangewezen waarvoor de zorgverzekeraar met iedere instelling die binnen zijn werkgebied is gelegen of waarvan zijn verzekerden naar verwachting regelmatig gebruik zullen maken, op haar verzoek een overeenkomst als bedoeld in het eerste lid sluit.
+  - index: 2
+    label: lid 3
+    sha256: 03229e05e361b9fba12b8a6b2c5fa010bbfa770d987ebfd684679f61d8cd845b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Een instelling als bedoeld in artikel 1, onderdeel l, onder 1° , die voor een in het tweede lid bedoelde vorm van zorg of dienst een overeenkomst met een zorgverzekeraar heeft gesloten, is verplicht desgevraagd met een andere zorgverzekeraar een gelijke overeenkomst te sluiten.
+  - index: 3
+    label: lid 4
+    sha256: d347233fd59e6498391431bf382ae523eee7b51ce68f7b4feb64fe9bf6da8acd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het tweede en het derde lid gelden niet indien de zorgverzekeraar respectievelijk instelling ernstige bezwaren heeft tegen het sluiten van een overeenkomst met de instelling respectievelijk zorgverzekeraar die om die overeenkomst vraagt.
+- number: '13'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: cec42db2203aa8a9c63d480e397d2fb0486c6f1d4c686383fd953993b7123626
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 13 1 Indien een verzekerde krachtens zijn zorgverzekering een bepaalde vorm van zorg of een andere dienst dient te betrekken van een aanbieder met wie zijn zorgverzekeraar een overeenkomst over deze zorg of dienst en de daarvoor in rekening te brengen prijs heeft gesloten of van een aanbieder die bij zijn zorgverzekeraar in dienst is, en hij deze zorg of andere dienst desalniettemin betrekt van een andere aanbieder, heeft hij recht op een door de zorgverzekeraar te bepalen vergoeding van de voor deze zorg of dienst gemaakte kosten.
+  - index: 1
+    label: lid 2
+    sha256: afa25b9ac319a316c248483e4639f8bd4cf63c6700c947168f594ba30d92bfa3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De zorgverzekeraar neemt de wijze waarop hij de vergoeding berekent in de modelovereenkomst op.
+  - index: 2
+    label: lid 3
+    sha256: 0d4413ece7a9b65abb84397d06c7f1d4443df79077f389d4ccbd7c33fb7fe1ba
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien bij of krachtens de algemene maatregel van bestuur, bedoeld in artikel 11 , is bepaald dat een deel van de kosten van een bepaalde vorm van zorg of van een bepaalde andere dienst voor rekening van de verzekerde komt, verwerkt de zorgverzekeraar dit in de wijze waarop hij de vergoeding voor de desbetreffende vorm van zorg of dienst berekent.
+  - index: 3
+    label: lid 4
+    sha256: b2f0e468d1d6ecb98b5c0d9ae6b93b5ac9a71f56a1a5749d3a8d3b5fbdc99fb1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De wijze waarop de vergoeding wordt berekend is voor alle verzekerden, bedoeld in het eerste lid, die in een zelfde situatie een zelfde vorm van zorg of dienst behoeven, gelijk.
+  - index: 4
+    label: lid 5
+    sha256: b6ca8ac81c36f8ed49a0df404ceb5c4e3b64cb0965a0d0fa1fbb39bf4191f644
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Indien een overeenkomst tussen een zorgverzekeraar en een aanbieder als bedoeld in het eerste lid wordt beëindigd, houdt een verzekerde die op het moment van beëindiging van de overeenkomst zorg ontvangt van deze aanbieder recht op zorgverlening door die aanbieder voor rekening van deze zorgverzekeraar.
+- number: '14'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ce2f3cd57c91f6804650ce5da3e39159f9518ba709aef87506b91dced66e2675
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 14 1 De vraag of een verzekerde behoefte heeft aan een bepaalde vorm van zorg of een bepaalde andere dienst wordt slechts op basis van zorginhoudelijke criteria beantwoord.
+  - index: 1
+    label: lid 2
+    sha256: 6caf6716b8b4254282f1a4d3e65a787486b08cd53501fbee3a6ed9b6a99a5385
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De zorgverzekeraar neemt in zijn modelovereenkomst op dat geneeskundige zorg zoals medisch-specialisten die plegen te bieden, met uitzondering van acute zorg, slechts toegankelijk is na verwijzing door in die overeenkomst aangewezen categorieën zorgaanbieders, waaronder in ieder geval de huisarts.
+  - index: 2
+    label: lid 3
+    sha256: f1ba647f75a352de5e9a99ebc4a18cc2d356f183c62a23b38e05e77c270e19d7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Dit lid is nog niet in werking getreden.
+  - index: 3
+    label: lid 4
+    sha256: c19e37f630d5c7d6ef2cd7a184dd1057e669fc087aca8fc5a5f69e8610a7275b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Dit lid is nog niet in werking getreden.
+- number: 14a
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6d14d98f0627b6fa077ae429d65e484309ac7cb090069ac075a080d53a24959a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 14a Dit onderdeel is nog niet inwerking getreden
+- number: '15'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 15e021ef50eb1d481d9220cd766f7a59b5c166e0caaef6f4bed78e4094c1817c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 15 1 De [artikelen 941, eerste lid](jci1.3:c:BWBR0005290&artikel=941) , en [957 van Boek 7 van het Burgerlijk Wetboek](jci1.3:c:BWBR0005290&artikel=957) zijn niet van toepassing.
+  - index: 1
+    label: lid 2
+    sha256: f7c0d8824462ed8e7ed4d31224d8992a8621122c07334b82f29cd561cba0dda7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Zonodig in afwijking van [artikel 952 van Boek 7 van het Burgerlijk Wetboek](jci1.3:c:BWBR0005290&artikel=952) is de zorgverzekeraar niet bevoegd een verzekerde prestatie geheel of gedeeltelijk te weigeren indien het intreden van het verzekerde risico aan de verzekerde is te wijten.
+- number: '16'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4e92385ac0c2cfb67f09d1506dc16c8cd6ccf5e986e86f8c41341b9b72c06afe
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 16 1 Krachtens de zorgverzekering is de verzekeringnemer premie verschuldigd.
+  - index: 1
+    label: lid 2
+    sha256: 1a5cf4ac6718787cabaab2f2d1c0e0c5226a44cd6cf699c2fab29ce006c39a30
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In afwijking van [artikel 925 van Boek 7 van het Burgerlijk Wetboek](jci1.3:c:BWBR0005290&artikel=925) en van het eerste lid is voor een verzekerde tot de eerste dag van de kalendermaand volgende op de kalendermaand waarin hij de leeftijd van achttien jaar heeft bereikt, geen premie verschuldigd.
+- number: '17'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d189539ebc425ab12faa6f8e6f50c8638b62a8537edb3ca4c4f2e0e58b446104
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 17 1 De zorgverzekeraar stelt voor iedere variant van de zorgverzekering die hij aanbiedt, de grondslag van de premie en de bij die variant behorende premiekorting of premiekortingen vast en neemt deze in de modelovereenkomst op.
+  - index: 1
+    label: lid 2
+    sha256: c02e7e25328cde2049c0647c581a96f27b529a2bcdb87dd1da184ff8508f779b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De grondslag van de premie is gelijk voor varianten die wat betreft de te verzekeren prestaties als bedoeld in artikel 11, eerste lid , of de keuzemogelijkheden tussen aanbieders van zorg of van overige diensten als bedoeld in dat lid, niet van elkaar verschillen.
+  - index: 2
+    label: lid 3
+    sha256: 7112d9b827f6711b715d96d54ddd3714cbcdff59805e43cfc8af6586591a54e4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien de zorgverzekeraar gebruik maakt van zijn bevoegdheid, bedoeld in artikel 11, vijfde lid , is de grondslag van de premie gelijk aan de grondslag die hij heeft of zou hebben vastgesteld voor een modelovereenkomst met volledige dekking.
+  - index: 3
+    label: lid 4
+    sha256: efba3dec74eee2ef2d69a6564ef5c423fb12090092771da77608d520420cdf04
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De grondslag van de premie is de premie indien geen premiekorting als bedoeld in artikel 18, vierde lid , of artikel 19 geldt of zou gelden.
+  - index: 4
+    label: lid 5
+    sha256: 7aacd5d9915dc14c8d7b0688d3225b82053f54cbe962a67c81acc0c7c2b5c7dd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De verschuldigde premie is gelijk aan de grondslag van de premie behorende bij de variant van de zorgverzekering die de verzekeringnemer gekozen heeft, verminderd met de premiekortingen, bedoeld in de artikelen 18, vierde lid , of 19 , indien deze van toepassing zijn.
+  - index: 5
+    label: lid 6
+    sha256: e5348cd9591a7645c93254b1b694590cdb3b4d77c166376e04d5b09db3f47165
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. De zorgverzekeraar geeft de wijze waarop de verschuldigde premie van de grondslag van de premie wordt afgeleid in de modelovereenkomst weer, en neemt de wijze waarop de door de verzekeringnemer verschuldigde premie van de grondslag van de premie is afgeleid in de zorgpolis op.
+  - index: 6
+    label: lid 7
+    sha256: cfd57536a9299d17c14a4d352683d373ffe02cd2e1b0f8841847b61d852d2b0f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. Een wijziging in de grondslag van de premie treedt niet eerder in werking dan met ingang van de eerste dag van de tweede kalendermaand volgende op de maand waarin deze aan de verzekeringnemer is medegedeeld.
+- number: '18'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6ed175ab1654048c6a53aafdec48b2e4afece6bef414b8a3e9247a07c8c20da2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 18 1 De zorgverzekeraar kan met een werkgever overeenkomen dat hij een geldelijk voordeel verstrekt indien diens werknemers of hun gezinsleden verzekerd worden op basis van een in die overeenkomst aan te wijzen modelovereenkomst.
+  - index: 1
+    label: lid 2
+    sha256: aa275742e73202892dcd4725ef51e2e3c360504cac65e457c670067a921eac1a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het voordeel bedraagt, per werknemer die of gezinslid dat op basis van de desbetreffende modelovereenkomst verzekerd wordt, niet meer dan 10% van de grondslag van de bij die modelovereenkomst behorende premie.
+  - index: 2
+    label: lid 3
+    sha256: b551072b4a3da5f19c727b78c255acffb47f95a4d0d684ad0cffbefbe4c64752
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. In de overeenkomst, bedoeld in het eerste lid, wordt ten minste bepaald:'
+  - index: 3
+    label: onderdeel a
+    sha256: 88f85434e88a291ed1a40f9d71fde5e675858e4ace73cf157011ecdca59ce8a6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de hoogte van het voordeel, waarbij die hoogte mag variëren al naar gelang het aantal volgens de desbetreffende modelovereenkomst verzekerde werknemers of gezinsleden;
+  - index: 4
+    label: onderdeel b
+    sha256: df2db2adfe9134bbd916af9b368bd742a0dec8d1cf840039d386220694f76106
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de verdeling van het voordeel over de werkgever en de volgens de desbetreffende modelovereenkomst verzekerde werknemers of gezinsleden.
+  - index: 5
+    label: lid 4
+    sha256: a07d7548d4849c57d31479269a191fb1ae8b621819768e418d3c3621edfc54aa
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Indien het voordeel of een deel daarvan aan de verzekeringnemer wordt verstrekt, geschiedt dit in de vorm van een korting op de grondslag van de premie.
+  - index: 6
+    label: lid 5
+    sha256: 508d3f4315dea571e56d2582ec9799e8f0a2b60de013694eece492bba506f7f2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Het eerste tot en met vierde lid zijn tevens van toepassing ten aanzien van een rechtspersoon, niet zijnde een werkgever, met betrekking tot de verzekering van natuurlijke personen wier belangen die rechtspersoon behartigt.
+  - index: 7
+    label: lid 6
+    sha256: d48dc1f2e444a7224796ad44ee0ac0853e068b5a61e2435b7d88c1859e5a6473
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Bij algemene maatregel van bestuur kunnen, om te voorkomen dat afbreuk wordt gedaan aan het sociale karakter van de verzekering, nadere en zonodig afwijkende regels worden gesteld.
+- number: '19'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: f12d21c2d8dc2198d2679e8db11a48c95bef131e61ae6c947fe752a666cc5645
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 19 1 De zorgverzekeraar biedt van iedere zorgverzekering met een bepaalde combinatie van te verzekeren prestaties als bedoeld in artikel 11, eerste lid , een variant zonder eigen risico aan.
+  - index: 1
+    label: lid 2
+    sha256: e2b1de5a09f0dcaa682e4ad40e7e0c7b1d88f073304c54704dd07a836f145b2e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De zorgverzekeraar kan voor de verzekering van een persoon van achttien jaar of ouder varianten van de zorgverzekering aanbieden met een eigen risico van € 100, € 200, € 300, € 400 of € 500 per kalenderjaar, waartegenover hij een korting op de grondslag van de premie verleent.
+  - index: 2
+    label: lid 3
+    sha256: f5e4bca35acf9e274ae4ac0e8b5e3bdc6f4c863ba759e75964843e9c056daa22
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. De korting mag afhangen van:'
+  - index: 3
+    label: onderdeel a
+    sha256: 591cfe441e6150b2b04337972d8cdd84bf0280f52e29269f571f5fbc3b14f458
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de omvang van het voor de verzekerde gekozen eigen risico;
+  - index: 4
+    label: onderdeel b
+    sha256: b17672bbb244db3ac096e8aafbeb403806e6aadcab2004562941b1aad68fe5c1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. het aantal kalenderjaren waarvoor een eigen risico voor de verzekerde gegolden heeft.
+  - index: 5
+    label: lid 4
+    sha256: db2f246bca6306aa5e625676cbb8657d379416cd710e6798e727c71330705eb8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De zorgverzekeraar neemt in zijn modelovereenkomst op welke premiekorting bij welk eigen risico voor welk aantal kalenderjaren geldt.
+  - index: 6
+    label: lid 5
+    sha256: 7b7c2773e956a0dde9c111af6e468b7059ff327bed9e34c8ac754a353d465d0c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Indien de zorgverzekeraar een of meer van de door hem aangeboden eigen risico’s laat vervallen, geeft de zorgverzekeraar de verzekeringnemers die een zorgverzekering met zo’n eigen risico hebben afgesloten, de mogelijkheid om te kiezen voor een zorgverzekering met een lager of zonder eigen risico.
+- number: '20'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d5f5c4ee0206beb6d667b14cc5f7e68b4f7bb7098d94e9cc10a9e859b54b63f3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 20 Bij algemene maatregel van bestuur kunnen vormen van zorg of overige diensten worden aangewezen waarvan de kosten tot een bij of krachtens die maatregel te bepalen bedrag buiten een eigen risico vallen.
+- number: '21'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 00a761a97bcb1d07343e4d2d9e8babcb6f766bc1efff3fa368c7cdf091c5fa26
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 21 1 Indien een zorgverzekering niet op 1 januari van een kalenderjaar ingaat of eindigt, is het in dat kalenderjaar voor die overeenkomst geldende bedrag van het eigen risico gelijk aan het voor het gehele kalenderjaar geldende bedrag, vermenigvuldigd met een breuk waarvan de teller gelijk is aan het aantal dagen in dat kalenderjaar waarover de zorgverzekering zal lopen of heeft gelopen, en de noemer aan het aantal dagen in het desbetreffende kalenderjaar.
+  - index: 1
+    label: lid 2
+    sha256: 5a37a11960791584be22a2894228db5aa3415b8024ea7b6aaffc0122ee32dba8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. In afwijking van het eerste lid wordt het in het kalenderjaar geldende bedrag van het eigen risico indien dat gedurende het kalenderjaar wijzigt en de verzekeringnemer onmiddellijk voorafgaande aan die wijziging reeds een zorgverzekering met de zorgverzekeraar had gesloten, als volgt berekend:'
+  - index: 2
+    label: onderdeel a
+    sha256: 77e1415f115765a60f1a4ab83494afdff8dcb5a977f1f80c1007d8e63c5dff99
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. ieder bedrag aan eigen risico dat in het desbetreffende kalenderjaar heeft gegolden of zal gelden, wordt vermenigvuldigd met het aantal in dat jaar gelegen dagen waarvoor dat risico gold of zal gelden;
+  - index: 3
+    label: onderdeel b
+    sha256: 2f1240571fadd1c6af9f32015f6daf5c86ea065fe1bbe589c925f305554056e5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de op grond van onderdeel a berekende bedragen worden bij elkaar opgeteld;
+  - index: 4
+    label: onderdeel c
+    sha256: db590b1daea103dccce9356d0e0b0967a044687dd860b5a79da086204693e4a5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. het op grond van onderdeel b berekende bedrag wordt gedeeld door het aantal dagen in het kalenderjaar.
+  - index: 5
+    label: lid 3
+    sha256: 577567dd716fbbfc7cfc5b47f093196b5cee54c38f02183c4b32819a3a276201
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het op grond van het eerste of tweede lid berekende bedrag wordt afgerond op hele euro’s.
+- number: '22'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 3a40b3d88a86092ffb58466f8e190379558b1aeef220c12aaf07ee9ac0a4aa72
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 22 1 Indien de waarde van de verzekerde prestaties die in een kalenderjaar ten behoeve van een verzekerde zijn verstrekt, lager is dan een bij algemene maatregel van bestuur te bepalen bedrag, heeft de verzekerde jegens de zorgverzekeraar recht op een bedrag, de no-claimteruggave, dat gelijk is aan het verschil tussen het bij de maatregel bepaalde bedrag en eerderbedoelde waarde.
+  - index: 1
+    label: lid 2
+    sha256: 330628d7f9dc813848a9207e485ed6036e9bf7d2f77722a82fd270528cefff85
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Geen recht op een no-claimteruggave hebben verzekerden voor wie geen premie verschuldigd is.
+  - index: 2
+    label: lid 3
+    sha256: 85e2f6f42f6d33481cf6dec26d3a60ed816ba7b4839914834ee19c269c9b43e1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien de zorgverzekering niet op 1 januari van een kalenderjaar is ingegaan respectievelijk is geëindigd en de verzekeringnemer niet direct voorafgaande aan de ingangsdatum respectievelijk direct volgende op de datum waarop de verzekering eindigde een zorgverzekering met de zorgverzekeraar had gesloten, dan wel indien voor de verzekerde gedurende het kalenderjaar premie verschuldigd is geworden, wordt het in het eerste lid bedoelde, bij algemene maatregel van bestuur te bepalen bedrag vermenigvuldigd met een breuk waarvan de teller gelijk is aan het aantal dagen in het kalenderjaar waarover de zorgverzekering liep dan wel premie verschuldigd was, en de noemer aan het aantal dagen in dat kalenderjaar.
+  - index: 3
+    label: lid 4
+    sha256: 68941e08781ddb300d77f6ef955f73a8645e998b5d7ecae6ba4dc8eec7e17266
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Indien het derde lid van toepassing is, wordt de no-claimteruggave berekend door van het ingevolge dat lid bepaalde bedrag af te trekken de waarde van de verzekerde prestaties, genoten vanaf respectievelijk tot de dag waarop de zorgverzekering inging respectievelijk eindigde, dan wel vanaf de dag waarop voor de verzekerde premie verschuldigd werd.
+  - index: 4
+    label: lid 5
+    sha256: aa01750bbac17c564861463aede950c3c1460201ad5ec57fd843d1969f6802fa
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '5. Bij algemene maatregel van bestuur wordt bepaald:'
+  - index: 5
+    label: onderdeel a
+    sha256: 4cb2417191f64bb9b48ea16f5cc90e87dd5e997097ad59ceb7aaf77a470b6f27
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. welke vormen van zorg of overige diensten in welke mate buiten beschouwing blijven bij het bepalen van de waarde van de verzekerde prestaties, bedoeld in het eerste en vierde lid;
+  - index: 6
+    label: onderdeel b
+    sha256: 17b429bf3cae9de59dfb1624502ae9a0ac2bf5afdcb2cbd2989c6b233cd66095
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. binnen welke termijn en op welke wijze de uitkering wordt betaald;
+  - index: 7
+    label: onderdeel c
+    sha256: 4dcf5b881e7beb89748f035ca075d5761c40b319c300de7e5552aaee96547d9d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. de gevolgen van het bekend worden van gebruik van zorg in een kalenderjaar waarvoor reeds uitbetaling van de uitkering heeft plaatsgevonden;
+  - index: 8
+    label: onderdeel d
+    sha256: f62c1a0135f2a047b91c5d97e084647b6ca98cc36899f99dca52f9dec91ab4ad
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. het indexcijfer waarmee het in het eerste lid bedoelde, bij algemene maatregel van bestuur te bepalen bedrag jaarlijks bij ministeriële regeling wordt herzien, alsmede de berekeningswijze en de afronding die bij die herziening worden gehanteerd.
+- number: '23'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 91cd41f3dc1295a19ad596321958c68cac622245ef6e026bfc934f2a60e4d5eb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 23 1 Kosten van zorg of een andere dienst worden toegerekend aan het kalenderjaar waarin de zorg of dienst is genoten, met dien verstande dat de kosten van zorg of een andere dienst die in twee achtereenvolgende kalenderjaren is genoten en door de zorgaanbieder of andere dienstverlener in één bedrag in rekening zijn gebracht, worden toegerekend aan het kalenderjaar waarin de zorg of dienst is aangevangen.
+  - index: 1
+    label: lid 2
+    sha256: 07eb7e173da890adc14a457979399e7b63f05e85bc34afaf97e4fd8eea330ef1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bedragen als bedoeld in artikel 11, derde of vierde lid , die voor rekening van de verzekerde komen, of kosten als bedoeld in artikel 13, eerste lid , voor zover zij voor rekening van de verzekerde blijven, worden bij de berekening van de no-claimteruggave en de beantwoording van de vraag of een voor zijn verzekering geldend eigen risico wordt overschreden, buiten aanmerking gelaten.
+  - index: 2
+    label: lid 3
+    sha256: 45e789b0b96559c99265a3c8d2febdfa2e6959521ac57987dc11b6c61c13ac55
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Een zorgverzekeraar brengt kosten van zorg of overige diensten slechts in mindering op een voor een bepaald kalenderjaar geldend eigen risico, voor zover deze het bij algemene maatregel van bestuur, bedoeld in artikel 22, eerste lid , voor dat kalenderjaar bepaalde bedrag, dan wel het op grond van artikel 22, derde lid , voor dat kalenderjaar berekende bedrag, hebben overschreden.
+- number: '24'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b57c953391a6927ca2ba2c8866517d0a74affeab8767e50aeb37a2026faf9e3a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 24 1 De rechten en plichten uit de zorgverzekering zijn van rechtswege opgeschort gedurende de periode waarover Onze Minister van Justitie in het kader van de uitvoering van een rechterlijke uitspraak verantwoordelijk is voor de verstrekking van geneeskundige zorg aan een verzekerde.
+  - index: 1
+    label: lid 2
+    sha256: f8e07826d2f2cb7c77caf1b56b7b100eb9bdaabeaca6aed9ac71f0f05abb9918
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De verzekeringnemer of de verzekerde meldt de zorgverzekeraar de dag waarop de periode, bedoeld in het eerste lid, aanvangt en eindigt.
+- number: '25'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b2a3616631b3f8d14130ff0ec2048bc626b6d963e462e996f7fc616e08c6ceb5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 25 1 Een verzekeraar meldt het voornemen zorgverzekeringen aan te bieden en uit te voeren schriftelijk aan het College toezicht, onder vermelding van de dag met ingang waarvan hij zorgverzekeringen zal aanbieden.
+  - index: 1
+    label: lid 2
+    sha256: b839d1d3847777c79347d4b387abea3bae3392ad2ca4f70b5f4b78bdcfe312ab
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De verzekeraar voegt bij de melding alle modelovereenkomsten volgens welke hij zorgverzekeringen wenst aan te bieden.
+  - index: 2
+    label: lid 3
+    sha256: e54c182f7db2ba25761f250359ed6dab7f4a6fe2d1d6fce073f89d9ad85d0a6e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Een zorgverzekeraar legt wijzigingen in zijn modelovereenkomsten of nieuwe modelovereenkomsten voordat deze ingaan aan het College toezicht over.
+- number: '26'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4eefbcb21b6341cb1e98baaa0704b99ea229816dd00b844e4906103a267f9f0e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 26 1 Het College toezicht tekent de datum van ontvangst aan op het geschrift waarmee de melding, bedoeld in artikel 25, eerste lid , is gedaan, alsmede op de modelovereenkomsten of wijzigingen daarvan, bedoeld in artikel 25, tweede en derde lid .
+  - index: 1
+    label: lid 2
+    sha256: bc4a6ad829906f054d249866b084df560c82ac3c2ede043721bce1fc69392e68
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het College toezicht zendt de verzekeraar onverwijld een bewijs van ontvangst, waarin die datum is vermeld.
+  - index: 2
+    label: lid 3
+    sha256: aa1ee77dae50ec6a151b10fa37fba9fcbd26599470e754d1deaba9167d73068e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het College toezicht zendt het College zorgverzekeringen onverwijld een afschrift van de melding, de modelovereenkomsten of de wijzigingen in de modelovereenkomsten, onder vermelding van de datum van ontvangst ervan.
+- number: '27'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2e752ebbd4f95c4f98459418c450b08f427ddf3ca6cd5a3bfc4224ff6458aa6c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 27 Een verzekeraar die ten onrechte een verzekering als zorgverzekering aanbiedt of uitvoert, is gehouden de schade die een verzekeringsplichtige of degene die hem heeft verzekerd dientengevolge lijdt, te vergoeden.
+- number: '28'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 7fc1221cddf0496f06773f3dbbe8d227ae7664a8f17d78e408edbe207c98d21d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 28 1 De statuten van een zorgverzekeraar:'
+  - index: 1
+    label: onderdeel a
+    sha256: 0a3513a417cc265414c0bb4d60b8cbfca13bd5607a5205ff611a554b96d13c2c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. voorzien in toezicht op het beleid van het bestuur en op de algemene gang van zaken in de rechtspersoon en de daarmee verbonden onderneming,
+  - index: 2
+    label: onderdeel b
+    sha256: f48c168b6ec4b83c1b2700508672d24f00342b64497ca75d7b813b7069839789
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. bieden waarborgen voor een redelijke mate van invloed van de verzekerden op het beleid, en
+  - index: 3
+    label: onderdeel c
+    sha256: 5f5fe63bcb7f604d51b0e915b2d4e6796df4fae6216f7da0e3dede9408dc9aef
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. sluiten iedere verplichting van de verzekeringnemers, verzekerden, gewezen verzekeringnemers of gewezen verzekerden tot het doen van een bijdrage in tekorten van de rechtspersoon uit.
+  - index: 4
+    label: lid 2
+    sha256: fefd579569b1d893a37777faefbf2e454383c7a989e2e5e845207c0cd0c680d5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij algemene maatregel van bestuur kunnen regels worden gesteld over de mate van invloed die verzekerden ten minste op het beleid van een zorgverzekeraar dienen te hebben.
+- number: '29'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: abdd8a94818979a73ce0322888643ef98c9e764a6298a8ea243bf0f74f85a365
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 29 1 Het werkgebied van een zorgverzekeraar is Nederland.
+  - index: 1
+    label: lid 2
+    sha256: fe726625d8939bdb8e1a2696415561d7cd3b95f7054b9fa9ea7f6dce7c905131
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In afwijking van het eerste lid kan een zorgverzekeraar zijn werkgebied tot een of meer gehele provincies van Nederland beperken zolang bij hem minder dan 850 000 verzekerden op basis van een zorgverzekering verzekerd zijn.
+  - index: 2
+    label: lid 3
+    sha256: eca24e9f9b9d14a46ace6727ab54ca0b80e2a9a486c1356a13f7137618410290
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Voor de bepaling van het aantal verzekerden, bedoeld in het tweede lid, wordt uitgegaan van het gemiddelde aantal verzekerden in het tweede jaar voorafgaande aan het jaar waarvoor de bepaling geschiedt.
+  - index: 3
+    label: lid 4
+    sha256: b8be44c294afb172811360333cd89e0f972502258db64bca1f96b4b3359e05d2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij ministeriële regeling kunnen regels worden gesteld over de wijze waarop het aantal verzekerden wordt bepaald indien de zorgverzekeraar in het tweede of eerste jaar voorafgaande aan het jaar waarvoor de bepaling geschiedt, rechtsopvolger is geweest van, gefuseerd is met, of afgesplitst is van een andere zorgverzekeraar dan wel indien deze verzekeraar zorgverzekeringen van een andere zorgverzekeraar heeft overgenomen.
+- number: '30'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6034a384f27b97a6024b71af6f244ca9d627e12c7c982f79682ced40333d81c4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 30 1 Een zorgverzekeraar die geen zorgverzekeringen meer wenst aan te bieden of uit te voeren, meldt het voornemen hiertoe schriftelijk aan het College toezicht, onder vermelding van de dag met ingang waarvan hij geen zorgverzekeringen meer zal uitvoeren.
+  - index: 1
+    label: lid 2
+    sha256: 85494f5c04d717f8a74bac1ea3aab59e4138fce48ca85149babc74842b382f3e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Artikel 26 is van overeenkomstige toepassing.
+- number: '31'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a1ed7c32bbe48ca79fbeee064c4b4d1be1560516532bb482876702caac241345
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 31 1 Indien krachtens [hoofdstuk IX van de Wet toezicht verzekeringsbedrijf 1993](jci1.3:c:BWBR0006509&hoofdstuk=IX) jegens een zorgverzekeraar of een voormalige zorgverzekeraar de noodregeling is uitgesproken of een voormalige zorgverzekeraar failliet is verklaard, voldoet het College zorgverzekeringen aan de verzekerden jegens die zorgverzekeraar of voormalige zorgverzekeraar bestaande vorderingen ter zake van een recht op vergoeding als bedoeld in artikel 11, eerste lid, onderdeel b , of artikel 13 .
+  - index: 1
+    label: lid 2
+    sha256: 35792d1a954cf14d81eaf55e18773e22a65e4da778c330c33eebbde458992a7f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De vorderingen, bedoeld in het eerste lid, gaan bij wijze van subrogatie op het College zorgverzekeringen over voor zover dat college deze heeft voldaan.
+  - index: 2
+    label: lid 3
+    sha256: df60b3b0db55a43b59235194f2f2ff9c590d83060fb5e59db4ae03ac45f6341c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het Rijk is tegenover het College zorgverzekeringen aansprakelijk voor de betalingen, bedoeld in het eerste lid.
+- number: '32'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 70014bd2de313f494477b23cbdbf03c97e3812fe0a9c50c44f94ccefc173f313
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 32 1 Het College zorgverzekeringen kent een zorgverzekeraar die voldaan heeft aan zijn verplichtingen, bedoeld in artikel 25 , voor ieder kalenderjaar waarin hij zorgverzekeringen aanbiedt en uitvoert een bijdrage toe.
+  - index: 1
+    label: lid 2
+    sha256: 5b2a93af13b2b6fd0016c04f524a6261162d95de7e70e9d9126cca143dd46d0d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij algemene maatregel van bestuur worden regels omtrent de berekening van de bijdragen gesteld.
+  - index: 2
+    label: lid 3
+    sha256: b569af0c2dbaf8610691339af731a42003a596fb525dd770582c590c1acbf478
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De regels, bedoeld in het tweede lid, bepalen ten minste dat de hoogte van de bijdrage wordt berekend op basis van bij die maatregel te bepalen, voor alle zorgverzekeraars gelijke criteria, waaronder in ieder geval het aantal verzekerden bij een zorgverzekeraar en een aantal verzekerdenkenmerken.
+  - index: 3
+    label: lid 4
+    sha256: dfcb3247398ee001c7b9e9e0d1efe29d7d0e86c0de1b294da6b060e54cad3b07
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. Bij ministeriële regeling:'
+  - index: 4
+    label: onderdeel a
+    sha256: 3770a49918f7a60e5f86e1de7d89770fe7220e8f01cd8c241051e218b82619cc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. wordt voor 1 oktober van ieder jaar bepaald welk bedrag in totaal voor het daaropvolgende kalenderjaar aan de zorgverzekeraars kan worden toegekend;
+  - index: 5
+    label: onderdeel b
+    sha256: 1bbec4d359b4fb7d8eef7bc5386efa3074576f4b2586bb6892360494fb6ee150
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. kan worden bepaald dat in aanvulling op de criteria, bedoeld in het derde lid, voor de berekening van de hoogte van de bijdragen eenmalig rekening wordt gehouden met een bij die regeling te bepalen, voor alle zorgverzekeraars gelijk criterium;
+  - index: 6
+    label: onderdeel c
+    sha256: 45dedc3b6e8a275ce9766580e565d4beaf01e2fd8aec54a56aa808836b0438aa
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. wordt statistisch onderbouwd aan elk criterium als bedoeld in het derde lid of aan een criterium als bedoeld in onderdeel b een bijdrage gekoppeld;
+  - index: 7
+    label: onderdeel d
+    sha256: b9ea9044c26b309f389940eab09d67c3f945d9fdc9560062956517ba590a2270
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. worden nadere regels omtrent de berekening van de bijdragen gesteld en wordt geregeld hoe de op grond van het eerste lid toegekende bijdragen door het College zorgverzekeringen worden betaald.
+  - index: 8
+    label: lid 5
+    sha256: ed1fd7fb72099b17f91d4651e069741bda4eca9fc702b2453dcb66b5908d956a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Het College zorgverzekeringen stelt jaarlijks voor 15 oktober beleidsregels vast waarin wordt aangegeven op welke wijze toepassing wordt gegeven aan de in het vierde lid bedoelde regels.
+  - index: 9
+    label: lid 6
+    sha256: f8d8f437b4510d382a6c88a0a6bacd36346c3b00312cbffc30e37aab87766176
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. De toekenning, bedoeld in het eerste lid, geschiedt voor 1 november van het jaar voorafgaande aan het jaar waarvoor de bijdrage wordt gegeven.
+  - index: 10
+    label: lid 7
+    sha256: 5ed1ddb60b1bedf5b17e792dcfbd1bfa8c2e30a86fd946342eebaf32b741d43d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. De beleidsregels, bedoeld in het vijfde lid, behoeven de goedkeuring van Onze Minister.
+- number: '33'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 54b094f63c8016cc8aed1eb3f6f008232d0f76fe31f694a5859d9d90c3c0801c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 33 1 Bij ministeriële regeling kunnen, ingeval van een kernexplosie of natuurramp, of andere buitengewone gebeurtenissen die niet tot het normale bedrijfsrisico van zorgverzekeraars kunnen worden gerekend, na aanvang van het kalenderjaar middelen voor bijdragen aan een of meer zorgverzekeraars beschikbaar worden gesteld.
+  - index: 1
+    label: lid 2
+    sha256: ec313b6208f159c715393cf0fbfdcd927891c7376521c8442e9322828fa2f167
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het College zorgverzekeringen kent de bijdragen aan de bij de ministeriële regeling aangewezen zorgverzekeraars toe.
+  - index: 2
+    label: lid 3
+    sha256: 060937566a04f023f95f3e30eff5a62100307ec819bd6c23f6f25444d17ac83f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij ministeriële regeling worden regels omtrent de berekening van de bijdragen gesteld en wordt geregeld hoe de toegekende bijdragen door het College zorgverzekeringen worden betaald.
+  - index: 3
+    label: lid 4
+    sha256: dc62f3f86538c41fc9e9af472da06bd24a3a504b2208a531985b100923f81f44
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Artikel 32, vijfde en zevende lid , zijn, met uitzondering van de in het vijfde lid genoemde datum, van overeenkomstige toepassing.
+- number: '34'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 43642b78d77887a39ac5aabf732aa964cb7dc21ccec7bda1e28c8322a6ad5b44
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 34 1 Uiterlijk in het tweede jaar volgende op het kalenderjaar waarvoor de bijdragen, bedoeld in artikel 32 en 33 , zijn toegekend, stelt het College zorgverzekeringen de bijdrage vast.
+  - index: 1
+    label: lid 2
+    sha256: d6d75fd147be66fd775a773269fea81d35604be94cd11ab67726d6b5df1138bf
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De vaststelling van een bijdrage als bedoeld in artikel 32 , houdt in ieder geval in een herberekening van de bijdrage op basis van het werkelijke aantal verzekerden dat de zorgverzekeraar in het desbetreffende jaar had en de werkelijke verdeling van de verzekerdenkenmerken als bedoeld in artikel 32, derde lid , over die verzekerden, voor zover de daartoe benodigde gegevens tijdig bij het College zorgverzekeringen zijn aangeleverd.
+  - index: 2
+    label: lid 3
+    sha256: f0b975e065aef7e016cfb19ed99a471c467829503ab0105b6a39f7ac61d50ab5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij of krachtens algemene maatregel van bestuur worden nadere regels omtrent de berekening van de bijdragen gesteld, met dien verstande dat generieke verevening slechts tot en met 31 december 2010 mogelijk is.
+  - index: 3
+    label: lid 4
+    sha256: dcf08a5deb3ae9b87d0128b76248c6d08d46ef687b97bb57b95a58da8ac236c1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het College zorgverzekeringen stelt beleidsregels op waarin wordt aangegeven op welke wijze toepassing wordt gegeven aan de in het derde lid bedoelde regels en op welke wijze een vergoeding voor rentekosten wordt verleend respectievelijk in rekening wordt gebracht.
+  - index: 4
+    label: lid 5
+    sha256: 687285a5be9aea70f1998f56775e668ba41960835b985064216c5a977a8d12a6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Indien de vastgestelde bijdrage hoger is dan de toegekende bijdrage betaalt het College zorgverzekeringen de zorgverzekeraar of diens rechtsopvolger het verschil, vermeerderd met de rentekosten, en indien de vastgestelde bijdrage lager is dan de toegekende bijdrage vordert het College zorgverzekeringen het verschil, vermeerderd met de rentekosten, van de zorgverzekeraar of diens rechtsopvolger terug.
+  - index: 5
+    label: lid 6
+    sha256: 0e8bbff02e7ab3a7607f1aaf07bb7deaf3fe08b942c3d58ab6dd1f8ec4854d4f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Het College zorgverzekeringen is bevoegd het bedrag dat na toepassing van het eerste en vijfde lid aan de zorgverzekeraar dient te worden betaald respectievelijk van de zorgverzekeraar dient te worden teruggevorderd, te verrekenen met een toekenning van een bijdrage als bedoeld in artikel 32 of 33 over een later jaar.
+- number: '35'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: dd1419edb85e0290d3eeaa820105060546ccb830fa935ba0c32b0db24fed655b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 35 1 Het College zorgverzekeringen draagt zorg voor het inrichten en in stand houden van een administratie, waarin van iedere verzekerde wordt opgenomen:'
+  - index: 1
+    label: onderdeel a
+    sha256: d45507bf20469c6fc8e58bd65605d2f0bef87834868951cf72c7562a3355705b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. het sociaal-fiscaalnummer;
+  - index: 2
+    label: onderdeel b
+    sha256: 4d8dbbc141dc422ec55ecbd8d65ac2f87083651da1ff858a33ca0572c019f281
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de zorgverzekeraar waarbij de verzekerde verzekerd is;
+  - index: 3
+    label: onderdeel c
+    sha256: f62fb7f703f7c69ec97f84554e2b17c09c24be287f5e140f8fe758398a4560e5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. de persoonsgegevens, waaronder persoonsgegevens betreffende de gezondheid als bedoeld in de [Wet bescherming persoonsgegevens](jci1.3:c:BWBR0011468) , die noodzakelijk zijn voor de berekening van aan de zorgverzekeraar toekomende bijdragen als bedoeld in de artikelen 32 tot en met 34 .
+  - index: 4
+    label: lid 2
+    sha256: a73c469a480b2bc31f053bd0a3da885f7b49eb8f6fcf7dd05fad2c5325a5f3f2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De zorgverzekeraar meldt het College zorgverzekeringen, onder vermelding van de ingangsdatum ervan, iedere door hem gesloten zorgverzekering, alsmede, indien de zorgverzekering is geëindigd, de datum waarop deze eindigde.
+  - index: 5
+    label: lid 3
+    sha256: 7f85ca52bd9f756d83e50c599a69fc9dee1c6b59abf3d41678af278cdb8dccf5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien het College zorgverzekeringen constateert dat een verzekerde bij twee of meer zorgverzekeraars verzekerd is, stelt hij de betrokken zorgverzekeraars daarvan, onder vermelding van de namen van alle zorgverzekeraars waarbij de verzekerde verzekerd is, terstond op de hoogte.
+  - index: 6
+    label: lid 4
+    sha256: deb091602e4ebdbc07cd309dbfe81fc8dbb92744901a2130932b37a4de2bd76f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. Bij ministeriële regeling kunnen:'
+  - index: 7
+    label: onderdeel a
+    sha256: 535fbc43d69dd8c6a8eb914281002da7f9970071e4f6d3f4e6284dc5ed4740f2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. regels worden gesteld over de in de administratie van het College zorgverzekeringen op te nemen persoonsgegevens als bedoeld in het eerste lid, onderdeel c;
+  - index: 8
+    label: onderdeel b
+    sha256: b909ea9dcb6eba5af318bbaf3bc8d41cbc97d6950be19c256bb541fe1a7b03fa
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. regels worden gesteld over de inrichting van de administratie van het College zorgverzekeringen, bedoeld in het eerste lid.
+- number: '36'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 0a329fba9dfbadc995acc6730e43f39152cc87eb03d433a3c8c7ac38a289f46b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 36 Op rechten of verplichtingen die voortvloeien uit hetgeen in deze paragraaf geregeld is, is [titel 4.2 van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&titeldeel=4.2) niet van toepassing.
+- number: '37'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: db91521e81557a8d8269b9f22d725616477637283cc80d18c5ac131363b5ebdc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 37 1 De zorgverzekeraar zendt binnen zes maanden na afloop van het boekjaar twee exemplaren van zijn jaarrekening en van zijn jaarverslag aan het College toezicht.
+  - index: 1
+    label: lid 2
+    sha256: 22b0ebfcf607b1bbdd826d0d1a32a5445f61ea27dbdde9a18f213052be3bcd63
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Een zorgverzekeraar die [artikel 403 van Boek 2 van het Burgerlijk Wetboek](jci1.3:c:BWBR0003045&artikel=403) toepast, zendt de jaarrekening, het jaarverslag en de geconsolideerde jaarrekening onverwijld na de neerlegging van het jaarverslag en de geconsolideerde jaarrekening ten kantore van het handelsregister, in tweevoud aan het College toezicht.
+  - index: 2
+    label: lid 3
+    sha256: fbefe1cdea6856530f873ce6e4dfd9e010554d628dc4fe898a85307a0b59ef56
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De zorgverzekeraar voegt bij de stukken, bedoeld in het eerste of tweede lid, twee afschriften van de accountantsverklaringen die hij op grond van het Burgerlijk Wetboek of de [Wet toezicht verzekeringsbedrijf 1993](jci1.3:c:BWBR0006509) over deze stukken dient te laten opstellen.
+  - index: 3
+    label: lid 4
+    sha256: 477526cce902bf5fd51d70df7a4976806331fe5647002edd62915febb1b4f4fd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het College toezicht zendt het College zorgverzekeringen onverwijld één exemplaar van de in het eerste tot en met derde lid bedoelde stukken.
+- number: '38'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c3b2033bff0b15bc1a1818dccc385733300fa1863b4199a787c8dbc64caeb1c8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 38 1 De zorgverzekeraar zendt voor 1 juli aan het College toezicht in tweevoud een uitvoeringsverslag waarin hij:'
+  - index: 1
+    label: onderdeel a
+    sha256: 099ea8ba4ad6f102f612da41a8fc1e428bea40d189a964cda9b099ca9a403c0b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. rapporteert over de uitvoering van deze wet in het voorafgaande kalenderjaar, en
+  - index: 2
+    label: onderdeel b
+    sha256: 0b1476d6e38a14d4a0935dec39d8602ad7de66ce3e48646cf6d917e943e60a60
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. een overzicht geeft van zijn voornemens met betrekking tot de uitvoering van deze wet in het lopende kalenderjaar en het daaropvolgende kalenderjaar.
+  - index: 3
+    label: lid 2
+    sha256: cf7138800b16338df2341e818a370d341931cb143b3ce00bf5dd1a4e63bb7d73
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij ministeriële regeling kunnen nadere voorschriften worden gesteld omtrent de inhoud van het uitvoeringsverslag.
+  - index: 4
+    label: lid 3
+    sha256: a3ef278bc0311a69fcabe6fe5bf8a348a0d152e14ff4ed5645b1a2d309a31aea
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De voorschriften, bedoeld in het tweede lid, kunnen in het bijzonder betrekking hebben op naleving van een in de regeling aan te wijzen gedragscode.
+  - index: 5
+    label: lid 4
+    sha256: 234b09bd41402b7df6810b8e119c4dda469016c17665c389aae3922ae220a70a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. De zorgverzekeraar voegt bij het uitvoeringsverslag twee exemplaren van een verslag met bevindingen van een accountant als bedoeld in [artikel 393 van Boek 2 van het Burgerlijk Wetboek](jci1.3:c:BWBR0003045&artikel=393) over de vraag of:'
+  - index: 6
+    label: onderdeel a
+    sha256: 519ceea4dc25af79bd089cb7513e52aca9619497be76c32e1c2c6bf016783e03
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. het uitvoeringsverslag overeenkomstig de daarvoor geldende regels is opgesteld;
+  - index: 7
+    label: onderdeel b
+    sha256: 912cbbf0ca2f98d3ff3b947d3f5c393c155d9886fb64cbb712dc9c98e594d249
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de uitvoering is geschied overeenkomstig de verplichtingen die bij of krachtens deze wet in het voorafgaande kalenderjaar op de zorgverzekeraar rustten.
+  - index: 8
+    label: lid 5
+    sha256: 643315c3fe4f1b740dcf2e908b9a345db3d659f0148270b589b93daf6424cad5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Artikel 37, vierde lid , is van overeenkomstige toepassing.
+- number: '39'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a99f9b510ed0c1e154e9a10a66f9195bc7158ba55e7c4ae5c0ad9e93cb327c31
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 39 1 Er is een Zorgverzekeringsfonds.
+  - index: 1
+    label: lid 2
+    sha256: 8c85bec4aac99c0ab8f7f0169cc5a096d60182f97ab47bfeeae47a47f3194c1c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Ten gunste van het Zorgverzekeringsfonds komen:'
+  - index: 2
+    label: onderdeel a
+    sha256: f969380c121d6b6891c250577ade6758201760238563b950be71e892c33c8e73
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de inkomensafhankelijke bijdragen, bedoeld in paragraaf 5.2 , alsmede de daarmee verband houdende bestuurlijke boeten en renten;
+  - index: 3
+    label: onderdeel b
+    sha256: daaa765d8d38e5e5d815dfe04f0eab9c8b6c6ec4f7e3367b25e077d05f4fc6bf
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de rijksbijdrage, bedoeld in artikel 54 ;
+  - index: 4
+    label: onderdeel c
+    sha256: 461d010b03e6c298fd4fb502ebfa3fb18063534e2372cf4feb5bdb1cbde08e53
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. een rijksbijdrage als bedoeld in de artikelen 55 of 56 ;
+  - index: 5
+    label: onderdeel d
+    sha256: 0ed73e95c812af8d70f5fadd67c840393ce568a87a9ef18ececb34e2f14b6382
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'd. een bedrag van iedere rekening, bedoeld in artikel 70 , gelijk aan:'
+  - index: 6
+    label: tekst
+    sha256: d291818333f96e99b0f37d547a74b43e071e8046c5ffcbab0c0a0c27e1c8b80f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1°. jaarlijks: de helft van de bijdragevervangende belastingen die degenen wier bijdragevervangende belastingen op die rekening werden gestort, over het voorafgaande kalenderjaar gezamenlijk verschuldigd waren, of zoveel minder als het saldo bedraagt;'
+  - index: 7
+    label: tekst
+    sha256: 0245ac00012bccc4ced95923d3cadde8b52af80662176988cc2104ee55d7cbc7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2°. voor iedere tot een huishouding als bedoeld in artikel 70, tweede lid , behorende gemoedsbezwaarde die alsnog verzekeringsplichtig wordt dan wel overlijdt: het saldo van de rekening gedeeld door het aantal tot de huishouding behorende gemoedsbezwaarden;'
+  - index: 8
+    label: tekst
+    sha256: d011b0a5b21fa3726906bca8501e37441f9e749c6601523a44811351f07ee02e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3°. indien de rekening met toepassing van artikel 70, achtste lid , wordt opgeheven: het saldo van de rekening;'
+  - index: 9
+    label: tekst
+    sha256: d291818333f96e99b0f37d547a74b43e071e8046c5ffcbab0c0a0c27e1c8b80f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '1°. jaarlijks: de helft van de bijdragevervangende belastingen die degenen wier bijdragevervangende belastingen op die rekening werden gestort, over het voorafgaande kalenderjaar gezamenlijk verschuldigd waren, of zoveel minder als het saldo bedraagt;'
+  - index: 10
+    label: tekst
+    sha256: 0245ac00012bccc4ced95923d3cadde8b52af80662176988cc2104ee55d7cbc7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2°. voor iedere tot een huishouding als bedoeld in artikel 70, tweede lid , behorende gemoedsbezwaarde die alsnog verzekeringsplichtig wordt dan wel overlijdt: het saldo van de rekening gedeeld door het aantal tot de huishouding behorende gemoedsbezwaarden;'
+  - index: 11
+    label: tekst
+    sha256: d011b0a5b21fa3726906bca8501e37441f9e749c6601523a44811351f07ee02e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3°. indien de rekening met toepassing van artikel 70, achtste lid , wordt opgeheven: het saldo van de rekening;'
+  - index: 12
+    label: onderdeel e
+    sha256: 4278e39bbd0e142a13bcd8221b1ed74261e14d0be18be1a815c54bbb9642726d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: e. aan het College zorgverzekeringen betaalde bedragen ter gehele of gedeeltelijke voldoening van vorderingen als bedoeld in artikel 31, tweede lid ;
+  - index: 13
+    label: onderdeel f
+    sha256: 51859c3610ff4614aa9589435532595530724c04e5e1f4f3f30f81030982edd3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: f. de bijdragen en boeten, bedoeld in artikel 69 ;
+  - index: 14
+    label: onderdeel g
+    sha256: c903c8b1668e3fe595f0c996315920093a0a8de5d670bc7335a4b2e6af65c8a4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: g. de inkomsten die in verband met deze wet voortvloeien uit internationale overeenkomsten;
+  - index: 15
+    label: onderdeel h
+    sha256: 448a8ef36903a29da7d673c39be1b9ba220cb9f3339aab5122c43db6cd9445c3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: h. door het College toezicht van verzekeraars geïnde dwangsommen, alsmede ingevorderde boeten als bedoeld in de artikelen 96 tot en met 100 , wat betreft de boeten, bedoeld in artikel 96 , nadat deze zijn verminderd met de in het zesde lid van dat artikel bedoelde vergoeding.
+  - index: 16
+    label: lid 3
+    sha256: b3adfa10e85b279c340aea3d7300a59c8cebe79874d2e049e9edfef131784206
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Ten laste van het Zorgverzekeringfonds komen:'
+  - index: 17
+    label: onderdeel a
+    sha256: 1472d25017e30f65ef78c19af64a5937eae29c84056c97d0291da46aaa68f398
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de bijdragen, bedoeld in de artikelen 32 , 33 en 34 ;
+  - index: 18
+    label: onderdeel b
+    sha256: bf5a30d5236f2dd1735d3908c02c9ae53363b4f89f5d767c7d8b0155be1781fa
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. subsidies als bedoeld in artikel 68 , inclusief vergoedingen als bedoeld in het tweede lid van dat artikel ;
+  - index: 19
+    label: onderdeel c
+    sha256: 24f55de8b6971b4779b264474721e730e24350ae1ae619e91e105fe6d90c01a4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. door het College zorgverzekeringen voldane vorderingen als bedoeld in artikel 31, eerste lid ;
+  - index: 20
+    label: onderdeel d
+    sha256: 440cfddf3c66c0c17431fc25bf638c585e7846d5e597c69ee76000f970d58491
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. uitgaven in verband met molest als bedoeld in artikel 55 , inclusief vergoedingen als bedoeld in het derde lid van dat artikel ;
+  - index: 21
+    label: onderdeel e
+    sha256: c4a5c06f59466b16d7e97bdebfe00a807003a4d891666e37d399941c28fb684d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: e. de uitgaven die in verband met deze wet voortvloeien uit internationale overeenkomsten.
+  - index: 22
+    label: lid 4
+    sha256: b2f0944316d187429ba61655c724eef22af209600ac78a011456bc398d8e6d57
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Uit het Zorgverzekeringsfonds worden, volgens bij ministeriële regeling te stellen regels, middelen gebruikt voor het vormen en in stand houden van een voor de doelstelling van het fonds noodzakelijke reserve.
+- number: '40'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 333f5b7f69bae92090ff454410c39cda362171c1f5d738fabbfa3777d4cf1700
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 40 1 Het College zorgverzekeringen beheert en administreert afzonderlijk het Zorgverzekeringsfonds.
+  - index: 1
+    label: lid 2
+    sha256: 31f99f2c0a7a232eb4fdecc2d574bcddcfdc39c1f6b09991dede29f0d89fd13e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het College zorgverzekeringen houdt de financiële middelen die deel uitmaken van het Zorgverzekeringsfonds, in rekening-courant bij Onze Minister van Financiën.
+  - index: 2
+    label: lid 3
+    sha256: b018e3f167fc200d0b74ad8096a4e5344f1a96aac419af97d5782b45462e6132
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het College zorgverzekeringen kan, voor de uitvoering van zijn wettelijke taken, beschikken over de financiële middelen die hij in rekening-courant bij Onze Minister van Financiën aanhoudt.
+  - index: 3
+    label: lid 4
+    sha256: e2d7345329ec80d247552f5053170c560ec17a644c50bbf26da417d6e34ee72a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. In afwijking van het tweede lid kan het College zorgverzekeringen een deel van de in dat lid bedoelde financiële middelen buiten de in dat lid bedoelde rekening-courant houden.
+  - index: 4
+    label: lid 5
+    sha256: e693bf7c2f18b98c20552855d181b4ae2c0c7815f5c044701732489d9d3d2111
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Onze Minister stelt in overeenstemming met Onze Minister van Financiën, na overleg met het College zorgverzekeringen, de omvang van het in het vierde lid bedoelde deel van de financiële middelen vast.
+  - index: 5
+    label: lid 6
+    sha256: db69ad90b53bab4845477e37e5d175dac403c0e91b3db1c45ab2d8a4516835a1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Bij een tekort aan financiële middelen maakt het College zorgverzekeringen uitsluitend gebruik van de kredietfaciliteiten die door Onze Minister van Financiën worden verleend.
+  - index: 6
+    label: lid 7
+    sha256: 15da5225b2b4480e3b663e4484d3c98b7e86166c9442b57097a328c7c0acf1f0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '7. Onze Minister van Financiën informeert dagelijks het College zorgverzekeringen ten aanzien van de rekening-courant, in elk geval met betrekking tot:'
+  - index: 7
+    label: onderdeel a
+    sha256: 282e2a01b6a8cd9ab623466746d6516be7d8b4940127b5cd4d4cb040416587e8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de slotstanden per dag;
+  - index: 8
+    label: onderdeel b
+    sha256: 73e859cd52b92103cebd93ee30e93440d6afcf94b9309f00f174bd0dad46603f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. alle dagelijks geboekte mutaties of transacties in de rekening-courant.
+  - index: 9
+    label: lid 8
+    sha256: c0708186e89db571f3b7984af5fbfedde755ee7638303447348abff7a4acaa5c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 8. Het College zorgverzekeringen informeert Onze Minister van Financiën ten aanzien van de rekening-courant in elk geval met betrekking tot de prognoses van de saldi van de rekening-courant.
+  - index: 10
+    label: lid 9
+    sha256: 69a04b7cef8ff743b8a0c893db9fa5813249b9884dd21f6dc5a82593004991dd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 9. Onze Minister van Financiën brengt voor het beheer van de rekening-courant geen kosten in rekening.
+  - index: 11
+    label: lid 10
+    sha256: 26c7c3bd38ac4e278b6520910f065f60fd9d9337d5f63baab98301525c1b90ba
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 10. Onze Minister stelt in overeenstemming met Onze Minister van Financiën, na overleg met het College zorgverzekeringen, regels omtrent de rente die over de saldi van de in het tweede lid bedoelde rekening-courant wordt vergoed onderscheidenlijk in rekening wordt gebracht.
+  - index: 12
+    label: lid 11
+    sha256: 4b174d385ab71fc1c0f2b4aaa943d220b86579c649f59458729cdad8f966e7e1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 11. Onze Minister kan in overeenstemming met Onze Minister van Financiën, na overleg met het College zorgverzekeringen, regels stellen omtrent het tweede, zevende en achtste lid.
+- number: '41'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 027d17f56a2ed54caf3b6651428ab76f3cc34cf1f46ae1ffeca20a611128fb43
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 41 De verzekeringsplichtige is een inkomensafhankelijke bijdrage verschuldigd.
+- number: '42'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2f81febd5ea74cbdc2ad732a5e76c80ab51662ab5ac4f041bd77ab8a3ec00c1b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 42 De inkomensafhankelijke bijdrage over een jaar wordt geheven over het bijdrage-inkomen van dat jaar.
+- number: '43'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4ba82f97517900234672f4950026554cdbdd85f870d904363d61191b18a1bc09
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 43 1 Het bijdrage-inkomen van een jaar is het gezamenlijke bedrag van hetgeen door de verzekeringsplichtige in dat jaar is genoten aan:'
+  - index: 1
+    label: onderdeel a
+    sha256: fc5cb68ee38e84fd9edaebb1e05f44165ae61d29d0e1a511834dd9f22dcfa5fd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. belastbaar loon overeenkomstig de wettelijke bepalingen van de loonbelasting, verminderd met de ingevolge artikel 46 genoten vergoeding en met uitzondering van loon als bedoeld in [artikel 31, eerste lid, onderdelen b tot en met h, van de Wet op de loonbelasting 1964](jci1.3:c:BWBR0002471&artikel=31) waarover de belasting op grond van [artikel 27a, eerste lid, van die wet](jci1.3:c:BWBR0002471&artikel=27a) is verschuldigd door de inhoudingsplichtige en het hierdoor voor de werknemer in de zin van [die wet](jci1.3:c:BWBR0002471) ontstane voordeel, en vermeerderd met loon, bepaald volgens de regels van [artikel 3.82 van de Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353&artikel=3.82) ;
+  - index: 2
+    label: onderdeel b
+    sha256: dfbc3273ef98e7d675a79d57013dab7ee4eb152a2a833f518bc943d5050c72c2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. belastbare winst uit onderneming, bepaald volgens de regels van [afdeling 3.2 van de Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353&afdeling=3.2) ;
+  - index: 3
+    label: onderdeel c
+    sha256: d3b54a2e9e2c1cf565b6a4f38539a5f5b0ac8b16755038a331201141939ea88d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. belastbaar resultaat uit overige werkzaamheden, bepaald volgens de regels van [afdeling 3.4 van de Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353&afdeling=3.4) , met uitzondering van de in de [artikelen 3.91](jci1.3:c:BWBR0011353&artikel=3.91) en [3.92 van de Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353&artikel=3.92) bedoelde werkzaamheden;
+  - index: 4
+    label: onderdeel d
+    sha256: a85ff1334ce0d446b4196417e4d8d1882e3c2039ef2df0260fa3d2f5c4c957cd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. belastbare periodieke uitkeringen en verstrekkingen, bepaald volgens de regels van [afdeling 3.5 van de Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353&afdeling=3.5) .
+  - index: 5
+    label: lid 2
+    sha256: 3e17f09da6267f5ec46cb8c7b77f717ccc9da2cd8ddc7ff219870488d41a8122
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het bijdrage-inkomen wordt ten minste op nihil gesteld en wordt tot geen hoger bedrag in aanmerking genomen dan het bij regeling van Onze Minister, in overeenstemming met Onze Minister van Sociale Zaken en Werkgelegenheid en Onze Minister van Financiën, vastgestelde bedrag.
+  - index: 6
+    label: lid 3
+    sha256: 3a055495d60fe6640b00e22f06152cca645be71da503bc83e36db86828ab3295
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij de berekening van het bijdrage-inkomen blijft het van dezelfde inhoudingsplichtige ontvangen loon als bedoeld in het eerste lid, onderdeel a, buiten aanmerking voor zover dat meer bedraagt dan een bij regeling van Onze Minister in overeenstemming met Onze Minister van Financiën en Onze Minister van Sociale Zaken en Werkgelegenheid, vastgesteld bedrag vermenigvuldigd met het aantal loontijdvakken van het bijdragebetalingstijdvak.
+  - index: 7
+    label: lid 4
+    sha256: 56b1d3dea98030f6b0fa469babf4845d6ff8ecf6d79aa1ec5df5c7ae4eeebec0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Indien een verzekeringsplichtige in het bijdragebetalingstijdvak zijn naam, adres of woonplaats niet aan de inhoudingsplichtige heeft verstrekt dan wel zijn identiteit niet is vastgesteld en niet is opgenomen in de administratie overeenkomstig [artikel 28, onderdeel e, van de Wet op de loonbelasting 1964](jci1.3:c:BWBR0002471&artikel=28) , alsmede indien de verzekeringsplichtige ter zake onjuiste gegevens heeft verstrekt en de inhoudingsplichtige dit weet of redelijkerwijs moet weten, blijft het tweede lid buiten toepassing bij de berekening van het als bijdrage-inkomen in aanmerking te nemen loon dat van de inhoudingsplichtige is genoten.
+- number: '44'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2a86b3f0a3b91effd39d9145b98b7fa4edeb5dd002db71d910954b5951af7c1e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 44 1 Het bedrag, bedoeld in artikel 43, tweede lid , wordt jaarlijks bij beschikking van Onze Minister, in overeenstemming met Onze Minister van Sociale Zaken en Werkgelegenheid en Onze Minister van Financiën, herzien, waarbij met inachtneming van het bij en krachtens het tweede lid bepaalde, het laatstelijk vastgestelde bedrag wordt verhoogd of verlaagd overeenkomstig het procentuele verschil tussen het indexcijfer der lonen op 31 juli daaraan voorafgaande en het indexcijfer, dat bij de laatste herziening is gehanteerd.
+  - index: 1
+    label: lid 2
+    sha256: b63091b3643a75c20a32a90fa5b34caa65da6dbf18f110dcc38ea472df240563
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onder indexcijfer der lonen wordt verstaan het indexcijfer van de CAO-lonen per maand inclusief bijzondere uitkeringen, sector particuliere bedrijven, zoals dat op basis van het jaar 2000 wordt berekend door het Centraal Bureau voor de Statistiek naar de stand op de laatste werkdag van elke kalendermaand en voor de eerste maal, al dan niet voorlopig, wordt gepubliceerd in het Statistisch Bulletin van het Centraal Bureau voor de Statistiek.
+  - index: 2
+    label: lid 3
+    sha256: 70ad1f9de6a514d0cd05f7c54452305cbbd540052b0992007e73938409b0d3e8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het in het tweede lid genoemde jaartal kan bij regeling van Onze Minister worden gewijzigd.
+  - index: 3
+    label: lid 4
+    sha256: 8279cb84d534cf16c8dd8fb7ee7ce14ad3979abab2701b0fab5e2a152e9697c2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij de eerstvolgende herziening nadat een in het derde lid bedoelde regeling is getroffen, wordt, in afwijking van het eerste lid, het procentuele verschil gehanteerd tussen het indexcijfer der lonen op 31 juli daaraan voorafgaande en het indexcijfer, dat bij de laatste herziening zou zijn gehanteerd, ware de indexcijferreeks reeds op het gewijzigde jaartal gebaseerd.
+  - index: 4
+    label: lid 5
+    sha256: b51d0187ac588e0c1383d3eb0236edc19a2f75c4657de381ab4b9726ccd2126c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Indien daartoe een bijzondere aanleiding bestaat, kan bij algemene maatregel van bestuur van de in het eerste en tweede lid aangegeven aanpassingsmethode worden afgeweken.
+  - index: 5
+    label: lid 6
+    sha256: 67323d0c52b059c306aed14cea4e0e1437d2ac89bf4a63059e166b4aae352101
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Indien een wijziging ingaat op een ander tijdstip dan 1 januari, vindt de vaststelling plaats in overeenstemming met Onze Minister van Financiën en kunnen daarbij regels worden gesteld omtrent de wijze van berekening van de bijdrage over het gehele kalenderjaar.
+- number: '45'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2490d408b04628015f82ad490b92dfd3cf3d1e4ed1089a3cd95e54b340d787d4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 45 1 De inkomensafhankelijke bijdrage bedraagt een percentage van het bijdrage-inkomen.
+  - index: 1
+    label: lid 2
+    sha256: 65da910846fdf3b13d46f82ee591713394bb70404d9f76774e4d3ae5b1500bf0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het in het eerste lid bedoelde bijdragepercentage wordt bij regeling van Onze Minister, in overeenstemming met Onze Minister van Sociale Zaken en Werkgelegenheid en Onze Minister van Financiën, vastgesteld.
+  - index: 2
+    label: lid 3
+    sha256: 09d368c1d3f62f37b16e7ac2cd0c3815fc10d5206abe30729e2ab242d44a9644
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Voor daarbij aan te geven bestanddelen van het bijdrage-inkomen kan een afwijkend bijdragepercentage worden vastgesteld.
+  - index: 3
+    label: lid 4
+    sha256: 03dbbb2b8e5ff7b9a411d026a39ceb106eb28be53f8f51fcb97fed490d17dc96
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De bijdragepercentages worden zodanig vastgesteld, dat de som van de inkomensafhankelijke bijdragen gelijk is aan 50% van de som van bij ministeriële regeling te bepalen, ten gunste van het Zorgverzekeringsfonds of van de zorgverzekeraars komende inkomsten.
+  - index: 4
+    label: lid 5
+    sha256: 7b8dadc3b78757ab4985aa644f32080158031eec236f482614137838bd229130
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Na afloop van het kalenderjaar vastgestelde verschillen tussen de bedragen van de inkomsten die in de ministeriële regeling, bedoeld in het vierde lid, in aanmerking waren genomen en de werkelijke bedragen van die inkomsten, worden verrekend bij de vaststelling van het bijdragepercentage in een volgend jaar.
+  - index: 5
+    label: lid 6
+    sha256: 12b13ca9d862b3da2b891863ef8dfc642e7b557186b401f4e6776d4f760151f3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Indien een wijziging van het bijdragepercentage ingaat op een ander tijdstip dan 1 januari, vindt de vaststelling plaats in overeenstemming met Onze Minister van Financiën en kunnen daarbij regels worden gesteld omtrent de wijze van berekening van de bijdrage over het gehele kalenderjaar.
+- number: '46'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b49828c5f0619bb4c46a096535e3f077fdc9d9bb850e7b6cd57f3dc76ecdbcd3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 46 1 Een verzekeringsplichtige die bij regeling van Onze Minister aan te wijzen loon overeenkomstig de wettelijke bepalingen van de loonbelasting geniet, heeft recht op een volledige vergoeding door de inhoudingsplichtige van de inkomensafhankelijke bijdrage over dit deel van het bijdrage-inkomen.
+  - index: 1
+    label: lid 2
+    sha256: e3e92b6b54818c9f902ccd01ccc54315d76a4cbe7cded76afc4bbb2daa6e8d4e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Voor de toepassing van het eerste lid is artikel 43, tweede lid , van overeenkomstige toepassing.
+- number: '47'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 95ea6ffe09a2a6ff4df9a640a43ef145b7e5cad9525f45627256d6321ca0a483
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 47 Bij regeling van Onze Minister, in overeenstemming met Onze Minister van Financiën en Onze Minister van Sociale Zaken en Werkgelegenheid, kunnen nadere regels worden gesteld met betrekking tot deze paragraaf.
+- number: '48'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ad9a126906973ff53fab661159294d3ecfd11662633460b12082a43880c13fc6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 48 De rijksbelastingdienst heft de inkomensafhankelijke bijdrage.
+- number: '49'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 3157ddaa57e33a701dd51778702fdc72dfd3b8e6f2d157eff2954d0826cef003
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 49 1 Voor zover het bijdrage-inkomen bestaat uit loon als bedoeld in artikel 43, eerste lid, onderdeel a , dat van een inhoudingsplichtige wordt genoten, wordt de inkomensafhankelijke bijdrage bij wijze van inhouding geheven met overeenkomstige toepassing van de voor de heffing van de loonbelasting geldende regels.
+  - index: 1
+    label: lid 2
+    sha256: c7a19c35620084912c8cbd042afafcb6373787b2c40ca83669844c3abd1ec9b4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Voor zover het bijdrage-inkomen bestaat uit andere dan de in het eerste lid bedoelde bestanddelen, wordt de inkomensafhankelijke bijdrage bij wege van aanslag geheven met overeenkomstige toepassing van de voor de heffing van de inkomstenbelasting geldende regels, met uitzondering van [artikel 3.154 van de Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353&artikel=3.154) .
+  - index: 2
+    label: lid 3
+    sha256: bebe80908c1644bd49a5ca08fca0049a829e8c2585d6496c6a0b32443d17c9a6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij de vaststelling van de ingevolge het tweede lid op te leggen aanslag wordt de bijdrage die op grond van artikel 43, tweede lid , juncto artikel 45 ten hoogste kan worden geheven verminderd met de bijdrage die op grond van het eerste lid is ingehouden.
+- number: '50'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: cc4bb1aaba7a3425aa965ce786d78b9c34da3f0bd1fbdf39de7bde798a5cd20c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 50 1 Indien over het bijdrage-inkomen inkomensafhankelijke bijdrage is ingehouden over een hoger bijdrage-inkomen dan het bedrag, bedoeld in artikel 43, tweede lid , stelt de inspecteur, bedoeld in de [Wet financiering sociale verzekeringen](jci1.3:c:BWBR0017745) , bij voor bezwaar vatbare beschikking het bedrag van de teveel betaalde bijdrage vast.
+  - index: 1
+    label: lid 2
+    sha256: 05d161708db86c3839a6be03e0925ed80bbe3aa7e1622d424a689410d125d7a4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien het bijdrage-inkomen waarover inkomensafhankelijke bijdrage is ingehouden van verschillende inhoudingsplichtigen is ontvangen, wordt het bedrag van de teveel ingehouden bijdrage als bedoeld in het eerste lid naar evenredigheid toegerekend aan de door deze inhoudingsplichtigen ingehouden bijdrage.
+  - index: 2
+    label: lid 3
+    sha256: ded2fad63acff42e570292f4ca890ceeb422d258a77f03d02a6c024a90f3353d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. In afwijking in zoverre van de vorige leden wordt het bedrag van teveel ingehouden bijdrage voor zover mogelijk toegerekend aan de inkomensafhankelijke bijdrage over het bijdrage-inkomen waarop artikel 46, eerste lid , niet van toepassing is.
+  - index: 3
+    label: lid 4
+    sha256: fdf77bf9925466e180a12f38196a45156beda230c0e6b4450b9e2d867bf5c5b4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij regeling van Onze Minister, in overeenstemming met Onze Minister van Financiën, kunnen nadere en zo nodig afwijkende regels worden gesteld.
+  - index: 4
+    label: lid 5
+    sha256: 2f147f9a122787af3623c33c797b2ad061b5f3d697c3880e617d112131462640
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. In afwijking van de [artikelen 25b](jci1.3:c:BWBR0002320&artikel=25b) , [27f](jci1.3:c:BWBR0002320&artikel=27f) , [27j, derde lid](jci1.3:c:BWBR0002320&artikel=27j) , en [29i van de Algemene wet inzake rijksbelastingen](jci1.3:c:BWBR0002320&artikel=29i) verleent de inspecteur een teruggave van een ingehouden bedrag aan inkomensafhankelijke bijdrage over loon als bedoeld in artikel 46, eerste lid , aan de inhoudingsplichtige.
+  - index: 5
+    label: lid 6
+    sha256: 9306bf5f9bb951750043cfb9fee73d2decf1aa09ecdfc2ceef2e5a6fce29d6eb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. In afwijking van [artikel 5a van de Algemene wet inzake rijksbelastingen](jci1.3:c:BWBR0002320&artikel=5a) beslist de inspecteur op aanvragen als bedoeld in dit artikel binnen een redelijke termijn als bedoeld in [afdeling 4.1.3 van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&afdeling=4.1.3) en met toepassing van die afdeling.
+  - index: 6
+    label: lid 7
+    sha256: 37e160eecd069ecdc248b1f0c7bdfaa0f205c344e7fa04ee9013f0b13348f45e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. Indien in verband met de gevraagde beschikking informatie is gevraagd aan een persoon of instantie buiten Nederland en om die reden de beschikking niet binnen redelijke termijn gegeven kan worden, wordt de termijn met ten hoogte zes maanden verlengd en wordt de aanvrager van deze verlenging schriftelijk op de hoogte gesteld.
+- number: '51'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 69ad587df5786d368aecfe52d0039ae8bf1a09b74f84a9733812426307662653
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 51 1 De rijksbelastingdienst vordert de inkomensafhankelijke bijdrage in.
+  - index: 1
+    label: lid 2
+    sha256: c923eb302b5a42a07b5f6a4e88dc28b8b1247a7c1a2454bf320f3bb3a2db1fa6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij de invordering van de bijdrage zijn, naar gelang artikel 49, eerste lid , dan wel tweede lid van toepassing is, de regels geldende voor de invordering van de loonbelasting, met uitzondering van [artikel 38, eerste lid, onderdeel a, van de Invorderingswet 1990](jci1.3:c:BWBR0004770&artikel=38) , onderscheidenlijk de inkomstenbelasting van overeenkomstige toepassing.
+- number: '52'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: bce6127621a024ae31af44b45e04ee5980f2b680c8f800fbec9d1a406a738cdd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 52 Bij regeling van Onze Minister en Onze Minister van Financiën worden regels gesteld met betrekking tot de afdracht van de inkomensafhankelijke bijdragen alsmede van de daarmee verband houdende bestuurlijke boeten en renten door de rijksbelastingdienst aan het Zorgverzekeringsfonds.
+- number: '53'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: d4b19265e4460b2f24daa20a22803b564524742b5da874fb35c8099e81923479
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 53 Bij regeling van Onze Minister, in overeenstemming met Onze Minister van Financiën en Onze Minister van Sociale Zaken en Werkgelegenheid, kunnen nadere regels worden gesteld met betrekking tot deze paragraaf.
+- number: '54'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 1a51ab2faf54509dc880ffbef8a738dbd2d06200ae5dc4bf07abd64be00c8174
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 54 1 Onze Minister verleent jaarlijks aan het Zorgverzekeringsfonds een bijdrage in de financiering van de zorgverzekering voor verzekerden jonger dan achttien jaar.
+  - index: 1
+    label: lid 2
+    sha256: eea2138e29d36dd269a750f37e5b2204d7d00ace09e532cb76869363a187a9f5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De bijdrage is gelijk aan het bedrag dat daarvoor in de wet tot vaststelling van de begroting van zijn ministerie voor dat jaar is toegestaan.
+  - index: 2
+    label: lid 3
+    sha256: 8c3b04e36701e109d852abc381948c6b0570b08c4d7d6c551a3542b4ac5b2687
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De bijdrage wordt betaald in gelijke maandelijkse delen.
+- number: '55'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b65fe66cf34f51b6cb882bc6051732d998341e7ab957ade5f9a00bbb22dd01d4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 55 1 Onze Minister kan, in overeenstemming met Onze Minister van Financiën, een bijdrage aan het Zorgverzekeringsfonds verlenen ter gehele of gedeeltelijke betaling van zorg of overige diensten als bedoeld in artikel 10 , in geval de behoefte aan die zorg of diensten is veroorzaakt door of ontstaan uit gewapend conflict, burgeroorlog, opstand, binnenlandse onlusten, oproer, muiterij of terrorisme.
+  - index: 1
+    label: lid 2
+    sha256: ff385355298e286dc8bad294abd33ae8cd2948e0a5b0dc77dea473a8236a6a47
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Bij ministeriële regeling wordt bepaald:'
+  - index: 2
+    label: onderdeel a
+    sha256: 57c53a63f8ad4c78e3bbe20a58b741c35a472eac3277270131933b36e3e9b7c0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. welke vormen van zorg of overige diensten voor welk gedeelte met de bijdrage worden betaald;
+  - index: 3
+    label: onderdeel b
+    sha256: 2cb7f2f5da1ec73619561e858abad22e5e21a4dbcc8183f7e5c7b76e0c0d3e7e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. ten behoeve van welke personen de bijdrage wordt betaald;
+  - index: 4
+    label: onderdeel c
+    sha256: 1b5be6dc8ae07e9ed32410dcacaedab585ffaafd8829b9243700ae64dacc993f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. onder welke voorwaarden en op welke wijze deze zorg of overige diensten door het College zorgverzekeringen wordt betaald.
+  - index: 5
+    label: lid 3
+    sha256: 3f85ff7d7a14822dd0c1506ff14429bf37860c0cf046549fa27bd63d99a2c2a0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. In een regeling als bedoeld in het tweede lid kan worden bepaald dat zorgverzekeraars het College zorgverzekeringen bijstand verlenen bij het uitvoeren van de ministeriële regeling, bedoeld in het tweede lid, en welke vergoeding daar voor de zorgverzekeraars tegenover staat.
+- number: '56'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: fcee9fd31ce6d5495ed7ee7c00983c296af3e61623b5c68cc1b3ab643f58322c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 56 Indien de situatie, bedoeld in artikel 31, eerste lid , zich heeft voorgedaan, verstrekt Onze Minister een bijdrage aan het Zorgverzekeringsfonds ter hoogte van het verschil tussen het bedrag aan voldane vorderingen, als bedoeld in artikel 31, eerste lid , en het bedrag dat het College zorgverzekeringen ter zake van de vorderingen, bedoeld in artikel 31, tweede lid , heeft ontvangen.
+- number: '57'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: acc1887c15fc0b92107cce8a3e1a026439ef69774f439cc65de17a826a3e8097
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 57 1 Van de persoon die op grond van artikel 2, tweede lid, onderdeel b , niet verzekeringsplichtig is, wordt met overeenkomstige toepassing van [hoofdstuk 5 van de Wet financiering sociale verzekeringen](jci1.3:c:BWBR0017745&hoofdstuk=5) en [artikel 58 van die wet](jci1.3:c:BWBR0017745&artikel=58) belasting geheven, tot het bedrag van de inkomensafhankelijke bijdrage, bedoeld in artikel 43, tweede lid , dat de persoon verschuldigd zou zijn als ware hij verzekeringsplichtig.
+  - index: 1
+    label: lid 2
+    sha256: bf8d49b867a7d65b5de6eda7cd65730c63fb0dfb65b8017ae24a794acf6de798
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien de in het eerste lid bedoelde belasting wordt geheven over op grond van artikel 46, eerste lid , aangewezen loon, is artikel 46 van overeenkomstige toepassing.
+  - index: 2
+    label: lid 3
+    sha256: fb0758992f609b089462efb3d2f32bc1bd2a9ba102c57a7bea67bc56c13925e6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De rijksbelastingdienst stort de belasting, bedoeld in het eerste lid, op de rekening, bedoeld in artikel 70, eerste dan wel tweede lid .
+- number: '58'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 636d2b502e1e90ad4f776cdb95d75d33823a439cea6f0edcd060d7155351e7e5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 58 1 Er is een College voor zorgverzekeringen, dat rechtspersoonlijkheid bezit.
+  - index: 1
+    label: lid 2
+    sha256: 4017cd99e5302fdd8f87ece830e65ad03cf2410676cc1163c12b8ffd8ee6c41d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het College zorgverzekeringen is gevestigd in een door Onze Minister te bepalen plaats.
+  - index: 2
+    label: lid 3
+    sha256: ac2530b8374ab59fb1a699df50d953e38bfbfd0d9cbadac75a701e8d15facbab
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het College zorgverzekeringen is belast met de taken die hem bij of krachtens wet of internationale overeenkomst zijn opgedragen.
+  - index: 3
+    label: lid 4
+    sha256: 058105fefebfbbdb703966378cba076d4c6c59a108cfa9cb74079baa6653c5b5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het College zorgverzekeringen wordt in en buiten rechte vertegenwoordigd door de voorzitter.
+- number: '59'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 1425548b460ed485e05d7819e9f23a7ed9cc7e1be20b6633c67d4b755cb071da
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 59 1 Het College zorgverzekeringen bestaat uit een oneven aantal van ten hoogste negen leden, onder wie de voorzitter.
+  - index: 1
+    label: lid 2
+    sha256: 44ff8003e412bc47274a1c086581ec2ec70fc6768f240169eb94afbb628ca9c0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister benoemt, schorst en ontslaat de voorzitter en de overige leden.
+  - index: 2
+    label: lid 3
+    sha256: 58fa557652d94daf2adca804663bd21af93f3d483b04ce9aa511bb61a1f6c854
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Benoeming vindt plaats op grond van de deskundigheid die nodig is voor de uitoefening van de taken van het College zorgverzekeringen alsmede op grond van maatschappelijke kennis en ervaring.
+  - index: 3
+    label: lid 4
+    sha256: ee08e72f16980f5064b4a2d286fbad61e11a11a3a7e1b3bf25619ed868508057
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De leden worden benoemd voor ten hoogste vier jaar. Herbenoeming kan twee maal en telkens voor ten hoogste vier jaar plaatsvinden.
+  - index: 4
+    label: lid 5
+    sha256: 18e56c9927c9123f8a7bef9d2cc34ade3fddee2f56745dd1365db5880f0effc4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Bij de samenstelling van het College zorgverzekeringen wordt gestreefd naar evenredige deelneming van vrouwen en van personen behorende tot etnische of culturele minderheidsgroepen.
+  - index: 5
+    label: lid 6
+    sha256: 0a1801b885bf6e52771bdd84b4cb8dd32021bc18dd50e2d6ea288c9379a527a0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Het lidmaatschap van het College zorgverzekeringen is onverenigbaar met het lidmaatschap van het College toezicht of van het bestuur van De Nederlandsche Bank N.V.
+  - index: 6
+    label: lid 7
+    sha256: bcbf84feb4c61af610cdc58772735aaa711f186dfa0f94d5972e071220800b93
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. Het lidmaatschap eindigt tussentijds door overlijden, ontslag op eigen verzoek of ontslag om zwaarwichtige redenen door Onze Minister.
+  - index: 7
+    label: lid 8
+    sha256: 8946288376d89bcae6f926f54e0e44b3395436df2332093f4cfb9d0aab17cd98
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 8. Van een besluit tot benoeming, schorsing of ontslag wordt mededeling gedaan in de Staatscourant.
+  - index: 8
+    label: lid 9
+    sha256: 8577a21d1908453b7a94549d4e66ee9653598e60057d2f52e27e611495641e67
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '9. Bij ministeriële regeling:'
+  - index: 9
+    label: onderdeel a
+    sha256: f4a5718e3b2375066358ff57f770ecfc0f106c14b171e645cbf9aef0f257d78b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. worden de vergoeding van reis- en verblijfkosten en verdere vergoedingen aan leden van het College zorgverzekeringen en leden van commissies vastgesteld;
+  - index: 10
+    label: onderdeel b
+    sha256: 1375f17619527bce05fe0c1a3751ec5675471202f8d652b398717d348f10fa1c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. kunnen nadere regels over hun rechtspositie worden vastgesteld;
+  - index: 11
+    label: onderdeel c
+    sha256: 3358d20bec086d988c977d18774ae904beb4df42f37d0c161bf3c568de24caee
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. worden andere functies of werkzaamheden dan die, genoemd in het zesde lid, aangewezen, die niet verenigbaar zijn met het lidmaatschap van het College zorgverzekeringen.
+- number: '60'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: f40b68c8a60524117e927e6793acc276c41be0f2017fb4ed442f44c09f007614
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 60 1 Het College zorgverzekeringen stelt een bestuursreglement vast.
+  - index: 1
+    label: lid 2
+    sha256: a6c7e26fe72b0881f43eb1ede33f8e01f36072c567406f38f4934189fea2b304
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In het bestuursreglement kan het College zorgverzekeringen voorzien in de instelling van commissies en kan het hun samenstelling en taken regelen.
+  - index: 2
+    label: lid 3
+    sha256: dabccdb1b33db284ba5cd585cfd2cfb6259f9388193670127feeabab3e28369f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. In commissies kunnen personen deelnemen die geen lid van het College zorgverzekeringen zijn.
+  - index: 3
+    label: lid 4
+    sha256: b3fd619cbe7ad5103fd1bf55cfef2b9e102da6c31ebfe8a1318d255e4cf8c9af
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Vergaderingen van het College zorgverzekeringen en van commissies zijn openbaar, behoudens voor zover in het bestuursreglement anders is bepaald.
+  - index: 4
+    label: lid 5
+    sha256: ffc86a8a82af4969a65f593705dec2a6456614bb752c866f8fef40afd5045629
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Het bestuursreglement behoeft de goedkeuring van Onze Minister.
+- number: '61'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: e18fcd408b04b694ee083a7f3fd12283be446a46d8b3671bd51f1371233b08bd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 61 1 Op de rechtspositie van het personeel van het College zorgverzekeringen zijn de regels die gelden voor ambtenaren die zijn aangesteld bij ministeries van toepassing, met dien verstande dat waar in deze regels een bevoegdheid is toegekend aan een andere minister dan Onze Minister van Binnenlandse Zaken en Koninkrijksrelaties, deze bevoegdheid wordt uitgeoefend door het College zorgverzekeringen.
+  - index: 1
+    label: lid 2
+    sha256: 96700962ce5c44cb2cb692418dbb7a897ed773e79ac523f58a3d47b6dbb40d17
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij algemene maatregel van bestuur kan worden afgeweken van de in het eerste lid bedoelde regels.
+- number: '62'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 580d385ab17b56c7afbb9eda52cfe48983986a409711563e23886c55740c547a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 62 Onze Minister kan beleidsregels vaststellen met betrekking tot de werkwijze en de uitoefening van de taken van het College zorgverzekeringen.
+- number: '63'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2a23fe20e4ea0f416281e7423d947f45627b672bbfac7e5e5a4a7067fe4fbd6b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 63 1 Een besluit van het College zorgverzekeringen kan bij koninklijk besluit worden vernietigd.
+  - index: 1
+    label: lid 2
+    sha256: 74a758a3b02df92ef42f4bbf79708319a16c066d63ad86fdc07b093e3e1c941a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Van een besluit tot vernietiging wordt mededeling gedaan door plaatsing in de Staatscourant.
+- number: '64'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ffd07814adb0c8401f8b65e716f5dd1125e882fd7ebae07eff2a49c70a2d4b13
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 64 1 Het College zorgverzekeringen bevordert de eenduidige uitleg van de aard, inhoud en omvang van de prestaties, bedoeld in artikel 11 .
+  - index: 1
+    label: lid 2
+    sha256: 520514772734a193ff1dc071b19754f33dcb98546a51554ad6c3c1a773d4d13f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het College zorgverzekeringen kan de zorgverzekeraars met het oog hierop richtlijnen geven.
+- number: '65'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 13c03c5eed8c690c45ad0cedb3af658c2e337fa60e7fea398a2a0a2e652c3463
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 65 Het College zorgverzekeringen geeft aan zorgverzekeraars, aan zorgaanbieders en aan burgers voorlichting over de aard, inhoud en omvang van de prestaties, bedoeld in artikel 11 .
+- number: '66'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2157ac0bd7bcdc706e660bf3dbeeb6432e1ed3bd7e9d850ae46783ba1f084de5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 66 1 Het College zorgverzekeringen rapporteert Onze Minister desgevraagd over voorgenomen beleid inzake aard, inhoud en omvang van de prestaties, bedoeld in artikel 11 .
+  - index: 1
+    label: lid 2
+    sha256: c490b07bf022700d7c0e3f9193f56c6eb8b706cc9b2676b0044f63a31a4afdef
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het College zorgverzekeringen signaleert gevraagd en ongevraagd aan Onze Minister feitelijke ontwikkelingen die aanleiding kunnen geven tot wijzigingen van de aard, inhoud en omvang van de prestaties, bedoeld in artikel 11 .
+- number: '67'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: cbce772f1d50852acec1d3baef2254e8cceeaa86dbd20c45ff688ba084f0ca2d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 67 Het College zorgverzekeringen bevordert de afstemming van de uitvoering:'
+  - index: 1
+    label: onderdeel a
+    sha256: d325dcc8650735b0f292f917e228beebdbe6763f1837df2617f4d89343913f2a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. van en tussen de zorgverzekering en de algemene verzekering bijzondere ziektekosten, en
+  - index: 2
+    label: onderdeel b
+    sha256: 981f0254e55d9b2ba30ecdfae846665561cec0faffc6cbed59c8180455a8a84c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. van deze verzekeringen met de uitvoering van het beleid op andere terreinen van de volksgezondheid en op andere terreinen van sociale zekerheid.
+- number: '68'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 4e719517cbc48f110bc182eac10876df3c39257c3cd00baec3b0e2d5bac3295e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 68 1 Bij ministeriële regeling kan worden bepaald dat het College zorgverzekeringen overeenkomstig in die regeling gestelde regels tijdelijk subsidies verstrekt voor zorg of andere diensten, ten aanzien waarvan het voornemen bestaat deze te doen opnemen in de te verzekeren prestaties.
+  - index: 1
+    label: lid 2
+    sha256: cb627f178e3f699149ddcadb60104e68e2841029dffa481051a214067f171ce8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In een regeling als bedoeld in het eerste lid kan worden bepaald dat zorgverzekeraars het College zorgverzekeringen bijstand verlenen bij de verstrekking van subsidies behorende tot een in die regeling genoemde categorie, en welke vergoeding zij daarvoor ontvangen.
+  - index: 2
+    label: lid 3
+    sha256: 7eccb8f32ec86b7fea16f38f8480cd679f75b5ddcd09bbdffd9769e5109d4df7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Onze Minister kan jaarlijks voor een categorie van subsidies het subsidieplafond voor het komende jaar bekendmaken.
+  - index: 3
+    label: lid 4
+    sha256: 1e390373e4a976c15d581a658d08a1ea2a2a949ba2923b1a2387948a134a759d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. In een regeling als bedoeld in het eerste lid kan aan het College zorgverzekeringen worden opgedragen nadere regels te stellen.
+  - index: 4
+    label: lid 5
+    sha256: d639efb6a203083379c486c23c01c5754bffec3eb376f72256ea6bb4d3ddeed3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Nadere regels als bedoeld in het vierde lid behoeven de goedkeuring van Onze Minister.
+  - index: 5
+    label: lid 6
+    sha256: 7aaba439483ccb9db01e9b22f73580efd52689bb4323f787052eff0e807e7cf0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Goedkeuring kan slechts worden onthouden wegens strijd met het recht of het belang van de volksgezondheid.
+- number: '69'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ace60dbc487108789580f2d061e5c435661d9c2f8d301c64d5c633b129855cab
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 69 1 In het buitenland wonende personen die met toepassing van een Verordening van de Raad van de Europese Gemeenschappen dan wel toepassing van zodanige verordening krachtens de overeenkomst betreffende de Europese Economische Ruimte of een verdrag inzake sociale zekerheid in geval van behoefte aan zorg recht hebben op zorg of vergoeding van de kosten daarvan, zoals voorzien in de wetgeving over de verzekering voor zorg van hun woonland, melden zich, tenzij zij op grond van deze wet verzekeringsplichtig zijn, bij het College zorgverzekeringen aan.
+  - index: 1
+    label: lid 2
+    sha256: 6c06ceb9b4448eaec742eab72e9f04d901f9f81af97616acb61b42033cc6715e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De in het eerste lid bedoelde personen zijn een bij ministeriële regeling te bepalen bijdrage verschuldigd, die voor de toepassing van artikel 22 alsmede, voor een bij die regeling te bepalen gedeelte van de bijdrage, voor de toepassing van de [Wet op de zorgtoeslag](jci1.3:c:BWBR0018451) als premie voor een zorgverzekering wordt beschouwd.
+  - index: 2
+    label: lid 3
+    sha256: e7f29f2b402b793b6dab30d3abd07817f3f3a97f5eb4c4a55f30738ca292ae59
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien de melding niet is geschied binnen vier maanden nadat het recht, bedoeld in het eerste lid, is ontstaan, legt het College zorgverzekeringen degene die de melding had moeten doen een boete op, die gelijk is aan 130% van een bij ministeriële regeling te bepalen gedeelte van de bijdrage, bedoeld in het tweede lid, over een periode gelijk aan de periode gelegen tussen de dag waarop het recht ontstond en de dag waarop de melding is geschied, maar met een maximum van vijf jaren.
+  - index: 3
+    label: lid 4
+    sha256: 266620b751178fdae8a4558342ad034792b5b51ee9ba69aa3a26c995a8607f7e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het College zorgverzekeringen is belast met de administratie, voortvloeiend uit het eerste lid en de daar genoemde internationale regels, alsmede met de heffing en de inning van de bijdrage, bedoeld in het tweede lid.
+  - index: 4
+    label: lid 5
+    sha256: 5bfa85086dcae28747be97bd96be1d0d2d3e6d4294920e7122f82f1aa68c5fba
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '5. Bij ministeriële regeling:'
+  - index: 5
+    label: onderdeel a
+    sha256: 33d8b34602160bd90f0ea923dfdb26ccf0b60aa1c863a618138b843556da39d9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. kan, in afwijking van het vierde lid, worden bepaald dat de bijdrage, bedoeld in het tweede lid, door een orgaan dat pensioen of rente uitkeert, op dat pensioen of die rente wordt ingehouden en aan het Zorgverzekeringsfonds wordt afgedragen;
+  - index: 6
+    label: onderdeel b
+    sha256: 929ca8dccd1329c1e3c19ea0cfc46ad9ca8d9402e9907815c06584c27286d2ff
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. kunnen regels worden gesteld over de wijze waarop het College zorgverzekeringen zijn taak, bedoeld in het vierde lid, uitoefent of de organen, bedoeld in onderdeel a, de in dat onderdeel bedoelde werkzaamheden uitvoeren.
+- number: '70'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: cdaf3b073b2949475a6da9eb58ce7ef2ed549d91ff15f04471808af34d374633
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 70 1 Het College zorgverzekeringen opent voor iedere gemoedsbezwaarde, bedoeld in artikel 2, tweede lid, onderdeel b , een rekening, waarop de geheven bijdragevervangende belasting, bedoeld in artikel 57, eerste lid , wordt gestort.
+  - index: 1
+    label: lid 2
+    sha256: f571bcd6ece1d1aaa056a2440a382d9dc41c90f0fcec37109b079e45135470dd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In afwijking van het eerste lid opent of houdt het College zorgverzekeringen één rekening in stand indien twee of meer gemoedsbezwaarden als bedoeld in artikel 2, tweede lid, onderdeel b , een gezamenlijke huishouding voeren, en worden op die rekening de belastingen van ieder van deze gemoedsbezwaarden gestort.
+  - index: 2
+    label: lid 3
+    sha256: a7e429b805c9fa98c8d74dc159910303496523b37103a34e4204fca59d17c460
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Tot de rekening is geen ander begunstigd dan het College zorgverzekeringen.
+  - index: 3
+    label: lid 4
+    sha256: 722bef666d9fab7d43da3e0dde21dc6d0e52d17ddc6643a4bcea0a34f3fa29b7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. Het saldo wordt door het College zorgverzekeringen gebruikt voor het doen van:'
+  - index: 4
+    label: onderdeel a
+    sha256: 8242b8bca57b53a62270d078a790e132151295cd0c541aae72ca2649f71dbf01
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. uitkeringen ter vergoeding van kosten van zorg of overige diensten als bedoeld in artikel 11 , voor zover deze zijn verleend aan een gemoedsbezwaarde voor wie de rekening in stand wordt gehouden, of aan een tot zijn huishouding behorend kind, jonger dan achttien jaar;
+  - index: 5
+    label: onderdeel b
+    sha256: 824794b6e1659fb03a46634ea6dc0a38c0865452b01a533b7a8fa25bab6cb2d6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. uitkeringen als bedoeld in artikel 39, tweede lid, onderdeel d .
+  - index: 6
+    label: lid 5
+    sha256: c42ac0a778e4870ac31676f71c210bcd5a7182f8bb71ddb18733d63fccda7f1b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Uitkeringen als bedoeld in het vierde lid, onderdeel a, worden slechts op verzoek van een gemoedsbezwaarde voor wie de rekening in stand wordt gehouden, gedaan.
+  - index: 7
+    label: lid 6
+    sha256: 27dd261347801ec395ef446c6c54129db1065a5b24eee2c342bfe33d6638faed
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. De kosten van zorg of overige diensten worden niet vergoed voor zover deze voor een verzekerde op grond van de regels, gesteld bij of krachtens de algemene maatregel van bestuur, bedoeld in artikel 11, derde of vierde lid , voor eigen rekening blijven.
+  - index: 8
+    label: lid 7
+    sha256: 67700422cb893cafa4d891495073527107a58b80b6c8472cb5953099a50d6093
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. De kosten van zorg of overige diensten, verleend aan een gemoedsbezwaarde van achttien jaar of ouder, worden slechts vergoed voor zover het bedrag daarvan in een kalenderjaar meer bedraagt dan het verschil tussen het bij algemene maatregel van bestuur te bepalen bedrag, bedoeld in artikel 22, eerste lid , en het geraamde gemiddelde bedrag dat een verzekerde naar verwachting in het daaropvolgende jaar ingevolge artikel 22 van de Zorgverzekeringswet terug ontvangt, bedoeld in artikel 4, eerste lid, van de Wet op de zorgtoeslag.
+  - index: 9
+    label: lid 8
+    sha256: 401d5b3b0e6ada53c2bd0b9b517a229546e512c067cdb7cbe884a16685fdcb50
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 8. Het College zorgverzekeringen heft een rekening op indien alle gemoedsbezwaarden voor wie de rekening in stand werd gehouden, verzekeringsplichtig zijn geworden dan wel zijn overleden.
+  - index: 10
+    label: lid 9
+    sha256: 37db7608ccb8e935affbdc915e29d0b9980995ca36780e9e5706429181dd8e0b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 9. Indien een gemoedsbezwaarde een gezamenlijke huishouding is gaan vormen met een andere gemoedsbezwaarde, heft het College zorgverzekeringen een van de twee rekeningen op, onder overmaking van het saldo naar de overblijvende rekening.
+  - index: 11
+    label: lid 10
+    sha256: f845afc610591fe7d6cb4d03f5482ba4925cfe2b32dbda1eb573044c6dd52a6d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 10. Het College zorgverzekeringen zorgt per gemoedsbezwaarde of huishouding, bedoeld in het tweede lid, voor een ordentelijke administratie van de stortingen op en de uitkeringen ten laste van de rekening.
+  - index: 12
+    label: lid 11
+    sha256: 7633595688a9fcdff2a11da173e649a68a6b97870e29956df8ab021672b2e063
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 11. Bij ministeriële regeling kunnen ter zake van het bepaalde in het eerste tot en met tiende lid nadere regels en uitvoeringsregels worden gegeven.
+  - index: 13
+    label: lid 12
+    sha256: 9801b271b619cbe0bc7b443424fce0df334aa5ceba8be0b0d8dc62e9fa01e031
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 12. Het College zorgverzekeringen is bevoegd de werkzaamheden, bedoeld bij of krachtens het eerste tot en met elfde lid, onder vergoeding van de daarmee gepaard gaande kosten, uit te besteden aan een of meer zorgverzekeraars.
+- number: '71'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 5d7dba35c3a1e56fff284dacc7da75544d201dca80809ef780a8a3575353a873
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 71 1 Het College zorgverzekeringen zendt jaarlijks voor 1 oktober aan Onze Minister een jaarplan voor het volgende kalenderjaar.
+  - index: 1
+    label: lid 2
+    sha256: 05b700a63fc5a3e60ff548667598b7397a64179ff5d5e5a174119478f070c936
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Het jaarplan omvat:'
+  - index: 2
+    label: onderdeel a
+    sha256: c8d96f7aaf450ff1608ab3ab875845d1d131cce9814a0bfb857752ba6347c699
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. een werkprogramma met een beschrijving van de activiteiten die het College zorgverzekeringen voornemens is ter uitvoering van zijn taken te verrichten,
+  - index: 3
+    label: onderdeel b
+    sha256: b4c911c7efc64f6e080efeca5de69f6764b2522c4bec4f9c8c9ab74b56149c73
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. een begroting van de beheerskosten voor de uitvoering van de voorgenomen activiteiten, en
+  - index: 4
+    label: onderdeel c
+    sha256: 4e77c9cfa72e164aa22719ce161998ebf78c1e1f5f4d8b6a542e1509e36310b6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. een meerjarenraming voor de vier kalenderjaren volgend op het begrotingsjaar.
+- number: '72'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b37dfc18486b99dd6117c4fa7398d4820738c5460f2bb2778dc01f56c965ff1d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 72 1 Onze Minister stelt jaarlijks voor 1 december het budget voor de beheerskosten van het College zorgverzekeringen voor het volgende kalenderjaar vast.
+  - index: 1
+    label: lid 2
+    sha256: e0bd1c5744375102761e6107e501484e335124f559d3b3fab71edcecc9d0893d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister kan besluiten het budget voor de beheerskosten van het College zorgverzekeringen te wijzigen.
+  - index: 2
+    label: lid 3
+    sha256: e649037cad8b448aca202eb471391916205e4e86152f389192a3f1f641440657
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien gedurende het jaar aanmerkelijke verschillen ontstaan of dreigen te ontstaan tussen de werkelijke en de begrote baten en lasten, doet het College zorgverzekeringen daarvan onverwijld mededeling aan Onze Minister, onder vermelding van de oorzaak van de verschillen.
+  - index: 3
+    label: lid 4
+    sha256: 59e7b1cea54e171401d9bd2b5d5a0861debfa406604424f563b23578e80c7a3b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het College zorgverzekeringen gaat met betrekking tot de beheerskosten geen verplichtingen aan en doet geen uitgaven die leiden tot overschrijding van het vastgestelde budget voor de beheerskosten.
+  - index: 4
+    label: lid 5
+    sha256: 0c1808418d086eb787103e5bfcaf362c58e6a1d87fb232805290e31f1ec1f76b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Indien het budget voor de beheerskosten niet is vastgesteld voor 1 januari van het kalenderjaar waarop de begroting betrekking heeft, is het College zorgverzekeringen bevoegd, teneinde zijn activiteiten gaande te houden, te beschikken over ten hoogste een derde gedeelte van het budget dat laatstelijk voor hem voor een geheel jaar is vastgesteld.
+  - index: 5
+    label: lid 6
+    sha256: c1fdb520f0ff45cf2bcebffc47ffd9fde00d6f52e31ba4168f520a5e56928d62
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Onze Minister kan besluiten dat het College zorgverzekeringen in een geval als bedoeld in het vijfde lid, kan beschikken over meer dan een derde gedeelte van het budget dat laatstelijk voor hem voor een geheel jaar is vastgesteld.
+  - index: 6
+    label: lid 7
+    sha256: a8a4fe675e879d5361a1e9c97126bccad480cb76740b269096301ca2426d3090
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. Het door Onze Minister vastgestelde budget voor de beheerskosten van het College zorgverzekeringen wordt gedekt uit ’s Rijks kas.
+- number: '73'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 64a9c0bee0ec404c8f79daccf5f157b8721b77d0868a109d2b54e89eeb07b80b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 73 1 Het College zorgverzekeringen zendt jaarlijks voor 15 maart aan Onze Minister een jaarverantwoording over het afgelopen kalenderjaar, alsmede het verslag van bevindingen, bedoeld in het zesde lid.
+  - index: 1
+    label: lid 2
+    sha256: 0c5fd7655910e7b8632c0e3798aa64c3efa6a7e1df1a529653044e0fea8f5b66
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. De jaarverantwoording omvat:'
+  - index: 2
+    label: onderdeel a
+    sha256: 80cbbb8b42bd324b62c6f49ea064ef8f45079d3f47be35c49d4bfe3c17222c61
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. een jaarrekening, en
+  - index: 3
+    label: onderdeel b
+    sha256: c79c2a6f12d0af133c6da8f1cdef7c4a63ab8934511d9140cbef2a8c43fd73ec
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. een jaarverslag omtrent het door het College zorgverzekeringen gevoerde beleid, de doeltreffendheid van dat beleid, de bedrijfsvoering en de uitvoering van het werkprogramma in het afgelopen kalenderjaar.
+  - index: 4
+    label: lid 3
+    sha256: 125ff508a25e872160f4f36a62da05f4f58df100b2b49026f805aab9d1dc92fb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het College zorgverzekeringen legt in zijn jaarrekening, die zoveel mogelijk met overeenkomstige toepassing van [titel 9 van Boek 2 van het Burgerlijk Wetboek](jci1.3:c:BWBR0003045&titeldeel=9) wordt ingericht, rekening en verantwoording af over zijn beheerskosten en over de rechtmatigheid en doelmatigheid van het beheer in het afgelopen kalenderjaar.
+  - index: 5
+    label: lid 4
+    sha256: 0ada50903936f51dbc2caa0d09e87a702604f7ad5ffad91c10fdda105f97e245
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De jaarrekening gaat vergezeld van een verklaring omtrent de getrouwheid, afgegeven door een accountant als bedoeld in [artikel 393 van Boek 2 van het Burgerlijk Wetboek](jci1.3:c:BWBR0003045&artikel=393) , die bereid is Onze Minister desgevraagd inzicht te geven in zijn controlewerkzaamheden.
+  - index: 6
+    label: lid 5
+    sha256: c50600953ce773259dc833f38eea3ed4d01788ec4a97acc22f35b1cf38df694e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De verklaring heeft mede betrekking op de rechtmatige verkrijging en besteding van de middelen door het College zorgverzekeringen.
+  - index: 7
+    label: lid 6
+    sha256: 2ab8b234132d633488da1de3c33b7ac5e5e46d16a590aee892196b362b6d9053
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. De accountant voegt bij de verklaring een verslag van zijn bevindingen over de vraag of het beheer en de organisatie voldoen aan eisen van rechtmatigheid, ordelijkheid, controleerbaarheid en doelmatigheid.
+- number: '74'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b01d4d0e2f84a527583b57d8ec1c28428a2c8dd4609bdb9b276f0f0a683e4779
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 74 1 Het College zorgverzekeringen zendt jaarlijks voor 15 maart aan Onze Minister met betrekking tot het Zorgverzekeringsfonds een jaarrekening over het afgelopen kalenderjaar, alsmede het verslag van bevindingen, bedoeld in het vijfde lid.
+  - index: 1
+    label: lid 2
+    sha256: 865b948cfa30391507087f0843b157a956156ccf229acd2b83ad83650cbbb732
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het College zorgverzekeringen legt in de jaarrekening, die zoveel mogelijk met overeenkomstige toepassing van [titel 9 van Boek 2 van het Burgerlijk Wetboek](jci1.3:c:BWBR0003045&titeldeel=9) wordt ingericht, rekening en verantwoording af over de baten en lasten van het Zorgverzekeringsfonds en de toestand van dat fonds per 31 december, alsmede over de rechtmatigheid en doelmatigheid van het beheer van dat fonds in het afgelopen kalenderjaar.
+  - index: 2
+    label: lid 3
+    sha256: 70539446d940601a6e15a6d7a15d4c04ceba9d72ee5ae65437daaa4be6b9740f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De jaarrekening gaat vergezeld van een verklaring omtrent de getrouwheid, afgegeven door een accountant als bedoeld in [artikel 393 van Boek 2 van het Burgerlijk Wetboek](jci1.3:c:BWBR0003045&artikel=393) , die bereid is Onze Minister desgevraagd inzicht te geven in zijn controlewerkzaamheden.
+  - index: 3
+    label: lid 4
+    sha256: ba7a8513704481db9ee479184a0a713a66941ff7d33ede74d17293cb7f03a29e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De verklaring heeft mede betrekking op de rechtmatige verkrijging en besteding van de middelen van het Zorgverzekeringsfonds.
+  - index: 4
+    label: lid 5
+    sha256: b33874b410bd00d78b09aa0b75b4626f5ba85c78792454f5471c41720595308b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De accountant voegt bij de verklaring een verslag van zijn bevindingen over de vraag of het beheer en de organisatie voldoen aan eisen van rechtmatigheid, ordelijkheid, controleerbaarheid en doelmatigheid.
+- number: '75'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 183acf3aa7ff07d190c51bf5f35cd6e766bfa39f60a360ef949d6a528481ccd3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 75 1 De onderdelen «werkprogramma» en «begroting» van het jaarplan, bedoeld in artikel 71 , het onderdeel «jaarrekening» van de jaarverantwoording, bedoeld in artikel 73 , en de jaarrekening, bedoeld in artikel 74 , behoeven de goedkeuring van Onze Minister.
+  - index: 1
+    label: lid 2
+    sha256: 2524205eecc0272a9add024b6a842af59919234aa904ab21389de2a2987f1fbb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Het eerste lid geldt niet voor wijzigingen in een goedgekeurde begroting, mits:'
+  - index: 2
+    label: onderdeel a
+    sha256: aff21fa68748c8178fb50e56a47b089cb92b96f0c147ed1a266a7b9926c82d04
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de totale omvang van de begroting geen wijziging ondergaat, en
+  - index: 3
+    label: onderdeel b
+    sha256: ce00a44dc6eb6ca52c30994ad94ef7c5410d2954c0cdd893077fef290310c863
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de wijziging per groep van kostensoorten en baten, gerekend over het desbetreffende begrotingsjaar, een bedrag van 5 procent van het in artikel 72 bedoelde budget niet te boven gaat.
+  - index: 4
+    label: lid 3
+    sha256: cc3a32f7be8b829d693c9410c23e9a1508989f439f679f25f19de060f7f98bd1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Bij ministeriële regeling kunnen regels worden gesteld over de inhoud en de inrichting van:'
+  - index: 5
+    label: onderdeel a
+    sha256: 48948732917555473a30c446a735db1884c597e967a463a3e4324de06dc7ac0b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. het jaarplan, bedoeld in artikel 71 ;
+  - index: 6
+    label: onderdeel b
+    sha256: 47aaf2d28680bdd9dbdc63b7c4f7619cb27397df86c2f6eebb1ce811dbafed0f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de jaarverantwoording, bedoeld in artikel 73 ;
+  - index: 7
+    label: onderdeel c
+    sha256: 594fec226ce312cfd66588aadaadff4d096afc7fb0e6308e937bc02730faf06b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. de jaarrekening, bedoeld in artikel 74 ;
+  - index: 8
+    label: onderdeel d
+    sha256: 73dc3977dce8b2165d1405f0e4ae1bebeddc7da1d939a05830f506f0d929aa12
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. de verklaringen, bedoeld in de artikelen 73, vierde lid en 74, derde lid , de verslagen van bevindingen, bedoeld in artikel 73, zesde lid en 74, vijfde lid , alsmede het aan die verklaringen en verslagen ten grondslag liggende onderzoek.
+  - index: 9
+    label: lid 4
+    sha256: 326a606055377fdae085a9e667e06f531b0fc43468d943de662ba909c5fdc605
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij ministeriële regeling worden regels gesteld over de wijze waarop en de voorwaarden waaronder het budget, bedoeld in artikel 72 , wordt vastgesteld.
+- number: '76'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: cc43dc610ef57e545c865cb1c1986b0ff425e11c78c8da598e8845cd0598d58b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 76 1 Na de goedkeuring, bedoeld in artikel 75, eerste lid , stelt het College zorgverzekeringen het jaarplan, de jaarverantwoording en de jaarrekening van het Zorgverzekeringsfonds algemeen verkrijgbaar.
+  - index: 1
+    label: lid 2
+    sha256: 57fe3457d182a99c1d715abb6cb7c3d2ac28e35a9e2cae8519a82a2bd5989a44
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister brengt zijn oordeel over het functioneren van het College zorgverzekeringen ter kennis van beide Kamers der Staten-Generaal.
+- number: '77'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: f6e090d330a024fa80d2a57c1030acb834b6cfe1eb516306fece118ca556b969
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 77 1 Er is een College van toezicht op de zorgverzekeringen, dat rechtspersoonlijkheid bezit.
+  - index: 1
+    label: lid 2
+    sha256: 72990b74124d47f344d5b1e6653bbb90d7bb5a5fb13af01519bbfe21cd173c54
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het College toezicht is gevestigd in een door Onze Minister te bepalen plaats.
+  - index: 2
+    label: lid 3
+    sha256: 48ba5cebff9ceedd9542a4cabdaa933ec94b8f4642f4edcd108001f00b450996
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '3. Het College toezicht is, voor zover dit niet aan andere toezichthouders is voorbehouden, belast met:'
+  - index: 3
+    label: onderdeel a
+    sha256: 2d340381698495ea43eca883c21902e5261ecffc6a7e456a54d0302195f0fd10
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. het toezicht op de rechtmatige uitvoering door de zorgverzekeraars van hetgeen bij of krachtens deze wet is geregeld;
+  - index: 4
+    label: onderdeel b
+    sha256: 324adab89e63af4b4ce4cc51a297f75bb096982b68f0a609f6911c35b4f82c11
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. het toezicht op de rechtmatige afrekening van de bijdragen, bedoeld in de artikelen 32 tot en met 34 , nadat een verzekeraar opgehouden is zorgverzekeringen uit te voeren;
+  - index: 5
+    label: onderdeel c
+    sha256: 7c0cc5b5bbccd1fa25773be2c2df5a0bb237f24f4c688cba50666fc42cb53558
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. het toezicht op de uitvoering van andere wetten, volgens bij of krachtens die wetten te bepalen criteria.
+  - index: 6
+    label: lid 4
+    sha256: 4993b01809cc3e19064efd2907ffd29bb2075ddcfd19656dabdf99c576224e65
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het College toezicht wordt in en buiten rechte vertegenwoordigd door de voorzitter.
+- number: '78'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 3da700360efe8728d684d484b5ae894b6d617c6511e52e74e097a0eb6b17d0c1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 78 1 Het College toezicht bestaat uit een oneven aantal van ten hoogste vijf leden, onder wie de voorzitter.
+  - index: 1
+    label: lid 2
+    sha256: 87954866764b4ccd400efa8aea600a48568078912f0302bbdecee9e44439994b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De artikelen 59, tweede tot en met negende lid , en 60 tot en met 63 zijn van overeenkomstige toepassing.
+- number: '79'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8926b19d5a0a3f85bfed51ea960c951135baedea18aedeb86cb0554e830b3bdd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 79 1 Het College toezicht wijst de medewerkers aan die toezichthouders zijn als bedoeld in [artikel 5:11 van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&artikel=5:11) .
+  - index: 1
+    label: lid 2
+    sha256: e020dfcff9bcb86461c99bbf133971e655e9218b202391fe19db98ad8867049f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Van een besluit als bedoeld in het eerste lid wordt mededeling gedaan door plaatsing in de Staatscourant.
+- number: '80'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 544b9129869be2fccd176a325b41c0214d6cd13e96fee1d9ab10f01fa9882d5e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 80 1 Het College toezicht zendt voor 1 november aan Onze Minister en aan het College zorgverzekeringen een samenvattend rapport over de rechtmatigheid van de uitvoering van deze wet en de daarop gebaseerde regelgeving door de zorgverzekeraars in het voorafgaande kalenderjaar.
+  - index: 1
+    label: lid 2
+    sha256: 5a2dded32fb4bfed96e80c400974640504a6c5e26129d2ecff94bab39445d133
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Onze Minister zendt het rapport, bedoeld in het eerste lid, aan beide kamers der Staten-Generaal.
+  - index: 2
+    label: lid 3
+    sha256: b45e1c2ddc73fc253a31febe74539e9959d222c885be22f42110224160df8f77
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het College toezicht stelt het rapport, bedoeld in het eerste lid, algemeen verkrijgbaar.
+  - index: 3
+    label: lid 4
+    sha256: 4e145162d8892c063edd9411b0e739e94ebd4a1579c88bd06611f706ba607ab6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij ministeriële regeling kunnen regels worden gesteld over de inhoud en inrichting van het rapport, bedoeld in het eerste lid.
+- number: '81'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 107b3ff05db622f71152a3c0766cd44a9983b13c723c7e710fecd7493dc36674
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 81 1 Het College toezicht maakt, onverminderd zijn bevoegdheid tot eigen onderzoek, zoveel mogelijk gebruik van de resultaten van door anderen verrichte controles.
+  - index: 1
+    label: lid 2
+    sha256: f1fe26331cd0949131fb1bb451dddf1a01c62fffe21763ebe2f2c97b4c9aa2d6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De zorgverzekeraars verstrekken desgevraagd aan het College toezicht de informatie over de uitgevoerde werkzaamheden van hen die met de controle zijn belast en lichten hem volledig in over de resultaten van de controle door overlegging van rapporten of op andere door het College toezicht aan te geven wijze.
+- number: '82'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 0b1455aa5d7e579c27956c84b40c094158ff85c019b2b38495531407f2179521
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 82 1 Het College toezicht rapporteert desgevraagd aan Onze Minister over de uitvoerbaarheid, doeltreffendheid en doelmatigheid van voorgenomen beleid in verband met de uitoefening van zijn toezichthoudende taak.
+  - index: 1
+    label: lid 2
+    sha256: 84d60e3501fd58a0c11f85656a8e265153c26ce1f4dd330b4d3e3eb9943c4ffb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het College toezicht stelt op verzoek van Onze Minister onderzoek in bij zorgverzekeraars.
+  - index: 2
+    label: lid 3
+    sha256: 05235d1400f1f1fc13549f373ac5aefeed28ce361ec743435a2bc01adf896143
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het College toezicht kan tevens op verzoek van het College zorgverzekeringen onderzoek bij de zorgverzekeraars instellen.
+- number: '83'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c98d8bb1ba35f08c72ff42bbb143bab8dd48bfee34311429393559d144b194e3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 83 1 Het College toezicht maakt ten behoeve van de inzichtelijkheid, voor verzekeringsplichtigen, van de zorgverzekeringsmarkt informatie openbaar met betrekking tot:'
+  - index: 1
+    label: onderdeel a
+    sha256: 654ce09b3febb67592c06ee9cca46348a145de54b72dbace032556b1a05192d4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de inhoud van de modelovereenkomsten;
+  - index: 2
+    label: onderdeel b
+    sha256: c62ee25c09520a5fc2f0d88430e5569d6b49e612e4ca24a50d7d76ae891ca74d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de wijze van dienstverlening aan verzekerden en verzekeringnemers.
+  - index: 3
+    label: lid 2
+    sha256: d879dec391bd6766d85bfa36a1ca16e9da4aeea058a9ba0fcbea813c3f451461
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het eerste lid geldt niet indien naar het oordeel van het College toezicht anderen reeds in voldoende mate in openbaarmaking van de daar bedoelde informatie voorzien.
+  - index: 4
+    label: lid 3
+    sha256: 5ce41655b92e9f76b9099f4272bff6912ee95e6d83e2bfba77ef862f23d91680
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij ministeriële regeling kan nader worden bepaald op welke onderwerpen de openbaarmaking, bedoeld in het eerste lid, betrekking heeft.
+- number: '84'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 7ec9eceb1160d40963efb0d70ba33596a008023035955b25003835502dec17f1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 84 1 Het College zorgverzekeringen kan in overeenstemming met het College toezicht regels stellen met betrekking tot de administratie van de zorgverzekeraars.
+  - index: 1
+    label: lid 2
+    sha256: 3a08d16bb60c92b6b8e4eb51054c56b1d8ffc4768451f3107b114dc6d3aa0d15
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Het College toezicht kan regels stellen met betrekking tot:'
+  - index: 2
+    label: onderdeel a
+    sha256: 3cb5341e26420ea5c61cb06dcc4ddc27a36a79fccd54240ad5f78706d8afa3cd
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de controle door de zorgverzekeraars;
+  - index: 3
+    label: onderdeel b
+    sha256: 1dadfc0390e2a34de58ba1909b67cfa5512c7c681d5df04571e4f7da62daface
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de inhoud en inrichting van het accountantsverslag, bedoeld in artikel 38 , en van het aan dat verslag ten grondslag liggende onderzoek.
+- number: '85'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 851287cc8f1b44a953826e92dd6b2a4b9a1577ff2918fdaf4176783e25de3c46
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 85 Paragraaf 6.3 is, met uitzondering van artikel 74 , van overeenkomstige toepassing.
+- number: '86'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6ccb9de42601c7d951a37218eb89a891c1c95b76203ef8ca31d098171e8b2c61
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 86 1 De zorgverzekeraar neemt het sociaal-fiscaalnummer van zijn verzekerden en, gedurende zeven jaren na het einde van de verzekering, van zijn gewezen verzekerden met het oog op de uitvoering van de zorgverzekering en van deze wet in zijn administratie op.
+  - index: 1
+    label: lid 2
+    sha256: c5bd123d935be5112a20f93d800b6bd193157ed94a24906c444a210520290d43
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De zorgverzekeraar verifieert het sociaal-fiscaalnummer in relatie tot de bijbehorende persoonsidentificerende gegevens van de verzekerde indien daartoe aanleiding is.
+  - index: 2
+    label: lid 3
+    sha256: c4f54bb16164f1968f47e1dafb58a5af95fb92b11cc208f371904b91139ffed3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij gegevensuitwisseling tussen de zorgverzekeraars en de in de artikelen 88 en 89 genoemde personen en instanties wordt, voor zover die personen en instanties tot gebruik van dat nummer bevoegd zijn, het sociaal-fiscaalnummer gebruikt.
+  - index: 3
+    label: lid 4
+    sha256: 509c565121d4fe0804076dcfd0fb5aa1d3a8bb939abaaccd111ac4a6587bbdc1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij algemene maatregel van bestuur kunnen nadere regels worden gesteld met betrekking tot het eerste en tweede lid.
+- number: '87'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c405e670d335d9cdb8a3cbe9f86e6fded9f856a418fc024e6980b4bc25bed8cf
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 87 1 Een zorgaanbieder die aan een verzekerde zorg of andere diensten, bedoeld in artikel 11 , heeft verleend, en die de kosten daarvan krachtens een door hem met de zorgverzekeraar gesloten overeenkomst rechtstreeks bij die zorgverzekeraar in rekening brengt, verstrekt die zorgverzekeraar of een door die zorgverzekeraar aangewezen persoon de persoonsgegevens van de verzekerde, waaronder persoonsgegevens betreffende de gezondheid als bedoeld in de [Wet bescherming persoonsgegevens](jci1.3:c:BWBR0011468) , die noodzakelijk zijn voor de uitvoering van de zorgverzekering of van deze wet, dan wel stelt hem deze gegevens voor dit doel voor inzage of het nemen van afschrift ter beschikking.
+  - index: 1
+    label: lid 2
+    sha256: 7176fcc54f594ed07d350216a476a66f12a1378fcc5dd4dcdc9b430acbf39c5d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Een zorgaanbieder die aan een verzekerde zorg of andere diensten, bedoeld in artikel 11 , heeft verleend en die de kosten daarvan bij de verzekerde in rekening brengt, verstrekt hem de persoonsgegevens, waaronder persoonsgegevens betreffende zijn gezondheid als bedoeld in de [Wet bescherming persoonsgegevens](jci1.3:c:BWBR0011468) , die voor zijn zorgverzekeraar noodzakelijk zijn voor de uitvoering van de zorgverzekering of van deze wet.
+  - index: 2
+    label: lid 3
+    sha256: d4d8682571db3c418adbd520cac996083e9bdd7c939fd5316aea36a9b45aaada
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De zorgaanbieder, bedoeld in het eerste of tweede lid, verstrekt een door Onze Minister aangewezen persoon kosteloos bij ministeriële regeling omschreven, voor de uitvoering van deze wet noodzakelijke persoonsgegevens, waaronder persoonsgegevens betreffende de gezondheid als bedoeld in de [Wet bescherming persoonsgegevens](jci1.3:c:BWBR0011468) .
+  - index: 3
+    label: lid 4
+    sha256: dc0c9a78c811c029738568d363ed953ce9c6a6a0ab26d490c806e11bdcbdc86b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Personen werkzaam ten behoeve van een zorgaanbieder als bedoeld in het eerste of tweede lid, verstrekken die zorgaanbieder de persoonsgegevens die hij nodig heeft om te kunnen voldoen aan zijn verplichtingen bedoeld in het eerste, tweede en derde lid.
+  - index: 4
+    label: lid 5
+    sha256: 4e9aeec42c3b1e671373dd2a16c99da8705b9b6b6da78fd564ae30ef87e3fa17
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Personen werkzaam bij de zorgverzekeraar, bij een door de zorgverzekeraar aangewezen persoon als bedoeld in het eerste lid, of bij de door Onze Minister aangewezen persoon als bedoeld in het derde lid, voor wie niet reeds uit hoofde van ambt of beroep een geheimhoudingplicht geldt, zijn verplicht tot geheimhouding van de gegevens als bedoeld in het eerste, tweede of derde lid, behoudens voor zover enig wettelijk voorschrift hen tot mededeling verplicht.
+  - index: 5
+    label: lid 6
+    sha256: 27eab5c0f46fa47e967de0a9dd3f4324f8c19df794b3b11bcaba7c08ebe24ee8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '6. Bij ministeriële regeling kan worden bepaald:'
+  - index: 6
+    label: onderdeel a
+    sha256: 51e8478ffc08470f93e98c824dcba009685afcf89beafe004c6da39e69f4b978
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. tot welke gegevens de verplichting, bedoeld in het eerste of tweede lid, zich in ieder geval uitstrekt;
+  - index: 7
+    label: onderdeel b
+    sha256: f9151d885eb6e09c737dafb76402cdeef684cca2c766caa971462ded9e5202fa
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. op welke wijze gegevens, bedoeld in het eerste of tweede lid, worden verstrekt;
+  - index: 8
+    label: onderdeel c
+    sha256: 34d41b76118353fc5627517e19972977f0e1476c3eee19f0e97f435f1aef47c0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. volgens welke technische standaarden elektronische gegevensverstrekking plaatsvindt;
+  - index: 9
+    label: onderdeel d
+    sha256: a264f1e18148c0b156b850a705f97e9c01099b56999b4b0a0a4befb8cc504a05
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. aan welke beveiligingseisen elektronische gegevensverstrekking voldoet.
+- number: '88'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 26f8114aa3460f28c89ef4de255ee130ba17f64905fa9eb1c41a6936003aa075
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 88 1 Een ieder verstrekt op verzoek aan de zorgverzekeraars, het College zorgverzekeringen, het College toezicht, Onze Minister, de rijksbelastingdienst, het Uitvoeringsinstituut werknemersverzekeringen, de Sociale verzekeringsbank, het gemeentebestuur, of aan een daartoe door of vanwege een van deze zorgverzekeraars of instanties aangewezen persoon kosteloos alle inlichtingen en gegevens, waaronder persoonsgegevens als bedoeld in de [Wet bescherming persoonsgegevens](jci1.3:c:BWBR0011468) , die noodzakelijk zijn voor de uitvoering van de zorgverzekeringen of van deze wet.
+  - index: 1
+    label: lid 2
+    sha256: efaa11f544c6d2088c5212c7c450b3ea46932424e369d9f595acd438e392ea6e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De in het eerste lid bedoelde gegevens en inlichtingen worden op verzoek verstrekt in schriftelijke vorm of in een andere vorm die redelijkerwijs kan worden verlangd, binnen een termijn die schriftelijk wordt gesteld bij het in het eerste lid bedoelde verzoek.
+  - index: 2
+    label: lid 3
+    sha256: 32e14dbda9eeaa5a6fdb24599206167816dc2f5899c4dcd393b0c717da6562c5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Een ieder geeft op verzoek van een rechtspersoon als bedoeld in het eerste lid, inzage in alle bescheiden en andere gegevensdragers, stelt deze op verzoek ter beschikking voor het nemen van afschrift en verleent de terzake verlangde medewerking, voor zover dit noodzakelijk is voor de uitvoering van deze wet door de desbetreffende zorgverzekeraars of instanties.
+  - index: 3
+    label: lid 4
+    sha256: 33c77f51e6c2c6ae21345e752c589db4f0c294858d21950a4163d659154f170f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij ministeriële regeling kunnen nadere regels worden gesteld met betrekking tot het eerste, tweede of derde lid.
+- number: '89'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 7773627dd337d525b2c257cda1ba55e41f4761898ac38751151418fa6b809e1f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 89 1 De in artikel 88, eerste lid , bedoelde zorgverzekeraars en instanties zijn bevoegd uit eigen beweging en verplicht op verzoek binnen een bij dat verzoek genoemde termijn, uit de onder hun verantwoordelijkheid gevoerde administratie, aan elkaar, aan een daartoe door of vanwege hen aangewezen persoon of aan een door Onze Minister aangewezen persoon, kosteloos, de gegevens, waaronder persoonsgegevens als bedoeld in de [Wet bescherming persoonsgegevens](jci1.3:c:BWBR0011468) , te verstrekken die noodzakelijk zijn voor de uitvoering van de zorgverzekeringen of van deze wet.
+  - index: 1
+    label: lid 2
+    sha256: 6cecb106a05b79d9cc46367b36918d3c3f1a60e0dc0ea729999782c55025531a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Een zorgverzekeraar verleent op verzoek van het College zorgverzekeringen dan wel van het College toezicht aan door het desbetreffende college aangewezen personen inzage in alle bescheiden en andere gegevensdragers, stelt deze op verzoek ter beschikking voor het nemen van afschrift en verleent de terzake verlangde medewerking, voor zover het desbetreffende college dit nodig acht voor de uitoefening van zijn taak.
+  - index: 2
+    label: lid 3
+    sha256: 8ab259778e5f7d795d819732688c68be5b7f806c051e3756c3ab79f2e31fc8de
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Alle ambtenaren tot afgifte van uittreksels uit registers van burgerlijke stand bevoegd, zijn verplicht aan een in artikel 88, eerste lid , bedoelde zorgverzekeraar of instantie de door deze gevraagde uittreksels uit de registers kosteloos toe te zenden.
+  - index: 3
+    label: lid 4
+    sha256: a6b743f907e63cbcff433be102a8c1cb56639d60e3f77744bb4b17d175cce399
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Griffiers van colleges, geheel of ten dele met rechtspraak belast, verstrekken op verzoek, kosteloos, aan een zorgverzekeraar, aan het College zorgverzekeringen of aan het College toezicht alle gegevens, inlichtingen en uittreksels uit of afschriften van uitspraken, registers en andere stukken, die noodzakelijk zijn voor de uitvoering van deze wet door de zorgverzekeraar of het desbetreffende college.
+  - index: 4
+    label: lid 5
+    sha256: 155df5deb8c090bddbe0edb37b7009b8d2df2bb902c8acdeb1868b8d955d54f3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Bij algemene maatregel van bestuur worden nadere regels gesteld over de verstrekking van gegevens door de rijksbelastingdienst aan de zorgverzekeraars.
+  - index: 5
+    label: lid 6
+    sha256: 7bd7ea8109ead2b7654c4516e33933dce951014059c7819229639cb5219a3772
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Bij ministeriële regeling kunnen nadere regels worden gesteld met betrekking tot het eerste of tweede lid.
+- number: '90'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: fc728aa5da4dc1e9cc5108d2bc2971f879238e748f0ca6a138569c4364318662
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 90 1 Het College toezicht, onderscheidenlijk het College zorgverzekeringen kan na overleg met het College zorgverzekeringen, onderscheidenlijk het College toezicht bij regeling bepalen welke gegevens en inlichtingen regelmatig door de zorgverzekeraars moeten worden verstrekt.
+  - index: 1
+    label: lid 2
+    sha256: 5b0600aab010c25dd85a0ee6a965d4c88908c175ec138db43ae7ff947db156b2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De regels kunnen mede omvatten het tijdstip en de wijze waarop de gegevens en inlichtingen moeten worden verstrekt, alsmede dat een accountant als bedoeld in [artikel 393 van Boek 2 van het Burgerlijk Wetboek](jci1.3:c:BWBR0003045&artikel=393) de juistheid van de verstrekte gegevens en inlichtingen bevestigt.
+  - index: 2
+    label: lid 3
+    sha256: fb293892367cabe6f0f27fdc45cbb5e6fff2ca3b57b2923d17ced13496c5e1ff
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij ministeriële regeling kan worden bepaald welke statistische gegevens de zorgverzekeraars verzamelen betreffende vormen van zorg en andere diensten.
+- number: '91'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 503ed46528ce580f33c0bc59ee10e959cdcaae6ed3e50c2e016d113a959e7178
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 91 1 Het College zorgverzekeringen en het College toezicht verstrekken Onze Minister uit eigen beweging inlichtingen over ontwikkelingen die ertoe leiden of kunnen leiden dat ten behoeve van verzekerden niet vrij kan worden gekozen tussen zorgverzekeraars en de door hen aangeboden varianten van de zorgverzekering of die een rechtmatige en volledige uitvoering van zorgverzekeringen jegens de verzekeringnemers of verzekerden in gevaar kunnen brengen.
+  - index: 1
+    label: lid 2
+    sha256: 94cb1952b68f3f696cb26507868673d2903496d2653570e3c7fce988d7b6e042
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het College zorgverzekeringen en het College toezicht verstrekken desgevraagd aan Onze Minister, aan het College tarieven gezondheidszorg, bedoeld in de [Wet tarieven gezondheidszorg](jci1.3:c:BWBR0003356) , of aan het College bouw of het College sanering, bedoeld in de Wet toelating zorginstellingen, de voor de uitoefening van hun taak benodigde inlichtingen en gegevens.
+  - index: 2
+    label: lid 3
+    sha256: 2542808d8bd975f4581b63035fa4e2ede5f35ba99b8fe0f554b7a307e82261b5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het College zorgverzekeringen en het College toezicht verlenen aan door Onze Minister of door een bestuursorgaan, bedoeld in het tweede lid, aangewezen personen toegang tot en inzage in zakelijke gegevens en bescheiden, voor zover dat voor de vervulling van hun taak redelijkerwijs nodig is.
+- number: '92'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: fe8b7ffc61a5a55f9ad53d981d371a4e957cbf79e059f5d728d2b3d4617deb27
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 92 1 Een zorgverzekeraar maakt voor de verstrekking of ontvangst van gegevens aan of van personen, aan te wijzen door het College zorgverzekeringen, gebruik van een elektronische infrastructuur.
+  - index: 1
+    label: lid 2
+    sha256: 1b9acebba403f32109338146ce4c7a41dfe8fad1e074f2f92798ae3b9c94edb0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Het College zorgverzekeringen kan met betrekking tot het eerste lid regels stellen over:'
+  - index: 2
+    label: onderdeel a
+    sha256: 2bdd0afbfea06abdc725e945cd57a5f94fbd3e35e01b107b292140c699476f2f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de aard en omvang van de gegevens en de voorschriften waaraan de verstrekking of ontvangst ten minste moet voldoen;
+  - index: 3
+    label: onderdeel b
+    sha256: 5d895c72e01d8c40ca50f07525ef14fdc6650beb0a4abb58fa939111f4e8ec9e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de wijze waarop de verstrekking of ontvangst van gegevens plaatsvindt, waaronder begrepen de aansluiting van zorgverzekeraars op de infrastructuur;
+  - index: 4
+    label: onderdeel c
+    sha256: 474c40ee2fc9a5dc71bfc735eda712608c7007d042bae95236ea08fb0c1a55ef
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. de wijze waarop het gebruik van de infrastructuur wordt georganiseerd en beheerd, waaronder begrepen de inrichting en instandhouding van een gemeenschappelijke database;
+  - index: 5
+    label: onderdeel d
+    sha256: 41dce0b8755336a8153479fd700d30c478509a2fce5644c3ec74365c08305974
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. de financiering van het gebruik van de infrastructuur en de wijze waarop de kosten ervan worden verdeeld.
+- number: '93'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 23907939f438a8c5206dbd131ec50cb0137e425499d9d2cb40e3c5aa263e3b45
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 93 1 Het is een ieder die uit hoofde van de toepassing van deze wet of van krachtens deze wet genomen besluiten enige taak vervult of heeft vervuld, verboden van vertrouwelijke gegevens of inlichtingen die ingevolge deze wet dan wel ingevolge [afdeling 5.2 van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&afdeling=5.2) zijn verstrekt of verkregen of van De Nederlandsche Bank N.V. of de Stichting Autoriteit Financiële Markten zijn ontvangen, verder of anders gebruik te maken of daaraan verder of anders bekendheid te geven dan voor de uitvoering van zijn taak of bij of krachtens deze wet wordt geëist.
+  - index: 1
+    label: lid 2
+    sha256: fef0fd39a04e1b0a7d6fddf4be34e6d9eab469606c165f317297f79b6cfcbf83
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. In afwijking van het eerste lid kunnen het College toezicht en het College zorgverzekeringen met gebruikmaking van vertrouwelijke gegevens of inlichtingen verkregen bij de uitvoering van hun taken op grond van deze wet, mededelingen doen, indien deze niet kunnen worden herleid tot afzonderlijke personen of ondernemingen.
+  - index: 2
+    label: lid 3
+    sha256: 5fb4dc6c9a7b0e07d867ee95d155afb59e2d63c1013c22692702e024aa5a0ef0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. In afwijking van het eerste lid en van [artikel 182 van de Wet toezicht verzekeringsbedrijf 1993](jci1.3:c:BWBR0006509&artikel=182) zijn het College toezicht, het College zorgverzekeringen, De Nederlandsche Bank N.V. en de Stichting Autoriteit Financiële Markten, voor zover dat voor hun taakuitoefening noodzakelijk is, bevoegd aan elkaar en aan Onze Minister vertrouwelijke gegevens of inlichtingen omtrent afzonderlijke verzekeraars te verschaffen.
+  - index: 3
+    label: lid 4
+    sha256: bc0d957cf7df378b4bb3f0408e0e8531d1e6886a4894460056924a315d00100e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. Het eerste lid laat, ten aanzien van degene op wie dat lid van toepassing is, onverlet:'
+  - index: 4
+    label: onderdeel a
+    sha256: 22e5b8c3af81b942236654c4f1b0244d9c57957e4924aeb30746bb084162ca9c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de toepasselijkheid van de bepalingen van het [Wetboek van Strafvordering](jci1.3:c:BWBR0001903) welke betrekking hebben op het als getuige of deskundige in strafzaken afleggen van een verklaring omtrent gegevens of inlichtingen verkregen bij de vervulling van de ingevolge deze wet opgedragen taak;
+  - index: 5
+    label: onderdeel b
+    sha256: 8e207ad8f81f4447334d2599003ddc215f84aa44b1a310be2656b91e662e7f46
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de toepasselijkheid van de bepalingen van het [Wetboek van Burgerlijke Rechtsvordering](jci1.3:c:BWBR0001827) en van [artikel 66 van de Faillissementswet](jci1.3:c:BWBR0001860&artikel=66) welke betrekking hebben op het als getuige of als partij in een comparitie van partijen dan wel als deskundige in burgerlijke zaken afleggen van een verklaring omtrent gegevens of inlichtingen verkregen bij de vervulling van zijn ingevolge deze wet opgedragen taak, voor zover het gaat om gegevens of inlichtingen omtrent een verzekeraar die in staat van faillissement is verklaard of op grond van een rechterlijke uitspraak is ontbonden;
+  - index: 6
+    label: onderdeel c
+    sha256: 7c1c4aa7bb64224deafd6808f794efcc1ef68bef93a07f36a95cdbb0b171cd64
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. de bevoegdheden van de Algemene Rekenkamer ingevolge [artikel 91 van de Comptabiliteitswet 2001](jci1.3:c:BWBR0013891&artikel=91) , voor zover deze niet bij artikel 121 zijn beperkt.
+  - index: 7
+    label: lid 5
+    sha256: 59f07ef6c0e4e91093dfaba0052f1acf48e902e1977ec372753eb8326b263ec3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Het vierde lid, onderdeel b, geldt niet voor gegevens of inlichtingen die betrekking hebben op verzekeraars die betrokken zijn of zijn geweest bij een poging de desbetreffende verzekeraar in staat te stellen zijn bedrijf voort te zetten.
+  - index: 8
+    label: lid 6
+    sha256: 455706986c7fef11ea0fef14872d10e02ea76cd0508cfcd64725ad4e7578935f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. De Algemene Rekenkamer is bij het doen van mededelingen als bedoeld in [artikel 91, elfde tot en met veertiende lid, van de Comptabiliteitswet 2001](jci1.3:c:BWBR0013891&artikel=91) , verplicht tot geheimhouding, voor zover het betreft gegevens en inlichtingen die haar ingevolge het vierde lid, onderdeel c, bekend zijn geworden.
+- number: '94'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c1582d15af331d17789b9a0399c9f05cc618dd01b607cf522e2e5b9bc85b0595
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 94 1 Het College toezicht kan uit hoofde van zijn toezichthoudende taak een aanwijzing geven aan een zorgverzekeraar, dan wel aan een verzekeraar die verzekeringen als zorgverzekering aanbiedt of uitvoert die niet aan het bij of krachtens deze wet geregelde voldoen.
+  - index: 1
+    label: lid 2
+    sha256: 16861756ca358dca59cf2b61ac6099a39ff24c96dfbf861ba9c9262b8dbff98a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het College toezicht geeft geen aanwijzing omtrent de beoordeling of behandeling van individuele gevallen.
+  - index: 2
+    label: lid 3
+    sha256: 2cdd58e88871dd1f088fb72cae19a84d9c0e1179bfcbdbb0f3204e9616e42fbb
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij de aanwijzing stelt het College toezicht een termijn waarbinnen de verzekeraar aan de aanwijzing voldoet.
+  - index: 3
+    label: lid 4
+    sha256: de6c8a5934bc149d5ee15ef845042c1b8fba42808c0027b6c20ffa63a9dd4f64
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. Indien de verzekeraar niet binnen de termijn, bedoeld in het derde lid, aan de aanwijzing voldoet, is het College toezicht bevoegd:'
+  - index: 4
+    label: onderdeel a
+    sha256: 5c85820c204a65eddc4624331e18f704eb61cdfc9326437ef112f9e35cccb86f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. bestuursdwang toe te passen, of
+  - index: 5
+    label: onderdeel b
+    sha256: 6699191212a77a182fdbda8011bbe457c64490ce15adad11513010513799aec0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'b. ter openbare kennis te brengen, zo nodig onder vermelding van de overwegingen die tot die kennisgeving hebben geleid:'
+  - index: 6
+    label: tekst
+    sha256: 7df350e518866723608f53272871099baeb8105a1cb36da8217e0262f2c0514f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1°. dat een verzekeraar verzekeringen als zorgverzekering aanbiedt of uitvoert die niet aan het bij of krachtens deze wet geregelde voldoen;
+  - index: 7
+    label: tekst
+    sha256: 2390f6129ef701a0fc422bf7f6f1f7cd9fec6cc2ac7907846e3373f305731b3b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2°. dat een zorgverzekeraar in strijd handelt met een of meer door het College toezicht genoemde, bij of krachtens deze wet geregelde bepalingen;
+  - index: 8
+    label: tekst
+    sha256: 98095150ab31b0ec320dbab56d5a8747866f06afa58eeb1ff7ac38f65e73b01f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3°. dat aan een verzekeraar een last onder dwangsom of een bestuurlijke boete is opgelegd.
+  - index: 9
+    label: tekst
+    sha256: 7df350e518866723608f53272871099baeb8105a1cb36da8217e0262f2c0514f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1°. dat een verzekeraar verzekeringen als zorgverzekering aanbiedt of uitvoert die niet aan het bij of krachtens deze wet geregelde voldoen;
+  - index: 10
+    label: tekst
+    sha256: 2390f6129ef701a0fc422bf7f6f1f7cd9fec6cc2ac7907846e3373f305731b3b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2°. dat een zorgverzekeraar in strijd handelt met een of meer door het College toezicht genoemde, bij of krachtens deze wet geregelde bepalingen;
+  - index: 11
+    label: tekst
+    sha256: 98095150ab31b0ec320dbab56d5a8747866f06afa58eeb1ff7ac38f65e73b01f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3°. dat aan een verzekeraar een last onder dwangsom of een bestuurlijke boete is opgelegd.
+  - index: 12
+    label: lid 5
+    sha256: 6e3ad8c0c650e9a878b12f433be7c5c83fcd7fcc1d0fb19ce1debe86c62b29ce
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Het College toezicht stelt, indien hij voornemens is een feit ter openbare kennis te brengen, de betrokken verzekeraar daarvan in kennis onder vermelding van de gronden waarop het voornemen berust.
+  - index: 13
+    label: lid 6
+    sha256: 4680e7441b68a982f45074cca4008a378bfb790beb2de0681f13875c98e1f29b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. In afwijking van [artikel 4:8 van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&artikel=4:8) is het College toezicht niet gehouden de betrokken verzekeraar in de gelegenheid te stellen om zijn zienswijze naar voren te brengen, indien van de betrokken verzekeraar geen adres bekend is en het adres ook niet met een redelijke inspanning kan worden verkregen.
+  - index: 14
+    label: lid 7
+    sha256: a2ac141e690adf3ecd155b5138d2fb5ccc547d00f31b66869e2f417868835218
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. De beschikking om een feit ter openbare kennis te brengen, vermeldt in ieder geval het feit dat ter openbare kennis wordt gebracht alsmede de wijze waarop en de termijn waarna dit zal geschieden.
+  - index: 15
+    label: lid 8
+    sha256: 64837b41cf2e15386ad5155c9a1bd6318389113de5c9b7224f22afed536fb93b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 8. Het ter openbare kennis brengen geschiedt niet eerder dan nadat vijf werkdagen zijn verstreken na de bekendmaking, bedoeld in het vijfde lid, aan de verzekeraar.
+  - index: 16
+    label: lid 9
+    sha256: 6365de43036e82c4f3ae9984caa4a3825ccba38807b7db119d42ff922b0808fe
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 9. Indien de verzekeraar verzoekt om een voorlopige voorziening als bedoeld in [artikel 8:81 van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&artikel=8:81) te treffen, wordt de werking van de beschikking opgeschort totdat er een uitspraak is van de voorzieningenrechter.
+  - index: 17
+    label: lid 10
+    sha256: 520e55b32f79f098c1bd94402277c0932238b7fad0ffe336241f9e3e7d363f44
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 10. Indien het adequaat functioneren van de verzekeringsmarkt of de positie van de verzekeraars op die markt geen uitstel toelaat, kan de toezichthouder, in afwijking van de voorgaande leden, het feit onverwijld ter openbare kennis brengen.
+  - index: 18
+    label: lid 11
+    sha256: 938ac2538c40d8d02276bc5332e59ba7e4aec4eed09c25439355e2c5c6b80e7d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 11. Indien de verzekeraar na een publicatie als bedoeld in het vierde lid, onderdeel b, alsnog voldoet aan de aanwijzing, doet het College toezicht hiervan op dezelfde wijze mededeling als bij de voorafgaande publicatie.
+- number: '95'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 351e44ec290c8e7cc1352e3d85483fc1ffacabe41e961e60133ec6a1fe3a5d40
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 95 1 Het College toezicht kan een zorgverzekeraar een last onder dwangsom opleggen ter zake van overtreding van de voorschriften gesteld bij of krachtens de artikelen 3 , 4, tweede tot en met vijfde lid , 5, derde lid , 9 , 25, derde lid , 28 , 29, eerste en tweede lid , 35, tweede lid , 37 , 38, eerste en vierde lid , 64, tweede lid , 68, tweede lid , 81, tweede lid , 84 , 86 , 89, eerste, tweede en vijfde lid , 90 , 92 , 96, vijfde lid , of 114 .
+  - index: 1
+    label: lid 2
+    sha256: 4847ff24f035eb04995f6542ec20de956815589dad07986b54a7f04716aad27b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het College toezicht kan een verzekeraar respectievelijk rechtspersoon een last onder dwangsom opleggen ter zake van overtreding van de artikelen 25, eerste en tweede lid , respectievelijk 30 .
+  - index: 2
+    label: lid 3
+    sha256: 653808d38706a1af33578ca3ce360fc92c4138e2e50666e0f1f85ad36172cee2
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het College toezicht kan een verzekeraar die verzekeringen als zorgverzekering aanbiedt of uitvoert die niet aan het bij of krachtens deze wet geregelde voldoen, een last onder dwangsom opleggen.
+  - index: 3
+    label: lid 4
+    sha256: 415f6ac33368e09d610ec8d6c250adcf35e6a1c9851bc90503e02ac8e10d3665
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. De [artikelen 5:32, tweede tot en met vijfde lid](jci1.3:c:BWBR0005537&artikel=5:32) , en [5:33 tot en met 5:35 van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&artikel=5:33) zijn van toepassing, met dien verstande dat een door het College toezicht ingevorderde dwangsom aan het Zorgverzekeringsfonds wordt afgedragen.
+- number: '96'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6bf7a1aa70778c13be6f7a477307b8a4a6dd0b46ddb31ea360b880701aeff476
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 96 1 Indien de zorgverzekering niet binnen vier maanden na het ontstaan van de verzekeringsplicht is ingegaan of indien een verzekeringsplichtige niet met ingang van de dag volgende op de dag waarop een zorgverzekering is geëindigd op grond van een andere zorgverzekering verzekerd is, legt het College zorgverzekeringen de verzekerde een bestuurlijke boete op.
+  - index: 1
+    label: lid 2
+    sha256: 9818a7f982c4e5393613a130c8ed35469586ade6d18797c5392d647e8ac76206
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. In afwijking van het eerste lid:'
+  - index: 2
+    label: onderdeel a
+    sha256: b1f7931de2cabf088f46c7fd7cf1aa3c6c6842069200a66eb10099c4a99b1169
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. wordt geen boete opgelegd indien de verzekerde op de eerste dag van de kalendermaand, volgende op de maand waarop de zorgverzekering ingaat, jonger dan achttien jaar was;
+  - index: 3
+    label: onderdeel b
+    sha256: 911ec3e9736e7994198682c9a572e51dcadfde8fc0ff854550cf3d97491bcf52
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. wordt de boete indien artikel 2, derde lid , van toepassing is, opgelegd aan de curator, de bewindvoerder of de mentor.
+  - index: 4
+    label: lid 3
+    sha256: b35706af6082bb5431eb1e42b0ce27fd54c7133d6853e8befd12358023403a69
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De hoogte van de boete is gelijk aan 130% van de premie, bedoeld in artikel 17, vijfde lid , over een periode gelijk aan de periode gelegen tussen de dag waarop de verzekeringsplicht ontstond en de dag waarop de zorgverzekering inging, dan wel gelegen tussen de dag waarop de zorgverzekering eindigde en de dag waarop een nieuwe zorgverzekering inging.
+  - index: 5
+    label: lid 4
+    sha256: 00cfced78bee0daef03192073c4a017dfb5cd5bde1eb37bed46cb7c365d2aa8d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Indien de periode, bedoeld in het derde lid, langer is dan vijf jaren, wordt zij op vijf jaren gesteld.
+  - index: 6
+    label: lid 5
+    sha256: 792e0638122a3869cdbbe10a4b9eea3cfe1cffc40747f27d6bd36e3b35fa1374
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. De voorbereiding en de uitvoering van boetebeschikkingen wordt namens het College zorgverzekeringen door de zorgverzekeraars verricht.
+  - index: 7
+    label: lid 6
+    sha256: 06ca92bc3bcdca79988dbb9b654a59a471110f8fe37c203d09d2588795928a98
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. De zorgverzekeraars hebben als vergoeding voor hun werkzaamheden, bedoeld in het vijfde lid, recht op een door het College zorgverzekeringen te bepalen percentage van de door hen ingevorderde boeten.
+  - index: 8
+    label: lid 7
+    sha256: d3068e359d7b9485764dfc91bfae806f54dbd2b6035fce29fc192925ae830f43
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. De zorgverzekeraars dragen de ingevorderde boeten onder aftrek van de vergoeding, bedoeld in het vijfde lid, af aan het Zorgverzekeringsfonds.
+- number: '97'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: e18e251abad432b840d1f3b465e4edefcb0835727bb0fb39fd822f68a394c178
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 97 1 Het College toezicht kan een bestuurlijke boete opleggen aan een zorgverzekeraar die niet voldoet aan de voorschriften, gesteld bij of krachtens de artikelen 3 , 25, derde lid , 28 , of 29, eerste en tweede lid .
+  - index: 1
+    label: lid 2
+    sha256: 5e18af86394e293b1910d946f099535a65f091ab42470d445bee797bbf358b59
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Het College toezicht kan een bestuurlijke boete opleggen aan een verzekeraar respectievelijk rechtspersoon die niet voldoet respectievelijk niet heeft voldaan aan de voorschriften, gesteld bij de artikelen 25, eerste en tweede lid , respectievelijk 30 .
+  - index: 2
+    label: lid 3
+    sha256: cb4a7b4e2f442af0337f10632f8033e0ebad79f873250d4e7847e8e2433d1d75
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De boete voor een afzonderlijke overtreding bedraagt ten hoogste € 500 000.
+  - index: 3
+    label: lid 4
+    sha256: 804632fb3a38148f9d7494e165492583aa0782ac689fa0f3ea4e1297ecdd9053
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het College toezicht draagt ingevorderde boeten af aan het Zorgverzekeringsfonds.
+- number: '98'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 83730a92b4c62b14866797a09a62b6ee05b5b8801a51603dab8d1efc7a02944f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 98 1 Het College toezicht kan een bestuurlijke boete opleggen aan een zorgverzekeraar die dat college of een door hem aangewezen persoon onjuiste of onvolledige informatie heeft verschaft met betrekking tot de aantallen bij hem verzekerde verzekeringsplichtigen of hun verzekerdenkenmerken, noodzakelijk voor de vaststelling van de bijdragen, bedoeld in de artikelen 32 tot en met 34 .
+  - index: 1
+    label: lid 2
+    sha256: b6b8d19fcad7465a0a523dc6f324ec112a5f7f416626beb0567ac4f6c5044e1d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De boete voor een afzonderlijke overtreding bedraagt ten hoogste € 10 000 000.
+  - index: 2
+    label: lid 3
+    sha256: 2ef45dcc4f81e8ec7573a7d07484cbf75307a56d93b6ec473ca5236f1954a8d0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het College toezicht draagt ingevorderde boeten af aan het Zorgverzekeringsfonds.
+- number: '99'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 54fcfe5371e65a8000bc30efb40b9536d48f0177062787816497e45493844e0e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 99 1 Het College toezicht kan een bestuurlijke boete opleggen aan een zorgverzekeraar die niet voldoet aan de voorschriften, gesteld bij of krachtens de artikelen 4, tweede tot en met vijfde lid , 5, derde lid , 9 , 35, tweede lid , 37 , 38, eerste en vierde lid , 64, tweede lid , 68, tweede lid , 81, tweede lid , 84 , 86 , 90 , 92 of 114 .
+  - index: 1
+    label: lid 2
+    sha256: 4b3a48541cbbbc26b54e9b6ff51f38b32664f3418935ac668697ae65d82b0d56
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De boete voor een afzonderlijke overtreding bedraagt ten hoogste € 100 000.
+  - index: 2
+    label: lid 3
+    sha256: 2ef45dcc4f81e8ec7573a7d07484cbf75307a56d93b6ec473ca5236f1954a8d0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het College toezicht draagt ingevorderde boeten af aan het Zorgverzekeringsfonds.
+- number: '100'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b31894895bf74edd2413f7a3db93177fea79e1fd2ffa1d0dec990067e8f6db6c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 100 1 Het College toezicht kan een bestuurlijke boete opleggen aan degene die niet voldoet aan een hem ingevolge artikel 88 of 89 opgelegde verplichting.
+  - index: 1
+    label: lid 2
+    sha256: 79afcc375e67e3e3d555910c889b8bf2d94abf27870c9dcba8bc94b9ba4ba874
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De boete voor een afzonderlijke overtreding bedraagt ten hoogste € 2 250.
+  - index: 2
+    label: lid 3
+    sha256: 2ef45dcc4f81e8ec7573a7d07484cbf75307a56d93b6ec473ca5236f1954a8d0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het College toezicht draagt ingevorderde boeten af aan het Zorgverzekeringsfonds.
+- number: '101'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 772440284d06ec7a523a4b9fcf7d1b761fe57282f0c3ee0bf59ff5f8d646096b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 101 1 In de artikelen 102 tot en met 112 wordt verstaan onder:'
+  - index: 1
+    label: onderdeel a
+    sha256: cde0c239ff3346f7e55ebbffaf97c38ca3cdd2bafcd05b38d4cd92036409dead
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'a. overtreding: een gedraging of het nalaten van een gedraging, die of dat kan leiden tot de oplegging van een bestuurlijke boete als bedoeld in de artikelen 69 , 96 , 97 , 98 , 99 of 100 ;'
+  - index: 2
+    label: onderdeel b
+    sha256: 08f878d9365ddec18d86c46b06b336c83eae8d539f33fcc54a457cdd20e60616
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'b. overtreder: degene aan wie het College zorgverzekeringen dan wel het College toezicht wegens een overtreding een bestuurlijke boete overweegt op te leggen of oplegt. 2 [Artikel 51 van het Wetboek van Strafrecht](jci1.3:c:BWBR0001854&artikel=51) is van overeenkomstige toepassing.'
+- number: '102'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 19bb3c587abac90a3e102c1e78bc762f4633d7ae20974df36664288a03db6492
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 102 1 Degene die wordt verhoord met het oog op het opleggen van een bestuurlijke boete, is niet verplicht ten behoeve daarvan verklaringen omtrent de overtreding af te leggen.
+  - index: 1
+    label: lid 2
+    sha256: d69cbd12bf0f94849790703f6a246b840a6d35355901657e6090a29f8ed647d3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De betrokkene wordt hierop gewezen alvorens hem mondeling wordt gevraagd verklaringen af te leggen, en in ieder geval wanneer hij in de gelegenheid wordt gesteld over het voornemen tot oplegging van de bestuurlijke boete zijn zienswijze naar voren te brengen.
+- number: '103'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: ef5c1e9e7c758caf17feb1cc717b148cd054fffb6c02ecdb182a1dbd16181505
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 103 1 Het College zorgverzekeringen dan wel het College toezicht maakt van de overtreding een rapport op.
+  - index: 1
+    label: lid 2
+    sha256: 125e90d18199ef645c3cea44e7b522b444da35efa2a72580d03fe9e961d17084
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Het rapport is gedagtekend en vermeldt:'
+  - index: 2
+    label: onderdeel a
+    sha256: dfa7d439fd7d7e38305fd044dc9bec20a0230af3341fcac0d871ef9506c47744
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de naam van de overtreder;
+  - index: 3
+    label: onderdeel b
+    sha256: a111d561cec2e9ce0715cefb76cd7cc6007d2e7b79f3a90bd0c74c862267b8a9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de overtreding alsmede het overtreden voorschrift;
+  - index: 4
+    label: onderdeel c
+    sha256: 52aa82274920358de1f776bd0b783afbe94b9cbd3b91ea88c87c580f067e3112
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. zo nodig een aanduiding van de plaats waar en het tijdstip waarop de overtreding is geconstateerd.
+  - index: 5
+    label: lid 3
+    sha256: 20a07cdcd96cafa338f5bcc831d83d2b7bec9a62846380621fa5c745390a6442
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien van de overtreding een proces-verbaal als bedoeld in [artikel 152 van het Wetboek van Strafvordering](jci1.3:c:BWBR0001903&artikel=152) is opgemaakt, treedt dit in de plaats van het rapport.
+- number: '104'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: c151dff675ef0c8ea11730eed8ecfe0753fd671c3536269b699d2b99bc2616e8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 104 1 Het College zorgverzekeringen dan wel het College toezicht stelt de overtreder desgevraagd in de gelegenheid de gegevens waarop het opleggen van de bestuurlijke boete, dan wel het voornemen daartoe, berust, in te zien en daarvan afschriften te vervaardigen.
+  - index: 1
+    label: lid 2
+    sha256: c083d0bf3b10ff2e31600b391229fae89f080f14efc0b523e0e8cc19e6401740
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Voor zover blijkt dat de verdediging van de overtreder dit redelijkerwijs vergt, draagt het College zorgverzekeringen dan wel het College toezicht er zoveel mogelijk zorg voor dat deze gegevens aan de overtreder worden medegedeeld in een voor deze begrijpelijke taal.
+- number: '105'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 13876f54d9599592006f265366bd1e6a54ef03ced4526b17e1b41f722c86ae12
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 105 1 In afwijking van artikel 4.1.2 van de Algemene wet bestuursrecht wordt de overtreder steeds in de gelegenheid gesteld zijn zienswijze over het voornemen tot het opleggen van een bestuurlijke boete naar voren te brengen.
+  - index: 1
+    label: lid 2
+    sha256: 93e1594da6b973585ebb2d01d1d83677121777cfcae5094331ba7c3552927156
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Bij de uitnodiging tot het naar voren brengen van zijn zienswijze wordt het rapport, bedoeld in artikel 103 , aan de overtreder toegezonden of uitgereikt.
+  - index: 2
+    label: lid 3
+    sha256: bd8dfc5061ca1813d170fcb5d6785958ee17874b972ee74f573766779c36967a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Het College zorgverzekeringen dan wel het College toezicht zorgt voor bijstand door een tolk, indien blijkt dat de verdediging van de overtreder dit redelijkerwijs vergt.
+  - index: 3
+    label: lid 4
+    sha256: 7bd17fc7f3b6a7d193e5de477cb0fa23de817be99a6ade862671b786fc495580
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. Indien het College zorgverzekeringen dan wel het College toezicht nadat de overtreder zijn zienswijze naar voren heeft gebracht, beslist dat:'
+  - index: 4
+    label: onderdeel a
+    sha256: c4364255799940980315b6028be04b9033cd9c0fc0a9050e9f52687414e50892
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. voor de overtreding geen bestuurlijke boete zal worden opgelegd, of
+  - index: 5
+    label: onderdeel b
+    sha256: 5cc539b8c517bb95d3ff531bbb94f96f7e23bd09b1fdad307b277855c58dc35c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de overtreding aan de officier van justitie zal worden voorgelegd, wordt dit schriftelijk aan de overtreder medegedeeld.
+- number: '106'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 2d67b36f52f9c2ca3345a4f77c0f079d0cd8dea697d328146135d4a1ac91ee98
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 106 1 Het College zorgverzekeringen dan wel het College toezicht legt geen bestuurlijke boete op:'
+  - index: 1
+    label: onderdeel a
+    sha256: 54f699dff5ce4ec7d216ca2560842ca1a311cdfd29a738b1291b88c4ef219794
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. voor zover de overtreding niet aan de overtreder kan worden verweten;
+  - index: 2
+    label: onderdeel b
+    sha256: e23bce9153695d56226a096f65759b024cf140d911494122a2a57c6c206b9720
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. voor zover voor de overtreding een rechtvaardigingsgrond bestond;
+  - index: 3
+    label: onderdeel c
+    sha256: cd53f9a627859dda4ff25c8d84ce70c750b0ff5c9d369945d8201044ee6863b0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. indien aan de overtreder wegens dezelfde overtreding reeds eerder een bestuurlijke boete is opgelegd, dan wel een kennisgeving als bedoeld in artikel 105, vierde lid, aanhef en onderdeel a , is bekendgemaakt;
+  - index: 4
+    label: onderdeel d
+    sha256: 2077690b3c75c1975f95c3822c67acd8b60e9516fa1dd2eeb54f7a3c61cc806c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'd. indien tegen de overtreder wegens dezelfde gedraging:'
+  - index: 5
+    label: tekst
+    sha256: 829df8ae2dc93a494a3d974d032ca235f5f941389ec12cd4e150d4c5cfc73982
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1°. een strafvervolging is ingesteld en het onderzoek ter terechtzitting is begonnen, of
+  - index: 6
+    label: tekst
+    sha256: 99a80bee9c39db284f33e1155837d73bec51403f5f0ed1a08a89d69947e57c56
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2°. het recht tot strafvordering is vervallen ingevolge [artikel 74](jci1.3:c:BWBR0001854&artikel=74) of [74c van het Wetboek van Strafrecht](jci1.3:c:BWBR0001854&artikel=74c) , ingevolge [artikel 37 van de Wet op de economische delicten](jci1.3:c:BWBR0002063&artikel=37) , dan wel ingevolge [artikel 76 van de Algemene wet inzake rijksbelastingen](jci1.3:c:BWBR0002320&artikel=76) .
+  - index: 7
+    label: tekst
+    sha256: 829df8ae2dc93a494a3d974d032ca235f5f941389ec12cd4e150d4c5cfc73982
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 1°. een strafvervolging is ingesteld en het onderzoek ter terechtzitting is begonnen, of
+  - index: 8
+    label: tekst
+    sha256: 99a80bee9c39db284f33e1155837d73bec51403f5f0ed1a08a89d69947e57c56
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2°. het recht tot strafvordering is vervallen ingevolge [artikel 74](jci1.3:c:BWBR0001854&artikel=74) of [74c van het Wetboek van Strafrecht](jci1.3:c:BWBR0001854&artikel=74c) , ingevolge [artikel 37 van de Wet op de economische delicten](jci1.3:c:BWBR0002063&artikel=37) , dan wel ingevolge [artikel 76 van de Algemene wet inzake rijksbelastingen](jci1.3:c:BWBR0002320&artikel=76) .
+  - index: 9
+    label: lid 2
+    sha256: 8a33c9e5bb80c47933dc177620b2cae24bed15ceda7f27e81ff75ba348beffe4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien de gedraging tevens een strafbaar feit is, wordt zij aan de officier van justitie voorgelegd, tenzij met het openbaar ministerie is overeengekomen, dat daarvan kan worden afgezien.
+  - index: 10
+    label: lid 3
+    sha256: 1eea51fd4f3202dda0c46dc2bd4d89d882f548e743532f649e55267fc41060dc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Bij ministeriële regeling kan worden bepaald in welke gevallen van een voorlegging als bedoeld in het tweede lid wordt afgezien.
+  - index: 11
+    label: lid 4
+    sha256: e4fb8791ce15f0a50d7351ee5985c3b2d5d4168fbf1854559f1623055f02c64c
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '4. Voor een gedraging die aan de officier van justitie moet worden voorgelegd, legt het College toezicht slechts een bestuurlijke boete op indien:'
+  - index: 12
+    label: onderdeel a
+    sha256: 9378f01ea64ffdf5acc7b9ad8db1ac6229231bd76567dfe0046896dc956121c0
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de officier van justitie aan het bestuursorgaan heeft medegedeeld van strafvervolging tegen de overtreder af te zien, of
+  - index: 13
+    label: onderdeel b
+    sha256: 0d24f316dd0504474939c8a59ae7b56d2eacdc8212a4a814b369ea7f2e36395f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. het College toezicht niet binnen dertien weken een reactie van de officier van justitie heeft ontvangen.
+- number: '107'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: e91ce6f4b9c76777c044b8802b5ea468377873abbee03ccffcc7cb59aeb066ad
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 107 1 Het College zorgverzekeringen dan wel het College toezicht legt geen bestuurlijke boete op indien de overtreder is overleden.
+  - index: 1
+    label: lid 2
+    sha256: 57be7dcbe318789f441a30f7d7bbf3c461b894809d8a9cbe8bf076691a344a85
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Een bestuurlijke boete vervalt indien zij op het tijdstip van het overlijden van de overtreder niet onherroepelijk is.
+  - index: 2
+    label: lid 3
+    sha256: 3057d9763b7c0a83773bd552e749bce0df77d0c2ea0695bab8be39f4814ef8d7
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Een onherroepelijke bestuurlijke boete vervalt voor zover zij op het in het tweede lid bedoelde tijdstip nog niet is betaald.
+- number: '108'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6427ac85163200fe2d7e56460a4a81c514f8ab0c36f3d51a8e5c848d1f8eb353
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 108 1 Indien de overtreder aannemelijk maakt dat een bestuurlijke boete, berekend op grond van artikel 69 of artikel 96, derde en vierde lid , wegens bijzondere omstandigheden te hoog is, legt het College zorgverzekeringen een lagere bestuurlijke boete op.
+  - index: 1
+    label: lid 2
+    sha256: 1a25e4a75effc66cd53f9b1d02e7520ef7fbd162894c44323007381961988b94
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Een bestuurlijke boete op grond van de artikelen 97 , 98 , 99 of 100 wordt afgestemd op de ernst van de overtreding en de mate waarin deze aan de overtreder kan worden verweten, waarbij zo nodig rekening wordt gehouden met de omstandigheden waaronder de overtreding is gepleegd. 3 [Artikel 1, tweede lid, van het Wetboek van Strafrecht](jci1.3:c:BWBR0001854&artikel=1) is van overeenkomstige toepassing.
+- number: '109'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: bf1105469edd81139805c256546d1a7fe07d5faf86eb7d59e7ab0d6fcd0187f8
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 109 Mandaat tot het opleggen van een bestuurlijke boete wordt niet verleend aan degene die van de overtreding een rapport of proces-verbaal heeft opgemaakt.
+- number: '110'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: af8feb3c705115a21441adffdb7d1d86ca8c94af6dbae890c3e63870e0307346
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 110 1 Het College zorgverzekeringen dan wel het College toezicht beslist omtrent het opleggen van de bestuurlijke boete binnen dertien weken na de dagtekening van het rapport.
+  - index: 1
+    label: lid 2
+    sha256: 7cb9250ed9257344d0db46630817933b8211b245c76f599c091e42250eb50b23
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De beslistermijn wordt opgeschort met ingang van de dag waarop de gedraging aan het openbaar ministerie is voorgelegd, tot de dag waarop het College zorgverzekeringen dan wel het College toezicht weer bevoegd wordt een bestuurlijke boete op te leggen.
+- number: '111'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 20deb677e650ab0af8ea7a390e02ee9728cad15e4b83266fa563aa3f39f12e37
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 111 De beschikking tot oplegging van een bestuurlijke boete vermeldt:'
+  - index: 1
+    label: onderdeel a
+    sha256: dfa7d439fd7d7e38305fd044dc9bec20a0230af3341fcac0d871ef9506c47744
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. de naam van de overtreder;
+  - index: 2
+    label: onderdeel b
+    sha256: a111d561cec2e9ce0715cefb76cd7cc6007d2e7b79f3a90bd0c74c862267b8a9
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. de overtreding alsmede het overtreden voorschrift;
+  - index: 3
+    label: onderdeel c
+    sha256: 913f2441593431cd84b51a22ef4022a037b287a9385f0a3d8d7b00660eedcbc3
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. zo nodig een aanduiding van de plaats waar en het tijdstip waarop de overtreding is geconstateerd;
+  - index: 4
+    label: onderdeel d
+    sha256: 3abcd1859003399c142d551cb8d938aea1f99223e53a80acb2532bd54bb109f1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: d. het bedrag van de boete;
+  - index: 5
+    label: onderdeel e
+    sha256: 8ae7e58d3b4a1b78b3267f61df0a640986f2e88319fa12b93c79666ecedda078
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: e. de termijn waarbinnen de boete betaald moet worden.
+- number: '112'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 248a963a93f30e524bb5444c7ffc328d6973b904bbbce94b390b54149993650a
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 112 1 De bevoegdheid tot het opleggen van een bestuurlijke boete vervalt vijf jaren nadat de overtreding heeft plaatsgevonden.
+  - index: 1
+    label: lid 2
+    sha256: 44d313b979f5005dfbaea9c8185f8fc720b6e13c6d7dc9b1ac249114c81ab808
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien tegen de bestuurlijke boete bezwaar wordt gemaakt of beroep wordt ingesteld, wordt de vervaltermijn opgeschort tot onherroepelijk op het bezwaar of beroep is beslist.
+- number: '113'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: b1ca333a809a5ce5ee2e843bd20fddc7b093c19040dee12e6f2a60b9b332e8fc
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 113 1 Een boete wordt betaald binnen zes weken na inwerkingtreding van de beschikking waarbij de boete is opgelegd.
+  - index: 1
+    label: lid 2
+    sha256: 787400cefcf4fee3d70e866f2bc7776d9121f4cfcaef50a7b38b11640f824e98
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De boete wordt vermeerderd met de wettelijke rente, te rekenen vanaf de dag waarop sedert de bekendmaking van de beschikking zes weken zijn verstreken.
+  - index: 2
+    label: lid 3
+    sha256: c8a9614833e15d1e14b6e53dccc69c008b033f03dd53e9eb0552f3a53d9b4841
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien niet is betaald binnen de in het eerste lid genoemde termijn, wordt degene aan wie de boete is opgelegd schriftelijk bevolen binnen twee weken het bedrag van de boete, verhoogd met de kosten van de aanmaning, alsnog te betalen.
+  - index: 3
+    label: lid 4
+    sha256: 445f4cbe8b1edb906b6b6afb9399890148bd0d98c95cc40eb95e8b2115518d53
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Bij gebreke van betaling binnen de in het derde lid genoemde termijn, kan het College zorgverzekeringen dan wel het College toezicht de verschuldigde boete, verhoogd met de kosten van de aanmaning en van de invordering, bij dwangbevel invorderen.
+  - index: 4
+    label: lid 5
+    sha256: 9a4009f80bbcfb6f0c305effaaf0225ca68a2ca4e897ab4d4f5abb9a514b2d70
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 5. Het dwangbevel wordt op kosten van degene die de boete verschuldigd is, bij deurwaardersexploot betekend en levert een executoriale titel op in de zin van het [Tweede Boek van het Wetboek van Burgerlijke Rechtsvordering](jci1.3:c:BWBR0001827&boek=Tweede) .
+  - index: 5
+    label: lid 6
+    sha256: e88150b1085009ad7d5a57aaebb538656588b55bb5a1c9f7ae83262d1f4e4b76
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 6. Gedurende zes weken na de dag van betekening staat verzet tegen het dwangbevel open door dagvaarding van het College zorgverzekeringen dan wel het College toezicht.
+  - index: 6
+    label: lid 7
+    sha256: ccc3c57f438533ef35830afa10a2e69c0c0b12751d039f4555a87481c527df5e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 7. Het verzet schorst de tenuitvoerlegging niet, tenzij de voorzieningenrechter van de rechtbank in kort geding desgevraagd anders beslist.
+  - index: 7
+    label: lid 8
+    sha256: 29cb73e23e5efa382556cdc09881fb48ffc6520f9be0ff747b27ed418068c027
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 8. Het verzet kan niet worden gegrond op de stelling dat de boete ten onrechte of voor een te hoog bedrag is vastgesteld.
+  - index: 8
+    label: lid 9
+    sha256: 739c07229d1f2868d3934b0a9610e39af0e5961b4a0d02ba7c4a32f4d7622057
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 9. De bevoegdheid tot invordering vervalt twee jaar nadat de beschikking inzake oplegging van de boete onherroepelijk is geworden.
+- number: '114'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 6acc5af78eb1428bb6728dcd1eaedfd355f4076e1e4208ed3ebf3ec3ffb8da71
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 114 1 De zorgverzekeraar zorgt ervoor dat zijn verzekeringnemers en verzekerden geschillen over de uitvoering van de zorgverzekering kunnen voorleggen aan een onafhankelijke instantie.
+  - index: 1
+    label: lid 2
+    sha256: 63c2d3d985591b4910d0ff74956d080eeb5ec14f708b646165c5f8d3fea84cea
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De onafhankelijke instantie neemt een geschil slechts in behandeling nadat de verzekeringnemer of de verzekerde de zorgverzekeraar heeft verzocht zijn beslissing te heroverwegen, en deze niet binnen redelijke termijn of niet naar tevredenheid van de verzekeringnemer of verzekerde heeft gereageerd.
+  - index: 2
+    label: lid 3
+    sha256: 4c27e2ba79d165ba99d17fbf4aa1691a65275c823cbc8c8ec816f54a09a02ed1
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De onafhankelijke instantie vraagt advies aan het College zorgverzekeringen indien het geschil betrekking heeft op de zorg of de overige diensten, bedoeld in artikel 11 , dan wel de vergoeding van die zorg of diensten.
+  - index: 3
+    label: lid 4
+    sha256: 0ee6560894e22eabff78e20665666c8ff142be3fb951765edf73de4a0f03d3db
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Het College zorgverzekeringen zendt zijn advies binnen vier weken na ontvangst van de adviesaanvraag aan de onafhankelijke instantie.
+- number: '115'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 3ba6081e774c00dd675e805fa13293f2dc351727c39e42bb20eb6a016583723e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 115 In afwijking van [artikel 8:7, tweede lid, van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&artikel=8:7) is voor beroepen tegen beschikkingen van het College toezicht, als bedoeld in de artikelen 94 , 95 , 97 , 98 , 99 of, indien de beschikking tot een verzekeraar is gericht, 100 , de rechtbank te Rotterdam bevoegd.
+- number: '116'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: efaac630625e462b88eb5f46351a8b8ec09bdf7d2a47155503fedb1fde7fcf4b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 116 1 In afwijking van [artikel 8:7, tweede lid, van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&artikel=8:7) kan een belanghebbende tegen ingevolge deze wet genomen besluiten, niet zijnde besluiten als bedoeld in [artikel 8:2 van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&artikel=8:2) , van Onze Minister, van het College zorgverzekeringen of van het College toezicht beroep instellen bij de Afdeling bestuursrechtspraak van de Raad van State.
+  - index: 1
+    label: lid 2
+    sha256: bb16f2be0151798637a05e2ebdf13421e97bc84c76bd253a32bc627641de1df5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: '2. Het eerste lid geldt niet:'
+  - index: 2
+    label: onderdeel a
+    sha256: cd484a489a061186ca774e3669296f2d777f87fc0064c3b4492dee89671d6eae
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: a. voor een beschikking tot oplegging van een boete als bedoeld in artikel 96 ;
+  - index: 3
+    label: onderdeel b
+    sha256: 79e604ecb481c39d70cf5fac29d40501e5fb52155f2f8bad67c133391e1e0a4d
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: b. voor een beschikking, inhoudende een aanwijzing als bedoeld in artikel 94 , een beschikking tot oplegging van een last onder dwangsom als bedoeld in artikel 95 , of een beschikking tot oplegging van een boete als bedoeld in artikel 97 , 98 , 99 of 100 ;
+  - index: 4
+    label: onderdeel c
+    sha256: d45e25fe083d2b14bdd96144ac93769c75d2cd76255a5dc39f3c3084c41ccda6
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: c. voor een beschikking, genomen jegens een persoon die behoort tot het personeel van de genoemde colleges.
+- number: '117'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: bea61b013191f824bfc49f08db76409299ddf0d9b471c6ad252c2930d85416ba
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 117 1 Indien beroep is ingesteld tegen een bestuurlijke boete is, in afwijking van de [artikelen 8:27](jci1.3:c:BWBR0005537&artikel=8:27) en [8:28 van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&artikel=8:28) , de partij aan wie de bestuurlijke boete is opgelegd, niet verplicht omtrent de overtreding verklaringen af te leggen.
+  - index: 1
+    label: lid 2
+    sha256: 6f1d6dba36a93d7f7781e1c5bdd6896ae41a8f23b2dfc181fbee276f70c65c0e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Voor de rechtbank deze partij ondervraagt, deelt zij haar mede dat zij niet verplicht is tot antwoorden.
+  - index: 2
+    label: lid 3
+    sha256: 765bdb6349a727fd06ac3c0ea8edb9dbbd81a8bababa6a2a044333112cf69731
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. Indien de rechtbank een beschikking tot het opleggen van een bestuurlijke boete vernietigt, neemt zij een beslissing omtrent het opleggen van de boete en bepaalt zij dat haar uitspraak in zoverre in de plaatst treedt van de vernietigde beschikking.
+- number: '118'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 7ed419ebfeef54d70d5b767bd508905335fc32537970ab94cf4c22bc46f0eb32
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 118 1 Een verzekerde die voor rekening van zijn zorgverzekering bij ministeriële regeling aan te wijzen zorg of andere diensten als bedoeld in artikel 11 wenst te genieten, verstrekt aan de persoon of instelling die die zorg of dienst verleent ter inzage een identiteitsbewijs als bedoeld in [artikel 1, eerste lid, van de Wet op de identificatieplicht](jci1.3:c:BWBR0006297&artikel=1) , of een ander bij ministeriële regeling aan te wijzen document waarmee zijn identiteit kan worden vastgesteld.
+  - index: 1
+    label: lid 2
+    sha256: cab6238916b4386612b917477d3e01d3f5df6b3978cca8c188f178f5e1652cff
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. Indien het identiteitsbewijs niet onmiddellijk ter inzage kan worden verstrekt, kan de persoon of instelling toestaan dat uiterlijk binnen een termijn van veertien dagen aan deze verplichting wordt voldaan.
+  - index: 2
+    label: lid 3
+    sha256: efdc3fa7c377e19b952c43c9233e66721e49222f828d699ae5d8c3bcdc31ce0f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 3. De persoon of instelling stelt aan de hand van het ter inzage verstrekte document de identiteit vast van degene aan wie de in het eerste lid bedoelde zorg of dienst wordt verleend, en neemt het in dat document opgenomen sociaal-fiscaalnummer van de verzekerde in zijn administratie op.
+  - index: 3
+    label: lid 4
+    sha256: c19e37f630d5c7d6ef2cd7a184dd1057e669fc087aca8fc5a5f69e8610a7275b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 4. Dit lid is nog niet in werking getreden.
+- number: '119'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 152360463eab71ba63bb161e7fbea549e24d7fa1627bfe12ead8b72eb2c6b483
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 119 1 Een overeenkomst met betrekking tot de verzekering van geneeskundige zorg of de kosten daarvan, gesloten voor een verzekerde met of ten behoeve van wie tevens een zorgverzekering is gesloten, vervalt met ingang van de dag waarop de bij en krachtens artikel 11 te verzekeren prestaties worden uitgebreid, voor zover aan de overeenkomst rechten kunnen worden ontleend, gelijkwaardig aan die, welke vanaf dat moment uit de zorgverzekering voortvloeien.
+  - index: 1
+    label: lid 2
+    sha256: 843f76b2ef223bd71ccc45c004b3151ec2893f79966e27acba3bda4a0b12e375
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 2. De premie die voor de op grond van het eerste lid geheel of gedeeltelijk vervallen overeenkomst is vooruitbetaald, wordt door de verzekeraar al naar gelang van het vervallen gedeelte der overeenkomst terugbetaald, onder aftrek van ten hoogste 25% van het terug te betalen bedrag.
+- number: '120'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 09e20dc5063a256244e7db8526751871f1c45fba59387b412128b0a76ea20b2b
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 120 Een beding van een verzekeraar die een ziektekostenverzekering ter aanvulling van de zorgverzekering aanbiedt, inhoudende dat de ziektekostenverzekering eindigt of door de verzekeraar mag worden opgezegd indien met of ten behoeve van de verzekerde een zorgverzekering met een andere zorgverzekeraar wordt gesloten, is nietig.
+- number: '121'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 253428cdb84151abc9da3a8fd39fb284260b8abd3c08aedd206ea62f8034a7ef
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 121 De bevoegdheden die [artikel 91 van de Comptabiliteitswet 2001](jci1.3:c:BWBR0013891&artikel=91) de Algemene Rekenkamer verschaft ten aanzien van rechtspersonen als bedoeld in het eerste lid, onderdeel d, van dat artikel, gelden niet ten aanzien van de wijze waarop zorgverzekeraars de opbrengst van bij of krachtens deze wet ingestelde heffingen aanwenden.
+- number: '122'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a1e443ca46431d13108fc843187c0a25b00a20b5514bd06da6115ef4fc59edf4
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 122 Een zorgverzekeraar wordt, voor zover deze niet kan worden aangemerkt als onderneming in de zin van artikel 81 van het Verdrag tot oprichting van de Europese Gemeenschap, voor de toepassing van de [Mededingingswet](jci1.3:c:BWBR0008691) aangemerkt als onderneming in de zin van [artikel 1 van die wet](jci1.3:c:BWBR0008691&artikel=1) .
+- number: '123'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 05ee4fc327f73a537ee9e6ffc7fbcbf48d17f6cec604c3b0065e21de19c29fa5
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 123 Bij algemene maatregel van bestuur kunnen, zo nodig in afwijking van deze wet, tijdelijke voorzieningen worden getroffen voor het geval het College zorgverzekeringen of het College toezicht zijn uit de wet voortvloeiende verplichtingen niet naar behoren nakomt.
+- number: '124'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 1cb9186cd24dd3e6dbc2941fb34e5996955deab77caaab82fa633ff335db9dbe
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 124 De voordracht voor een krachtens de artikelen 11, derde of vierde lid , 22, vijfde lid , en 32, tweede lid , vast te stellen algemene maatregel van bestuur wordt niet eerder gedaan dan vier weken nadat het ontwerp aan beide kamers der Staten-Generaal is overgelegd.
+- number: '125'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 682b22826649336f2e538f4fd43b1ea8a86ec9eb550e410460b05245f998500f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 125 Onze Minister zendt binnen vijf jaar na de inwerkingtreding van deze wet aan de Staten-Generaal een verslag over de doeltreffendheid en de effecten van deze wet in de praktijk.
+- number: '126'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 59eb518aef3d3b5924cb40ab82f2d534172317ad586d081d7134255e7adcaf8f
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 126 Voor de uitvoering van deze wet kunnen bij algemene maatregel van bestuur nadere regels worden gesteld.
+- number: '127'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: 8e098f733ef759c9f11b966713b1da1385c32003a78a30e1aee5b5a0fd3ce1ed
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: Artikel 127 De artikelen van deze wet treden in werking op een bij koninklijk besluit te bepalen tijdstip, dat voor de verschillende artikelen of onderdelen daarvan verschillend kan worden vastgesteld.
+- number: '128'
+  chunks:
+  - index: 0
+    label: aanhef
+    sha256: a2f0a31b58f4fcd781f01db4a0cd3327c61bfa68abdd131653f9a0f5bfaa051e
+    verified_against: pending
+    captured_at: '2026-06-01'
+    text: 'Artikel 128 Deze wet wordt aangehaald als: Zorgverzekeringswet.'


### PR DESCRIPTION
## Wat
Een **twee-lagen tekstgetrouwheid-guard** voor de corpus, per lid/onderdeel.

- **`bless`** (methodologisch, periodiek) capture't per artikel de genormaliseerde `text:`-chunks als gecommitte fixture (sha256 + tekst + herkomst).
- **`check`** (deterministisch, CI) herberekent de hashes uit de corpus en vergelijkt; mismatch → faal. Hermetisch (zuivere functie van repo-inhoud).

Een chunk = één lege-regel-gescheiden alinea van een artikel-`text:` — in deze corpus precies één lid/onderdeel/aanhef. Normalisatie = de enige whitespace-regel uit `law-version-drift-check/reference.md` §2.

## Waarom zo
De *vergelijking* is triviaal deterministisch; het niet-deterministische zit in het **orakel**. De geldende wettekst leeft op wetten.overheid.nl — remote, mutabel, te interpreteren → geen CI-orakel. Daarom splitsen:
- **Laag 1 (bless):** de live tekst ophalen + verifiëren doet de `law-version-drift-check`-skill; die zet `verified_against` van `pending` naar een wetten.overheid.nl-datum.
- **Laag 2 (check):** CI vergelijkt tegen de gecommitte fixture.

**Eerlijke grens:** de gate bewaakt *"YAML ≡ laatst geverifieerde tekst"* (vangt stille edits direct), niet *"YAML ≡ huidige live wet"* (dat blijft de periodieke drift-check). Approval-testing + per-chunk provenance, verwant aan RFC-013's `regulation_hash` maar per lid.

## Inhoud
- `script/textguard.py` (bless/check, gedeelde normalisatie)
- `textguard/` — seeded fixtures: **21 wetten, 1751 chunks**, `verified_against: pending`
- CI-job `text-fidelity` (fail-closed gate) + Justfile `textguard-check`/`textguard-bless`
- yamllint negeert de gegenereerde fixtures (verbatim wettekst > 125 tekens)
- `textguard/README.md` — workflow + de eerlijke grens

## Verifieerd
- `check` op de seeded corpus: 1751 chunks, 0 afwijkingen, exit 0
- Negatieve test: één woord wijzigen → exact gedetecteerd (`art 2.75 [lid 1]`), exit 1; revert → groen

## Let op
Seeding is een *baseline-bless* (`pending`): de gate is meteen actief, maar de tekst is nog niet tegen wetten.overheid.nl gekruist. Dat upgraden gebeurt wanneer de drift-check per wet draait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)