### PR TITLE
docs(docs): herschik volgorde van disciplines (swimlanes) op de roadmap

### DIFF
--- a/docs/src/data/roadmap-config.json
+++ b/docs/src/data/roadmap-config.json
@@ -38,9 +38,9 @@
       "ondertitel": "Van standaarden naar intelligente tooling"
     },
     {
-      "id": "recht",
-      "naam": "Recht & Instituties",
-      "ondertitel": "Van kaders naar herinrichting van de macht"
+      "id": "service-design",
+      "naam": "Service Design",
+      "ondertitel": ""
     },
     {
       "id": "mensen",
@@ -48,14 +48,14 @@
       "ondertitel": "Van competenties naar een interdisciplinaire cultuur"
     },
     {
+      "id": "recht",
+      "naam": "Recht & Instituties",
+      "ondertitel": "Van kaders naar herinrichting van de macht"
+    },
+    {
       "id": "ethiek",
       "naam": "Ethiek & Waarden",
       "ondertitel": "Van principes naar toetsbare waarborgen"
-    },
-    {
-      "id": "service-design",
-      "naam": "Service Design",
-      "ondertitel": ""
     }
   ]
 }


### PR DESCRIPTION
## Samenvatting

De volgorde van de swimlanes (disciplines) op `/roadmap` wijzigt van
Techniek, Recht & Instituties, Mensen & Proces, Ethiek & Waarden, Service Design
naar
**Techniek, Service Design, Mensen & Proces, Recht & Instituties, Ethiek & Waarden**.

Dit is een wijziging in `docs/src/data/roadmap-config.json` (de volgorde van de
`disciplines`-array bepaalt de rijvolgorde in de matrix, er is geen apart
volgnummer-veld zoals bij fases). Geen naamswijzigingen, geen wijziging aan
werkpakketten of hun discipline-toewijzing.

## Waarom

De huidige volgorde van de swimlanes volgt de categorie-indeling uit het
position paper met losse onderzoeksvragen, maar weerspiegelt geen
roadmap-logica voor RegelRecht zelf. De nieuwe volgorde loopt van de
categorieën waar we de meeste invloed op hebben en die het meest relevant voor
ons zijn, naar de categorieën met de minste invloed en relevantie.

## Test plan

- [ ] `just docs-build`
- [ ] `just docs` en `/roadmap` handmatig bekijken — swimlane-volgorde klopt