### PR TITLE
docs(docs): herschik volgorde van disciplines (swimlanes) op de roadmap

### DIFF
--- a/docs/src/data/roadmap-config.json
+++ b/docs/src/data/roadmap-config.json
@@ -38,9 +38,9 @@
       "ondertitel": "Van standaarden naar intelligente tooling"
     },
     {
-      "id": "recht",
-      "naam": "Recht & Instituties",
-      "ondertitel": "Van kaders naar herinrichting van de macht"
+      "id": "service-design",
+      "naam": "Service Design",
+      "ondertitel": ""
     },
     {
       "id": "mensen",
@@ -48,14 +48,14 @@
       "ondertitel": "Van competenties naar een interdisciplinaire cultuur"
     },
     {
+      "id": "recht",
+      "naam": "Recht & Instituties",
+      "ondertitel": "Van kaders naar herinrichting van de macht"
+    },
+    {
       "id": "ethiek",
       "naam": "Ethiek & Waarden",
       "ondertitel": "Van principes naar toetsbare waarborgen"
-    },
-    {
-      "id": "service-design",
-      "naam": "Service Design",
-      "ondertitel": ""
     }
   ]
 }


### PR DESCRIPTION
Vervangt #1324, met ongewijzigde inhoud: dezelfde commit van Abram, cherry-gepickt en ondertekend, want main eist ondertekende commits en de fork-commit is dat niet (zelfde situatie als #1323/#1332).

Zet de disciplines in de volgorde techniek, service-design, mensen, recht, ethiek. Sluit aan op de herziening uit #1332, die service-design vulde met drie werkpakketten.
