### PR TITLE
docs: bevoegdheid als resolvebare graaf (RFC-036)

### DIFF
--- a/docs/src/content/rfcs/rfc-036.md
+++ b/docs/src/content/rfcs/rfc-036.md
@@ -1,0 +1,426 @@
+---
+title: "RFC-036: Bevoegdheid als resolvebare graaf"
+status: Proposed
+implementation: Not implemented
+date: '2026-08-20'
+authors:
+  - humanintheloop25
+depends_on:
+  - RFC-002 (Bevoegdheid / Authority)
+  - RFC-003 (Inversion of Control for Delegated Legislation)
+  - RFC-007 (Cross-Law Execution Model)
+  - RFC-008 (Awb Administrative Procedures)
+short_title: Bevoegdheid
+---
+
+## Context
+
+Een besluit dat door het verkeerde orgaan is genomen, is vernietigbaar. In het
+corpus levert het vandaag exact dezelfde output op als een besluit door het
+juiste orgaan. Dat komt niet doordat er een veld ontbreekt. `competent_authority`
+bestaat, is in RFC-002 besloten, en wordt vervolgens door niemand gedragen.
+
+### Wat er nu is
+
+[RFC-002](/rfcs/rfc-002) voerde `competent_authority` in op artikelniveau: een
+naam plus een `type` (`INSTANCE` of `CATEGORY`). Die RFC staat op *Accepted* en
+*Implemented*. Bij nameting valt dat uiteen in drie bronnen die het oneens zijn:
+
+- **Het schema** kent het object `{name, type: INSTANCE|CATEGORY}`, uitsluitend
+  onder `machine_readable`, dus op artikelniveau, zoals RFC-002 besloot.
+- **Het model** kent `CompetentAuthority::Structured { name: String }`
+  (`packages/law-model/src/model.rs:15`). Er is geen `type`-veld; serde laat het
+  stilzwijgend vallen. De engine kán `INSTANCE` niet van `CATEGORY`
+  onderscheiden. Het model kent het veld daarnaast óók op wetniveau
+  (`model.rs:750`), wat het schema daar niet declareert.
+- **Het corpus** zet `competent_authority` consequent op documentniveau. Dat
+  valideert alleen omdat het root-object geen `additionalProperties: false`
+  heeft. De objectvorm mét `type` komt nul keer voor.
+
+En in de uitvoering: `competent_authority` wordt nergens gelezen. De enige code
+die het veld aanraakt zijn twee parse-tests in `packages/engine/src/article.rs`.
+
+[RFC-003](/rfcs/rfc-003) voerde de enige bevoegdheidscontrole in die wél draait.
+Bij het resolven van een open term vergelijkt de engine de `regulatory_layer`
+van de implementerende regeling met de `delegation_type` op de term, en faalt
+hard bij een verschil (`packages/engine/src/service.rs:1753`). Die controle is
+smal. Ze kijkt naar de *laag* en niet naar het *orgaan*, en ze draait alleen op
+de winnende kandidaat, ná scope-filtering en prioriteitsresolutie. Ze vergelijkt
+bovendien vrije strings exact, en ze draait alleen tijdens uitvoering, nooit in
+`just validate`. Het zusterveld `delegated_to`, het veld waar het orgaan in
+staat, wordt geparsed (`model.rs:438`) en nergens gebruikt.
+
+### Wat daardoor niet kan
+
+1. **Onbevoegdheid is geen detecteerbare klasse fouten.** Er is geen
+   testscenario dat het kan vangen, want de engine kent het onderscheid niet.
+2. **De laag is een te grove proxy voor het orgaan.** Gemeenteraad en college
+   van burgemeester en wethouders produceren allebei
+   `GEMEENTELIJKE_VERORDENING`. Precies het onderscheid dat Awb 10:14-10:17
+   regelt, is voor de engine onzichtbaar.
+3. **Mandaat bestaat niet.** Awb 10:10 eist dat een in mandaat genomen besluit
+   de naam en hoedanigheid van de mandataris vermeldt. De uitvoeringstrace kan
+   dat niet produceren, omdat de informatie er niet is.
+4. **Discretie moet zich vermommen.** "Het college kan" en "het college stelt
+   vast" zijn in YAML ononderscheidbaar. De eerste is een bevoegdheid met
+   beoordelingsruimte, de tweede een gebonden plicht.
+
+Dit is de open vraag die RFC-002 zelf stelde en liet staan: *"How to handle
+delegation of authority (mandaat/delegatie)?"*
+
+## Decision
+
+**Een bevoegdheidsinstrument is zelf een regeling en hoort in het corpus.**
+
+Een delegatiebesluit en een mandaatbesluit zijn juridische instrumenten met een
+eigen vindplaats, een eigen grondslag en een eigen `valid_from`/`valid_to`. Ze
+staan dus in `corpus/regulation/nl/…`, niet als blok bovenaan een wet.
+
+Daarmee wordt bevoegdheid geresolved door dezelfde machinerie als cross-law
+dependencies uit [RFC-007](/rfcs/rfc-007): dezelfde graafwandeling, dezelfde
+temporele semantiek, dezelfde cykeldetectie. Geen tweede resolutiemechanisme.
+
+### 1. De drie rechtsfiguren
+
+Het model moet drie figuren onderscheiden die de wet zelf onderscheidt:
+
+| | Attributie | Delegatie | Mandaat |
+|---|---|---|---|
+| Aard | schept de bevoegdheid | draagt haar over | oefent haar namens een ander uit |
+| Bevoegd na afloop | het geattribueerde orgaan | de delegataris | de mandans (blijft) |
+| Op wiens naam | eigen naam | eigen naam | naam van de mandans |
+| Grondslag vereist | wettelijk voorschrift | wettelijk voorschrift (10:15) | geen, wel grenzen (10:3) |
+| Instructiebevoegdheid | n.v.t. | alleen beleidsregels (10:16) | ja, per geval (10:6) |
+| Zelf blijven uitoefenen | n.v.t. | nee (10:17) | ja (10:7) |
+
+De Awb definieert mandaat (10:1) en delegatie (10:13); attributie kent geen
+Awb-definitie en komt uit de doctrine. De regels hieronder zijn getoetst aan de
+geldende tekst van de Awb.
+
+Twee regels die het schema structureel moet kunnen afdwingen:
+
+- **Delegatie herbindt de houder, mandaat niet.** Delegatie verplaatst het
+  knooppunt in de graaf; mandaat voegt een uitvoerder toe terwijl de houder
+  blijft staan.
+- **Delegatie aan ondergeschikten is niet toegestaan** (Awb 10:14). Dat is
+  checkbaar zodra organen een hiërarchierelatie kennen.
+
+Ondermandaat (10:9) is een keten van mandaten en vereist geen apart construct,
+wel een `submandate_allowed`-vlag.
+
+### 2. Bevoegdheid declareren in een wet
+
+```yaml
+powers:
+  - id: bijstand.vaststellen
+    description: Vaststellen van het recht op en de hoogte van bijstand
+    origin: ATTRIBUTIE
+    holder:
+      organ_ref: college_van_bw      # verwijst naar het organenregister, §5
+      generic: true                  # elk college, niet één specifiek
+    legal_basis:                     # de vorm van definitions.legalBasis
+      bwb_id: BWBR0015703
+      article: '7'
+      paragraph: '1'
+      juriconnect: jci1.3:c:BWBR0015703&artikel=7&lid=1
+    modality: DISCRETIONAIR          # of GEBONDEN
+    scope:
+      legal_character: BESCHIKKING
+      decision_type: TOEKENNING
+```
+
+Een actie verwijst naar de bevoegdheid die zij uitoefent:
+
+```yaml
+actions:
+  - output: bijstandsnorm
+    requires_power: bijstand.vaststellen
+```
+
+`scope` hergebruikt de bestaande vocabulaires uit
+[RFC-008](/rfcs/rfc-008): `legal_character` en `decision_type` zijn dezelfde
+enums als op `produces`, zodat een bevoegdheid en een procedure over hetzelfde
+soort besluit praten.
+
+### 3. Delegatie en mandaat als eigen instrument
+
+```yaml
+# corpus/regulation/nl/delegatiebesluit/voorbeeldstad/…/2024-01-01.yaml
+regulatory_layer: DELEGATIEBESLUIT
+delegation:
+  power_id: bijstand.nadere_regels
+  from: {organ_ref: gemeenteraad_voorbeeldstad}
+  to: {organ_ref: college_van_bw_voorbeeldstad}
+  legal_basis: {bwb_id: BWBR0015703, article: '8'}   # vereist (10:15)
+valid_from: '2024-01-01'
+```
+
+```yaml
+regulatory_layer: MANDAATBESLUIT
+mandate:
+  power_id: bijstand.vaststellen
+  mandans: {organ_ref: college_van_bw_voorbeeldstad}
+  mandataris:
+    function: teamleider Inkomen     # functie, nooit een persoon
+    subordinate: true
+  submandate_allowed: false          # 10:9
+  constraints:
+    - decision_type: TOEKENNING      # alleen toekennen, niet afwijzen
+valid_from: '2024-03-01'
+```
+
+`function` in plaats van een persoonsnaam is een bewuste keuze: mandaat wordt in
+de praktijk aan functies verleend, en persoonsgegevens horen niet in een
+publiek corpus.
+
+### 4. Enginesemantiek
+
+**Uitvoeringscontext.** De private `ResolutionContext`
+(`packages/engine/src/service.rs:89`) krijgt een handelend orgaan en een
+hoedanigheid; de `LawExecutionService` krijgt een modus, naar het model van
+`untranslatable_mode` uit [RFC-012](/rfcs/rfc-012):
+
+```rust
+acting_organ: Option<OrganRef>,
+acting_capacity: Option<FunctionRef>,   // voor mandaat
+competence_mode: CompetenceMode,        // Strict | Warn | Off
+```
+
+**Resolutie vóór uitvoering.** Voor elke actie met `requires_power` wandelt de
+engine de graaf. De vraag is of er op de referentiedatum een geldig pad loopt
+van de bevoegdheid naar het handelende orgaan, met de vorm
+`ATTRIBUTIE → DELEGATIE* → MANDAAT*`: één attributie, daarna nul of meer
+delegaties, daarna nul of meer mandaten. Structureel gecontroleerd tijdens die
+wandeling:
+
+- delegatie zonder `legal_basis` → ongeldig (10:15)
+- delegatie naar een ondergeschikt orgaan → ongeldig (10:14)
+- ondermandaat waar `submandate_allowed: false` → ongeldig (10:9 lid 1)
+- mandaat op een bevoegdheid tot het vaststellen van algemeen verbindende
+  voorschriften → ongeldig, tenzij de verlening daarin voorziet (10:3 lid 2
+  sub a). Toetsbaar tegen de bestaande `decision_type:
+  ALGEMEEN_VERBINDEND_VOORSCHRIFT`
+- mandaat tot het vernietigen van of onthouden van goedkeuring aan een besluit
+  van een ander bestuursorgaan → ongeldig (10:3 lid 2 sub c)
+- mandaat tot beslissen op een bezwaarschrift, verleend aan degene die het
+  bestreden besluit krachtens mandaat nam → ongeldig (10:3 lid 3). Deze regel
+  is pas toetsbaar met de stage-informatie uit [RFC-008](/rfcs/rfc-008): hij
+  vergelijkt de mandataris van het BESLUIT met die van het besluit op bezwaar
+- mandaat verplaatst de houder niet: het besluit wordt aan de mandans toegerekend
+- elke schakel geldig op de referentiedatum (hergebruikt de temporele
+  machinerie van [RFC-019](/rfcs/rfc-019))
+
+**Drie uitkomsten, geen exceptions.**
+
+- `COMPETENT`: uitvoeren; de keten gaat mee in de trace
+- `INCOMPETENT`: halt met een juridische reden en de vindplaats van de
+  gebroken schakel. Dit is een rechtsgevolg, geen bug, en hoort als
+  eersteklas resultaattype terug te komen zodat het uitgelegd kan worden.
+- `UNRESOLVED`: geen keten gemodelleerd. Mag nooit stilzwijgend slagen: onder
+  `Warn` gaat de uitvoering door met een markering in de trace, onder `Strict`
+  faalt hij.
+
+**Trace.** De bevoegdheidsketen wordt aan de trace toegevoegd, naast de
+bestaande `HookResolution`- en `OverrideResolution`-knopen. Daarmee komt Awb
+10:10 er bijna gratis uit. Het voorbeeld hieronder is volledig fictief. De
+gemeente Voorbeeldstad bestaat niet, het genoemde mandaatbesluit bestaat niet,
+en het is geen weergave van hoe enige gemeente haar mandaat feitelijk heeft
+geregeld. Het staat er alleen om te laten zien welke elementen zo'n uitleg moet
+bevatten:
+
+> Dit besluit is genomen door de teamleider Inkomen, namens het college van
+> burgemeester en wethouders van Voorbeeldstad, op grond van het Mandaatbesluit
+> Werk en Inkomen Voorbeeldstad 2024, artikel 3.
+
+Dat is nu niet produceerbaar en is het concreet demonstreerbare resultaat van
+deze RFC.
+
+### 5. Organenregister
+
+De graaf heeft stabiele identiteiten voor organen nodig. Voorstel: een apart
+`corpus/organ/`-register met dezelfde versionerings- en PR-discipline als het
+regelcorpus.
+
+- **OIN is onvoldoende als enige sleutel.** OIN identificeert rechtspersonen,
+  niet bestuursorganen; het college van B&W en de gemeenteraad delen een
+  rechtspersoon maar zijn verschillende organen met verschillende bevoegdheden.
+- **De aanhef van een regeling** wijst de verantwoordelijke bewindspersoon aan
+  en is voor attributie de juiste bron.
+- **A-organen en b-organen** (Awb 1:1) moeten onderscheiden worden zodra ZBO's
+  en gemandateerde private partijen in beeld komen.
+- **Generiek versus specifiek** is precies het `INSTANCE`/`CATEGORY`-onderscheid
+  van RFC-002. Dat onderscheid moet eerst wérken: het model moet `type` gaan
+  dragen voordat 342 colleges van B&W dezelfde generieke bevoegdheid kunnen
+  instantiëren.
+- **Hiërarchie tussen organen** is nodig voor de 10:14-check.
+
+### 6. Verhouding tot de bestaande `delegation_type`-controle
+
+De controle uit RFC-003 blijft en wordt de degenerate vorm van
+bevoegdheidsresolutie: één schakel, op laagniveau, zonder datum en zonder
+orgaan. `delegated_to`, nu dood, krijgt betekenis door naar een `organ_ref` te
+wijzen. Waar een open term zowel een `delegation_type` als een bevoegd orgaan
+kent, wint de orgaancontrole en degradeert de laagcontrole tot een
+consistentiecheck.
+
+### 7. Bevoegdheid filtert vóór de prioriteitsbepaling
+
+De bestaande volgorde bij open-term-resolutie is: kandidaten verzamelen →
+temporeel filteren → filteren op scope → **winnaar kiezen** met lex superior en
+lex posterior → **daarna pas** de `delegation_type` van die winnaar controleren
+(`packages/engine/src/service.rs:1753`). De bevoegdheidscontrole staat dus
+achter de wedstrijd in plaats van ervoor, en dat is aantoonbaar verkeerd.
+
+Gemeten met twee invullers voor dezelfde open term, gedeclareerd als
+`delegation_type: MINISTERIELE_REGELING`:
+
+| geladen regelingen | uitkomst |
+|---|---|
+| alleen de ministeriële regeling (waarde 100) | `Ok({"uitkomst": 100})` |
+| diezelfde regeling plus een wet (waarde 999) | `Err: Implementation onbevoegde_wet for open term 'bedrag' has regulatory_layer WET but delegation_type requires MINISTERIELE_REGELING` |
+
+Een wet staat hoger dan een ministeriële regeling, dus de onbevoegde kandidaat
+wint de wedstrijd en maakt daarmee de geldige implementatie onbereikbaar.
+Juridisch vertaald: een partij die de bevoegdheid niet had wordt eerst tot
+winnaar uitgeroepen en blokkeert vervolgens de beslissing, terwijl de bevoegde
+partij ernaast stond.
+
+**Besluit: bevoegdheid is een filter vóór de prioriteitsbepaling, geen controle
+erna.** Een kandidaat die de bevoegdheid niet houdt, doet niet mee. De volgorde
+wordt: temporeel filteren → scope → **bevoegdheid** → prioriteit.
+
+**Een afgevallen kandidaat wordt gemeld.** Stil wegfilteren zou een
+onbevoegde regeling in het corpus onzichtbaar maken, terwijl dat een
+auteursfout is die iemand moet repareren. De afwijzing komt in de trace naast de
+bestaande `OpenTermResolution`-knoop, met reden en vindplaats.
+
+Zolang er geen organenregister is, blijft `delegation_type` het criterium van
+dat filter; zodra er wel een is, wordt het criterium "houdt dit orgaan op deze
+datum de regelgevende bevoegdheid voor deze term". Deze herordening is niet
+afhankelijk van de rest van deze RFC en kan als eerste landen; ze is als
+#1302 apart belegd.
+
+## Why
+
+### Benefits
+
+- Onbevoegd genomen besluiten worden een detecteerbare klasse fouten in plaats
+  van een onzichtbare.
+- "Kan" wordt uitdrukbaar zonder zich te vermommen als rekenregel.
+- De uitleg aan een burger kan vermelden wie besloot, namens wie, en op welke
+  grondslag. Awb 10:10 wordt daarmee afleidbaar.
+- Bevoegdheid wordt registreerbaar, en daarmee wordt zichtbaar waar zij
+  ontbreekt. Je kunt alleen gaten registreren waarvoor je vocabulaire hebt.
+- Geen tweede resolutiemechanisme. Bevoegdheid loopt over dezelfde graaf als
+  cross-law resolution, onder dezelfde temporele regels.
+
+### Tradeoffs
+
+- **Elke actie een graafwandeling erbij.** Waarschijnlijk cachebaar per
+  `(power, organ, datum)`, maar `just bench` moet dat uitwijzen.
+- **Het organenregister is een nieuw corpus** met eigen onderhoud, eigen
+  versionering en eigen vindplaatsproblemen.
+- **Op dag één is vrijwel alles `UNRESOLVED`.** Dat is alleen aanvaardbaar
+  zolang het zichtbaar is; zie de implementatienotities.
+- **Twee nieuwe `regulatory_layer`-waarden** moeten in schema én model tegelijk
+  landen, anders laadt het bestand niet.
+
+### Alternatives Considered
+
+**Alternatief 1: bevoegdheid als metadata op de wet uitbreiden.**
+`competent_authority` verrijken met een delegatie- en mandaatveld. Afgewezen:
+een delegatiebesluit treedt zelfstandig in werking, rust op zijn eigen
+grondslag en kan zelfstandig worden ingetrokken. Als blok in een andere
+regeling verliest het zijn temporele identiteit, en de RFC-007-machinerie kan
+er niet overheen lopen.
+
+**Alternatief 2: de laagcontrole van RFC-003 uitbreiden.**
+`delegation_type` fijnmaziger maken tot orgaanniveau. Afgewezen: het adresseert
+alleen delegatie, kent geen ketens, geen datums en geen mandaat, en het schrijft
+de bevoegdheid nog steeds op bij de consument in plaats van bij het instrument.
+
+**Alternatief 3: bevoegdheid buiten het corpus, in een applicatielaag.**
+Afgewezen: dan is onbevoegdheid geen eigenschap van de wet maar van een
+deployment, en verschillende afnemers komen tot verschillende oordelen over
+hetzelfde besluit.
+
+**Alternatief 5: de bestaande volgorde laten staan** en bevoegdheid blijven
+controleren op de winnaar. Afgewezen op grond van de meting in §7: een
+onbevoegde kandidaat kan de wedstrijd winnen en daarmee een geldige
+implementatie onbereikbaar maken. Het gedrag hangt dan af van welke regelingen
+toevallig geladen zijn.
+
+**Alternatief 6: stil wegfilteren zonder spoor.** Afgewezen: een onbevoegde
+regeling in het corpus is een auteursfout. Wordt zij alleen genegeerd, dan is
+het verschil tussen "er was geen invuller" en "de invuller mocht het niet"
+onzichtbaar, en verdwijnt precies de bevinding die dit model moet opleveren.
+
+**Alternatief 4: `INCOMPETENT` als engine-fout.** Afgewezen: onbevoegdheid is
+een rechtsgevolg met een vindplaats, geen technische storing. Als exception is
+het niet uitlegbaar aan een burger en niet te onderscheiden van een kapotte
+YAML.
+
+### Implementation Notes
+
+Migratiepad, in deze volgorde:
+
+1. **De herordening uit §7** hangt van niets af en kan als eerste landen: het
+   bevoegdheidsfilter vóór de prioriteitsbepaling, met de afgevallen kandidaat
+   in de trace. Zolang er geen organenregister is, blijft `delegation_type` het
+   criterium; alleen het moment waarop het wordt toegepast verandert.
+2. **Voorwaarde, elders belegd: het gat in RFC-002 dichten.** Drie defecten
+   staan tussen het besluit van RFC-002 en de code: het ontbrekende
+   `type`-veld op `CompetentAuthority::Structured` samen met het verschil
+   tussen artikelniveau en documentniveau (#1299), het dode `delegated_to`
+   (#1300), en het ontbreken van `additionalProperties: false` op het
+   root-object (#1301). Dit zijn geen ontwerpvragen maar afwijkingen van een
+   genomen besluit, en ze zijn daarom als issue belegd en niet als beslissing
+   van deze RFC. Zonder die reparaties heeft stap
+   3 geen fundament: `INSTANCE` versus `CATEGORY` moet werken voordat één
+   generieke bevoegdheid door 342 organen geïnstantieerd kan worden.
+3. **Schema v0.6.0**: `powers`, `delegation`, `mandate`, `requires_power`, alle
+   optioneel. Engine draait standaard in `Off`.
+4. **Organenregister bootstrappen** voor de organen die al in het corpus
+   voorkomen.
+5. **Per wet opt-in naar `Warn`.** Bevoegdheidsdekking wordt een metriek naast
+   inhoudelijke dekking.
+6. **`Strict` als default voor nieuwe wetten**, zodra het organenregister
+   stabiel is.
+
+Een ontbrekende schakel is een registreerbare bevinding met een eigenaar,
+meestal de uitvoeringsorganisatie zelf.
+
+## Open Questions
+
+1. **Delegatiebandbreedte.** Een delegatiebesluit begrenst vaak de ruimte van de
+   delegataris (een percentage tussen twee waarden, een termijn met een
+   maximum). Dat als validatieregel modelleren raakt aan `open_terms` en
+   `implements` en verdient een eigen RFC.
+2. **Onderbepaaldheid als uitkomsttype.** `modality: DISCRETIONAIR` declareren
+   kan binnen deze RFC, maar de engine kan er nog niets mee: hij geeft altijd
+   een waarde terug en kent geen `Undetermined(reden)` of `Range`. Tot die er
+   is, betekent `DISCRETIONAIR` in de praktijk: halt naar een mens.
+3. **Gegevensbevoegdheid.** De bevoegdheid om te weten (doelbinding,
+   autorisatiebesluit BRP, SUWI-gegevensdeling) is een andere figuur met een
+   andere grondslag. Het `powers`-model is er wel op ontworpen: een bevoegdheid
+   met een scope op gegevenscategorieën past in dezelfde graaf. Aparte RFC.
+4. **Waar staan mandaatbesluiten?** Veel worden niet centraal gepubliceerd. Als
+   het corpus ze nodig heeft en ze zijn niet vindbaar, is dat zelf een
+   bevinding.
+5. **Versionering van organen.** Herindelingen, opheffing en fusie. Wat gebeurt
+   er met besluiten van een orgaan dat niet meer bestaat?
+6. **Retroactiviteit.** Een mandaatbesluit dat achteraf ongeldig blijkt: welke
+   besluiten raakt dat, en kan de engine dat bereik berekenen?
+
+## References
+
+- [RFC-002](/rfcs/rfc-002): voert `competent_authority` in; deze RFC beantwoordt
+  zijn eerste open vraag
+- [RFC-003](/rfcs/rfc-003): de bestaande `delegation_type`-controle
+- [RFC-009](/rfcs/rfc-009): gebruikt `competent_authority` voor de
+  uitvoeringsgrens tussen organisaties
+- [RFC-015](/rfcs/rfc-015): de rangorde van regelingslagen
+- Awb 1:1 (bestuursorgaan), afdeling 10.1.1 (mandaat), afdeling 10.2.1
+  (delegatie). De aangehaalde artikelen zijn op 20 augustus 2026 getoetst aan
+  de geldende tekst op `wetten.overheid.nl` (BWBR0005537, versie 2024-01-01)
+- [Glossary of Dutch Legal Terms](/reference/glossary)


### PR DESCRIPTION
Voorstel om bevoegdheid (attributie, delegatie, mandaat) als eerste-klas
constructie in het corpus op te nemen, geresolved door dezelfde graafmachinerie
als cross-law dependencies. Status is `Proposed`: het ontwerp staat open voor
discussie, er is nog niets gebouwd.

## Waarom nu

RFC-002 voerde `competent_authority` in en liet één vraag expliciet open:
*"How to handle delegation of authority (mandaat/delegatie)?"* Deze RFC
beantwoordt die vraag.

Bij het schrijven bleek de aanleiding scherper dan verwacht. Bevoegdheid is niet
afwezig, maar wordt nergens gedragen:

- het schema kent `competent_authority` met `type: INSTANCE|CATEGORY`, het
  Rust-model kent alleen `Structured { name: String }` en laat `type` vallen;
- het corpus zet het veld op documentniveau, terwijl RFC-002 artikelniveau koos;
- in de uitvoering wordt het veld nergens gelezen: de enige code die het
  aanraakt zijn twee parse-tests.

## Eén gemeten gedragsbevinding (§7)

De enige bevoegdheidscontrole die vandaag draait, de `delegation_type`-check uit
RFC-003, staat áchter de prioriteitsbepaling in plaats van ervoor. Met twee
invullers voor dezelfde open term:

| geladen | uitkomst |
|---|---|
| alleen de ministeriële regeling | `Ok({"uitkomst": 100})` |
| diezelfde regeling plus een wet | `Err: … has regulatory_layer WET but delegation_type requires MINISTERIELE_REGELING` |

De onbevoegde kandidaat wint de wedstrijd op lex superior en maakt de geldige
implementatie onbereikbaar. De RFC stelt voor bevoegdheid als filter vóór de
prioriteitsbepaling te draaien, met de afgevallen kandidaat in de trace.

## Verificatie

- De aangehaalde Awb-artikelen (10:1, 10:3, 10:6, 10:7, 10:9, 10:10, 10:13,
  10:14, 10:15, 10:16, 10:17) zijn getoetst aan de geldende tekst op
  `wetten.overheid.nl` (BWBR0005537, versie 2024-01-01). Dat leverde drie
  correcties op en drie extra structurele controles uit 10:3 die het schema al
  kan uitdrukken.
- Alle bestand:regel-verwijzingen naar schema, `law-model` en `engine` zijn
  nagelopen op `main`.
- Het voorbeeld in §4 is expliciet fictief; gemeente Voorbeeldstad bestaat niet.

## Bewust buiten scope

Delegatiebandbreedte, gegevensbevoegdheid en onderbepaaldheid als
uitkomsttype staan als open vragen genoteerd, met een eigen RFC in het
vooruitzicht.

Vier defecten die tussen RFC-002 en de code in staan, worden in de
Implementation Notes benoemd als voorwaarde die elders belegd hoort. Die zijn
nog niet als issue aangemaakt.
