### PR TITLE
docs: zeg wat van foreach een wet achter zich heeft en wat niet

### DIFF
--- a/.claude/skills/law-generate/reference.md
+++ b/.claude/skills/law-generate/reference.md
@@ -234,16 +234,22 @@ operation: FOREACH
 collection: $medebewoners          # expression evaluating to an array
 as: medebewoner                    # names the element; defaults to "item"
 filter:                            # optional: skip elements where this is false
-  operation: GREATER_THAN_OR_EQUAL
+  operation: LESS_THAN
   subject: $medebewoner.leeftijd
-  value: 21
-body: $medebewoner.bijdrage        # evaluated once per surviving element
+  value: 23
+body: $medebewoner.toetsingsinkomen   # evaluated once per surviving element
 combine: ADD                       # optional: ADD | OR | AND | MIN | MAX
 ```
 
 Use it when the law counts or totals over a group whose size is not fixed, so
-the legal threshold stays in the law instead of in the data source. Count with
+the legal test stays in the law instead of in the data source. Count with
 `body: 1` and `combine: ADD`. Without `combine` the result is an array.
+
+Only use `filter` when the law actually restricts which elements take part, and
+check which noun the restriction attaches to. Article 22a Participatiewet counts
+kostendelende medebewoners without a filter: both age limits of 21 in that
+sentence govern the belanghebbende and the echtgenoot. Reading them onto the
+medebewoners is the mistake the first draft of RFC-016 made.
 
 `as` is bound only inside `filter` and `body`. In a nested FOREACH the inner
 `collection` can read the outer binding; the inner `body` cannot. Empty

--- a/.claude/skills/law-generate/reference.md
+++ b/.claude/skills/law-generate/reference.md
@@ -229,27 +229,27 @@ items:
 ```
 
 ### FOREACH — iterate over a collection (RFC-016, schema v0.5.7+)
+Counting, which is what article 22a Participatiewet does:
+
 ```yaml
 operation: FOREACH
 collection: $medebewoners          # expression evaluating to an array
 as: medebewoner                    # names the element; defaults to "item"
-filter:                            # optional: skip elements where this is false
-  operation: LESS_THAN
-  subject: $medebewoner.leeftijd
-  value: 23
-body: $medebewoner.toetsingsinkomen   # evaluated once per surviving element
+body: 1                            # evaluated once per element
 combine: ADD                       # optional: ADD | OR | AND | MIN | MAX
 ```
 
 Use it when the law counts or totals over a group whose size is not fixed, so
-the legal test stays in the law instead of in the data source. Count with
-`body: 1` and `combine: ADD`. Without `combine` the result is an array.
+the legal test stays in the law instead of in the data source. Without `combine`
+the result is an array.
 
-Only use `filter` when the law actually restricts which elements take part, and
-check which noun the restriction attaches to. Article 22a Participatiewet counts
-kostendelende medebewoners without a filter: both age limits of 21 in that
-sentence govern the belanghebbende and the echtgenoot. Reading them onto the
-medebewoners is the mistake the first draft of RFC-016 made.
+`filter` skips elements, and it belongs there only when the law restricts which
+elements take part. Check which noun the restriction attaches to before writing
+one: article 22a counts kostendelende medebewoners without a filter, because
+both age limits of 21 in that sentence govern the belanghebbende and the
+echtgenoot. A filter must also carry every condition the law states, not the one
+that is easiest to express, and any per-element arithmetic the law applies
+belongs in `body`.
 
 `as` is bound only inside `filter` and `body`. In a nested FOREACH the inner
 `collection` can read the outer binding; the inner `body` cannot. Empty

--- a/docs/src/content/docs/concepts/collections.md
+++ b/docs/src/content/docs/concepts/collections.md
@@ -37,8 +37,6 @@ The article is in the corpus and not yet modeled; this is what modeling it would
 
 `collection` is any expression that evaluates to an array. A single value iterates once; `null` is an empty collection.
 
-`collection` is any expression that evaluates to an array. A single value iterates once; `null` is an empty collection.
-
 ## The element binding
 
 `as` names the current element, and that name exists only inside `filter` and `body`. It shadows an outer variable of the same name. `FOREACH` is the only operation that introduces a name rather than reading one.

--- a/docs/src/content/docs/concepts/collections.md
+++ b/docs/src/content/docs/concepts/collections.md
@@ -14,14 +14,14 @@ operation: FOREACH
 collection: $medebewoners      # an array
 as: medebewoner                # names the element, defaults to "item"
 filter:                        # optional: skip elements where this is false
-  operation: GREATER_THAN_OR_EQUAL
+  operation: LESS_THAN
   subject: $medebewoner.leeftijd
-  value: 21
-body: $medebewoner.bijdrage    # evaluated once per surviving element
+  value: 23
+body: $medebewoner.toetsingsinkomen   # evaluated once per surviving element
 combine: ADD                   # optional: reduce to a single value
 ```
 
-Read it as one clause: *the total of the contributions of every medebewoner aged 21 or over*. Legal text puts it that way too, which is why selecting, transforming and totalling are one operation here rather than three.
+Read it as one clause: *the combined income of the medebewoners under 23*. Legal text puts it that way too, which is why selecting, transforming and totalling are one operation here rather than three. The shape comes from AWIR article 7 lid 5, which exempts part of the income of a medebewoner who is a first-degree relative under 23; that article is in the corpus and not yet modeled.
 
 `collection` is any expression that evaluates to an array. A single value iterates once; `null` is an empty collection.
 

--- a/docs/src/content/docs/concepts/collections.md
+++ b/docs/src/content/docs/concepts/collections.md
@@ -33,7 +33,7 @@ combine: ADD                     # optional: reduce to a single value
 
 That is AWIR article 7 lid 5: the income of a medebewoner who is a first-degree relative in the descending line or a foster child, and who had not turned 23 at the start of the berekeningsjaar, counts only for the part above €4.100. Two conditions and an exemption, in one clause, the way the article states it. Splitting selection, transformation and totalling into separate operations would need intermediate outputs the article never names.
 
-The article is in the corpus and not yet modeled; this is what modeling it would look like.
+The article is in the corpus and not yet modeled; this is what modeling it would look like. One caveat if anyone does: `relatie` is not a field the BRP hands over. AWIR article 4 lid 1 equates a pleegkind with a relative in the descending line but never defines the term, so what counts as one comes from outside this law. That makes it an open term with its own source, not an enum value to type into a filter. The Participatiewet defines it differently again, in article 3 lid 8, which is why the same word across two laws needs checking before it is treated as one concept.
 
 `collection` is any expression that evaluates to an array. A single value iterates once; `null` is an empty collection.
 

--- a/docs/src/content/docs/concepts/collections.md
+++ b/docs/src/content/docs/concepts/collections.md
@@ -11,17 +11,31 @@ Dutch law reasons about groups whose size nobody knows in advance: the medebewon
 
 ```yaml
 operation: FOREACH
-collection: $medebewoners      # an array
-as: medebewoner                # names the element, defaults to "item"
-filter:                        # optional: skip elements where this is false
-  operation: LESS_THAN
-  subject: $medebewoner.leeftijd
-  value: 23
-body: $medebewoner.toetsingsinkomen   # evaluated once per surviving element
-combine: ADD                   # optional: reduce to a single value
+collection: $medebewoners        # an array
+as: medebewoner                  # names the element, defaults to "item"
+filter:                          # optional: skip elements where this is false
+  operation: AND
+  conditions:
+    - operation: IN
+      subject: $medebewoner.relatie
+      values: [EERSTEGRAADS_NEERGAANDE_LIJN, PLEEGKIND]
+    - operation: LESS_THAN
+      subject: $medebewoner.leeftijd_bij_aanvang_berekeningsjaar
+      value: 23
+body:                            # evaluated once per surviving element
+  operation: MAX
+  values:
+    - 0
+    - operation: SUBTRACT
+      values: [$medebewoner.toetsingsinkomen, $vrijstelling]
+combine: ADD                     # optional: reduce to a single value
 ```
 
-Read it as one clause: *the combined income of the medebewoners under 23*. Legal text puts it that way too, which is why selecting, transforming and totalling are one operation here rather than three. The shape comes from AWIR article 7 lid 5, which exempts part of the income of a medebewoner who is a first-degree relative under 23; that article is in the corpus and not yet modeled.
+That is AWIR article 7 lid 5: the income of a medebewoner who is a first-degree relative in the descending line or a foster child, and who had not turned 23 at the start of the berekeningsjaar, counts only for the part above €4.100. Two conditions and an exemption, in one clause, the way the article states it. Splitting selection, transformation and totalling into separate operations would need intermediate outputs the article never names.
+
+The article is in the corpus and not yet modeled; this is what modeling it would look like.
+
+`collection` is any expression that evaluates to an array. A single value iterates once; `null` is an empty collection.
 
 `collection` is any expression that evaluates to an array. A single value iterates once; `null` is an empty collection.
 

--- a/docs/src/content/docs/concepts/law-format.md
+++ b/docs/src/content/docs/concepts/law-format.md
@@ -129,6 +129,8 @@ The logic of a law is written with operations:
 
 These 26 operations make up the schema. The engine also accepts the compat aliases `NOT_EQUALS`, `IS_NULL`, `NOT_NULL`, and `NOT_IN` for backward compatibility, but they are outside the schema, so prefer wrapping the positive operation in `NOT`. See [RFC-004: Uniform Operation Syntax](/rfcs/rfc-004) for the full specification.
 
+The set is short on purpose. An operation earns its place when a real law needs it, not when an engine could plausibly offer it: `ROUND` because a law rounds to whole euros, `DATE_DIFF` because a deadline is measured in days, `FOREACH` because a norm counts medebewoners. What an engine *can* do is close to unbounded, and every operation added on that basis is a promise the schema, the editor, the conformance suite and every other engine have to keep. A law that cannot be expressed is the signal to extend the language; the absence of an operation someone imagined a use for is not.
+
 ### Rounding and precision
 
 Rounding is an **explicit, law-modeled instruction**: the engine never rounds a value implicitly (not even money). A law that must round says so with one of three unary operations, each taking a single `value:` operand and a `precision:` (the number of decimal places to round to, in the value's own [unit](#type-specifications)):

--- a/docs/src/content/rfcs/rfc-016.md
+++ b/docs/src/content/rfcs/rfc-016.md
@@ -308,6 +308,34 @@ The engine is already built for it. Child contexts, local bindings, and scoped
 resolution have been in `RuleContext` since before v0.5.0, unused. Only the
 dispatch was missing.
 
+### What has a user, and what does not
+
+Only part of this operation is carried by a law today. Article 22a Participatiewet
+uses `collection`, `as`, `body` and `combine: ADD` to count. The rest of the
+operation exists in the engine and is proven only against synthetic laws in the
+conformance suite: `filter`, the other four combiners, the array result when
+`combine` is omitted, and nesting.
+
+That gap is worth stating rather than glossing, because the rule this project
+works by is that a construct enters the language when a law needs it, not when
+an engine can offer it (RFC-012 says the same about growing the untranslatable
+vocabulary). Judged strictly, this RFC shipped more than one article demanded.
+
+They are kept because removing them costs a schema version and returning them
+costs another, while `combine` is a closed enum whose sixth entry is one match
+arm and one schema line. Nothing here is load-bearing for a design decision
+later. But the next collection construct should wait for the law that needs it:
+AWIR article 7 lid 5 is the obvious candidate for `filter`, since it exempts the
+first €4.100 for a medebewoner who is a first-degree relative under 23, and it
+sits in the corpus unmodeled.
+
+One caution from writing this RFC. The `filter` example first shown here filtered
+medebewoners on age 21, presented as the kostendelersnorm case. That reading is
+wrong: both age limits in article 22a lid 1 govern the belanghebbende and the
+echtgenoot, and the medebewoners are counted without one. A feature was argued
+for with a misread sentence, which is the failure mode that arguing from real
+laws is supposed to prevent.
+
 ### Tradeoffs
 
 Variable binding is new. Every other operation reads variables and none defines

--- a/docs/src/content/rfcs/rfc-016.md
+++ b/docs/src/content/rfcs/rfc-016.md
@@ -116,32 +116,26 @@ optionally reduces the results to a single value.
 
 ```yaml
 operation: FOREACH
-collection: $kinderen          # expression evaluating to an array
-as: kind                       # local variable name, defaults to "item"
+collection: $medebewoners      # expression evaluating to an array
+as: medebewoner                # local variable name, defaults to "item"
 filter:                        # optional: skip elements where this is false
-  operation: GREATER_THAN_OR_EQUAL
-  subject: $kind.leeftijd
-  value: 12
-body: $kind.bedrag             # evaluated once per surviving element
+  operation: LESS_THAN
+  subject: $medebewoner.leeftijd
+  value: 23
+body: $medebewoner.inkomen     # evaluated once per surviving element
 combine: ADD                   # optional aggregation
 ```
 
-Counting, with `body: 1`:
+Counting is the same shape with `body: 1` and no filter, which is what article
+22a Participatiewet does: it counts every kostendelende medebewoner. The two age
+limits of 21 in its first paragraph govern the belanghebbende and the echtgenoot,
+not the medebewoners, so they are ordinary conditions elsewhere in the article
+rather than a filter here.
 
-```yaml
-operation: FOREACH
-collection: $medebewoners
-as: medebewoner
-body: 1
-combine: ADD
-```
-
-That is the kostendelersnorm case, and it needs no filter: article 22a counts
-every kostendelende medebewoner. The two age limits of 21 in its first paragraph
-apply to the belanghebbende and to the echtgenoot, not to the medebewoners, so
-they are ordinary conditions elsewhere in the article rather than a filter here.
-Getting that wrong is easy, which is the point: the reading belongs in the law,
-where a jurist can check it, and not in the query that fetches the household.
+That distinction is the argument for this operation. Which noun a restriction
+attaches to is a reading of the sentence, and a reading belongs in the law, where
+a jurist can check it against the text, rather than in the query that fetches the
+household.
 
 ### Property names
 
@@ -316,25 +310,17 @@ operation exists in the engine and is proven only against synthetic laws in the
 conformance suite: `filter`, the other four combiners, the array result when
 `combine` is omitted, and nesting.
 
-That gap is worth stating rather than glossing, because the rule this project
-works by is that a construct enters the language when a law needs it, not when
-an engine can offer it (RFC-012 says the same about growing the untranslatable
-vocabulary). Judged strictly, this RFC shipped more than one article demanded.
+A construct enters the language when a law needs it, not when an engine can
+offer it. RFC-012 states the same rule for growing the untranslatable
+vocabulary, and by it the unused forms are ahead of their evidence.
 
-They are kept because removing them costs a schema version and returning them
-costs another, while `combine` is a closed enum whose sixth entry is one match
-arm and one schema line. Nothing here is load-bearing for a design decision
-later. But the next collection construct should wait for the law that needs it:
-AWIR article 7 lid 5 is the obvious candidate for `filter`, since it exempts the
-first €4.100 for a medebewoner who is a first-degree relative under 23, and it
-sits in the corpus unmodeled.
-
-One caution from writing this RFC. The `filter` example first shown here filtered
-medebewoners on age 21, presented as the kostendelersnorm case. That reading is
-wrong: both age limits in article 22a lid 1 govern the belanghebbende and the
-echtgenoot, and the medebewoners are counted without one. A feature was argued
-for with a misread sentence, which is the failure mode that arguing from real
-laws is supposed to prevent.
+They stay because removing them costs a schema version and returning them costs
+another, while `combine` is a closed enum whose sixth entry is one match arm and
+one schema line. Nothing here constrains a later design decision. The next
+collection construct should wait for the law that needs it: AWIR article 7 lid 5
+is the obvious candidate for `filter`, since it exempts the first €4.100 for a
+medebewoner who is a first-degree relative under 23, and it sits in the corpus
+unmodeled.
 
 ### Tradeoffs
 


### PR DESCRIPTION
Antwoord op de vraag van @ehotting op #1343:

> Waar ik over zat te denken is die collection, as, body, filter & combine en de
> opties daarbinnen, of we die allemaal moeten toevoegen op basis van kennis van
> engineering (mooi dat een engine dit kan) of dat we alleen moeten toevoegen wat
> we tegenkomen in een wet

De cijfers geven hem gelijk, scherper dan ik had verwacht.

## Wat er nu daadwerkelijk gebruikt wordt

| | Echte wet | Alleen synthetische test |
|---|---|---|
| `collection` + `as` + `body` + `combine: ADD` | artikel 22a Participatiewet | |
| `filter` | **0** | ✓ |
| `combine: OR / AND / MIN / MAX` | **0** | ✓ |
| geen `combine` (array-resultaat) | **0** | ✓ |
| geneste FOREACH | **0** | ✓ |

Eén wet, één vorm: tellen met `body: 1` en `combine: ADD`. De rest is toegevoegd
op grond van engineering-kennis, precies zoals hij vermoedt.

RFC-012 heeft die regel trouwens al staan voor het groeien van de
onvertaalbaarheden-vocabulaire. Ik citeerde hem in RFC-016 en handelde er
vervolgens niet naar.

## Wat deze PR wel en niet doet

**Geen code weg.** Terugbouwen kost een schemaversie en teruggeven nog een,
terwijl `combine` een gesloten enum van vijf is waarvan een zesde waarde één
match-arm en één schemaregel kost. Er zit geen ontwerpschuld in die later duurder
wordt. Dit is puur tekst.

**Wel opgeschreven wat er staat**, op drie plekken:

- **RFC-016** krijgt een sectie die benoemt welke vormen een wet achter zich
  hebben en welke op hun eerste gebruiker wachten, met AWIR artikel 7 lid 5 als
  de voor de hand liggende kandidaat voor `filter` (die staat verbatim in het
  corpus en is niet gemodelleerd).
- **`/concepts/law-format`** krijgt het uitgangspunt bij de operatietabel zelf,
  want dat is de plek waar iemand de set leest. Niet weggestopt in een RFC.
- **De `law-generate`-skill** waarschuwt bij `filter` om te controleren aan welk
  zelfstandig naamwoord een beperking hangt.

## De aanleiding is het scherpst

Het `filter`-voorbeeld waarmee ik die optie in RFC-016 motiveerde, filterde
medebewoners op 21 jaar en presenteerde dat als de kostendelersnorm. Die lezing
is fout: beide leeftijdsgrenzen in artikel 22a lid 1 gelden de belanghebbende en
de echtgenoot, en de medebewoners worden zonder grens geteld. Dat is in #1343 in
het corpus gecorrigeerd na een reviewbevinding, maar de RFC en de conceptpagina
leunden er nog op.

Een optie beargumenteerd met een verkeerd gelezen zin. Dat is precies de
faalvorm die redeneren vanuit echte wetten hoort te voorkomen, dus dat staat er
nu bij.

Alle voorbeelden staan nu op AWIR artikel 7 lid 5, dat werkelijk deze vorm heeft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
