### PR TITLE
fix(editor): open taken sluiten bij het verwijderen van een traject

### DIFF
--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -37,6 +37,7 @@ import { useDocumentUpload } from './composables/useDocumentUpload.js';
 import { useAddActions } from './composables/useAddActions.js';
 import { useDocumentTaskReview } from './composables/useDocumentTaskReview.js';
 import { humanizeLawId } from './lib/lawName.js';
+import { sameTraject } from './lib/taskReview.js';
 import { apiFetch, apiFetchJson, ApiError } from './lib/apiFetch.js';
 import { uploadMultipart } from './lib/uploadMultipart.js';
 import { useLatest } from './lib/useLatest.js';
@@ -735,7 +736,10 @@ watch(
       // both the body and any docError alone rather than seeding the wrong
       // document (or wiping a real 'not-found'/'load-error' for it).
       const payload = docReviewTask.value?.payload;
-      if (payload?.target_path !== openDocPath.value || payload?.traject_ref !== activeTrajectRef.value) {
+      if (
+        payload?.target_path !== openDocPath.value ||
+        !sameTraject(payload?.traject_ref, activeTrajectRef.value)
+      ) {
         return;
       }
       // The target document doesn't exist yet on the branch (the usual
@@ -823,7 +827,8 @@ async function onDocSaved(savedPath) {
   if (!docReviewActive.value) return;
   const path = savedPath ?? openDocPath.value;
   const payload = docReviewTask.value?.payload;
-  if (payload?.target_path !== path || payload?.traject_ref !== activeTrajectRef.value) return;
+  if (payload?.target_path !== path || !sameTraject(payload?.traject_ref, activeTrajectRef.value))
+    return;
   try {
     await docReviewApproveAfterSave();
   } catch (e) {

--- a/frontend/src/composables/useEnrichState.js
+++ b/frontend/src/composables/useEnrichState.js
@@ -19,7 +19,7 @@ import { computed, onMounted, toValue } from 'vue';
 import { useRouter } from 'vue-router';
 import { useAuth } from './useAuth.js';
 import { useTaskActions, usePollWhile } from './useTasks.js';
-import { reviewTarget } from '../lib/taskReview.js';
+import { reviewTarget, sameTraject } from '../lib/taskReview.js';
 
 /**
  * @param {object} sources - refs/getters van de view.
@@ -40,14 +40,25 @@ export function useEnrichState({ trajectRef, lawId, articleNumber, reviewActive 
     tasks: openTasks,
   } = useTaskActions();
 
-  // Loopt er al een verrijking voor deze wet? Dan meldt de lege pane dat in
-  // plaats van opnieuw de knoppen aan te bieden; een tweede aanvraag zou toch
-  // op een 409 stuiten.
-  const isEnriching = computed(() =>
-    runningJobs.value.some(
-      (job) => job.job_type === 'enrich' && job.law_id === toValue(lawId),
-    ),
-  );
+  // Loopt er al een verrijking voor deze wet in dit traject? Dan meldt de lege
+  // pane dat in plaats van opnieuw de knoppen aan te bieden; een tweede
+  // aanvraag zou toch op een 409 stuiten.
+  //
+  // Ook hier op traject matchen: `running` is net als de takenlijst
+  // account-breed, terwijl de 409 per (wet, traject) geldt
+  // (`idx_unique_active_enrich_job`). Een verrijking die in traject A loopt
+  // zette de pane in traject B anders op "bezig" en verborg daar de "Genereer
+  // een voorstel"-knop voor een aanvraag die gewoon gehonoreerd zou worden.
+  const isEnriching = computed(() => {
+    const traject = toValue(trajectRef);
+    if (!traject) return false;
+    return runningJobs.value.some(
+      (job) =>
+        job.job_type === 'enrich' &&
+        job.law_id === toValue(lawId) &&
+        sameTraject(job.traject_ref, traject),
+    );
+  });
   // Alleen pollen zolang je naar de bezig-staat kijkt; zie usePollWhile. Staat
   // hier ná isEnriching en achter de argumenten van deze composable: de watch
   // leest zijn bron meteen om de dependency te leggen, dus alles wat hij
@@ -68,6 +79,11 @@ export function useEnrichState({ trajectRef, lawId, articleNumber, reviewActive 
   // die dan naar A navigeert en de "Genereer een voorstel"-knop van B verdringt.
   // Zonder actief traject (globale corpus-weergave) matcht er dus niets: een
   // voorstel hoort bij een traject en valt daarbuiten niet te beoordelen.
+  //
+  // Vergelijken via sameTraject en niet op de hele string: de taak draagt de
+  // ref van het aanvraagmoment, en het slug-deel daarvan verandert mee met de
+  // naam van het traject. Na een hernoeming zou een letterlijke vergelijking
+  // het eigen voorstel niet meer herkennen.
   const pendingReviewTask = computed(() => {
     const traject = toValue(trajectRef);
     if (!traject) return null;
@@ -75,7 +91,7 @@ export function useEnrichState({ trajectRef, lawId, articleNumber, reviewActive 
       (t) =>
         t.task_type === 'job_review' &&
         t.payload?.law_id === toValue(lawId) &&
-        t.payload?.traject_ref === traject,
+        sameTraject(t.payload?.traject_ref, traject),
     );
     if (!forLaw.length) return null;
     const here = String(toValue(articleNumber) ?? '');

--- a/frontend/src/composables/useEnrichState.js
+++ b/frontend/src/composables/useEnrichState.js
@@ -61,9 +61,21 @@ export function useEnrichState({ trajectRef, lawId, articleNumber, reviewActive 
   // voor deze wet. Je kijkt naar één artikel, dus de taak van dát artikel gaat
   // voor; is die er niet, dan de eerste van de wet - beter naar een naburig
   // voorstel wijzen dan naar niets.
+  //
+  // Ook op traject matchen, niet alleen op wet: de takenlijst is account-breed
+  // en dezelfde wet leeft in meerdere trajecten. Een open taak uit traject A
+  // kaapte anders de pane in traject B - inclusief de "Beoordeel voorstel"-knop,
+  // die dan naar A navigeert en de "Genereer een voorstel"-knop van B verdringt.
+  // Zonder actief traject (globale corpus-weergave) matcht er dus niets: een
+  // voorstel hoort bij een traject en valt daarbuiten niet te beoordelen.
   const pendingReviewTask = computed(() => {
+    const traject = toValue(trajectRef);
+    if (!traject) return null;
     const forLaw = openTasks.value.filter(
-      (t) => t.task_type === 'job_review' && t.payload?.law_id === toValue(lawId),
+      (t) =>
+        t.task_type === 'job_review' &&
+        t.payload?.law_id === toValue(lawId) &&
+        t.payload?.traject_ref === traject,
     );
     if (!forLaw.length) return null;
     const here = String(toValue(articleNumber) ?? '');

--- a/frontend/src/composables/useEnrichState.test.js
+++ b/frontend/src/composables/useEnrichState.test.js
@@ -107,6 +107,26 @@ describe('useEnrichState', () => {
     expect(reviewReady.value).toBe(false);
   });
 
+  // De takenlijst is account-breed. Een open taak voor dezelfde wet in een
+  // ander traject (of in een traject dat inmiddels verwijderd is, waarvan de
+  // taak bleef staan) mag hier geen voorstel melden: de "Beoordelen"-knop zou
+  // naar dat andere traject navigeren en de "Genereer een voorstel"-knop van
+  // het actieve traject verdringen.
+  it('negeert taken van een ander traject', async () => {
+    apiFetch.mockResolvedValue(
+      tasksResponse({
+        tasks: [
+          reviewTask('2', {
+            payload: { traject_ref: 'ander-traject-9f8e7d6c', law_id: LAW, article: '2' },
+          }),
+        ],
+      }),
+    );
+    const { pendingReviewTask, reviewReady } = await mountState({ articleNumber: '2' });
+    expect(pendingReviewTask.value).toBeNull();
+    expect(reviewReady.value).toBe(false);
+  });
+
   it('staat in de bezig-staat zolang er een enrich-job voor deze wet loopt', async () => {
     apiFetch.mockResolvedValue(
       tasksResponse({ running: [{ job_id: 'j1', job_type: 'enrich', law_id: LAW }] }),

--- a/frontend/src/composables/useEnrichState.test.js
+++ b/frontend/src/composables/useEnrichState.test.js
@@ -28,6 +28,13 @@ function reviewTask(article, overrides = {}) {
   };
 }
 
+// Een lopende taak-flow-job zoals /api/tasks hem teruggeeft: altijd mét
+// traject_ref (`RunningTaskJob`), want elke taak-flow-job wordt met een
+// traject aangemaakt.
+function runningEnrich(overrides = {}) {
+  return { job_id: 'j1', job_type: 'enrich', law_id: LAW, traject_ref: TRAJECT, ...overrides };
+}
+
 function tasksResponse({ tasks = [], running = [] } = {}) {
   return { status: 200, json: async () => ({ tasks, open_count: tasks.length, running }) };
 }
@@ -127,12 +134,38 @@ describe('useEnrichState', () => {
     expect(reviewReady.value).toBe(false);
   });
 
-  it('staat in de bezig-staat zolang er een enrich-job voor deze wet loopt', async () => {
+  // Hernoemen verandert het slug-deel van de ref; de taak draagt nog die van
+  // het aanvraagmoment. Dat is hetzelfde traject en het voorstel hoort gewoon
+  // in de pane te blijven staan.
+  it('herkent de taak nog na een hernoeming van het traject', async () => {
     apiFetch.mockResolvedValue(
-      tasksResponse({ running: [{ job_id: 'j1', job_type: 'enrich', law_id: LAW }] }),
+      tasksResponse({
+        tasks: [
+          reviewTask('2', {
+            payload: { traject_ref: 'oude-naam-1a2b3c4d', law_id: LAW, article: '2' },
+          }),
+        ],
+      }),
     );
+    const { reviewReady } = await mountState({ articleNumber: '2' });
+    expect(reviewReady.value).toBe(true);
+  });
+
+  it('staat in de bezig-staat zolang er een enrich-job voor deze wet loopt', async () => {
+    apiFetch.mockResolvedValue(tasksResponse({ running: [runningEnrich()] }));
     const { isEnriching } = await mountState();
     expect(isEnriching.value).toBe(true);
+  });
+
+  // `running` is net zo account-breed als de takenlijst, terwijl de 409 op een
+  // tweede aanvraag per (wet, traject) geldt. Een verrijking in traject A mag
+  // hier dus niet "bezig" melden en de "Genereer een voorstel"-knop verbergen.
+  it('negeert een lopende verrijking van een ander traject', async () => {
+    apiFetch.mockResolvedValue(
+      tasksResponse({ running: [runningEnrich({ traject_ref: 'ander-traject-9f8e7d6c' })] }),
+    );
+    const { isEnriching } = await mountState();
+    expect(isEnriching.value).toBe(false);
   });
 
   // De bug die deze composable opheft: zonder refresh na de aanvraag blijft
@@ -146,7 +179,7 @@ describe('useEnrichState', () => {
     apiFetch.mockImplementation(async (url) =>
       url.endsWith('/enrich')
         ? { status: 200 }
-        : tasksResponse({ running: [{ job_id: 'j1', job_type: 'enrich', law_id: LAW }] }),
+        : tasksResponse({ running: [runningEnrich()] }),
     );
     const result = await requestEnrich();
     expect(result).toEqual({ alreadyRunning: false, tooMany: false });

--- a/frontend/src/lib/taskReview.js
+++ b/frontend/src/lib/taskReview.js
@@ -18,6 +18,32 @@
  * onvolledige taak) - de aanroeper toont dan geen/een disabled knop in
  * plaats van te crashen of naar een kapotte route te navigeren.
  */
+/**
+ * sameTraject - horen twee traject-refs (`{slug}-{8hex}`) bij hetzelfde
+ * traject?
+ *
+ * Het slug-deel is cosmetisch: het wordt afgeleid uit de naam van dát moment,
+ * dus hernoemen verandert het terwijl het traject hetzelfde blijft. Alleen de
+ * laatste 8 hex-tekens zijn de identiteit - de backend zoekt er ook uitsluitend
+ * daarop op (`resolve_traject_ref`: "renaming a traject does not break existing
+ * URLs"). Een taak draagt de ref van het moment van aanvragen, dus een
+ * letterlijke stringvergelijking laat een klaarstaand voorstel na een
+ * hernoeming stilletjes verdwijnen.
+ *
+ * Een ref zonder herkenbare 8-hex-staart (leeg, null, afgekapt) hoort nergens
+ * bij: dan `false`, niet "matcht met alles".
+ */
+export function sameTraject(a, b) {
+  const key = trajectKey(a);
+  return key !== null && key === trajectKey(b);
+}
+
+function trajectKey(ref) {
+  if (typeof ref !== 'string') return null;
+  const match = /-([0-9a-f]{8})$/i.exec(ref);
+  return match ? match[1].toLowerCase() : null;
+}
+
 export function reviewTarget(task) {
   const trajectRef = task?.payload?.traject_ref;
   if (!trajectRef) return null;

--- a/frontend/src/lib/taskReview.test.js
+++ b/frontend/src/lib/taskReview.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import router from '../router.js';
-import { reviewTarget, proposalDivergence } from './taskReview.js';
+import { reviewTarget, sameTraject, proposalDivergence } from './taskReview.js';
 
 describe('reviewTarget', () => {
   it('bouwt de editor-traject-route met ?task= voor een job_review-taak', () => {
@@ -103,6 +103,38 @@ describe('reviewTarget', () => {
     expect(resolved.fullPath).toBe(
       '/trajecten/mijn-traject-1a2b3c4d/editor/werkinstructie_toetsing?task=t8',
     );
+  });
+});
+
+describe('sameTraject', () => {
+  it('herkent hetzelfde traject', () => {
+    expect(sameTraject('mijn-traject-1a2b3c4d', 'mijn-traject-1a2b3c4d')).toBe(true);
+  });
+
+  it('onderscheidt twee trajecten', () => {
+    expect(sameTraject('mijn-traject-1a2b3c4d', 'ander-traject-9f8e7d6c')).toBe(false);
+  });
+
+  // Het slug-deel komt uit de naam van het moment van aanmaken; hernoemen
+  // verandert het zonder dat het traject een ander traject wordt. De backend
+  // zoekt alleen op de 8-hex-staart op, dus dit moet meebewegen - anders
+  // verdwijnt een klaarstaand voorstel uit de pane zodra iemand zijn traject
+  // hernoemt.
+  it('negeert het cosmetische slug-deel, zodat hernoemen niets breekt', () => {
+    expect(sameTraject('oude-naam-1a2b3c4d', 'nieuwe-naam-1a2b3c4d')).toBe(true);
+  });
+
+  it('vergelijkt de hex-staart hoofdletterongevoelig', () => {
+    expect(sameTraject('traject-1A2B3C4D', 'traject-1a2b3c4d')).toBe(true);
+  });
+
+  // Een ref zonder herkenbare staart hoort bij geen enkel traject; "matcht met
+  // alles" zou precies de kaping terugbrengen die de traject-check afsluit.
+  it('matcht niets bij een ontbrekende of vormloze ref', () => {
+    expect(sameTraject(null, 'mijn-traject-1a2b3c4d')).toBe(false);
+    expect(sameTraject('mijn-traject-1a2b3c4d', undefined)).toBe(false);
+    expect(sameTraject('', '')).toBe(false);
+    expect(sameTraject('geen-hex-staart', 'geen-hex-staart')).toBe(false);
   });
 });
 

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -12,6 +12,8 @@ use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use uuid::Uuid;
 
+use regelrecht_pipeline::tasks;
+
 use crate::accounts::AccountRecord;
 use crate::state::AppState;
 
@@ -1291,6 +1293,17 @@ pub async fn update(
 /// touched — that's a manual cleanup decision and there's no way to
 /// know whether the user still wants the in-flight edits preserved
 /// elsewhere.
+///
+/// Open review tasks are a different story: `tasks.traject_id` is
+/// `ON DELETE SET NULL`, so the delete would only cut the link and leave
+/// an unresolvable task behind — it keeps showing up in the account-wide
+/// task list and its `payload.traject_ref` points at a traject that no
+/// longer exists, so "review" lands on the traject picker. They are
+/// therefore dismissed in the same transaction as the delete (before it,
+/// since afterwards there is no way to tell which tasks belonged here),
+/// and the result blobs of the jobs involved are cleaned up along the
+/// same "only when no open task is left on that job" path that `resolve`
+/// uses.
 pub async fn delete(
     State(state): State<AppState>,
     Extension(account): Extension<AccountRecord>,
@@ -1299,16 +1312,37 @@ pub async fn delete(
     let pool = get_pool(&state)?;
     require_owner(pool, id, account.id).await?;
 
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(db_err("begin delete traject tx"))?;
+
+    let job_ids = tasks::dismiss_open_tasks_for_traject(&mut *tx, id)
+        .await
+        .map_err(db_err("dismiss open tasks of deleted traject"))?;
+
     let affected = sqlx::query("DELETE FROM trajects WHERE id = $1")
         .bind(id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await
         .map_err(db_err("delete traject"))?
         .rows_affected();
 
     if affected == 0 {
+        // Dropping the tx rolls the dismissals back with it — nothing was
+        // deleted, so nothing should have been closed either.
         return Err(StatusCode::NOT_FOUND);
     }
+
+    for job_id in job_ids {
+        tasks::delete_blobs_for_finished_job(&mut *tx, job_id)
+            .await
+            .map_err(db_err("cleanup job blobs of deleted traject"))?;
+    }
+
+    tx.commit()
+        .await
+        .map_err(db_err("commit delete traject tx"))?;
 
     state.trajects.invalidate(id).await;
     Ok(StatusCode::NO_CONTENT)

--- a/packages/editor-api/tests/trajects_test.rs
+++ b/packages/editor-api/tests/trajects_test.rs
@@ -29,6 +29,9 @@ use regelrecht_editor_api::trajects::{
     self, AddMemberRequest, CreateTrajectRequest, UpdateMemberRequest, UpdateTrajectRequest,
 };
 
+use regelrecht_pipeline::job_queue::{self, CreateJobRequest};
+use regelrecht_pipeline::models::JobType;
+use regelrecht_pipeline::tasks::{self, BlobKind, NewTask, Task, TaskStatus, TaskType};
 use regelrecht_pipeline::test_utils::TestDb;
 
 // ---------------------------------------------------------------------------
@@ -949,6 +952,137 @@ async fn delete_is_owner_only_and_cascades() {
     assert_eq!(members, 0, "traject_members should cascade-delete");
     assert_eq!(sources, 0, "traject_corpus_sources should cascade-delete");
     assert_eq!(trajects_count, 0);
+}
+
+/// Een verwijderd traject mag geen open taken achterlaten: `tasks.traject_id`
+/// is `ON DELETE SET NULL`, dus zonder de expliciete afhandeling in `delete`
+/// blijft de taak staan, hangt hij in de account-brede takenlijst en wijst zijn
+/// `payload.traject_ref` naar een traject dat niet meer bestaat.
+#[tokio::test]
+async fn delete_dismisses_open_tasks_and_clears_their_blobs() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
+    let doomed = create_traject(&state, &alice, "Tarief").await;
+    let survivor = create_traject(&state, &alice, "Toeslag").await;
+
+    // Eén job met twee review-taken (het per-artikel-patroon) plus een blob,
+    // en een al afgehandelde taak op een eigen job.
+    let job = job_queue::create_job(&db.pool, CreateJobRequest::new(JobType::Enrich, "test_wet"))
+        .await
+        .unwrap();
+    tasks::insert_blob(
+        &db.pool,
+        job.id,
+        BlobKind::Result,
+        "corpus/regulation/nl/wet/test_wet/2025-01-01.yaml",
+        "$id: test_wet\n",
+    )
+    .await
+    .unwrap();
+    let open_a = seed_task(&db.pool, &alice, doomed, Some(job.id), "1").await;
+    let open_b = seed_task(&db.pool, &alice, doomed, Some(job.id), "2").await;
+
+    let done_job =
+        job_queue::create_job(&db.pool, CreateJobRequest::new(JobType::Enrich, "test_wet"))
+            .await
+            .unwrap();
+    let done = seed_task(&db.pool, &alice, doomed, Some(done_job.id), "3").await;
+    let done = tasks::resolve_task(&db.pool, done.id, alice.id, TaskStatus::Approved)
+        .await
+        .unwrap()
+        .expect("assignee mag resolven");
+
+    // Een open taak van een ánder traject blijft er buiten.
+    let elsewhere = seed_task(&db.pool, &alice, survivor, None, "1").await;
+
+    assert_eq!(
+        trajects::delete(State(state.clone()), Extension(alice.clone()), Path(doomed))
+            .await
+            .unwrap(),
+        StatusCode::NO_CONTENT
+    );
+
+    for id in [open_a.id, open_b.id] {
+        let (status, resolved_at, resolved_by): (TaskStatus, Option<i64>, Option<Uuid>) =
+            task_state(&db.pool, id).await;
+        assert_eq!(
+            status,
+            TaskStatus::Dismissed,
+            "open taak moet gesloten zijn"
+        );
+        assert!(resolved_at.is_some(), "resolved_at moet gestempeld zijn");
+        assert_eq!(
+            resolved_by, None,
+            "niemand heeft de taak beoordeeld; het traject verdween eronder"
+        );
+    }
+
+    let (status, _, resolved_by) = task_state(&db.pool, done.id).await;
+    assert_eq!(
+        status,
+        TaskStatus::Approved,
+        "afgehandelde taak moet onaangeroerd blijven"
+    );
+    assert_eq!(resolved_by, Some(alice.id));
+
+    let (status, _, _) = task_state(&db.pool, elsewhere.id).await;
+    assert_eq!(
+        status,
+        TaskStatus::Open,
+        "taak van een ander traject blijft open"
+    );
+
+    let blobs = tasks::load_blobs(&db.pool, job.id, BlobKind::Result)
+        .await
+        .unwrap();
+    assert!(
+        blobs.is_empty(),
+        "result-blobs van de gesloten taken moeten weg zijn"
+    );
+}
+
+/// Maak een open `job_review`-taak voor `traject_id`, met dezelfde
+/// payload-vorm als de worker die aanmaakt.
+async fn seed_task(
+    pool: &PgPool,
+    assignee: &AccountRecord,
+    traject_id: Uuid,
+    job_id: Option<Uuid>,
+    article: &str,
+) -> Task {
+    tasks::create_task(
+        pool,
+        NewTask {
+            task_type: TaskType::JobReview,
+            assignee_account_id: Some(assignee.id),
+            traject_id: Some(traject_id),
+            job_id,
+            title: format!("Verrijking beoordelen: test_wet artikel {article}"),
+            payload: Some(serde_json::json!({
+                "law_id": "test_wet",
+                "article": article,
+            })),
+        },
+    )
+    .await
+    .unwrap()
+}
+
+/// Status + audit-velden van één taak, ongeacht assignee: de store-helpers
+/// filteren op account, hier willen we de rauwe rij zien. `resolved_at` komt
+/// als unix-seconde terug — de test kijkt alleen of hij gezet is.
+async fn task_state(pool: &PgPool, task_id: Uuid) -> (TaskStatus, Option<i64>, Option<Uuid>) {
+    let row: (
+        TaskStatus,
+        Option<chrono::DateTime<chrono::Utc>>,
+        Option<Uuid>,
+    ) = sqlx::query_as("SELECT status, resolved_at, resolved_by FROM tasks WHERE id = $1")
+        .bind(task_id)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    (row.0, row.1.map(|t| t.timestamp()), row.2)
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/pipeline/migrations/0034_dismiss_tasks_of_deleted_trajects.sql
+++ b/packages/pipeline/migrations/0034_dismiss_tasks_of_deleted_trajects.sql
@@ -1,0 +1,34 @@
+-- Eenmalige opruiming van open taken die een traject-verwijdering hebben
+-- overleefd.
+--
+-- `tasks.traject_id` is `ON DELETE SET NULL` (0028), dus een verwijderd traject
+-- liet zijn open taken staan met alleen de koppeling doorgeknipt. Taken krijgen
+-- bij aanmaak altijd een traject mee (elke `create_task`-aanroep zit in een
+-- traject-gebonden taak-flow, en de aanvraag-endpoints resolven het traject
+-- voordat de job in de queue gaat), dus een open taak met `traject_id IS NULL`
+-- is per constructie zo'n wees. Beoordelen kan niet meer — `payload.traject_ref`
+-- wijst naar een traject dat er niet meer is — terwijl de taak wel in de
+-- account-brede takenlijst blijft staan.
+--
+-- De taakrij blijft bestaan als audit-spoor (patroon 0028); alleen de status
+-- gaat dicht. `resolved_by` blijft leeg: niemand heeft de taak beoordeeld.
+UPDATE tasks
+SET status = 'dismissed',
+    resolved_at = now()
+WHERE status = 'open'
+  AND traject_id IS NULL;
+
+-- De result/input-blobs van de bijbehorende jobs zijn daarmee wees. Zelfde
+-- voorwaarde als `delete_blobs_for_finished_job`: alleen opruimen als er op die
+-- job geen open taak meer staat. Beperkt tot jobs die zo'n verweesde taak
+-- hadden — een blanco opruiming zou ook de input-blobs van nog lopende jobs
+-- wissen, want die krijgen hun taak pas bij afronding.
+DELETE FROM job_blobs jb
+WHERE EXISTS (
+    SELECT 1 FROM tasks t
+    WHERE t.job_id = jb.job_id AND t.traject_id IS NULL
+)
+  AND NOT EXISTS (
+    SELECT 1 FROM tasks t
+    WHERE t.job_id = jb.job_id AND t.status = 'open'
+);

--- a/packages/pipeline/src/tasks.rs
+++ b/packages/pipeline/src/tasks.rs
@@ -212,6 +212,51 @@ pub async fn resolve_task(
     Ok(task)
 }
 
+/// Sluit alle open taken van een traject als `dismissed` en levert de job-ids
+/// van die taken terug (ontdubbeld) zodat de aanroeper per job de blobs kan
+/// opruimen met [`delete_blobs_for_finished_job`].
+///
+/// Bedoeld voor het verwijderen van een traject. Zonder dit blijven de open
+/// taken staan: `tasks.traject_id` is `ON DELETE SET NULL` (migratie 0028), dus
+/// de traject-DELETE knipt alleen de koppeling door en laat een taak achter die
+/// in de account-brede takenlijst blijft hangen en via `payload.traject_ref`
+/// naar een traject wijst dat niet meer bestaat.
+///
+/// Moet daarom lópen vóór de traject-DELETE en in dezelfde transactie: erna is
+/// niet meer te achterhalen welke taken bij dit traject hoorden.
+///
+/// De taakrij blijft bestaan (audit-spoor, zelfde afweging als `resolve_task`);
+/// `resolved_by` blijft leeg, want niemand heeft deze taak beoordeeld — het
+/// traject verdween eronder.
+pub async fn dismiss_open_tasks_for_traject<'e, E>(
+    executor: E,
+    traject_id: Uuid,
+) -> Result<Vec<Uuid>>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let rows = sqlx::query_as::<_, (Option<Uuid>,)>(
+        "UPDATE tasks SET status = 'dismissed', resolved_at = now() \
+         WHERE traject_id = $1 AND status = 'open' \
+         RETURNING job_id",
+    )
+    .bind(traject_id)
+    .fetch_all(executor)
+    .await?;
+
+    let mut job_ids: Vec<Uuid> = Vec::new();
+    for (job_id,) in rows {
+        // Eén verrijking levert een taak per gewijzigd artikel op dezelfde job;
+        // die job hoeft maar één keer opgeruimd te worden.
+        if let Some(id) = job_id {
+            if !job_ids.contains(&id) {
+                job_ids.push(id);
+            }
+        }
+    }
+    Ok(job_ids)
+}
+
 /// Target paths reserved by OPEN document-review tasks of a traject: a
 /// task-delivered conversion is already `completed` on the underlying job
 /// (see `finish_document_convert_task_job`) while the review itself is still

--- a/packages/pipeline/src/tasks.rs
+++ b/packages/pipeline/src/tasks.rs
@@ -244,6 +244,17 @@ where
     .fetch_all(executor)
     .await?;
 
+    if !rows.is_empty() {
+        // Zelfde reden als de log in `resolve_task`: een taak die dichtgaat is
+        // een gebeurtenis die iemand later wil kunnen terugvinden, en deze gaan
+        // dicht zonder dat een gebruiker erop klikte.
+        tracing::info!(
+            traject_id = %traject_id,
+            tasks = rows.len(),
+            "open tasks dismissed with deleted traject"
+        );
+    }
+
     let mut job_ids: Vec<Uuid> = Vec::new();
     for (job_id,) in rows {
         // Eén verrijking levert een taak per gewijzigd artikel op dezelfde job;

--- a/packages/pipeline/tests/tasks_tests.rs
+++ b/packages/pipeline/tests/tasks_tests.rs
@@ -300,6 +300,96 @@ async fn test_cleanup_orphaned_blobs_keeps_open_task_blobs() {
     );
 }
 
+/// `dismiss_open_tasks_for_traject` belooft twee dingen die de aanroeper in
+/// `trajects::delete` niet zelf nog eens nagaat: alléén de open taken van dít
+/// traject gaan dicht, en de teruggegeven job-ids zijn ontdubbeld. Dat laatste
+/// is geen detail — één verrijking levert een taak per gewijzigd artikel op
+/// dezelfde job, dus zonder ontdubbeling ruimt de aanroeper diezelfde job zo
+/// vaak op als er artikelen wijzigden.
+#[tokio::test]
+async fn test_dismiss_open_tasks_for_traject_scopes_and_dedupes() {
+    let db = TestDb::new().await;
+    let (account_id, traject_id) = seed_account_and_traject(&db).await;
+    let (other_traject_id,): (uuid::Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, created_by) VALUES ('Ander traject', $1) RETURNING id",
+    )
+    .bind(account_id)
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+
+    let job = job_queue::create_job(&db.pool, CreateJobRequest::new(JobType::Enrich, "wet_a"))
+        .await
+        .unwrap();
+    // Twee taken op dezelfde job (per-artikel), één zonder job, één elders.
+    let article_1 = seed_open_task(&db, account_id, traject_id, Some(job.id)).await;
+    let article_2 = seed_open_task(&db, account_id, traject_id, Some(job.id)).await;
+    let jobless = seed_open_task(&db, account_id, traject_id, None).await;
+    let elsewhere = seed_open_task(&db, account_id, other_traject_id, Some(job.id)).await;
+    // Een al afgehandelde taak van hetzelfde traject blijft zoals hij is.
+    let resolved = seed_open_task(&db, account_id, traject_id, Some(job.id)).await;
+    tasks::resolve_task(&db.pool, resolved.id, account_id, TaskStatus::Approved)
+        .await
+        .unwrap()
+        .expect("assignee mag resolven");
+
+    let job_ids = tasks::dismiss_open_tasks_for_traject(&db.pool, traject_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        job_ids,
+        vec![job.id],
+        "dezelfde job hoort één keer terug te komen, en de job-loze taak levert er geen"
+    );
+
+    for id in [article_1.id, article_2.id, jobless.id] {
+        let (status,): (TaskStatus,) = sqlx::query_as("SELECT status FROM tasks WHERE id = $1")
+            .bind(id)
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+        assert_eq!(status, TaskStatus::Dismissed);
+    }
+    let (status,): (TaskStatus,) = sqlx::query_as("SELECT status FROM tasks WHERE id = $1")
+        .bind(elsewhere.id)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        status,
+        TaskStatus::Open,
+        "een taak van een ander traject op dezelfde job blijft open"
+    );
+    let (status,): (TaskStatus,) = sqlx::query_as("SELECT status FROM tasks WHERE id = $1")
+        .bind(resolved.id)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert_eq!(status, TaskStatus::Approved);
+}
+
+/// Open `job_review`-taak met de minimale velden die deze test nodig heeft.
+async fn seed_open_task(
+    db: &TestDb,
+    account_id: uuid::Uuid,
+    traject_id: uuid::Uuid,
+    job_id: Option<uuid::Uuid>,
+) -> tasks::Task {
+    tasks::create_task(
+        &db.pool,
+        NewTask {
+            task_type: TaskType::JobReview,
+            assignee_account_id: Some(account_id),
+            traject_id: Some(traject_id),
+            job_id,
+            title: "t".into(),
+            payload: None,
+        },
+    )
+    .await
+    .unwrap()
+}
+
 #[tokio::test]
 async fn test_finish_enrich_task_job_creates_task_and_result_blobs() {
     let db = TestDb::new().await;


### PR DESCRIPTION
## Waarom

Een gebruiker opende een artikel in zijn traject, kreeg in de Machine-/YAML-pane "Er ligt een voorstel klaar" te zien en belandde na een klik op **Beoordeel voorstel** op de trajectkiezer met "Het traject dat je probeerde te openen bestaat niet, niet meer of je hebt geen toegang".

Twee dingen werkten samen:

1. `tasks.traject_id` is `ON DELETE SET NULL`, dus het verwijderen van een traject knipte alleen de koppeling door en liet de open `job_review`-taken staan. Niets sloot ze; hun payload hield het oude `traject_ref` als string vast.
2. De takenlijst is account-breed en `pendingReviewTask` matchte open taken op **alleen** `payload.law_id`. Een achtergebleven taak uit een verwijderd (of gewoon ander) traject kaapte daarmee de pane voor dezelfde wet in elk ander traject — inclusief de knop, die dan naar het dode traject navigeerde, en ondertussen verdrong het de "Genereer een voorstel"-knop.

## Wat er verandert

**Backend** — `DELETE /api/trajects/:id` sluit de open taken van het traject in dezelfde transactie als de verwijdering, vóór de DELETE zelf: daarna is niet meer te achterhalen welke taken erbij hoorden. De taakrijen blijven staan als audit-spoor (het bestaande patroon van migratie 0028), alleen de status gaat op `dismissed`; `resolved_by` blijft leeg, want niemand heeft ze beoordeeld. De result-blobs van de betrokken jobs worden opgeruimd via hetzelfde `delete_blobs_for_finished_job`-pad dat `resolve` gebruikt — dat wist per job pas als er geen open taak meer op staat, want één verrijking levert een taak per gewijzigd artikel op dezelfde blobs.

**Migratie 0034** — eenmalige opruiming van de wezen die er al zijn: open taken met `traject_id IS NULL`. Taken krijgen bij aanmaak altijd een traject mee (elke `create_task`-aanroep zit in een traject-gebonden taak-flow en de aanvraag-endpoints resolven het traject voordat de job in de queue gaat), dus zo'n rij kán alleen van een verwijderd traject komen. De blob-opruiming ernaast is beperkt tot jobs die zo'n verweesde taak hadden: een blanco opruiming zou ook de input-blobs van nog lopende jobs wissen, want die krijgen hun taak pas bij afronding.

**Frontend (defensief)** — `pendingReviewTask` matcht nu ook op `payload.traject_ref` tegen het actieve traject. Zonder actief traject (globale corpus-weergave) matcht er niets: een voorstel hoort bij een traject en valt daarbuiten niet te beoordelen.

## Buiten scope

De account-brede takenlijst blijft taken uit alle trajecten tonen — dat is bewust, en na deze fix staan er geen dode meer in. De traject-branch op GitHub blijft bij een delete onaangeroerd, zoals de doc-comment bij `trajects::delete` al beschreef.

## Checks

- Nieuwe integratietest `delete_dismisses_open_tasks_and_clears_their_blobs`: open taken dismissed, blobs weg, een al afgehandelde taak onaangeroerd, een open taak van een ander traject onaangeroerd.
- Nieuwe unit-test in `useEnrichState.test.js`: een open taak voor dezelfde wet in een ander traject levert geen `pendingReviewTask`/`reviewReady` op.
- `just check` groen; `vitest run` in `frontend/` groen (799 tests; het enige rode bestand, `harvester/views/OverviewView.test.js`, faalt ook op `main` op een ontbrekende `jsdom` in deze omgeving).
