### PR TITLE
fix(editor): laat de beoordeel-modus de taak volgen in plaats van blijven hangen

### DIFF
--- a/frontend/src/EditorView.taskReview.test.js
+++ b/frontend/src/EditorView.taskReview.test.js
@@ -1,0 +1,446 @@
+// Gerichte tests voor de review-modus-orkestratie in EditorView.vue (de
+// `?task=`-watches, `applyProposedContent` en het opruimen daarvan).
+// EditorView.vue is een view van ~3000 regels zonder eigen testharnas, dus dit
+// bestand mount hem `shallow` met elke composable die hij aanraakt vervangen
+// door een stuurbare stub - net als LibraryView.docReview.test.js doet voor de
+// werkdocument-review. Bewust smal: alleen het review-oppervlak, de rest van de
+// view (panes, notities, scenario's, graaf) blijft in zijn lege standaardstaat.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref, computed, reactive, nextTick } from 'vue';
+
+// --- vue-router: geen echte router. `route` is reactief, want de hele bug
+// hangt aan een watch op `route.query.task`: die moet in een test net zo
+// kunnen wisselen als bij een tabwissel in de echte editor.
+const routeState = reactive({
+  name: 'editor-traject',
+  params: { trajectRef: 'kieswet-kandidaatstelling-86070ac7', lawId: 'kieswet', articleNumber: 'B 5' },
+  query: {},
+  fullPath: '/trajecten/kieswet-kandidaatstelling-86070ac7/editor/kieswet/B 5',
+});
+const replaceMock = vi.fn();
+const pushMock = vi.fn();
+vi.mock('vue-router', () => ({
+  useRoute: () => routeState,
+  useRouter: () => ({
+    replace: (...a) => replaceMock(...a),
+    push: (...a) => pushMock(...a),
+    resolve: () => ({ href: '#' }),
+  }),
+  onBeforeRouteUpdate: vi.fn(),
+  onBeforeRouteLeave: vi.fn(),
+}));
+
+vi.mock('./composables/useAuth.js', () => ({
+  useAuth: () => ({ authenticated: ref(true), oidcConfigured: ref(true), login: vi.fn() }),
+}));
+
+vi.mock('./composables/useFeatureFlags.js', () => ({
+  useFeatureFlags: () => ({ isEnabled: () => true }),
+}));
+
+vi.mock('./composables/useTrajects.js', () => ({
+  useTrajects: () => ({
+    activeTrajectRef: ref('kieswet-kandidaatstelling-86070ac7'),
+    activeTraject: ref({ name: 'Kieswet-Kandidaatstelling' }),
+    trajectMissing: ref(false),
+  }),
+  refreshTrajects: vi.fn(),
+}));
+
+// --- useLaw: de wet zoals hij opgeslagen staat. `selectedArticle` volgt
+// `selectedArticleNumber`, zodat een artikelwissel in de test hetzelfde
+// aanvoelt als in de view.
+const SAVED_LAW_YAML = [
+  '$id: kieswet',
+  'articles:',
+  "  - number: 'B 1'",
+  '    text: B1 opgeslagen',
+  "  - number: 'B 5'",
+  '    text: B5 opgeslagen',
+].join('\n');
+const SAVED_ARTICLES = [
+  { number: 'B 1', text: 'B1 opgeslagen', machine_readable: null },
+  { number: 'B 5', text: 'B5 opgeslagen', machine_readable: null },
+];
+const articles = ref(SAVED_ARTICLES);
+const selectedArticleNumber = ref('B 5');
+const selectedArticle = computed(
+  () => articles.value.find((a) => String(a.number) === String(selectedArticleNumber.value)) ?? null,
+);
+const loading = ref(false);
+const lawError = ref(null);
+const currentEtag = ref('etag-1');
+const seedFromYaml = vi.fn();
+const saveLaw = vi.fn().mockResolvedValue(undefined);
+vi.mock('./composables/useLaw.js', () => ({
+  useLaw: () => ({
+    law: ref({ $id: 'kieswet', valid_from: '2025-01-01' }),
+    lawId: ref('kieswet'),
+    rawYaml: ref(SAVED_LAW_YAML),
+    articles,
+    lawName: ref('Kieswet'),
+    selectedArticle,
+    selectedArticleNumber,
+    switchLaw: vi.fn().mockResolvedValue(true),
+    clearLaw: vi.fn(),
+    lawTrajectRef: ref('kieswet-kandidaatstelling-86070ac7'),
+    loading,
+    error: lawError,
+    saving: ref(false),
+    saveError: ref(null),
+    saveLaw: (...a) => saveLaw(...a),
+    seedFromYaml,
+    createLaw: vi.fn().mockResolvedValue(undefined),
+    currentEtag,
+    lastSavedPr: ref(null),
+  }),
+  fetchLaw: vi.fn(),
+}));
+
+vi.mock('./composables/useCorpusLaws.js', () => ({
+  useCorpusLaws: () => ({ displayName: (id) => id, refresh: vi.fn() }),
+}));
+
+vi.mock('./composables/useEngine.js', () => ({
+  useEngine: () => ({
+    ready: ref(false),
+    initError: ref(null),
+    initEngine: vi.fn().mockResolvedValue(null),
+    getEngine: vi.fn(),
+    loadLawYaml: vi.fn(),
+    unloadAllLaws: vi.fn(),
+  }),
+}));
+
+vi.mock('./composables/useNotes.js', () => ({
+  useNotes: () => ({
+    notesForArticle: ref([]),
+    issues: ref([]),
+    error: ref(null),
+    reload: vi.fn(),
+  }),
+  useResolvedDraftNotes: () => ({ draftNotesForArticle: ref([]) }),
+}));
+
+vi.mock('./composables/useDraftNotes.js', () => ({
+  useDraftNotes: () => ({
+    drafts: ref([]),
+    draftCount: ref(0),
+    addDraft: vi.fn(),
+    removeDraft: vi.fn(),
+    exportYaml: vi.fn(),
+    exportYamlFromNotes: vi.fn(),
+    publishNote: vi.fn(),
+  }),
+}));
+
+vi.mock('./composables/useOpenTabs.js', () => ({
+  useOpenTabs: () => ({
+    tabs: ref([]),
+    activeTab: ref(null),
+    publishedTrajectRef: ref(null),
+    tabsFor: () => [],
+    activeTabFor: () => null,
+    findTab: () => null,
+    openTab: vi.fn(),
+    setActiveTab: vi.fn(),
+    closeTab: vi.fn(),
+    reorderTabs: vi.fn(),
+    dropLaw: vi.fn(),
+  }),
+}));
+
+vi.mock('./composables/useTabRestore.js', () => ({
+  createTabRestore: () => ({ restoreForTraject: vi.fn().mockResolvedValue(undefined) }),
+}));
+
+vi.mock('./composables/useEnrichState.js', () => ({
+  useEnrichState: () => ({
+    isEnriching: ref(false),
+    reviewReady: ref(false),
+    reviewArticleForPane: ref(''),
+    openReviewForLaw: vi.fn(),
+    openTasksForLaw: vi.fn(),
+    requestEnrich: vi.fn().mockResolvedValue({}),
+  }),
+}));
+
+vi.mock('./composables/useLastVisitedRoute.js', () => ({
+  lastHomePath: ref({ name: 'home' }),
+  homeTarget: () => ({ name: 'home' }),
+}));
+
+vi.mock('./lib/apiFetch.js', () => ({
+  apiFetch: vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({}) }),
+  apiFetchJson: vi.fn().mockResolvedValue({}),
+  ApiError: class ApiError extends Error {},
+}));
+
+// De app-shell rendert de review-balk en de Wijzigingenbalk; EditorView
+// publiceert er alleen naartoe. `editorChanges` is dus precies wat de
+// gebruiker ziet: `review: true` = de beoordeel-weergave staat op het scherm.
+let editorChanges = null;
+vi.mock('./composables/useAppChrome.js', () => ({
+  registerSearchPopover: vi.fn(),
+  setEditorChrome: vi.fn(),
+  registerTabActions: vi.fn(),
+  setEditorChanges: (state) => {
+    editorChanges = state;
+  },
+  registerEditorActions: vi.fn(),
+  clearEditorChrome: vi.fn(),
+}));
+
+// useTaskReview zelf blijft ECHT - dit bestand test juist de samenloop van de
+// composable met de watches in de view. Alleen de HTTP-laag eronder is een stub.
+const fetchTask = vi.fn();
+const resolveTask = vi.fn();
+vi.mock('./composables/useTasks.js', () => ({
+  useTaskActions: () => ({
+    fetchTask: (...a) => fetchTask(...a),
+    resolveTask: (...a) => resolveTask(...a),
+    refresh: vi.fn(),
+    requestEnrich: vi.fn(),
+    running: ref([]),
+    tasks: ref([]),
+  }),
+  useTasks: () => ({ tasks: ref([]), refresh: vi.fn() }),
+  usePollWhile: vi.fn(),
+}));
+
+import EditorView from './EditorView.vue';
+
+const PROPOSAL_YAML = [
+  '$id: kieswet',
+  'articles:',
+  '  - number: B 5',
+  '    text: B5 voorstel uit verrijking',
+].join('\n');
+
+function reviewTaskDetail(overrides = {}) {
+  return {
+    id: 'taak-1',
+    task_type: 'job_review',
+    status: 'open',
+    payload: {
+      law_id: 'kieswet',
+      article: 'B 5',
+      source_etag: 'etag-1',
+      yaml_path: 'laws/kieswet.yaml',
+    },
+    results: [{ path: 'laws/kieswet.yaml', content: PROPOSAL_YAML }],
+    ...overrides,
+  };
+}
+
+async function settle(times = 4) {
+  for (let i = 0; i < times; i += 1) await nextTick();
+}
+
+// De Tekst-pane leest `activeFormats` van zijn ArticleTextEditor-ref voor de
+// vet/schuin-control; een kale shallow-stub heeft dat veld niet, dus geven we
+// er een die het wél publiceert.
+const ArticleTextEditorStub = {
+  name: 'ArticleTextEditor',
+  template: '<div />',
+  setup() {
+    return { activeFormats: { bold: false, italic: false }, clearHistory: () => {} };
+  },
+};
+
+let mounted = null;
+function mountEditor() {
+  mounted = shallowMount(EditorView, {
+    global: { stubs: { teleport: true, ArticleTextEditor: ArticleTextEditorStub } },
+  });
+  return mounted;
+}
+
+// Ook na een gefaalde assertie: een gemount gebleven view blijft meeluisteren
+// naar de gedeelde reactieve route en vervuilt dan de volgende test.
+afterEach(() => {
+  mounted?.unmount();
+  mounted = null;
+});
+
+beforeEach(() => {
+  fetchTask.mockReset().mockResolvedValue(reviewTaskDetail());
+  resolveTask.mockReset().mockResolvedValue(undefined);
+  replaceMock.mockReset();
+  pushMock.mockReset();
+  seedFromYaml.mockReset();
+  saveLaw.mockReset().mockResolvedValue(undefined);
+  editorChanges = null;
+  articles.value = SAVED_ARTICLES;
+  selectedArticleNumber.value = 'B 5';
+  loading.value = false;
+  lawError.value = null;
+  currentEtag.value = 'etag-1';
+  routeState.params = {
+    trajectRef: 'kieswet-kandidaatstelling-86070ac7',
+    lawId: 'kieswet',
+    articleNumber: 'B 5',
+  };
+  routeState.query = {};
+});
+
+describe('EditorView review-modus', () => {
+  it('opent de beoordeel-weergave bij ?task= en seedt het voorstel', async () => {
+    routeState.query = { task: 'taak-1' };
+    mountEditor();
+    await settle();
+
+    expect(fetchTask).toHaveBeenCalledWith('taak-1');
+    expect(editorChanges.review).toBe(true);
+    expect(editorChanges.reviewStatus).toContain('gegenereerd voorstel');
+    // Het voorstel staat als niet-opgeslagen wijziging in de panes.
+    expect(editorChanges.dirty).toBe(true);
+  });
+
+  // De bug: een artikelwissel (tabwissel in de editor) doet
+  // `router.replace(editorRouteFor(...))` en dat laat `?task=` vallen, maar de
+  // review-state bleef staan. Resultaat: de beoordeel-weergave hing over een
+  // artikel waar de taak niet over gaat - inclusief een actieve "Sla voorstel
+  // op" die de taak zou goedkeuren met de inhoud van dát andere artikel.
+  it('sluit de beoordeel-weergave zodra ?task= uit de URL verdwijnt', async () => {
+    routeState.query = { task: 'taak-1' };
+    mountEditor();
+    await settle();
+    expect(editorChanges.review).toBe(true);
+
+    // Tabwissel naar een ander artikel: de URL houdt geen taak meer vast.
+    routeState.params = { ...routeState.params, articleNumber: 'B 1' };
+    routeState.query = {};
+    selectedArticleNumber.value = 'B 1';
+    await settle();
+
+    expect(editorChanges.review).toBe(false);
+    expect(editorChanges.reviewStatus).toBeNull();
+  });
+
+  // De taak reist mee met de navigatie: elke editor-route die de view bouwt
+  // (tabwissel, artikelwissel, wetwissel) houdt `?task=` vast, zodat een
+  // uitstapje - of een refresh onderweg - de beoordeling niet weggooit.
+  it('houdt ?task= vast op elke editor-route zolang de taak open staat', async () => {
+    routeState.query = { task: 'taak-1' };
+    const wrapper = mountEditor();
+    await settle();
+
+    expect(wrapper.vm.editorRouteFor('kieswet', 'B 1')).toMatchObject({
+      name: 'editor-traject',
+      params: { lawId: 'kieswet', articleNumber: 'B 1' },
+      query: { task: 'taak-1' },
+    });
+    // Zonder wet is er niets om bij te horen.
+    expect(wrapper.vm.editorRouteFor(null, null).query).toBeUndefined();
+  });
+
+  // Het gevaarlijke geval: de balk hing over een ander artikel én "Sla voorstel
+  // op" bleef werken. Die keurde de taak goed met de inhoud van dát artikel.
+  it('zet de beoordeel-weergave uit op een ander artikel, ook met ?task= in de URL', async () => {
+    routeState.query = { task: 'taak-1' };
+    const wrapper = mountEditor();
+    await settle();
+    expect(editorChanges.review).toBe(true);
+
+    // Tabwissel: de taak blijft in de URL staan, het zicht verschuift.
+    routeState.params = { ...routeState.params, articleNumber: 'B 1' };
+    selectedArticleNumber.value = 'B 1';
+    await settle();
+
+    expect(editorChanges.review).toBe(false);
+    expect(editorChanges.reviewStatus).toBeNull();
+
+    // Opslaan is hier een gewone artikel-save, geen goedkeuring.
+    await wrapper.vm.handleLawSave();
+    await settle();
+    expect(saveLaw).toHaveBeenCalled(); // de save gebeurt wel...
+    expect(resolveTask).not.toHaveBeenCalled(); // ...maar keurt niets goed.
+  });
+
+  it('zet balk en voorstel terug zodra je terug bent op het artikel van de taak', async () => {
+    routeState.query = { task: 'taak-1' };
+    mountEditor();
+    await settle();
+
+    routeState.params = { ...routeState.params, articleNumber: 'B 1' };
+    selectedArticleNumber.value = 'B 1';
+    await settle();
+    expect(editorChanges.review).toBe(false);
+
+    routeState.params = { ...routeState.params, articleNumber: 'B 5' };
+    selectedArticleNumber.value = 'B 5';
+    await settle();
+
+    expect(editorChanges.review).toBe(true);
+    // Het voorstel staat er weer als niet-opgeslagen wijziging...
+    expect(editorChanges.dirty).toBe(true);
+    // ...zonder de taak opnieuw op te halen: die was nooit weg.
+    expect(fetchTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('springt niet weg wanneer je met ?task= op een ander artikel binnenkomt', async () => {
+    // Refresh terwijl je even bij B 1 keek: de taak reist mee in de URL, maar
+    // het artikel uit de URL wint - geen ongevraagde sprong naar B 5.
+    routeState.params = { ...routeState.params, articleNumber: 'B 1' };
+    routeState.query = { task: 'taak-1' };
+    selectedArticleNumber.value = 'B 1';
+    mountEditor();
+    await settle();
+
+    expect(selectedArticleNumber.value).toBe('B 1');
+    expect(editorChanges.review).toBe(false);
+
+    // En zodra je naar het artikel van de taak gaat, staat het voorstel er.
+    routeState.params = { ...routeState.params, articleNumber: 'B 5' };
+    selectedArticleNumber.value = 'B 5';
+    await settle();
+
+    expect(editorChanges.review).toBe(true);
+    expect(editorChanges.dirty).toBe(true);
+  });
+
+  it('laat de taak wel los bij verwerpen', async () => {
+    routeState.query = { task: 'taak-1' };
+    const wrapper = mountEditor();
+    await settle();
+
+    await wrapper.vm.rejectReview();
+    await settle();
+
+    expect(resolveTask).toHaveBeenCalledWith('taak-1', 'rejected');
+    // De enige route die de taak bewust NIET meeneemt.
+    const target = replaceMock.mock.calls.at(-1)[0];
+    expect(target.query).toBeUndefined();
+    expect(target.params).toMatchObject({ lawId: 'kieswet' });
+  });
+
+  // Tweede helft van dezelfde bug: terug op het artikel van de taak was de
+  // inhoud weg (de panes zijn opnieuw uit de opgeslagen wet gevuld) terwijl de
+  // beoordeel-weergave er nog stond. Komt de taak wél terug in de URL, dan
+  // hoort het voorstel opnieuw geladen en geseed te worden.
+  it('laadt de taak opnieuw wanneer je met ?task= terugkeert', async () => {
+    routeState.query = { task: 'taak-1' };
+    mountEditor();
+    await settle();
+    expect(fetchTask).toHaveBeenCalledTimes(1);
+
+    routeState.params = { ...routeState.params, articleNumber: 'B 1' };
+    routeState.query = {};
+    selectedArticleNumber.value = 'B 1';
+    await settle();
+    expect(editorChanges.review).toBe(false);
+
+    // Terug naar het artikel van de taak, via "Beoordeel voorstel" - dat is
+    // een route mét ?task=.
+    routeState.params = { ...routeState.params, articleNumber: 'B 5' };
+    routeState.query = { task: 'taak-1' };
+    selectedArticleNumber.value = 'B 5';
+    await settle();
+
+    expect(fetchTask).toHaveBeenCalledTimes(2);
+    expect(editorChanges.review).toBe(true);
+    expect(editorChanges.dirty).toBe(true);
+  });
+});

--- a/frontend/src/EditorView.taskReview.test.js
+++ b/frontend/src/EditorView.taskReview.test.js
@@ -63,7 +63,22 @@ const SAVED_ARTICLES = [
   { number: 'B 1', text: 'B1 opgeslagen', machine_readable: null },
   { number: 'B 5', text: 'B5 opgeslagen', machine_readable: null },
 ];
+// Een tweede wet in hetzelfde traject die tóevallig dezelfde artikelnummers
+// gebruikt - doodgewoon ("B 1", "1", "2" bestaan in half de corpus). Precies
+// dat maakt hem interessant: bij een wetwissel verandert `selectedArticleNumber`
+// dan niet, alleen de wet eronder.
+const OTHER_LAW_ARTICLES = [
+  { number: 'B 1', text: 'B1 andere wet', machine_readable: null },
+  { number: 'B 5', text: 'B5 andere wet', machine_readable: null },
+];
 const articles = ref(SAVED_ARTICLES);
+const lawId = ref('kieswet');
+// Wissel van wet zoals `switchLaw` dat doet: de wet eronder verandert, het
+// artikelnummer in de URL kan hetzelfde blijven.
+function switchToLaw(id, lawArticles) {
+  lawId.value = id;
+  articles.value = lawArticles;
+}
 const selectedArticleNumber = ref('B 5');
 const selectedArticle = computed(
   () => articles.value.find((a) => String(a.number) === String(selectedArticleNumber.value)) ?? null,
@@ -73,10 +88,11 @@ const lawError = ref(null);
 const currentEtag = ref('etag-1');
 const seedFromYaml = vi.fn();
 const saveLaw = vi.fn().mockResolvedValue(undefined);
+const reloadLaw = vi.fn().mockResolvedValue(undefined);
 vi.mock('./composables/useLaw.js', () => ({
   useLaw: () => ({
     law: ref({ $id: 'kieswet', valid_from: '2025-01-01' }),
-    lawId: ref('kieswet'),
+    lawId,
     rawYaml: ref(SAVED_LAW_YAML),
     articles,
     lawName: ref('Kieswet'),
@@ -90,6 +106,7 @@ vi.mock('./composables/useLaw.js', () => ({
     saving: ref(false),
     saveError: ref(null),
     saveLaw: (...a) => saveLaw(...a),
+    reloadLaw: (...a) => reloadLaw(...a),
     seedFromYaml,
     createLaw: vi.fn().mockResolvedValue(undefined),
     currentEtag,
@@ -196,10 +213,14 @@ vi.mock('./composables/useAppChrome.js', () => ({
 // composable met de watches in de view. Alleen de HTTP-laag eronder is een stub.
 const fetchTask = vi.fn();
 const resolveTask = vi.fn();
+const fetchJobTasks = vi.fn();
+const applyEnrichment = vi.fn();
 vi.mock('./composables/useTasks.js', () => ({
   useTaskActions: () => ({
     fetchTask: (...a) => fetchTask(...a),
     resolveTask: (...a) => resolveTask(...a),
+    fetchJobTasks: (...a) => fetchJobTasks(...a),
+    applyEnrichment: (...a) => applyEnrichment(...a),
     refresh: vi.fn(),
     requestEnrich: vi.fn(),
     running: ref([]),
@@ -267,12 +288,15 @@ afterEach(() => {
 beforeEach(() => {
   fetchTask.mockReset().mockResolvedValue(reviewTaskDetail());
   resolveTask.mockReset().mockResolvedValue(undefined);
+  fetchJobTasks.mockReset();
+  applyEnrichment.mockReset().mockResolvedValue({ accepted: 1, total: 1 });
   replaceMock.mockReset();
   pushMock.mockReset();
   seedFromYaml.mockReset();
   saveLaw.mockReset().mockResolvedValue(undefined);
+  reloadLaw.mockReset().mockResolvedValue(undefined);
   editorChanges = null;
-  articles.value = SAVED_ARTICLES;
+  switchToLaw('kieswet', SAVED_ARTICLES);
   selectedArticleNumber.value = 'B 5';
   loading.value = false;
   lawError.value = null;
@@ -409,7 +433,16 @@ describe('EditorView review-modus', () => {
     await wrapper.vm.rejectReview();
     await settle();
 
-    expect(resolveTask).toHaveBeenCalledWith('taak-1', 'rejected');
+    // Een taak zonder job_id is in haar eentje de verrijking: "Verwerpen"
+    // legt het oordeel vast en verwerkt meteen - dat schrijft niet meer via
+    // een losse `resolveTask` per taak, maar via `applyEnrichment` op de
+    // verrijking (hier: alleen deze taak).
+    expect(resolveTask).not.toHaveBeenCalled();
+    expect(applyEnrichment).toHaveBeenCalledWith(
+      'taak-1',
+      [{ task_id: 'taak-1', action: 'rejected' }],
+      'etag-1',
+    );
     // De enige route die de taak bewust NIET meeneemt.
     const target = replaceMock.mock.calls.at(-1)[0];
     expect(target.query).toBeUndefined();
@@ -440,6 +473,45 @@ describe('EditorView review-modus', () => {
     await settle();
 
     expect(fetchTask).toHaveBeenCalledTimes(2);
+    expect(editorChanges.review).toBe(true);
+    expect(editorChanges.dirty).toBe(true);
+  });
+
+  // De taak reist mee met de navigatie, dus `?task=` staat ook in de URL van een
+  // ANDERE wet. Een refresh daar laadt de taak opnieuw - en dan mag het voorstel
+  // niet in die vreemde wet landen. Het artikelnummer alleen is geen bewijs dat
+  // je goed zit: nummers als "B 5" bestaan in meerdere wetten.
+  it('seedt het voorstel niet in een andere wet bij binnenkomen met ?task=', async () => {
+    switchToLaw('andere-wet', OTHER_LAW_ARTICLES);
+    routeState.query = { task: 'taak-1' };
+    mountEditor();
+    await settle();
+
+    expect(editorChanges.review).toBe(false);
+    // Niets geseed: de panes staan nog op de opgeslagen tekst van de andere wet.
+    expect(editorChanges.dirty).toBe(false);
+  });
+
+  // Dezelfde valkuil bij terugkeren. Wissel je naar een wet die hetzelfde
+  // artikelnummer heeft, dan verandert `selectedArticleNumber` niet - alleen de
+  // wet eronder. De panes zijn dan wél teruggezet naar de opgeslagen wet, dus
+  // terug op de taak moet het voorstel er opnieuw in.
+  it('seedt opnieuw na een uitstapje naar een wet met hetzelfde artikelnummer', async () => {
+    routeState.query = { task: 'taak-1' };
+    mountEditor();
+    await settle();
+    expect(editorChanges.review).toBe(true);
+    expect(editorChanges.dirty).toBe(true);
+
+    // Wetwissel, zelfde artikelnummer: de beoordeling hoort uit beeld.
+    switchToLaw('andere-wet', OTHER_LAW_ARTICLES);
+    await settle();
+    expect(editorChanges.review).toBe(false);
+    expect(editorChanges.dirty).toBe(false);
+
+    // Terug op de wet van de taak: balk én voorstel horen er weer te staan.
+    switchToLaw('kieswet', SAVED_ARTICLES);
+    await settle();
     expect(editorChanges.review).toBe(true);
     expect(editorChanges.dirty).toBe(true);
   });

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -180,6 +180,14 @@ const canEditArticleText = computed(() => canEdit.value);
 const route = useRoute();
 const router = useRouter();
 
+// De review-taak uit de URL (`?task=`). Staat hier hoog omdat `editorRouteFor`
+// hem meeneemt: zolang een taak in beoordeling is, reist hij mee met elke
+// navigatie binnen de editor (tab-, artikel- en wetwissel). De hele
+// review-modus verderop hangt aan deze ene bron.
+const reviewTaskIdParam = computed(() =>
+  typeof route.query.task === 'string' ? route.query.task : null,
+);
+
 // Bibliotheek tab / "naar bibliotheek" buttons: restore the last library
 // position but re-stamp it with the currently active traject, so the
 // traject survives the Editor→Bibliotheek switch (it lives in the URL).
@@ -898,17 +906,24 @@ watch(graphSheetOpen, async (open) => {
  * fire here - but for safety it routes to the chooser with the law as
  * query rather than the (now removed) no-traject editor.
  */
-function editorRouteFor(lawIdVal, articleNumber) {
+function editorRouteFor(lawIdVal, articleNumber, { keepReviewTask = true } = {}) {
   const trajectRef = route.params.trajectRef;
+  // Een lopende beoordeling reist mee met de navigatie: `?task=` blijft op elke
+  // editor-URL staan tot de taak is afgehandeld (`clearReviewQuery` bouwt de
+  // enige route zonder). Zo overleeft de beoordeling een uitstapje naar een
+  // ander artikel - en een refresh onderweg - in plaats van stilletjes weg te
+  // vallen bij de eerste tabwissel. Zonder wet is er niets om bij te horen.
+  const task = keepReviewTask && lawIdVal ? reviewTaskIdParam.value : null;
   if (trajectRef) {
     return {
       name: 'editor-traject',
       params: { trajectRef, lawId: lawIdVal, articleNumber },
+      ...(task ? { query: { task } } : {}),
     };
   }
   return {
     name: 'editor',
-    query: { law: lawIdVal || undefined, article: articleNumber || undefined },
+    query: { law: lawIdVal || undefined, article: articleNumber || undefined, task: task || undefined },
   };
 }
 
@@ -1533,10 +1548,10 @@ const {
   loadReview,
   decide: decideReviewPart,
   processEnrichment,
+  reset: resetReview,
   approveAfterSave,
   reject: rejectReviewInternal,
 } = useTaskReview();
-const reviewActive = computed(() => !!reviewTask.value);
 // `law_create`-taak: de wet bestaat nog niet in het traject; het voorstel
 // wordt integraal in de editor geseed en Opslaan gaat via het create-pad
 // (POST) in plaats van de PUT.
@@ -1554,14 +1569,34 @@ const reviewArticleNumber = computed(() => {
   const number = reviewTask.value?.payload?.article;
   return number == null ? null : String(number);
 });
+// Kijk je op dit moment naar waar de taak over gaat? De taak reist mee met de
+// navigatie (zie `editorRouteFor`), zodat een uitstapje naar een ander artikel
+// de beoordeling niet weggooit - maar de beoordeel-weergave hoort alleen te
+// staan boven het artikel waarover je je uitspreekt. Anders hangt de balk over
+// vreemde inhoud en keurt "Opslaan" de taak goed met een artikel dat de
+// verrijking nooit heeft aangeraakt.
+//
+// Een taak zonder artikelnummer gaat over de hele wet: die slaat het voorstel
+// integraal op (`reviewSavesWholeLaw`), dus dan is elk artikel van die wet een
+// geldige plek om hem te beoordelen.
+const reviewOnTarget = computed(() => {
+  const task = reviewTask.value;
+  if (!task) return false;
+  const taskLawId = task.payload?.law_id;
+  if (taskLawId && lawId.value && taskLawId !== lawId.value) return false;
+  const number = reviewArticleNumber.value;
+  if (number == null) return true;
+  return String(selectedArticleNumber.value ?? '') === number;
+});
+// De beoordeel-weergave (balk, Opslaan-als-goedkeuren, Verwerpen) staat aan.
+// Bewust smaller dan "er is een taak geladen": zie `reviewOnTarget`.
+const reviewActive = computed(() => !!reviewTask.value && reviewOnTarget.value);
+
 // Een taak die één artikel aanwijst, accordeert dat artikel zoals het in de
 // panes staat - inclusief wat de beoordelaar er zelf nog aan veranderde. Een
 // taak zonder artikelnummer accordeert het voorstel in zijn geheel, want daar
 // is geen kleinere eenheid om over te beslissen.
 const reviewSavesWholeLaw = computed(() => reviewActive.value && !reviewArticleNumber.value);
-const reviewTaskIdParam = computed(() =>
-  typeof route.query.task === 'string' ? route.query.task : null,
-);
 // Guards against re-firing loadReview for a task id already attempted -
 // approve/reject null out `reviewTask`, which would otherwise look
 // indistinguishable from "not loaded yet" and re-trigger against the
@@ -1577,7 +1612,9 @@ let reviewAttemptedForTaskId = null;
 // stale route param disagree with `selectedArticleNumber` and snap the
 // editor back to the pre-review article right after resolving.
 function clearReviewQuery() {
-  router.replace(editorRouteFor(lawId.value, selectedArticleNumber.value));
+  router.replace(
+    editorRouteFor(lawId.value, selectedArticleNumber.value, { keepReviewTask: false }),
+  );
 }
 
 // Whether the proposal seeded anything (false when every proposed article
@@ -1590,6 +1627,19 @@ const reviewSeeded = ref(false);
 // Opslaan now approves the FULL proposal regardless - this only drives the
 // banner copy that points the reviewer at the YAML panel for the rest.
 const reviewHasHiddenChanges = ref(false);
+// In welk artikel het voorstel hoort te landen (`payload.article`, of - bij een
+// voorstel over de hele wet - het artikel dat `proposalDivergence` uitkoos), en
+// welk artikel het op dit moment daadwerkelijk vasthoudt. Die twee lopen uiteen
+// zodra je naar een ander artikel kijkt: `watch(selectedArticle)` zet de panes
+// dan terug naar de opgeslagen wet. Het verschil is precies het signaal om bij
+// terugkomst opnieuw te seeden.
+const reviewSeedTarget = ref(null);
+const reviewSeededArticle = ref(null);
+watch(selectedArticleNumber, (nr) => {
+  if (reviewSeededArticle.value && reviewSeededArticle.value !== String(nr)) {
+    reviewSeededArticle.value = null;
+  }
+});
 
 function applyProposedContent(proposedYaml) {
   reviewSeeded.value = false;
@@ -1614,6 +1664,12 @@ function applyProposedContent(proposedYaml) {
   reviewHasHiddenChanges.value = hiddenChanges;
   if (!target) return; // nothing seedable differs - nothing to seed
   reviewSeeded.value = true;
+  reviewSeedTarget.value = String(target.number);
+  // Meteen (niet pas in de nextTick hieronder): de watch die bij een
+  // artikelwissel opruimt en de her-seed-watch draaien in de flush ertussen, en
+  // moeten dit al als "geseed" zien - anders seeden ze er direct nog eens
+  // overheen.
+  reviewSeededArticle.value = String(target.number);
   selectedArticleNumber.value = String(target.number);
   // `watch(selectedArticle)` (above) resets editedText/machineReadable to
   // the (still-saved) newly selected article; wait a tick so the seed
@@ -1720,7 +1776,21 @@ watch(
     if (reviewAttemptedForTaskId === taskId) return;
     reviewAttemptedForTaskId = taskId;
     loadReview(taskId).then(() => {
-      if (reviewProposedContent.value) applyProposedContent(reviewProposedContent.value);
+      if (!reviewProposedContent.value) return;
+      // Een taak die één artikel aanwijst hoort in dát artikel te landen, en
+      // `applyProposedContent` springt er zo nodig heen. Meestal ben je er al
+      // (de takenlijst linkt erheen), maar doordat de taak meereist met de
+      // navigatie kun je met `?task=` op een ánder artikel binnenkomen - een
+      // refresh terwijl je even elders keek. Dan wint het artikel uit de URL:
+      // niet ongevraagd wegspringen. Het seed-doel wordt wel vastgelegd, zodat
+      // de her-seed-watch het voorstel oppakt zodra je er terug bent.
+      const taskArticle = reviewArticleNumber.value;
+      const urlArticle = route.params.articleNumber;
+      if (taskArticle && urlArticle && String(urlArticle) !== taskArticle) {
+        reviewSeedTarget.value = taskArticle;
+        return;
+      }
+      applyProposedContent(reviewProposedContent.value);
     });
   },
   { immediate: true },
@@ -1756,6 +1826,45 @@ watch(
   },
   { immediate: true },
 );
+
+// De keerzijde van de twee watches hierboven: `?task=` is niet alleen hoe een
+// review begint, het is ook wat hem gaande houdt. Elke artikel- of wetwissel in
+// de editor (een tabwissel, `selectTab`) stampt de URL opnieuw met
+// `editorRouteFor`, en die draagt geen query - de taak valt er dus vanzelf uit
+// zodra je iets anders bekijkt. Zonder deze watch bleef `reviewTask` staan: de
+// beoordeel-balk hing over een artikel waar de taak niet over gaat, terwijl het
+// geseede voorstel allang was teruggezet door `watch(selectedArticle)`. Erger
+// dan lelijk: "Opslaan" keurde de taak dan goed met de inhoud van dát andere
+// artikel, en zolang de modus aanstond hield `reviewReady` de knop "Beoordeel
+// voorstel" verborgen waarmee je terug had gekund.
+//
+// De guard gaat mee terug op null: kom je later met dezelfde taak terug (via de
+// takenlijst of "Beoordeel voorstel"), dan hoort het voorstel opnieuw geladen en
+// geseed te worden in plaats van als "al geprobeerd" te worden overgeslagen.
+watch(reviewTaskIdParam, (taskId) => {
+  if (taskId) return;
+  reviewAttemptedForTaskId = null;
+  resetReview();
+  reviewSeeded.value = false;
+  reviewHasHiddenChanges.value = false;
+  reviewSeedTarget.value = null;
+  reviewSeededArticle.value = null;
+});
+
+// Terug op het artikel van de taak: zet het voorstel er weer in. De panes zijn
+// bij de artikelwissel teruggezet naar de opgeslagen wet, dus zonder dit zie je
+// een beoordeling zonder iets te beoordelen - balk aan, voorstel weg. Dat was
+// de tweede helft van de gemelde bug.
+//
+// `law_create` blijft erbuiten: daar is de wet zelf het voorstel en is het
+// integraal geseed (`seedFromYaml`), niet als artikel-splice.
+watch([reviewOnTarget, selectedArticle], ([onTarget, article]) => {
+  if (!onTarget || !article || reviewIsLawCreate.value) return;
+  if (!reviewProposedContent.value || !reviewSeedTarget.value) return;
+  if (String(article.number) !== reviewSeedTarget.value) return;
+  if (reviewSeededArticle.value === String(article.number)) return;
+  applyProposedContent(reviewProposedContent.value);
+});
 
 // "Verwerpen": bij een `law_create` is er niets samen te stellen - die taak
 // staat op zichzelf en wordt direct afgehandeld. Bij een verrijking is dit een

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -1634,10 +1634,19 @@ const reviewHasHiddenChanges = ref(false);
 // dan terug naar de opgeslagen wet. Het verschil is precies het signaal om bij
 // terugkomst opnieuw te seeden.
 const reviewSeedTarget = ref(null);
-const reviewSeededArticle = ref(null);
-watch(selectedArticleNumber, (nr) => {
-  if (reviewSeededArticle.value && reviewSeededArticle.value !== String(nr)) {
-    reviewSeededArticle.value = null;
+// Waar het voorstel op dit moment daadwerkelijk in de panes staat, als
+// `wet::artikel`. De wet hoort in die sleutel: twee wetten in hetzelfde traject
+// kunnen dezelfde artikelnummers hebben ("B 5", "1", "2" zijn niet uniek), en
+// bij een wetwissel verandert `selectedArticleNumber` dan niet terwijl
+// `watch(selectedArticle)` de panes wél heeft teruggezet naar de opgeslagen wet.
+// Op het nummer alleen zou het voorstel er bij terugkomst niet opnieuw in gaan.
+const reviewSeededAt = ref(null);
+function reviewSeedKey(number) {
+  return `${lawId.value ?? ''}::${number ?? ''}`;
+}
+watch([lawId, selectedArticleNumber], ([, nr]) => {
+  if (reviewSeededAt.value && reviewSeededAt.value !== reviewSeedKey(nr)) {
+    reviewSeededAt.value = null;
   }
 });
 
@@ -1669,7 +1678,7 @@ function applyProposedContent(proposedYaml) {
   // artikelwissel opruimt en de her-seed-watch draaien in de flush ertussen, en
   // moeten dit al als "geseed" zien - anders seeden ze er direct nog eens
   // overheen.
-  reviewSeededArticle.value = String(target.number);
+  reviewSeededAt.value = reviewSeedKey(String(target.number));
   selectedArticleNumber.value = String(target.number);
   // `watch(selectedArticle)` (above) resets editedText/machineReadable to
   // the (still-saved) newly selected article; wait a tick so the seed
@@ -1777,17 +1786,19 @@ watch(
     reviewAttemptedForTaskId = taskId;
     loadReview(taskId).then(() => {
       if (!reviewProposedContent.value) return;
-      // Een taak die één artikel aanwijst hoort in dát artikel te landen, en
-      // `applyProposedContent` springt er zo nodig heen. Meestal ben je er al
-      // (de takenlijst linkt erheen), maar doordat de taak meereist met de
-      // navigatie kun je met `?task=` op een ánder artikel binnenkomen - een
-      // refresh terwijl je even elders keek. Dan wint het artikel uit de URL:
-      // niet ongevraagd wegspringen. Het seed-doel wordt wel vastgelegd, zodat
-      // de her-seed-watch het voorstel oppakt zodra je er terug bent.
-      const taskArticle = reviewArticleNumber.value;
-      const urlArticle = route.params.articleNumber;
-      if (taskArticle && urlArticle && String(urlArticle) !== taskArticle) {
-        reviewSeedTarget.value = taskArticle;
+      // Alleen seeden waar de taak over gaat - dezelfde vraag als voor de balk,
+      // dus dezelfde `reviewOnTarget`. Een taak die één artikel aanwijst hoort
+      // in dát artikel te landen, en `applyProposedContent` springt er zo nodig
+      // heen. Meestal ben je er al (de takenlijst linkt erheen), maar doordat de
+      // taak meereist met de navigatie staat `?task=` ook op de route van een
+      // ander artikel - en van een andere wet. Kom je daar binnen (een refresh
+      // terwijl je even elders keek), dan wint wat er op het scherm staat: niet
+      // ongevraagd wegspringen, en zeker het voorstel niet in vreemde inhoud
+      // laten landen. Het artikelnummer alleen is daarvoor geen toets: nummers
+      // als "B 5" bestaan in meerdere wetten. Het seed-doel wordt wel
+      // vastgelegd, zodat de her-seed-watch het oppakt zodra je er terug bent.
+      if (!reviewOnTarget.value) {
+        reviewSeedTarget.value = reviewArticleNumber.value;
         return;
       }
       applyProposedContent(reviewProposedContent.value);
@@ -1848,7 +1859,7 @@ watch(reviewTaskIdParam, (taskId) => {
   reviewSeeded.value = false;
   reviewHasHiddenChanges.value = false;
   reviewSeedTarget.value = null;
-  reviewSeededArticle.value = null;
+  reviewSeededAt.value = null;
 });
 
 // Terug op het artikel van de taak: zet het voorstel er weer in. De panes zijn
@@ -1860,9 +1871,19 @@ watch(reviewTaskIdParam, (taskId) => {
 // integraal geseed (`seedFromYaml`), niet als artikel-splice.
 watch([reviewOnTarget, selectedArticle], ([onTarget, article]) => {
   if (!onTarget || !article || reviewIsLawCreate.value) return;
-  if (!reviewProposedContent.value || !reviewSeedTarget.value) return;
-  if (String(article.number) !== reviewSeedTarget.value) return;
-  if (reviewSeededArticle.value === String(article.number)) return;
+  if (!reviewProposedContent.value) return;
+  if (reviewSeededAt.value === reviewSeedKey(String(article.number))) return;
+  // Waar het voorstel heen moet. Bij een taak over één artikel ligt dat vast;
+  // bij een voorstel over de hele wet kiest `proposalDivergence` het artikel, en
+  // is het doel dus pas bekend na de eerste keer seeden. Kwam je binnen op een
+  // andere wet, dan is dat nog niet gebeurd - laat `applyProposedContent` het
+  // dan alsnog bepalen (die springt zo nodig zelf naar het juiste artikel).
+  if (reviewSeedTarget.value) {
+    if (String(article.number) !== reviewSeedTarget.value) return;
+  } else if (reviewArticleNumber.value) {
+    // Artikel-taak zonder doel: `applyProposedContent` vond niets seedbaars.
+    return;
+  }
   applyProposedContent(reviewProposedContent.value);
 });
 

--- a/frontend/src/composables/useTaskReview.js
+++ b/frontend/src/composables/useTaskReview.js
@@ -106,6 +106,11 @@ export function useTaskReview() {
   const partCount = computed(() => openParts.value.length);
 
   async function loadReview(taskId) {
+    // Elke load begint schoon. Niet elke wissel van taak gaat langs `reset()`:
+    // via de takenlijst springt `?task=` rechtstreeks van de ene taak naar de
+    // andere, en dan zou de foutmelding van de vorige taak boven de nieuwe
+    // blijven hangen.
+    loadError.value = null;
     try {
       const detail = await fetchTask(taskId);
       if (detail.task_type !== 'job_review' || detail.status !== 'open') {

--- a/frontend/src/composables/useTaskReview.js
+++ b/frontend/src/composables/useTaskReview.js
@@ -201,9 +201,7 @@ export function useTaskReview() {
       .filter(Boolean);
     const result = await applyEnrichment(key, decisions, etag);
     clearVerdicts(key);
-    reviewTask.value = null;
-    proposedContent.value = null;
-    jobParts.value = [];
+    reset();
     return result;
   }
 
@@ -214,17 +212,21 @@ export function useTaskReview() {
    */
   async function approveAfterSave() {
     if (reviewTask.value) await resolveTask(reviewTask.value.id, 'approved');
-    resetReview();
+    reset();
   }
 
   async function reject() {
     if (reviewTask.value) await resolveTask(reviewTask.value.id, 'rejected');
-    resetReview();
+    reset();
   }
 
-  function resetReview() {
+  // Terug naar "geen review". Ook `loadError` gaat mee: een foutmelding van de
+  // vorige taak hoort niet boven de volgende (of boven een artikel waar
+  // helemaal geen taak op staat) te blijven hangen.
+  function reset() {
     reviewTask.value = null;
     proposedContent.value = null;
+    loadError.value = null;
     jobParts.value = [];
   }
 
@@ -242,5 +244,6 @@ export function useTaskReview() {
     processEnrichment,
     approveAfterSave,
     reject,
+    reset,
   };
 }

--- a/frontend/src/composables/useTaskReview.test.js
+++ b/frontend/src/composables/useTaskReview.test.js
@@ -273,6 +273,25 @@ describe('useTaskReview', () => {
     expect(resolveTask).not.toHaveBeenCalled();
   });
 
+  // Vanuit de editor kun je via de takenlijst rechtstreeks van de ene taak naar
+  // de andere - `?task=` gaat dan van A naar B zonder tussenstop op "geen taak",
+  // dus zonder dat er iets `reset()` aanroept. Een nieuwe load hoort daarom zelf
+  // schoon te beginnen; anders staat de foutmelding van A boven het voorstel
+  // van B (en kleurt de balk kritiek terwijl er niets mis is).
+  it('begint schoon bij een volgende load, ook zonder reset ertussen', async () => {
+    fetchTask.mockResolvedValueOnce(openTask({ status: 'resolved' }));
+    const { reviewTask, proposedContent, loadError, loadReview } = useTaskReview();
+    await loadReview('t1');
+    expect(loadError.value).toBe('Deze taak is al afgehandeld.');
+
+    fetchTask.mockResolvedValueOnce(openTask({ id: 't2' }));
+    await loadReview('t2');
+
+    expect(reviewTask.value?.id).toBe('t2');
+    expect(proposedContent.value).toBe('proposed: yaml');
+    expect(loadError.value).toBeNull();
+  });
+
   it('reset laat een foutmelding van een mislukte load niet blijven staan', async () => {
     fetchTask.mockRejectedValue(new Error('netwerk'));
     const { loadError, loadReview, reset } = useTaskReview();

--- a/frontend/src/composables/useTaskReview.test.js
+++ b/frontend/src/composables/useTaskReview.test.js
@@ -256,4 +256,31 @@ describe('useTaskReview', () => {
     expect(resolveTask).not.toHaveBeenCalled();
     expect(applyEnrichment).not.toHaveBeenCalled();
   });
+
+  it('reset ruimt ook loadError op, niet alleen de taak', async () => {
+    fetchTask.mockResolvedValue(openTask());
+    fetchJobTasks.mockResolvedValue(twoParts());
+    const { reviewTask, proposedContent, jobParts, loadReview, reset } = useTaskReview();
+    await loadReview('t1');
+    expect(reviewTask.value).not.toBeNull();
+
+    reset();
+
+    expect(reviewTask.value).toBeNull();
+    expect(proposedContent.value).toBeNull();
+    expect(jobParts.value).toEqual([]);
+    // Puur lokaal: de taak zelf blijft open, reset is geen afhandeling.
+    expect(resolveTask).not.toHaveBeenCalled();
+  });
+
+  it('reset laat een foutmelding van een mislukte load niet blijven staan', async () => {
+    fetchTask.mockRejectedValue(new Error('netwerk'));
+    const { loadError, loadReview, reset } = useTaskReview();
+    await loadReview('t1');
+    expect(loadError.value).toBe('Taak laden mislukt.');
+
+    reset();
+
+    expect(loadError.value).toBeNull();
+  });
 });


### PR DESCRIPTION
## Wat er misging

Een artikelwissel in de editor (tabbalk → `selectTab`) stampt de URL opnieuw met `editorRouteFor`, en die droeg geen query mee — `?task=` viel er dus uit zodra je iets anders bekeek. `reviewTask` werd alleen bij goedkeuren of verwerpen leeggemaakt, dus:

- de beoordeel-balk bleef staan boven een artikel waar de taak niet over gaat;
- terug op het artikel van de taak was het geseede voorstel wél weg (`watch(selectedArticle)` had de panes teruggezet naar de opgeslagen wet), de balk niet.

Gereproduceerd op productie met twee open artikel-tabs (Kieswet B 1 + B 5).

Twee dingen die je niet ziet, maar erger zijn dan de blijvende balk:

1. **"Sla voorstel op" bleef werken op het verkeerde artikel.** `handleLawSave` sloeg dan de splice van het zichtbare artikel op en resolvete daarna de taak als `approved` — voorstel weg, taak goedgekeurd.
2. Zolang de modus vastzat, verborg `reviewReady` in `useEnrichState` juist de knop **"Beoordeel voorstel"** waarmee je terug had gekund.

## Wat er nu gebeurt

De taak reist mee met de navigatie en gaat er alleen af als hij is afgehandeld:

| Situatie | Gedrag |
|---|---|
| Taak openen via de takenlijst | Ongewijzigd: voorstel geseed, balk + Opslaan/Verwerpen |
| Naar een ander artikel of een andere wet | `?task=` blijft in de URL, balk en knoppen zijn weg; Opslaan is daar een gewone save |
| Terug op het artikel van de taak | Balk terug én voorstel opnieuw geseed, zonder de taak opnieuw op te halen |
| Refresh onderweg | Beoordeling blijft leven; je blijft op het artikel uit de URL, geen sprong |
| Opslaan / verwerpen | De enige routes die `?task=` bewust laten vallen |

Drie stukken:

- `editorRouteFor` draagt `?task=` mee (`clearReviewQuery` is de uitzondering, via `keepReviewTask: false`);
- `reviewActive` versmald tot `reviewOnTarget` — kijk je naar waar de taak over gaat? Een taak zonder artikelnummer slaat integraal op en geldt daarom voor de hele wet;
- een watch die bij terugkomst opnieuw seedt, plus een vangnet-watch die de state opruimt (en de attempt-guard reset) als `?task=` alsnog uit de URL verdwijnt.

`useTaskReview` krijgt een `reset()` die ook `stale` en `loadError` opruimt — een foutmelding van de vorige taak bleef anders hangen.

## Tests

`EditorView.vue` had nog geen testharnas; `EditorView.taskReview.test.js` mount hem shallow met stubs (zelfde aanpak als `LibraryView.docReview.test.js`) en dekt af: openen + seeden, balk uit op een ander artikel, Opslaan keurt daar niets goed, terugkomen herstelt balk + voorstel, `?task=` blijft op elke route staan, verwerpen laat hem los, en geen sprong bij binnenkomen op een ander artikel. Plus twee unit-tests op `reset()`.

Frontend-suite groen: 77 bestanden / 819 tests.

Geen extra CSS.

## Nog te doen

Verificatie op de preview (`deploy:preview` staat erop) met hetzelfde reproductie-scenario als hierboven.