### PR TITLE
feat(editor): maak "Beoordelen" in de takenlijst een echte link

### DIFF
--- a/frontend/src/components/TasksListPane.test.js
+++ b/frontend/src/components/TasksListPane.test.js
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
+// De echte app-router, alleen voor `resolve` in de router-stub verderop: de
+// href van het Beoordelen-item hoort uit de route-definities van de app te
+// komen, niet uit een handgemaakte url.
+import appRouter from '../router.js';
 
 // nldd-sheet compileert tot een kaal custom element; de details-sheet stuurt
 // het imperatief aan met show()/hide(). Zelfde stub als MobileTrajectSheet.test.js.
@@ -15,9 +19,14 @@ beforeAll(() => {
 });
 
 // Route useTasks.js's network leg through a controllable spy - same pattern
-// as useTasks.test.js.
+// as useTasks.test.js. Only apiFetch is replaced; the rest of the package
+// stays real, because the app router (imported above) pulls useAuth from it
+// through AppShell.
 const apiFetch = vi.fn();
-vi.mock('@regelrecht/frontend-shared', () => ({ apiFetch: (...a) => apiFetch(...a) }));
+vi.mock('@regelrecht/frontend-shared', async (importOriginal) => ({
+  ...(await importOriginal()),
+  apiFetch: (...a) => apiFetch(...a),
+}));
 
 // De pane vertaalt law_ids naar weergavenamen via useCorpusLaws; dat is de
 // tweede netwerkpoot (zelfde mock-vorm als useCorpusLaws.test.js).
@@ -27,11 +36,15 @@ vi.mock('../lib/apiFetch.js', () => ({
   apiFetch: (...a) => apiFetch(...a),
 }));
 
-// The component navigates on "Beoordelen" via vue-router; stub it so the
+// The component navigates on "Beoordelen" via vue-router; stub `push` so the
 // pane mounts without a real router (route-building itself is verified
-// against the real router in ../lib/taskReview.test.js).
+// against the real router in ../lib/taskReview.test.js). `resolve` is the real
+// one, so the item's href is the url the app would produce.
 const pushMock = vi.fn();
-vi.mock('vue-router', () => ({ useRouter: () => ({ push: pushMock }) }));
+vi.mock('vue-router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRouter: () => ({ push: pushMock, resolve: (target) => appRouter.resolve(target) }),
+}));
 
 const DOC_TASK = {
   id: 't5',
@@ -102,10 +115,32 @@ describe('TasksListPane', () => {
   function itemLabels(wrapper) {
     return menuItems(wrapper).map((i) => i.attributes('text'));
   }
-  async function selectItem(wrapper, text) {
+  function findItem(wrapper, text) {
     const item = menuItems(wrapper).find((i) => i.attributes('text') === text);
     if (!item) throw new Error(`Geen menu-item "${text}" - wel: ${itemLabels(wrapper).join(', ')}`);
-    await item.trigger('select');
+    return item;
+  }
+  async function selectItem(wrapper, text) {
+    await findItem(wrapper, text).trigger('select');
+  }
+
+  // Een echte klik op een nldd-menu-item loopt in deze volgorde: capture-fase
+  // op het host-element, dan de click-handler ín het item (die `select` vuurt,
+  // composed + bubbles), dan de bubble-fase op het host-element. Hier is het
+  // item een onbekend element zonder shadow root (het ontwerpsysteem wordt in
+  // deze test niet geladen), dus staat dat "binnenwerk" als tijdelijke
+  // kindnode die het select-event vuurt - alleen zo loopt het select-pad écht
+  // tussen beide click-fases door.
+  function clickItem(item, init = {}) {
+    const inner = document.createElement('span');
+    item.element.appendChild(inner);
+    inner.addEventListener('click', () => {
+      inner.dispatchEvent(new CustomEvent('select', { bubbles: true, composed: true }));
+    });
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true, ...init });
+    inner.dispatchEvent(event);
+    inner.remove();
+    return event;
   }
 
   it('geeft elke rij één Acties-knop in plaats van losse knoppen', async () => {
@@ -212,9 +247,67 @@ describe('TasksListPane', () => {
     const wrapper = await mountPane([
       { id: 't3', task_type: 'job_review', title: 'Verrijking beoordelen: ???', payload: {} },
     ]);
-    const item = menuItems(wrapper).find((i) => i.attributes('text') === 'Beoordelen');
+    const item = findItem(wrapper, 'Beoordelen');
     expect(item.attributes('disabled')).toBeDefined();
+    // Geen href: zonder bestemming is er niets om naartoe te linken, en een
+    // disabled item blijft een <button>. Zo ontstaat er geen kapotte link.
+    expect(item.attributes('href')).toBeUndefined();
     await item.trigger('select');
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  // --- Beoordelen is een echte link ---
+
+  it('geeft Beoordelen de href van de editor-route, met het artikel als de taak er een noemt', async () => {
+    const wrapper = await mountPane([LAW_TASK]);
+    expect(findItem(wrapper, 'Beoordelen').attributes('href')).toBe(
+      '/trajecten/traject-abcd1234/editor/test_wet?task=t2',
+    );
+
+    const withArticle = await mountPane([
+      { ...LAW_TASK, id: 't2a', payload: { ...LAW_TASK.payload, article: '2' } },
+    ]);
+    expect(findItem(withArticle, 'Beoordelen').attributes('href')).toBe(
+      '/trajecten/traject-abcd1234/editor/test_wet/2?task=t2a',
+    );
+  });
+
+  it('geeft Beoordelen op een document-review de href van de werkdocumenten-route', async () => {
+    const wrapper = await mountPane([DOC_TASK]);
+    expect(findItem(wrapper, 'Beoordelen').attributes('href')).toBe(
+      '/trajecten/traject-abcd1234/werkdocumenten/bijv-rapport.md?task=t5',
+    );
+  });
+
+  it('houdt een gewone klik op Beoordelen bij de router - geen page load', async () => {
+    const wrapper = await mountPane([LAW_TASK]);
+    const event = clickItem(findItem(wrapper, 'Beoordelen'));
+    // preventDefault: anders volgt de browser de href en herlaadt de hele app.
+    expect(event.defaultPrevented).toBe(true);
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    expect(pushMock).toHaveBeenCalledWith({
+      name: 'editor-traject',
+      params: { trajectRef: 'traject-abcd1234', lawId: 'test_wet' },
+      query: { task: 't2' },
+    });
+  });
+
+  it('laat een ctrl/cmd/shift-klik en een middenklik aan de browser - navigeert niet zelf', async () => {
+    const wrapper = await mountPane([LAW_TASK]);
+    for (const init of [
+      { ctrlKey: true },
+      { metaKey: true },
+      { shiftKey: true },
+      { altKey: true },
+      // Middenklik vuurt in de praktijk auxclick, maar een click met button=1
+      // hoort net zo goed niet door ons afgevangen te worden.
+      { button: 1 },
+    ]) {
+      const event = clickItem(findItem(wrapper, 'Beoordelen'), init);
+      expect(event.defaultPrevented).toBe(false);
+    }
+    // Ook het select-event dat het menu-item bij zo'n klik meestuurt mag niet
+    // alsnog het huidige tabblad meenemen.
     expect(pushMock).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/components/TasksListPane.test.js
+++ b/frontend/src/components/TasksListPane.test.js
@@ -249,9 +249,13 @@ describe('TasksListPane', () => {
     ]);
     const item = findItem(wrapper, 'Beoordelen');
     expect(item.attributes('disabled')).toBeDefined();
-    // Geen href: zonder bestemming is er niets om naartoe te linken, en een
-    // disabled item blijft een <button>. Zo ontstaat er geen kapotte link.
-    expect(item.attributes('href')).toBeUndefined();
+    // Geen bruikbare href: zonder bestemming is er niets om naartoe te linken,
+    // dus houdt het ontwerpsysteem het item op de <button>-tak en ontstaat er
+    // geen kapotte link. Niet `toBeUndefined()`: in deze test is het item een
+    // onbekend element en verdwijnt het attribuut, maar in de app reflecteert
+    // een opgewaardeerde nldd-menu-item zijn lege standaardwaarde terug als
+    // `href=""`. Leeg óf afwezig is wat telt - beide vallen op de button-tak.
+    expect(item.attributes('href')).toBeFalsy();
     await item.trigger('select');
     expect(pushMock).not.toHaveBeenCalled();
   });
@@ -309,6 +313,13 @@ describe('TasksListPane', () => {
     // Ook het select-event dat het menu-item bij zo'n klik meestuurt mag niet
     // alsnog het huidige tabblad meenemen.
     expect(pushMock).not.toHaveBeenCalled();
+
+    // En het overslaan geldt alleen voor die klik: een select zónder klik
+    // erachter (het menu activeert een item programmatisch als je op het ene
+    // item indrukt en op het andere loslaat) moet daarna gewoon weer
+    // navigeren. Zonder de terugzetter zou dat pad hierna dood blijven.
+    await selectItem(wrapper, 'Beoordelen');
+    expect(pushMock).toHaveBeenCalledTimes(1);
   });
 
   // --- Probeer opnieuw: één bedoeling, twee mechanieken ---

--- a/frontend/src/components/TasksListPane.vue
+++ b/frontend/src/components/TasksListPane.vue
@@ -139,6 +139,55 @@ function review(task) {
   router.push(target);
 }
 
+// Beoordelen is een echte link en geen knop: de bestemming is volledig
+// deep-linkbaar (alle review-logica hangt aan de URL - EditorView leest
+// `?task=` bij binnenkomst - en de klik zelf doet niets anders dan navigeren),
+// dus hoort hij ook te doen wat een link doet: middenklik, ctrl/cmd-klik,
+// "open in nieuw tabblad", "kopieer linkadres". nldd-menu-item rendert met een
+// `href` een <a> met dezelfde role="menuitem", dus de ARIA van het menu blijft
+// gelijk. Een taak zonder bruikbare bestemming krijgt geen href: `disabled`
+// houdt het item dan op de <button>-tak, dus er is geen kapotte link.
+// `router.resolve` bouwt de url, zodat de route-definitie de enige bron van
+// waarheid blijft (geen handgemaakte url-strings).
+function reviewHref(task) {
+  const target = reviewTarget(task);
+  return target ? router.resolve(target).href : undefined;
+}
+
+// Een gewone klik moet SPA-navigatie blijven; het menu-item doet zelf geen
+// preventDefault, dus zonder deze guard herlaadt de browser de hele pagina.
+// Hetzelfde patroon als router-link: alleen een onbewerkte primaire klik
+// afvangen, de rest aan de browser laten (nieuw tabblad/venster).
+//
+// De guard hangt in de capture-fase op het host-element, dus vóór de
+// click-handler in de shadow root van het item. Die handler vuurt `select`, en
+// dat pad navigeert ook (zie hieronder) - bij een ctrl-klik zou je anders in
+// het nieuwe tabblad én in het huidige belanden. `activatedByClick` markeert
+// dat er een echte klik in het spel is; de bubble-fase (die ná `select` komt)
+// zet 'm weer terug.
+let activatedByClick = false;
+function onReviewClickCapture(event, task) {
+  activatedByClick = true;
+  if (event.defaultPrevented || event.button !== 0) return;
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+  event.preventDefault();
+  review(task);
+}
+function onReviewClick() {
+  activatedByClick = false;
+}
+
+// `select` zonder klik erachter is een programmatische activatie door het menu
+// zelf - pointerdown op het ene item en loslaten op het andere, of een
+// aanroep van item.select(). Er is dan geen link-navigatie die het overneemt,
+// dus doen we het hier. Enter op een gefocust item loopt wél via een echte
+// click (het menu heeft geen eigen Enter-afhandeling), en dus via de guard
+// hierboven.
+function onReviewSelect(task) {
+  if (activatedByClick) return;
+  review(task);
+}
+
 // "Bekijk document" op een lopende conversie: de .md bestaat nog niet, dus we
 // willen de job-weergave ("Aan het converteren…"), niet het document. Via een
 // emit i.p.v. router.push, zodat LibraryView viewingJobPath vóór de navigatie
@@ -193,10 +242,14 @@ function viewLaw(job) {
                 <nldd-menu-item text="Probeer opnieuw" @select="retry(task)"></nldd-menu-item>
               </template>
               <template v-else>
+                <!-- Echte link: zie reviewHref/onReviewClickCapture hierboven. -->
                 <nldd-menu-item
                   text="Beoordelen"
+                  :href="reviewHref(task)"
                   :disabled="!reviewTarget(task) || undefined"
-                  @select="review(task)"
+                  @click.capture="onReviewClickCapture($event, task)"
+                  @click="onReviewClick()"
+                  @select="onReviewSelect(task)"
                 ></nldd-menu-item>
               </template>
               <nldd-menu-divider></nldd-menu-divider>

--- a/frontend/src/components/TasksListPane.vue
+++ b/frontend/src/components/TasksListPane.vue
@@ -182,7 +182,11 @@ function onReviewClick() {
 // aanroep van item.select(). Er is dan geen link-navigatie die het overneemt,
 // dus doen we het hier. Enter op een gefocust item loopt wél via een echte
 // click (het menu heeft geen eigen Enter-afhandeling), en dus via de guard
-// hierboven.
+// hierboven. Spatie niet: dat activeert een <a> nergens op het web, terwijl de
+// <button>-takken van de andere items er wél op reageren. Dat verschil hoort
+// bij het ontwerpsysteem (het rendert de href-tak), niet bij dit component -
+// hier het gedrag van één item nabouwen zou het juist uit de pas laten lopen
+// met elk ander link-menu-item.
 function onReviewSelect(task) {
   if (activatedByClick) return;
   review(task);


### PR DESCRIPTION
## Wat

"Beoordelen" in de takenlijst (`/trajecten/{ref}/taken`) was een menu-item dat `router.push()` deed. Het is nu een echte `<a href>` die bij een gewone klik nog steeds SPA-navigatie doet.

## Waarom

De bestemming is volledig deep-linkbaar: alle review-logica hangt aan de URL (de editor leest `?task=` bij binnenkomst en seedt het voorgestelde artikel), en de klik zelf deed niets anders dan navigeren — geen API-call, geen state-mutatie. Als knop miste hij wel alles wat een link wél kan: middenklik, ctrl/cmd-klik, "open in nieuw tabblad", "kopieer linkadres", en voor een screenreader was het een knop in plaats van navigatie.

## Hoe

- De href komt uit `router.resolve(reviewTarget(task)).href`, dus de route-definities blijven de enige bron van de bestemming; er wordt geen url-string met de hand gebouwd.
- `nldd-menu-item` rendert met een `href` een `<a>` met dezelfde `role="menuitem"` als de button-tak, dus de ARIA van `nldd-menu` blijft geldig en de toetsenbordnavigatie (pijltjes, Enter, Escape, focusvolgorde) verandert niet.
- Een taak zonder bruikbare bestemming (`reviewTarget()` is `null`) blijft `disabled` en krijgt geen href — het item blijft dan een `<button>`, dus er ontstaat geen kapotte link.
- Een gewone klik blijft router-navigatie: een guard in de capture-fase vangt de onbewerkte primaire klik af en pusht zelf (hetzelfde patroon als `router-link`). Ctrl/cmd/shift/alt-klik en middenklik blijven aan de browser. De capture-fase is nodig omdat het menu-item zelf `select` vuurt vanuit zijn click-handler: zonder die volgorde zou een ctrl-klik zowel een nieuw tabblad openen als het huidige tabblad meenemen. Het select-pad blijft bestaan voor de programmatische activatie van het menu zelf (pointerdown op het ene item, loslaten op het andere).

Geen version bump nodig: `href` zit al in de gepinde versie van het ontwerpsysteem.

## Tests

`frontend/src/components/TasksListPane.test.js` dekt nu de href-opbouw voor beide varianten (wet-review met en zonder artikel, document-review), de disabled-tak zonder href, de gewone klik (preventDefault + `router.push`) en de bewerkte klikken (browser doet het, geen dubbele navigatie). De hele vitest-suite van `frontend/` is groen (813 tests).