### PR TITLE
docs(github): skill voor het onderhouden van de roadmap-inhoud

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -77,9 +77,11 @@ omvang: ''
 categorie: ''
 capability: ''
 capaciteit: ''
-toelichting: >-
+toelichting: |-
   Twee of drie alinea's die uitleggen wat de opgave is. Markdown mag:
   **vet**, een lijst, een link.
+
+  Een lege regel wordt alleen een alinea-einde onder `|`.
 volgorde: 1000
 onderzoek: ''
 bouw: ''
@@ -109,6 +111,16 @@ werkpakketten hebben geen prioriteit, zes geen categorie. De roadmap groeit door
 eerst een titel en een plek vast te leggen en de rest later in te vullen. Vul
 niets in om het vakje te vullen; een verzonnen prioriteit is slechter dan een
 lege.
+
+`toelichting` — markdown, als **letterlijke** blok-scalar (`|-`). Neem geen
+`>-`: dat is een gevouwen scalar, en YAML plakt daarin een lege regel samen tot
+één regelovergang. Remark leest dat als een zachte afbreking, niet als een
+nieuwe alinea, dus je krijgt één doorlopende lap tekst — zonder dat de build
+iets zegt. Alleen onder `|` telt een lege regel als alinea-einde, en alleen daar
+wijst de bewerkknop naar de juiste regels in plaats van naar het hele veld.
+
+`capaciteit` — vrije tekst, bijvoorbeeld "2 fte, 6 maanden". Geen enum, geen
+getal; leeg laten mag.
 
 `onderzoek` — `open`, `loopt`, `beantwoord`, of `''`.
 `bouw` — `niet`, `deels`, `wel`, of `''`.
@@ -182,17 +194,28 @@ RFC van `Not implemented` naar `Implemented`, dan verandert de roadmap mee
 zonder dat je iets aanraakt.
 
 Een nummer dat niet bestaat laat de build vallen (`RFC 99 bestaat niet`), met
-het werkpakket erbij.
+het werkpakket erbij. Dezelfde RFC bij meerdere werkpakketten mag: RFC-013 hangt
+nu aan drie. Twee keer hetzelfde nummer in één lijst levert één regel op, geen
+twee.
 
 ### Welke RFC's nog nergens hangen
 
 Elke RFC met `implementation: Implemented` hoort ergens in de roadmap terug te
-komen: hij beschrijft werk dat gedaan is. De build zegt bij `just docs-build`
-welke dat nog niet doen:
+komen: hij beschrijft werk dat gedaan is. Eén commando zegt welke dat nog niet
+doen:
+
+```bash
+cd docs && node scripts/check-roadmap-rfcs.mjs
+```
 
 ```
-[roadmap] 4 geïmplementeerde RFC(s) zonder werkpakket: RFC-000, RFC-005, …
+Roadmap-RFC-dekking: 5 van 15 geïmplementeerde RFC(s) hangen nog aan geen
+enkel werkpakket:
+  RFC-002  Bevoegdheid (Authority) in Machine-Readable Law
+  …
 ```
+
+Het draait ook mee in `just docs-a11y`, naast de andere `check-*`-scripts.
 
 Dat is een melding en geen fout, met opzet. Een RFC die eerder landt dan de
 roadmap-bijwerking is een redactionele achterstand, geen defect, en een poort
@@ -272,9 +295,12 @@ onder de naam van een andere zetten, en dat zie je aan niets.
 ## Verifiëren
 
 ```bash
-just docs-build     # schema + de drie controles hieronder
-just docs           # dev-server op :4321, kijk het na op /roadmap
+just docs-build     # schema + de controles hieronder; dit is de echte poort
+just docs           # dev-server op :4321, om het na te kijken
 ```
+
+De controles zitten in de paginasjablonen, dus onder de dev-server slaan ze pas
+aan zodra je `/roadmap` echt opvraagt. Vertrouw op `docs-build`.
 
 `docs-build` faalt met een leesbare melding bij:
 

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -251,8 +251,10 @@ laat de build daarop vallen en zegt welke regel ontbreekt; volg die melding.
 ## Het outcome-mappingwerkblad
 
 `docs/src/data/outcome-mapping.json` voedt `/roadmap/outcome-mapping`. Het staat
-grotendeels leeg: alleen `mission` en de vier boundary partners zijn ingevuld.
-Aanvullen is gewoon het JSON-bestand bewerken.
+grotendeels leeg: gevuld zijn `mission`, de vier boundary partners en de
+eerste outcome challenge. De rest staat op lege strings. Aanvullen is gewoon
+het JSON-bestand bewerken, maar kijk eerst wat er staat: overschrijven is net
+zo makkelijk als aanvullen.
 
 Eén regel maakt het lastiger dan het eruitziet: **de arrays zijn positioneel**.
 Index i van `outcomeChallenges`, `progressMarkers` en `strategyMaps` hoort bij

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roadmap
-description: Onderhoudt de inhoud van de roadmap op /roadmap — werkpakketten toevoegen, wijzigen, verplaatsen of verwijderen, onderzoeksvragen schrijven en aan een sectie van het position paper koppelen, en het outcome-mappingwerkblad invullen. Gebruik dit bij "voeg een werkpakket toe", "verplaats X naar de Hoe-fase", "zet er een onderzoeksvraag bij", of het bijwerken van fases en disciplines.
+description: Onderhoudt de inhoud van de roadmap op /roadmap — werkpakketten toevoegen, wijzigen, verplaatsen of verwijderen, onderzoeksvragen schrijven en aan een sectie van het position paper koppelen, RFC's koppelen die het ontwerp beschrijven, en het outcome-mappingwerkblad invullen. Gebruik dit bij "voeg een werkpakket toe", "verplaats X naar de Hoe-fase", "zet er een onderzoeksvraag bij", of het bijwerken van fases en disciplines.
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write
 ---
@@ -81,6 +81,9 @@ toelichting: >-
   Twee of drie alinea's die uitleggen wat de opgave is. Markdown mag:
   **vet**, een lijst, een link.
 volgorde: 1000
+onderzoek: ''
+bouw: ''
+rfcs: []
 onderzoeksvragen: []
 samenhangIds: []
 ---
@@ -106,6 +109,14 @@ werkpakketten hebben geen prioriteit, zes geen categorie. De roadmap groeit door
 eerst een titel en een plek vast te leggen en de rest later in te vullen. Vul
 niets in om het vakje te vullen; een verzonnen prioriteit is slechter dan een
 lege.
+
+`onderzoek` — `open`, `loopt`, `beantwoord`, of `''`.
+`bouw` — `niet`, `deels`, `wel`, of `''`.
+
+Dat zijn twee assen en met opzet geen één. Een vraag kan beantwoord zijn zonder
+dat er iets gebouwd is, en er kan iets staan terwijl de vraag erachter nog open
+is. Eén gecombineerde status zou in de helft van de gevallen een verkeerd beeld
+geven. Beide mogen leeg blijven; de pagina toont dan "Nog niet bepaald".
 
 `volgorde` — een getal dat de plek binnen één matrixcel bepaalt, laag eerst.
 Dit veld is verplicht en heeft met opzet geen default: een ontbrekend veld zou
@@ -152,6 +163,42 @@ antwoord in plaats van dezelfde vraag.
 sectie omdat ze te algemeen zijn ("Hoe navolgbaar is het?"). Een gedwongen
 verwijzing kost de lezer een klik en levert niets op. Een verzonnen anker laat
 de build vallen met het werkpakket en de vraag erbij.
+
+## RFC's koppelen
+
+`rfcs` is een lijst met RFC-nummers, als getal:
+
+```yaml
+rfcs:
+  - 13
+  - 21
+```
+
+De pagina toont ze onder "Ontwerp en implementatie", met de titel van de RFC en
+zijn eigen `implementation`-waarde erbij. **Die waarde wordt niet overgenomen in
+het werkpakket.** De RFC is het ding dat gebouwd wordt, dus die bezit dat feit;
+een kopie hier zou een tweede waarheid zijn die niemand bijwerkt. Verandert een
+RFC van `Not implemented` naar `Implemented`, dan verandert de roadmap mee
+zonder dat je iets aanraakt.
+
+Een nummer dat niet bestaat laat de build vallen (`RFC 99 bestaat niet`), met
+het werkpakket erbij.
+
+### Welke RFC's nog nergens hangen
+
+Elke RFC met `implementation: Implemented` hoort ergens in de roadmap terug te
+komen: hij beschrijft werk dat gedaan is. De build zegt bij `just docs-build`
+welke dat nog niet doen:
+
+```
+[roadmap] 4 geïmplementeerde RFC(s) zonder werkpakket: RFC-000, RFC-005, …
+```
+
+Dat is een melding en geen fout, met opzet. Een RFC die eerder landt dan de
+roadmap-bijwerking is een redactionele achterstand, geen defect, en een poort
+die daarop blokkeert zet de roadmap in de weg van het werk dat hij beschrijft.
+Niet elke RFC hoort trouwens bij een werkpakket — RFC-000 gaat over het
+RFC-proces zelf.
 
 ## Een werkpakket verplaatsen
 
@@ -233,6 +280,7 @@ just docs           # dev-server op :4321, kijk het na op /roadmap
 - een `samenhangId` dat nergens heen wijst
 - twee bestanden met hetzelfde `id`, of een bestandsnaam die niet het `id` is
 - een `paper:`-anker dat niet in het paper staat
+- een RFC-nummer in `rfcs` dat niet bestaat
 - een ontbrekende of foute waarde volgens het zod-schema
 
 Raak je ook de pagina's aan, draai dan `just docs-a11y` (duurt ~10 minuten en

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -34,11 +34,35 @@ matrix toont dan twee kaarten die naar dezelfde pagina wijzen. De build vangt
 het (`id "…" wordt door meer dan één bestand gebruikt`), maar je hebt dan al
 gewerkt aan het verkeerde bestand.
 
-Genereer een nieuwe UUID en gebruik die als bestandsnaam én als `id`:
+### De UUID moet gegenereerd worden
+
+**Schrijf nooit zelf een UUID op.** Een verzonnen UUID ziet er goed uit en komt
+door het schema — dat toetst alleen de vorm — maar hij is niet uniform
+getrokken. Een taalmodel dat er een "bedenkt" grijpt terug op patronen uit zijn
+invoer en herhaalt cijferreeksen; de kans op een botsing met een bestaand id is
+dan niet meer verwaarloosbaar. En een botsing is precies de fout die twee
+kaarten naar dezelfde pagina laat wijzen. Laat een generator het doen:
 
 ```bash
-uuidgen | tr 'A-Z' 'a-z'
+node -e "console.log(require('node:crypto').randomUUID())"
 ```
+
+Node is de veilige keuze omdat de docs-build er toch al op draait, en het geeft
+op elk platform hetzelfde resultaat: kleine letters, versie 4. Alternatieven,
+als je die liever hebt:
+
+| Waar | Commando |
+|---|---|
+| Overal met Python | `python3 -c "import uuid; print(uuid.uuid4())"` |
+| macOS, Linux met util-linux | `uuidgen \| tr 'A-Z' 'a-z'` |
+| Windows PowerShell | `[guid]::NewGuid().ToString()` |
+
+**Kleine letters, altijd.** `uuidgen` geeft op macOS hoofdletters terug, vandaar
+de `tr` erachter; PowerShell geeft al kleine letters. Het schema accepteert
+hoofdletters wel, maar de controle op bestandsnaam-is-id vergelijkt letterlijk,
+en op macOS is het bestandssysteem hoofdletter-ongevoelig: lokaal lijkt dan
+alles in orde terwijl git de afwijkende schrijfwijze vastlegt en de build bij
+een ander valt. Alle negentien bestaande ids zijn kleine letters; houd dat zo.
 
 Het bestand bevat alleen frontmatter, geen body:
 

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roadmap
-description: Onderhoudt de inhoud van de roadmap op /roadmap — werkpakketten toevoegen, wijzigen of verplaatsen, onderzoeksvragen schrijven en aan een sectie van het position paper koppelen. Gebruik dit bij "voeg een werkpakket toe", "verplaats X naar de Hoe-fase", "zet er een onderzoeksvraag bij", of het bijwerken van fases en disciplines.
+description: Onderhoudt de inhoud van de roadmap op /roadmap — werkpakketten toevoegen, wijzigen, verplaatsen of verwijderen, onderzoeksvragen schrijven en aan een sectie van het position paper koppelen, en het outcome-mappingwerkblad invullen. Gebruik dit bij "voeg een werkpakket toe", "verplaats X naar de Hoe-fase", "zet er een onderzoeksvraag bij", of het bijwerken van fases en disciplines.
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write
 ---
@@ -159,6 +159,30 @@ Binnen een cel: pas `volgorde` aan. Naar een andere cel: pas `faseId` of
 `disciplineId` aan, en geef het een `volgorde` die past tussen de buren in de
 nieuwe cel.
 
+## Een werkpakket verwijderen
+
+Het bestand weggooien is niet genoeg: andere werkpakketten kunnen er via
+`samenhangIds` naar wijzen, en die verwijzingen blijven achter. De build valt
+daarop, en noemt elk bestand dat opgeruimd moet worden:
+
+```
+werkpakket 8faa572b-… (Controle en herstel): samenhangId "413459cd-…" bestaat niet
+werkpakket 992fa816-… (Discretionaire ruimte): samenhangId "413459cd-…" bestaat niet
+```
+
+Kijk dus eerst wie er naar verwijst, dan weet je vooraf wat je aanpast:
+
+```bash
+grep -l '<uuid>' docs/src/content/roadmap/werkpakketten/*.md
+```
+
+Het bestand zelf staat ook in die uitkomst, want zijn eigen `id` staat erin;
+de rest zijn de verwijzers.
+
+De app die hier ooit stond ruimde die verwijzingen zelf op bij het verwijderen;
+dat deed een server die er niet meer is. Nu doet de build het niet voor je, hij
+zegt alleen waar het misgaat.
+
 ## Fases en disciplines wijzigen
 
 Die staan in `roadmap-config.json`. Een fase heeft een `volgnummer` dat de
@@ -176,6 +200,25 @@ geen inhoudelijke wijziging maar een codewijziging**, en er hoort een regel bij
 in `docs/src/styles/roadmap.css`. Zonder die regel rendert het filtervakje wel,
 maar blijven die kaarten verborgen zodra er gefilterd wordt. `assertFilterRules`
 laat de build daarop vallen en zegt welke regel ontbreekt; volg die melding.
+
+## Het outcome-mappingwerkblad
+
+`docs/src/data/outcome-mapping.json` voedt `/roadmap/outcome-mapping`. Het staat
+grotendeels leeg: alleen `mission` en de vier boundary partners zijn ingevuld.
+Aanvullen is gewoon het JSON-bestand bewerken.
+
+Eén regel maakt het lastiger dan het eruitziet: **de arrays zijn positioneel**.
+Index i van `outcomeChallenges`, `progressMarkers` en `strategyMaps` hoort bij
+`boundaryPartners[i]`, en `organizationalPractices` loopt gelijk op met de acht
+praktijken in de code. Een vijfde boundary partner toevoegen betekent dus alle
+vier de arrays uitbreiden; doe je er één, dan valt de build met het veld erbij:
+
+```
+too_small … "outcomeChallenges"
+```
+
+Dat is opzet: zonder die controle zou de pagina de gegevens van de ene partner
+onder de naam van een andere zetten, en dat zie je aan niets.
 
 ## Verifiëren
 

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: roadmap
+description: Onderhoudt de inhoud van de roadmap op /roadmap — werkpakketten toevoegen, wijzigen of verplaatsen, onderzoeksvragen schrijven en aan een sectie van het position paper koppelen. Gebruik dit bij "voeg een werkpakket toe", "verplaats X naar de Hoe-fase", "zet er een onderzoeksvraag bij", of het bijwerken van fases en disciplines.
+user-invocable: true
+allowed-tools: Bash, Read, Grep, Glob, Edit, Write
+---
+
+# Roadmap
+
+De roadmap op `regelrecht.rijks.app/roadmap` is een read-only weergave van
+bestanden in deze repo. Er is geen beheerscherm en geen schrijf-API: wijzigen
+is een pull request, net als bij de rest van de repo.
+
+Deze skill gaat over de **inhoud**. Voor de pagina's, het schema en de
+buildcontroles die eronder liggen: die staan beschreven in de code zelf, en de
+redenering erachter in de commits van PR #1317.
+
+## Waar de inhoud staat
+
+```
+docs/src/content/roadmap/werkpakketten/<uuid>.md   één bestand per werkpakket
+docs/src/data/roadmap-config.json                  de fases en de disciplines
+docs/src/data/outcome-mapping.json                 het outcome-mappingwerkblad
+```
+
+De bestandsnaam ís het `id` uit de frontmatter. Dat wordt bij de build
+gecontroleerd, dus hernoem nooit het een zonder het ander.
+
+## Een werkpakket toevoegen
+
+Kopieer géén bestaand bestand. Dat is de manier waarop je een dubbel `id`
+maakt: de bestandsnaam pas je aan, het `id` in de frontmatter vergeet je, en de
+matrix toont dan twee kaarten die naar dezelfde pagina wijzen. De build vangt
+het (`id "…" wordt door meer dan één bestand gebruikt`), maar je hebt dan al
+gewerkt aan het verkeerde bestand.
+
+Genereer een nieuwe UUID en gebruik die als bestandsnaam én als `id`:
+
+```bash
+uuidgen | tr 'A-Z' 'a-z'
+```
+
+Het bestand bevat alleen frontmatter, geen body:
+
+```yaml
+---
+id: <de uuid van hierboven>
+titel: Korte titel van het werkpakket
+faseId: wat
+disciplineId: recht
+prioriteit: ''
+omvang: ''
+categorie: ''
+capability: ''
+capaciteit: ''
+toelichting: >-
+  Twee of drie alinea's die uitleggen wat de opgave is. Markdown mag:
+  **vet**, een lijst, een link.
+volgorde: 1000
+onderzoeksvragen: []
+samenhangIds: []
+---
+```
+
+### Wat er in de velden mag
+
+`faseId` — een van `wat`, `wat-fase-2`, `hoe`, `waar`, `garantie`.
+`disciplineId` — een van `techniek`, `recht`, `mensen`, `ethiek`,
+`service-design`.
+
+Beide staan in `roadmap-config.json`; een waarde die daar niet in staat laat de
+build vallen met de naam van het werkpakket erbij.
+
+`prioriteit` — `hoog`, `midden`, `laag`, of `''`.
+`omvang` — `S`, `M`, `L`, `XL`, of `''`.
+`categorie` — `lat`, `pivot`, `bet`, of `''`.
+`capability` — `basis`, `ontwikkelen`, `simuleren`, `publiceren`, `analyseren`,
+`implementeren`, `verifieren`, of `''`.
+
+**Lege strings zijn normaal, geen tekortkoming.** Vijftien van de negentien
+werkpakketten hebben geen prioriteit, zes geen categorie. De roadmap groeit door
+eerst een titel en een plek vast te leggen en de rest later in te vullen. Vul
+niets in om het vakje te vullen; een verzonnen prioriteit is slechter dan een
+lege.
+
+`volgorde` — een getal dat de plek binnen één matrixcel bepaalt, laag eerst.
+Dit veld is verplicht en heeft met opzet geen default: een ontbrekend veld zou
+het werkpakket stilzwijgend bovenaan zetten. Gebruik stappen van 1000, dan kun
+je er later tussen schuiven zonder alles te hernummeren.
+
+`samenhangIds` — UUID's van andere werkpakketten. De build controleert of ze
+bestaan. Dit is eenrichtingsverkeer: zet je A → B, dan verschijnt B niet
+automatisch bij A. Zet 'm er handmatig bij als de relatie wederzijds is.
+
+## Onderzoeksvragen
+
+Een vraag is een gewone string, óf een mapping met een verwijzing naar het
+position paper *Rules as Executed*:
+
+```yaml
+onderzoeksvragen:
+  - >-
+    Een vraag waar het paper niets over zegt blijft een gewone string.
+  - vraag: >-
+      Heeft een burger recht op de technische logbestanden van hoe een besluit
+      tot stand is gekomen?
+    paper: sec:traceaccess
+```
+
+Beide vormen mogen door elkaar in één lijst staan.
+
+### De juiste sectie vinden
+
+De ankers staan in de headings van het paper:
+
+```bash
+node -e "require('./docs/src/research/rules-as-executed.headings.json')
+  .forEach(h => console.log(h.slug.padEnd(28), h.text))"
+```
+
+Sectie 12 is een onderzoeksagenda per discipline — `sec:agenda-legal`,
+`sec:agenda-cs`, `sec:agenda-polsci`, `sec:agenda-philosophy`. Stelt het paper
+de vraag daar zelf, wijs dan daarheen. Werkt een inhoudelijk hoofdstuk hem uit,
+wijs dan naar dat hoofdstuk. Bij twijfel: het hoofdstuk, want daar staat een
+antwoord in plaats van dezelfde vraag.
+
+**Koppel niet wat niet past.** Drie van de drieënvijftig vragen hebben geen
+sectie omdat ze te algemeen zijn ("Hoe navolgbaar is het?"). Een gedwongen
+verwijzing kost de lezer een klik en levert niets op. Een verzonnen anker laat
+de build vallen met het werkpakket en de vraag erbij.
+
+## Een werkpakket verplaatsen
+
+Binnen een cel: pas `volgorde` aan. Naar een andere cel: pas `faseId` of
+`disciplineId` aan, en geef het een `volgorde` die past tussen de buren in de
+nieuwe cel.
+
+## Fases en disciplines wijzigen
+
+Die staan in `roadmap-config.json`. Een fase heeft een `volgnummer` dat de
+kolomvolgorde bepaalt; disciplines staan in de volgorde van het bestand.
+
+Een fase of discipline verwijderen kan alleen als geen enkel werkpakket er nog
+naar wijst — anders faalt de build. Zoek eerst wie er hangt:
+
+```bash
+grep -l 'faseId: hoe' docs/src/content/roadmap/werkpakketten/*.md
+```
+
+**Een categorie toevoegen aan `CATEGORIEEN` in `docs/src/lib/roadmap.ts` is
+geen inhoudelijke wijziging maar een codewijziging**, en er hoort een regel bij
+in `docs/src/styles/roadmap.css`. Zonder die regel rendert het filtervakje wel,
+maar blijven die kaarten verborgen zodra er gefilterd wordt. `assertFilterRules`
+laat de build daarop vallen en zegt welke regel ontbreekt; volg die melding.
+
+## Verifiëren
+
+```bash
+just docs-build     # schema + de drie controles hieronder
+just docs           # dev-server op :4321, kijk het na op /roadmap
+```
+
+`docs-build` faalt met een leesbare melding bij:
+
+- een onbekende `faseId` of `disciplineId`
+- een `samenhangId` dat nergens heen wijst
+- twee bestanden met hetzelfde `id`, of een bestandsnaam die niet het `id` is
+- een `paper:`-anker dat niet in het paper staat
+- een ontbrekende of foute waarde volgens het zod-schema
+
+Raak je ook de pagina's aan, draai dan `just docs-a11y` (duurt ~10 minuten en
+draait ook in CI).
+
+### Wat de build níét controleert, met opzet
+
+Onvolledige inhoud is geen fout. Een werkpakket zonder prioriteit, een cel
+zonder werkpakketten, een vraag zonder papersectie: dat is de stand van het
+werk, niet een defect. Een poort die daarover klaagt zou bij elke commit
+afgaan en daarmee genegeerd worden — en hij zou het toevoegen van een
+half-uitgewerkt werkpakket blokkeren, wat juist de manier is waarop deze
+roadmap groeit.
+
+Wil je weten waar de roadmap onaf is, kijk dan zelf:
+
+```bash
+grep -L 'prioriteit: [a-z]' docs/src/content/roadmap/werkpakketten/*.md
+```
+
+## Twee dingen om te weten
+
+**De pagina staat bewust nergens gelinkt.** Niet in de navigatie, niet op de
+landingspagina, en hij is uitgesloten van de zoekindex. Hij is wel gewoon
+publiek bereikbaar, op zowel `regelrecht.rijks.app` als
+`docs.regelrecht.rijks.app`. Wil je hem gaan linken, dan is dat het moment om
+de inhoud publicatierijp te maken: er staan nu werktitels en lege velden in.
+
+**Er is geen ondersteuning voor meerdere papers.** Het veld heet `paper` en het
+anker wordt getoetst aan dat ene paper. Komt er een tweede, dan is dat een
+codewijziging, geen inhoudelijke.

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "preview": "astro preview",
     "check:rfc-coverage": "node scripts/check-rfc-coverage.mjs",
     "check:schema-version": "node scripts/check-schema-version.mjs",
-    "a11y": "astro build && node scripts/check-rfc-coverage.mjs && node scripts/check-mermaid-alt.mjs && node scripts/check-heading-order.mjs && node scripts/check-links.mjs && node scripts/gen-pa11yci.mjs && start-server-and-test 'astro preview --port 4173' http://localhost:4173 'pa11y-ci'",
+    "a11y": "astro build && node scripts/check-rfc-coverage.mjs && node scripts/check-roadmap-rfcs.mjs && node scripts/check-mermaid-alt.mjs && node scripts/check-heading-order.mjs && node scripts/check-links.mjs && node scripts/gen-pa11yci.mjs && start-server-and-test 'astro preview --port 4173' http://localhost:4173 'pa11y-ci'",
     "nldd:imports": "node ../script/check-nldd-imports.mjs src src/nldd-components.js --write",
     "nldd:check": "node ../script/check-nldd-imports.mjs src src/nldd-components.js"
   },

--- a/docs/scripts/check-roadmap-rfcs.mjs
+++ b/docs/scripts/check-roadmap-rfcs.mjs
@@ -1,0 +1,71 @@
+// Report which implemented RFCs no werkpakket on the roadmap points at.
+//
+// An RFC with `implementation: Implemented` describes work that is done, so it
+// belongs somewhere in the roadmap. Nothing enforces that: an RFC lands, the
+// roadmap is updated later or not at all, and the gap is invisible.
+//
+// This REPORTS and always exits 0. Failing would put the roadmap in the way of
+// the work it describes — an RFC could not merge until someone edited a
+// werkpakket — and a gate that blocks on editorial lag gets worked around
+// rather than satisfied. The roadmap's own build already fails on the errors
+// that produce a wrong page (a non-existent RFC number, a dangling reference);
+// this is the softer question of coverage.
+//
+// Reads source files, not the build, so it runs without `astro build`.
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const RFC_DIR = fileURLToPath(new URL('../src/content/rfcs', import.meta.url));
+const WP_DIR = fileURLToPath(
+  new URL('../src/content/roadmap/werkpakketten', import.meta.url),
+);
+
+// RFC-000 is the RFC process itself; it describes no work a werkpakket could
+// carry, so counting it would make the report permanently non-empty.
+const EXEMPT = new Set(['RFC-000']);
+
+const field = (text, name) =>
+  (text.match(new RegExp(`^${name}:\\s*(.*)$`, 'm')) ?? [])[1]?.trim() ?? '';
+
+const implemented = readdirSync(RFC_DIR)
+  .filter((f) => /^rfc-\d+\.md$/.test(f))
+  .map((f) => {
+    const text = readFileSync(`${RFC_DIR}/${f}`, 'utf8');
+    return {
+      num: parseInt(f.match(/\d+/)[0], 10),
+      id: `RFC-${f.match(/\d+/)[0]}`,
+      title: field(text, 'title').replace(/"/g, '').replace(/^RFC-\d+:\s*/, ''),
+      implementation: field(text, 'implementation'),
+    };
+  })
+  .filter((r) => r.implementation === 'Implemented' && !EXEMPT.has(r.id));
+
+// Every RFC number any werkpakket references, from the `rfcs:` sequence.
+const referenced = new Set();
+for (const f of readdirSync(WP_DIR).filter((x) => x.endsWith('.md'))) {
+  const text = readFileSync(`${WP_DIR}/${f}`, 'utf8');
+  const block = text.match(/^rfcs:\n((?:\s+-\s*\d+\n)+)/m);
+  if (!block) continue;
+  for (const m of block[1].matchAll(/-\s*(\d+)/g)) {
+    referenced.add(parseInt(m[1], 10));
+  }
+}
+
+const missing = implemented.filter((r) => !referenced.has(r.num));
+
+if (missing.length === 0) {
+  console.log(
+    `Roadmap-RFC-dekking: alle ${implemented.length} geïmplementeerde RFC(s) ` +
+      `hangen aan een werkpakket (${[...EXEMPT].join(', ')} uitgezonderd).`,
+  );
+} else {
+  console.log(
+    `Roadmap-RFC-dekking: ${missing.length} van ${implemented.length} ` +
+      'geïmplementeerde RFC(s) hangen nog aan geen enkel werkpakket:',
+  );
+  for (const r of missing) console.log(`  ${r.id}  ${r.title}`);
+  console.log(
+    '\nDat is een melding, geen fout: niet elke RFC hoort bij een werkpakket, ' +
+      'en de roadmap mag achterlopen op het werk dat hij beschrijft.',
+  );
+}

--- a/docs/scripts/check-roadmap-rfcs.mjs
+++ b/docs/scripts/check-roadmap-rfcs.mjs
@@ -44,7 +44,11 @@ const implemented = readdirSync(RFC_DIR)
 const referenced = new Set();
 for (const f of readdirSync(WP_DIR).filter((x) => x.endsWith('.md'))) {
   const text = readFileSync(`${WP_DIR}/${f}`, 'utf8');
-  const block = text.match(/^rfcs:\n((?:\s+-\s*\d+\n)+)/m);
+  // \r? throughout, and [ \t] rather than \s for the indent: a file written on
+  // Windows has CRLF endings, and without this the block simply does not match
+  // — under-reporting coverage instead of failing, which is the hardest kind of
+  // wrong to notice. (\s would also swallow the newline and span list items.)
+  const block = text.match(/^rfcs:\r?\n((?:[ \t]+-[ \t]*\d+\r?\n)+)/m);
   if (!block) continue;
   for (const m of block[1].matchAll(/-\s*(\d+)/g)) {
     referenced.add(parseInt(m[1], 10));

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,6 +1,8 @@
 import { defineCollection, z } from 'astro:content';
 import { glob } from 'astro/loaders';
 import {
+  ONDERZOEK_IDS,
+  BOUW_IDS,
   PRIORITEIT_IDS,
   OMVANG_IDS,
   CATEGORIE_IDS,
@@ -104,6 +106,21 @@ const werkpakketten = defineCollection({
       )
       .default([]),
     samenhangIds: z.array(z.string().uuid()).default([]),
+    // Two axes that genuinely diverge, so two fields rather than one.
+    // A question can be answered without anything being built (onderzoek
+    // 'beantwoord', bouw 'niet'), and a thing can be built while the question
+    // behind it stays open (the reverse). Collapsing them into one status
+    // would force a choice the roadmap cannot make.
+    //
+    // Both default to the least-claim value, so an existing werkpakket keeps
+    // meaning what it meant: nothing asserted is not the same as "nothing
+    // done", and the pages render an unset field as "niet bepaald".
+    onderzoek: z.enum(ONDERZOEK_IDS).or(z.literal('')).default(''),
+    bouw: z.enum(BOUW_IDS).or(z.literal('')).default(''),
+    // RFC numbers whose design work belongs to this werkpakket, e.g. [13, 21].
+    // The RFC keeps its own `implementation` field; this is a pointer, not a
+    // copy of it. assertRfcReferences() checks each number exists.
+    rfcs: z.array(z.number().int().positive()).default([]),
   }),
 });
 

--- a/docs/src/content/roadmap/werkpakketten/11d2326e-e367-4c35-a1f4-084331855cf1.md
+++ b/docs/src/content/roadmap/werkpakketten/11d2326e-e367-4c35-a1f4-084331855cf1.md
@@ -94,5 +94,10 @@ toelichting: >-
   welke functies prioriteit hebben voor ontwikkeling).
 volgorde: 1000
 onderzoeksvragen: []
+onderzoek: loopt
+bouw: deels
+rfcs:
+  - 2
+  - 3
 samenhangIds: []
 ---

--- a/docs/src/content/roadmap/werkpakketten/11d2326e-e367-4c35-a1f4-084331855cf1.md
+++ b/docs/src/content/roadmap/werkpakketten/11d2326e-e367-4c35-a1f4-084331855cf1.md
@@ -95,7 +95,7 @@ toelichting: >-
 volgorde: 1000
 onderzoeksvragen: []
 onderzoek: loopt
-bouw: niet
+bouw: deels
 rfcs:
   - 3
   - 12

--- a/docs/src/content/roadmap/werkpakketten/11d2326e-e367-4c35-a1f4-084331855cf1.md
+++ b/docs/src/content/roadmap/werkpakketten/11d2326e-e367-4c35-a1f4-084331855cf1.md
@@ -95,9 +95,8 @@ toelichting: >-
 volgorde: 1000
 onderzoeksvragen: []
 onderzoek: loopt
-bouw: deels
+bouw: niet
 rfcs:
-  - 2
-  - 3
+  - 35
 samenhangIds: []
 ---

--- a/docs/src/content/roadmap/werkpakketten/11d2326e-e367-4c35-a1f4-084331855cf1.md
+++ b/docs/src/content/roadmap/werkpakketten/11d2326e-e367-4c35-a1f4-084331855cf1.md
@@ -97,6 +97,8 @@ onderzoeksvragen: []
 onderzoek: loopt
 bouw: niet
 rfcs:
+  - 3
+  - 12
   - 35
 samenhangIds: []
 ---

--- a/docs/src/content/roadmap/werkpakketten/306e5714-76c7-437f-9b77-0d5f9f1e74fa.md
+++ b/docs/src/content/roadmap/werkpakketten/306e5714-76c7-437f-9b77-0d5f9f1e74fa.md
@@ -116,5 +116,10 @@ onderzoeksvragen:
       aan de originele, betrouwbare bron van de inputdata, zodat er geen
       onduidelijkheid is over welke waarden zijn gebruikt?
     paper: sec:relying
+onderzoek: loopt
+bouw: deels
+rfcs:
+  - 13
+  - 19
 samenhangIds: []
 ---

--- a/docs/src/content/roadmap/werkpakketten/3cf6a77e-2a9b-46a8-987c-10e72e8cc1a0.md
+++ b/docs/src/content/roadmap/werkpakketten/3cf6a77e-2a9b-46a8-987c-10e72e8cc1a0.md
@@ -8,60 +8,30 @@ omvang: ''
 categorie: lat
 capability: publiceren
 capaciteit: ''
-toelichting: >-
-  Deze onderzoeksopgave richt zich op het beheer van versies en de temporele
-  consistentie (Temporal Consistency) van wetgeving wanneer deze wordt omgezet
-  in uitvoerbare specificaties. Het centrale uitgangspunt is dat een juridisch
-  besluit altijd moet worden genomen op basis van de regels die op dat
-  specifieke moment van kracht waren.
-
+toelichting: |-
+  Deze onderzoeksopgave richt zich op het beheer van versies en de temporele consistentie (Temporal Consistency) van wetgeving wanneer deze wordt omgezet in uitvoerbare specificaties. Het centrale uitgangspunt is dat een juridisch besluit altijd moet worden genomen op basis van de regels die op dat specifieke moment van kracht waren.
 
   De belangrijkste punten zijn:
 
-
-  - **Het probleem van temporele consistentie**: In tegenstelling tot reguliere
-  softwareontwikkeling (waarbij vaak de nieuwste compatibele versie wordt
-  gebruikt), vereist het recht een exacte reconstructie van de rechtstoestand op
-  een specifieke datum (chronolexografie). Het systeem moet vragen kunnen
-  beantwoorden als: "Wat was de wet op 15 maart 2020?" en alle afhankelijke
-  regels uit diezelfde periode ophalen.
+  - **Het probleem van temporele consistentie**: In tegenstelling tot reguliere softwareontwikkeling (waarbij vaak de nieuwste compatibele versie wordt gebruikt), vereist het recht een exacte reconstructie van de rechtstoestand op een specifieke datum (chronolexografie). Het systeem moet vragen kunnen beantwoorden als: "Wat was de wet op 15 maart 2020?" en alle afhankelijke regels uit diezelfde periode ophalen.
 
   - Omgang met wetswijzigingen:
 
-  - - **Retroactieve werking**: Wijzigingen met terugwerkende kracht moeten
-  expliciet worden gecodeerd als 'tijdreizen', waarbij het effect van een vorige
-  versie wordt teruggedraaid vanaf een bepaalde datum.
+  - **Retroactieve werking**: Wijzigingen met terugwerkende kracht moeten expliciet worden gecodeerd als 'tijdreizen', waarbij het effect van een vorige versie wordt teruggedraaid vanaf een bepaalde datum.
 
-  - - **Prospectieve werking**: Wijzigingen die pas in de toekomst ingaan,
-  moeten een exacte ingangsdatum hebben.
+  - **Prospectieve werking**: Wijzigingen die pas in de toekomst ingaan, moeten een exacte ingangsdatum hebben.
 
-  - **Het Staatsblad als bron van versies**: Het Staatsblad dient als de bron
-  voor 'release tags'. Een publicatiedatum wordt direct de versienummering
-  (bijv. versie 2020-03-15). Verwijzingen tussen wetten zijn niet vastgepind op
-  één versie, maar worden dynamisch opgelost op basis van de relevante datum van
-  de zaak.
+  - **Het Staatsblad als bron van versies**: Het Staatsblad dient als de bron voor 'release tags'. Een publicatiedatum wordt direct de versienummering (bijv. versie 2020-03-15). Verwijzingen tussen wetten zijn niet vastgepind op één versie, maar worden dynamisch opgelost op basis van de relevante datum van de zaak.
 
-  - **Verifieerbaarheid en het Register**: Om te voorkomen dat twee besluiten
-  met dezelfde specificatie-hash verschillende uitkomsten geven (omdat
-  afhankelijke wetten zijn gewijzigd), moet per uitvoering worden vastgelegd
-  welke specifieke versies zijn gebruikt. Er is een register nodig dat:
+  - **Verifieerbaarheid en het Register**: Om te voorkomen dat twee besluiten met dezelfde specificatie-hash verschillende uitkomsten geven (omdat afhankelijke wetten zijn gewijzigd), moet per uitvoering worden vastgelegd welke specifieke versies zijn gebruikt. Er is een register nodig dat:
 
-  - - De inhoud teruggeeft die bij een specifieke digest (hash) hoort.
+  - De inhoud teruggeeft die bij een specifieke digest (hash) hoort.
 
-  - - Historische versies onveranderlijk (immutable) bewaart, zodat besluiten
-  van jaren geleden exact opnieuw kunnen worden uitgevoerd.
+  - Historische versies onveranderlijk (immutable) bewaart, zodat besluiten van jaren geleden exact opnieuw kunnen worden uitgevoerd.
 
-  - **Niet-wetgevende wijzigingen**: Het model houdt rekening met veranderingen
-  die buiten het Staatsblad om gaan, zoals direct toepasbare EU-verordeningen of
-  rechterlijke uitspraken (bijv. het SyRI-vonnis) die een bepaling onmiddellijk
-  ongeldig kunnen maken. Deze worden als 'events' in de versiehistorie
-  opgenomen.
+  - **Niet-wetgevende wijzigingen**: Het model houdt rekening met veranderingen die buiten het Staatsblad om gaan, zoals direct toepasbare EU-verordeningen of rechterlijke uitspraken (bijv. het SyRI-vonnis) die een bepaling onmiddellijk ongeldig kunnen maken. Deze worden als 'events' in de versiehistorie opgenomen.
 
-  - F**ormele vs. Materiële status**: Door strikt versiebeheer wordt het
-  onderscheid zichtbaar tussen de formele status (wat staat er in het
-  Staatsblad?) en de materiële status (welke regel is daadwerkelijk
-  geïmplementeerd in het systeem?). Gaten tussen deze twee worden hierdoor
-  detecteerbaar en corrigeerbaar.
+  - **Formele vs. Materiële status**: Door strikt versiebeheer wordt het onderscheid zichtbaar tussen de formele status (wat staat er in het Staatsblad?) en de materiële status (welke regel is daadwerkelijk geïmplementeerd in het systeem?). Gaten tussen deze twee worden hierdoor detecteerbaar en corrigeerbaar.
 volgorde: 3500
 onderzoeksvragen:
   - vraag: Wat publiceer je doel & wat is de status van de publicatie?

--- a/docs/src/content/roadmap/werkpakketten/3cf6a77e-2a9b-46a8-987c-10e72e8cc1a0.md
+++ b/docs/src/content/roadmap/werkpakketten/3cf6a77e-2a9b-46a8-987c-10e72e8cc1a0.md
@@ -78,5 +78,7 @@ onderzoek: loopt
 bouw: deels
 rfcs:
   - 10
+  - 13
+  - 20
 samenhangIds: []
 ---

--- a/docs/src/content/roadmap/werkpakketten/3cf6a77e-2a9b-46a8-987c-10e72e8cc1a0.md
+++ b/docs/src/content/roadmap/werkpakketten/3cf6a77e-2a9b-46a8-987c-10e72e8cc1a0.md
@@ -74,5 +74,9 @@ onderzoeksvragen:
     paper: sec:ownership
   - vraag: Wat moet het versiebeheer mogelijk maken?
     paper: sec:versionedartifact
+onderzoek: loopt
+bouw: deels
+rfcs:
+  - 10
 samenhangIds: []
 ---

--- a/docs/src/content/roadmap/werkpakketten/413459cd-4f34-48f2-9fbd-ae4ad2dbf67b.md
+++ b/docs/src/content/roadmap/werkpakketten/413459cd-4f34-48f2-9fbd-ae4ad2dbf67b.md
@@ -62,9 +62,8 @@ onderzoeksvragen:
       publiceren?
     paper: sec:agenda-legal
 onderzoek: loopt
-bouw: deels
-rfcs:
-  - 12
+bouw: ''
+rfcs: []
 samenhangIds:
   - 9f359af7-a6f1-4af3-bdb5-f038ce871325
 ---

--- a/docs/src/content/roadmap/werkpakketten/413459cd-4f34-48f2-9fbd-ae4ad2dbf67b.md
+++ b/docs/src/content/roadmap/werkpakketten/413459cd-4f34-48f2-9fbd-ae4ad2dbf67b.md
@@ -61,6 +61,10 @@ onderzoeksvragen:
       Wat betekent het juridisch om een 'uitvoerbare specificatie' officieel te
       publiceren?
     paper: sec:agenda-legal
+onderzoek: loopt
+bouw: deels
+rfcs:
+  - 12
 samenhangIds:
   - 9f359af7-a6f1-4af3-bdb5-f038ce871325
 ---

--- a/docs/src/content/roadmap/werkpakketten/61523500-1eb0-4141-95fb-dbbd10be9a72.md
+++ b/docs/src/content/roadmap/werkpakketten/61523500-1eb0-4141-95fb-dbbd10be9a72.md
@@ -46,5 +46,9 @@ onderzoeksvragen:
       verschillende versie van dezelfde regel publiceren, en welke juridische
       status hebben onafhankelijke monitors die dit controleren?
     paper: sec:ownership
+onderzoek: open
+bouw: deels
+rfcs:
+  - 19
 samenhangIds: []
 ---

--- a/docs/src/content/roadmap/werkpakketten/61523500-1eb0-4141-95fb-dbbd10be9a72.md
+++ b/docs/src/content/roadmap/werkpakketten/61523500-1eb0-4141-95fb-dbbd10be9a72.md
@@ -46,9 +46,11 @@ onderzoeksvragen:
       verschillende versie van dezelfde regel publiceren, en welke juridische
       status hebben onafhankelijke monitors die dit controleren?
     paper: sec:ownership
-onderzoek: open
+onderzoek: loopt
 bouw: deels
 rfcs:
+  - 9
+  - 13
   - 19
 samenhangIds: []
 ---

--- a/docs/src/content/roadmap/werkpakketten/9f359af7-a6f1-4af3-bdb5-f038ce871325.md
+++ b/docs/src/content/roadmap/werkpakketten/9f359af7-a6f1-4af3-bdb5-f038ce871325.md
@@ -76,12 +76,12 @@ onderzoeksvragen:
       delingen) die bepalen wanneer twee verschillende software-implementaties van
       dezelfde wet tot een juridisch identieke uitkomst komen?
     paper: sec:engines
-onderzoek: beantwoord
-bouw: wel
+onderzoek: loopt
+bouw: deels
 rfcs:
   - 1
   - 4
-  - 11
+  - 14
   - 21
   - 23
   - 24

--- a/docs/src/content/roadmap/werkpakketten/9f359af7-a6f1-4af3-bdb5-f038ce871325.md
+++ b/docs/src/content/roadmap/werkpakketten/9f359af7-a6f1-4af3-bdb5-f038ce871325.md
@@ -76,6 +76,15 @@ onderzoeksvragen:
       delingen) die bepalen wanneer twee verschillende software-implementaties van
       dezelfde wet tot een juridisch identieke uitkomst komen?
     paper: sec:engines
+onderzoek: beantwoord
+bouw: wel
+rfcs:
+  - 1
+  - 4
+  - 11
+  - 21
+  - 23
+  - 24
 samenhangIds:
   - 413459cd-4f34-48f2-9fbd-ae4ad2dbf67b
 ---

--- a/docs/src/lib/roadmap.ts
+++ b/docs/src/lib/roadmap.ts
@@ -16,6 +16,7 @@ import { z } from 'astro:content';
 import configJson from '~/data/roadmap-config.json';
 import worksheetJson from '~/data/outcome-mapping.json';
 import paperHeadings from '~/research/rules-as-executed.headings.json';
+import { getRfcs } from '~/lib/rfcs';
 
 export interface Fase {
   id: string;
@@ -45,6 +46,9 @@ export interface WerkpakketData {
   volgorde: number;
   onderzoeksvragen: (string | { vraag: string; paper: string })[];
   samenhangIds: string[];
+  onderzoek: string;
+  bouw: string;
+  rfcs: number[];
 }
 
 export const PRIORITEITEN = [
@@ -54,6 +58,32 @@ export const PRIORITEITEN = [
 ] as const;
 
 export const OMVANGEN = ['S', 'M', 'L', 'XL'] as const;
+
+/*
+ * Two axes, deliberately separate.
+ *
+ * `onderzoek` is how far the question is answered; `bouw` is how much of it
+ * stands in the codebase. They diverge in both directions, which is why one
+ * combined status would be a lie in half the cases.
+ *
+ * The tag colours follow the same reading as elsewhere on the site: neutral
+ * for "not started", warning for "under way", success for "done".
+ */
+export const ONDERZOEK_STANDEN = [
+  { id: 'open', label: 'Open', tagColor: 'neutral' },
+  { id: 'loopt', label: 'Loopt', tagColor: 'warning' },
+  { id: 'beantwoord', label: 'Beantwoord', tagColor: 'success' },
+] as const;
+
+export const BOUW_STANDEN = [
+  { id: 'niet', label: 'Niet gebouwd', tagColor: 'neutral' },
+  { id: 'deels', label: 'Deels gebouwd', tagColor: 'warning' },
+  { id: 'wel', label: 'Gebouwd', tagColor: 'success' },
+] as const;
+
+export const getOnderzoek = (id: string) =>
+  ONDERZOEK_STANDEN.find((s) => s.id === id);
+export const getBouw = (id: string) => BOUW_STANDEN.find((s) => s.id === id);
 
 export const CATEGORIEEN = [
   { id: 'lat', label: 'Lat' },
@@ -122,6 +152,8 @@ export function assertFilterRules(css: string): void {
   }
 }
 
+export const ONDERZOEK_IDS = ONDERZOEK_STANDEN.map((s) => s.id) as NonEmpty;
+export const BOUW_IDS = BOUW_STANDEN.map((s) => s.id) as NonEmpty;
 export const PRIORITEIT_IDS = PRIORITEITEN.map((p) => p.id) as NonEmpty;
 export const OMVANG_IDS = [...OMVANGEN] as NonEmpty;
 export const CATEGORIE_IDS = CATEGORIEEN.map((c) => c.id) as NonEmpty;
@@ -256,6 +288,87 @@ export function onderzoeksvraagLijst(
       ? { vraag: v }
       : { vraag: v.vraag, paper: getPaperSectie(v.paper) },
   );
+}
+
+/** An RFC a werkpakket points at, with the RFC's own implementation state. */
+export interface RfcVerwijzing {
+  /** Zero-padded id, e.g. "RFC-013". */
+  id: string;
+  title: string;
+  /** "Implemented" | "Partially implemented" | "Not implemented". */
+  implementation: string;
+  link: string;
+}
+
+/**
+ * The RFCs a werkpakket points at, resolved against the RFC collection.
+ *
+ * The implementation state is read from the RFC and never copied into the
+ * werkpakket: the RFC is the thing that gets built, so it owns that fact. A
+ * copy would be a second truth that nobody updates.
+ */
+export function rfcVerwijzingen(nummers: number[]): RfcVerwijzing[] {
+  const alle = new Map(getRfcs().map((r) => [r.num, r]));
+  return nummers
+    .map((n) => alle.get(n))
+    .filter((r): r is NonNullable<typeof r> => Boolean(r))
+    .map((r) => ({
+      id: r.id,
+      title: r.title,
+      implementation: r.implementation ?? 'Not implemented',
+      link: r.link,
+    }));
+}
+
+/**
+ * Fail the build on a werkpakket pointing at an RFC that does not exist.
+ *
+ * Same reason as assertPaperSections: check-links.mjs would catch the dead
+ * link once it is in the HTML, but it reports the route, not the werkpakket
+ * that wrote it.
+ */
+export function assertRfcReferences(
+  werkpakketten: { data: WerkpakketData }[],
+): void {
+  const bestaande = new Set(getRfcs().map((r) => r.num));
+  const problems: string[] = [];
+
+  for (const { data } of werkpakketten) {
+    for (const nummer of data.rfcs) {
+      if (bestaande.has(nummer)) continue;
+      problems.push(
+        `werkpakket ${data.id} (${data.titel}): RFC ${nummer} bestaat niet`,
+      );
+    }
+  }
+
+  if (problems.length) {
+    throw new Error(
+      `Verwijzingen naar RFC's kloppen niet:\n  ${problems.join('\n  ')}`,
+    );
+  }
+}
+
+/**
+ * The implemented RFCs no werkpakket points at.
+ *
+ * Reported, not enforced. An RFC that lands before anyone updates the roadmap
+ * is a redactional gap, not a defect, and a gate that blocked the RFC on it
+ * would put the roadmap in the way of the work it describes. Printing the
+ * list at build time keeps it visible without that cost.
+ */
+export function ongekoppeldeRfcs(
+  werkpakketten: { data: WerkpakketData }[],
+): RfcVerwijzing[] {
+  const gekoppeld = new Set(werkpakketten.flatMap((w) => w.data.rfcs));
+  return getRfcs()
+    .filter((r) => r.implementation === 'Implemented' && !gekoppeld.has(r.num))
+    .map((r) => ({
+      id: r.id,
+      title: r.title,
+      implementation: r.implementation ?? '',
+      link: r.link,
+    }));
 }
 
 /**

--- a/docs/src/lib/roadmap.ts
+++ b/docs/src/lib/roadmap.ts
@@ -294,11 +294,30 @@ export function onderzoeksvraagLijst(
 export interface RfcVerwijzing {
   /** Zero-padded id, e.g. "RFC-013". */
   id: string;
+  /** The RFC's own English title; a name, not a label, so not translated. */
   title: string;
-  /** "Implemented" | "Partially implemented" | "Not implemented". */
+  /** The RFC's `implementation` value, in Dutch — this page is lang="nl". */
   implementation: string;
   link: string;
 }
+
+/*
+ * The RFC's implementation state, in Dutch.
+ *
+ * The RFC pages are lang="en" and show the frontmatter value as it stands; a
+ * werkpakket page is lang="nl", and an English string there is not only
+ * inconsistent but read aloud with Dutch pronunciation rules. The RFC's own
+ * title stays English: that is its name, and translating it would stop
+ * matching the page the link goes to.
+ *
+ * An unknown value falls through unchanged rather than being dropped, so a new
+ * state added to the RFC schema shows up as itself instead of disappearing.
+ */
+const IMPLEMENTATIE_NL: Record<string, string> = {
+  Implemented: 'Gebouwd',
+  'Partially implemented': 'Deels gebouwd',
+  'Not implemented': 'Niet gebouwd',
+};
 
 /**
  * The RFCs a werkpakket points at, resolved against the RFC collection.
@@ -317,7 +336,10 @@ export function rfcVerwijzingen(nummers: number[]): RfcVerwijzing[] {
     .map((r) => ({
       id: r.id,
       title: r.title,
-      implementation: r.implementation ?? 'Not implemented',
+      implementation:
+        IMPLEMENTATIE_NL[r.implementation ?? ''] ??
+        r.implementation ??
+        'Niet gebouwd',
       link: r.link,
     }));
 }

--- a/docs/src/lib/roadmap.ts
+++ b/docs/src/lib/roadmap.ts
@@ -309,7 +309,9 @@ export interface RfcVerwijzing {
  */
 export function rfcVerwijzingen(nummers: number[]): RfcVerwijzing[] {
   const alle = new Map(getRfcs().map((r) => [r.num, r]));
-  return nummers
+  // Deduped: the same number twice used to render two identical rows, and the
+  // build said nothing. Harmless to write by accident, invisible once shipped.
+  return [...new Set(nummers)]
     .map((n) => alle.get(n))
     .filter((r): r is NonNullable<typeof r> => Boolean(r))
     .map((r) => ({

--- a/docs/src/pages/roadmap/index.astro
+++ b/docs/src/pages/roadmap/index.astro
@@ -39,7 +39,6 @@ assertReferencesResolve(werkpakketten);
 // Fails the build when a filter option has no rule to show its cards again.
 assertFilterRules(roadmapCss);
 
-
 const pathname = '/roadmap';
 ---
 

--- a/docs/src/pages/roadmap/index.astro
+++ b/docs/src/pages/roadmap/index.astro
@@ -186,6 +186,9 @@ const pathname = '/roadmap';
                                   accessible-label={[
                                     wp.data.titel,
                                     ...tags.map((t: any) => t.label),
+                                    ...(wp.data.rfcs.length
+                                      ? [`${wp.data.rfcs.length} RFC${wp.data.rfcs.length > 1 ? "'s" : ''}`]
+                                      : []),
                                   ].join(', ')}
                                   data-categorie={wp.data.categorie || GEEN_CATEGORIE}
                                 >
@@ -196,8 +199,12 @@ const pathname = '/roadmap';
                                     <nldd-text size="sm" weight="medium">
                                       {wp.data.titel}
                                     </nldd-text>
-                                    {tags.length > 0 && (
-                                      <nldd-container layout="wrap" gap="4">
+                                    {(tags.length > 0 || wp.data.rfcs.length > 0) && (
+                                      <nldd-container
+                                        layout="wrap"
+                                        gap="4"
+                                        vertical-alignment="center"
+                                      >
                                         {tags.map((tag: any) => (
                                           <nldd-tag
                                             color={tag.color}
@@ -206,6 +213,17 @@ const pathname = '/roadmap';
                                             size="sm"
                                           />
                                         ))}
+                                        {/* Not a tag: the card already carries
+                                            up to four, and a fifth would make
+                                            the title compete with its own
+                                            metadata. This is a quiet count of
+                                            the design behind the werkpakket —
+                                            the detail page names them. */}
+                                        {wp.data.rfcs.length > 0 && (
+                                          <nldd-text size="xs" color="secondary">
+                                            {wp.data.rfcs.length} RFC{wp.data.rfcs.length > 1 ? "'s" : ''}
+                                          </nldd-text>
+                                        )}
                                       </nldd-container>
                                     )}
                                   </nldd-container>

--- a/docs/src/pages/roadmap/index.astro
+++ b/docs/src/pages/roadmap/index.astro
@@ -25,7 +25,6 @@ import {
   werkpakkettenInCel,
   assertReferencesResolve,
   assertFilterRules,
-  ongekoppeldeRfcs,
 } from '~/lib/roadmap';
 import '~/styles/roadmap.css';
 // The stylesheet's own text, so the filter check below can read the rules it
@@ -40,16 +39,6 @@ assertReferencesResolve(werkpakketten);
 // Fails the build when a filter option has no rule to show its cards again.
 assertFilterRules(roadmapCss);
 
-// Reported, not enforced: an implemented RFC that no werkpakket points at is a
-// gap in the roadmap, not a defect in the build. Blocking on it would put the
-// roadmap in the way of the work it describes.
-const zonderWerkpakket = ongekoppeldeRfcs(werkpakketten);
-if (zonderWerkpakket.length) {
-  console.info(
-    `[roadmap] ${zonderWerkpakket.length} geïmplementeerde RFC(s) zonder werkpakket: ` +
-      zonderWerkpakket.map((r) => r.id).join(', '),
-  );
-}
 
 const pathname = '/roadmap';
 ---

--- a/docs/src/pages/roadmap/index.astro
+++ b/docs/src/pages/roadmap/index.astro
@@ -25,6 +25,7 @@ import {
   werkpakkettenInCel,
   assertReferencesResolve,
   assertFilterRules,
+  ongekoppeldeRfcs,
 } from '~/lib/roadmap';
 import '~/styles/roadmap.css';
 // The stylesheet's own text, so the filter check below can read the rules it
@@ -38,6 +39,17 @@ const werkpakketten = await getCollection('werkpakketten');
 assertReferencesResolve(werkpakketten);
 // Fails the build when a filter option has no rule to show its cards again.
 assertFilterRules(roadmapCss);
+
+// Reported, not enforced: an implemented RFC that no werkpakket points at is a
+// gap in the roadmap, not a defect in the build. Blocking on it would put the
+// roadmap in the way of the work it describes.
+const zonderWerkpakket = ongekoppeldeRfcs(werkpakketten);
+if (zonderWerkpakket.length) {
+  console.info(
+    `[roadmap] ${zonderWerkpakket.length} geïmplementeerde RFC(s) zonder werkpakket: ` +
+      zonderWerkpakket.map((r) => r.id).join(', '),
+  );
+}
 
 const pathname = '/roadmap';
 ---

--- a/docs/src/pages/roadmap/werkpakket/[id].astro
+++ b/docs/src/pages/roadmap/werkpakket/[id].astro
@@ -28,7 +28,11 @@ import {
   getCapability,
   assertReferencesResolve,
   assertPaperSections,
+  assertRfcReferences,
   onderzoeksvraagLijst,
+  rfcVerwijzingen,
+  getOnderzoek,
+  getBouw,
   NIET_BEPAALD,
   NIET_GESPECIFICEERD,
 } from '~/lib/roadmap';
@@ -42,6 +46,8 @@ export async function getStaticPaths() {
   assertReferencesResolve(werkpakketten);
   // Fails the build on a question pointing at a paper section that is gone.
   assertPaperSections(werkpakketten);
+  // Fails the build on a werkpakket pointing at an RFC that does not exist.
+  assertRfcReferences(werkpakketten);
   return werkpakketten.map((entry) => ({
     params: { id: entry.data.id },
     props: { entry, all: werkpakketten },
@@ -93,8 +99,14 @@ const editBase = entry.filePath
 
 const pathname = `/roadmap/werkpakket/${wp.id}`;
 
+// The RFCs whose design work belongs here. Their implementation state comes
+// from the RFC itself, so it cannot drift from what was actually decided.
+const rfcs = rfcVerwijzingen(wp.rfcs);
+
 // The metadata pairs, so the sidebar is one loop instead of five near-copies.
 const kerngegevens = [
+  { label: 'Onderzoek', tag: getOnderzoek(wp.onderzoek), value: '' },
+  { label: 'Bouw', tag: getBouw(wp.bouw), value: '' },
   { label: 'Prioriteit', tag: prioriteit, value: '' },
   { label: 'Geschatte omvang', value: wp.omvang, leeg: NIET_BEPAALD },
   { label: 'Categorie', value: categorie?.label, leeg: NIET_BEPAALD },
@@ -223,6 +235,30 @@ const kerngegevens = [
           )
         }
       </nldd-container>
+
+      {
+        rfcs.length > 0 && (
+          <nldd-container gap="12">
+            <nldd-title size="4">
+              <h2>Ontwerp en implementatie</h2>
+            </nldd-title>
+            <nldd-list type="navigation" variant="box-tinted">
+              {rfcs.map((rfc) => (
+                <nldd-list-item href={rfc.link}>
+                  <nldd-text-cell
+                    overline={rfc.id}
+                    text={rfc.title.replace(/^RFC-\d+:\s*/, '')}
+                    supporting-text={rfc.implementation}
+                    width="full"
+                  />
+                  <nldd-spacer-cell />
+                  <nldd-icon-cell size="20" icon="chevron-right" />
+                </nldd-list-item>
+              ))}
+            </nldd-list>
+          </nldd-container>
+        )
+      }
 
       <nldd-container gap="12">
         <nldd-title size="4"><h2>Samenhang</h2></nldd-title>

--- a/docs/src/pages/roadmap/werkpakket/[id].astro
+++ b/docs/src/pages/roadmap/werkpakket/[id].astro
@@ -245,12 +245,16 @@ const kerngegevens = [
             <nldd-list type="navigation" variant="box-tinted">
               {rfcs.map((rfc) => (
                 <nldd-list-item href={rfc.link}>
-                  <nldd-text-cell
-                    overline={rfc.id}
-                    text={rfc.title}
-                    supporting-text={rfc.implementation}
-                    width="full"
-                  />
+                  {/* The implementation state renders as a tag, the same
+                      treatment /rfcs gives the same field. A bare string here
+                      would have the site showing one value two ways. */}
+                  <nldd-text-cell overline={rfc.id} text={rfc.title} width="full">
+                    <nldd-container slot="supporting-text" layout="wrap" gap="4">
+                      <nldd-tag color="neutral" size="md">
+                        {rfc.implementation}
+                      </nldd-tag>
+                    </nldd-container>
+                  </nldd-text-cell>
                   <nldd-spacer-cell />
                   <nldd-icon-cell size="20" icon="chevron-right" />
                 </nldd-list-item>

--- a/docs/src/pages/roadmap/werkpakket/[id].astro
+++ b/docs/src/pages/roadmap/werkpakket/[id].astro
@@ -247,7 +247,7 @@ const kerngegevens = [
                 <nldd-list-item href={rfc.link}>
                   <nldd-text-cell
                     overline={rfc.id}
-                    text={rfc.title.replace(/^RFC-\d+:\s*/, '')}
+                    text={rfc.title}
                     supporting-text={rfc.implementation}
                     width="full"
                   />


### PR DESCRIPTION
De roadmap op `/roadmap` heeft geen beheerscherm: een werkpakket toevoegen of verplaatsen is een pull request op een YAML-bestand. Wat daarbij mag en moet stond nergens opgeschreven, en zit verspreid over een zod-schema, drie build-assertions en een JSON met de fase- en discipline-ids.

Deze skill legt dat vast voor wie de roadmap bijhoudt: waar de bestanden staan, welke waarden de velden aannemen, hoe je een onderzoeksvraag aan een sectie van het position paper koppelt, en wat de build precies afkeurt.

## Wat er met opzet in staat

**Kopieer geen bestaand bestand.** Dat is de manier waarop je een dubbel `id` maakt: de bestandsnaam pas je aan, het `id` in de frontmatter vergeet je. De build vangt het, maar dan heb je al aan het verkeerde bestand gewerkt.

**Lege velden zijn normaal.** Vijftien van de negentien werkpakketten hebben geen prioriteit, zes geen categorie. De roadmap groeit door eerst een titel en een plek vast te leggen en de rest later in te vullen; een verzonnen prioriteit is slechter dan een lege. Dat staat er expliciet in, omdat de neiging om een leeg vakje te vullen groot is.

**Koppel niet wat niet past.** Drie van de drieënvijftig onderzoeksvragen hebben geen papersectie omdat ze te algemeen zijn. Een gedwongen verwijzing kost de lezer een klik en levert niets op.

## Over CI-validatie

Die blijft zoals hij is, en de skill legt uit waarom.

De build valt al over de fouten die een verkeerde weergave opleveren: een onbekende `faseId` of `disciplineId`, een `samenhangId` dat nergens heen wijst, twee bestanden met hetzelfde `id`, een bestandsnaam die niet het `id` is, en een `paper:`-anker dat niet in het paper bestaat. Elke melding noemt het werkpakket.

Onvolledige inhoud daar bovenop afdwingen — elk werkpakket een prioriteit, elke discipline een werkpakket — zou het toevoegen van een half-uitgewerkt werkpakket blokkeren, en dat is juist hoe deze roadmap groeit. Een poort die bij elke commit afgaat wordt bovendien genegeerd. De skill zet daarom in plaats daarvan het `grep`-commando erbij waarmee je zelf ziet waar de roadmap onaf is.

## Nagelopen

Elke bewering in de skill is tegen de code getoetst, niet uit het hoofd opgeschreven:

- het sjabloon voor een nieuw werkpakket bouwt, en levert een pagina met beide vormen van een onderzoeksvraag (met en zonder papersectie), inclusief werkende regelnummers voor de bewerkknop;
- een foute `faseId` laat de build vallen met `werkpakket 9f994802-… (Transition support): onbekende faseId "bestaatniet"`, precies zoals de skill belooft;
- de fase- en discipline-ids, de enum-waarden en de aantallen komen uit de bestanden zelf;
- alle shell-commando's zijn vanaf de repo-root uitgevoerd.

De testbestanden zijn weer verwijderd; deze PR raakt alleen `.claude/skills/roadmap/SKILL.md`.
