### PR TITLE
fix(docs): alias-naam voor het onderzoek-icoon in de hero

### DIFF
--- a/docs/src/components/LandingSections.astro
+++ b/docs/src/components/LandingSections.astro
@@ -121,7 +121,7 @@ function exampleImage(key: string): ImageMetadata {
             <nldd-button
               variant="inherit-tinted"
               href="/research/"
-              start-icon="file-text"
+              start-icon="text-document"
               text={t.nav.research}
             />
           </nldd-button-group>


### PR DESCRIPTION
Nagekomen review-opmerking op #1313: CLAUDE.md verkiest de alias boven de canonieke icoonnaam, dus `text-document` in plaats van `file-text` op de Onderzoek-knop in de hero. Eén regel.