### PR TITLE
feat(docs): bespreek een passage uit een paper op GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+---
+# This directory holds the repository's only issue form, so its mere presence
+# switches every new issue from a blank body to the template chooser. Keeping
+# the blank option enabled is deliberate: the form is for one narrow case
+# (feedback on a published paper) and everything else in this repo is still an
+# ordinary issue.
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/paper-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/paper-feedback.yml
@@ -1,0 +1,57 @@
+---
+# Feedback on a published paper. Reached from the "Discuss this passage"
+# button on a paper page (docs/src/layouts/Base.astro), which prefills the
+# passage and source fields from the reader's text selection; it is also
+# usable directly from the issue chooser with those fields left empty.
+#
+# Papers under docs/src/research/ are frozen published artifacts, so this
+# form deliberately collects discussion rather than an edit: the response to
+# a paper is an argument, and where it leads to a change that change belongs
+# in an erratum or a new version, which is the authors' call.
+name: Discuss a paper
+description: Comment on a passage in a published paper
+title: 'paper: '
+labels: [contribution:paper, comp:docs]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reading closely enough to respond.
+
+        Papers here are published work, fixed at the moment they were
+        written, so this is not an edit request: it is a place to argue with
+        a claim, point out an error, or ask a question. Where that leads to a
+        correction, the authors decide whether it becomes an erratum or a new
+        version.
+  - type: input
+    id: paper
+    attributes:
+      label: Paper
+      description: Which paper, and which section.
+      placeholder: Rules as Executed — 2.1 Proactive Service and Known Data
+    validations:
+      required: true
+  - type: textarea
+    id: passage
+    attributes:
+      label: Passage
+      description: The text you are responding to, quoted.
+    validations:
+      required: false
+  - type: textarea
+    id: comment
+    attributes:
+      label: Your comment
+      description: >-
+        What is your point? Disagreement, a question, a factual correction,
+        or a reference we missed are all welcome.
+    validations:
+      required: true
+  - type: input
+    id: source
+    attributes:
+      label: Link
+      description: Link to the passage on the site (filled in automatically).
+      placeholder: https://regelrecht.rijks.app/research/rules-as-executed#sec:introduction
+    validations:
+      required: false

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -1089,17 +1089,35 @@ const legalLinks = [
         // anchor the issue links back to. The generated paper HTML gives every
         // heading a stable id (pandoc's sec: prefixes), so this is a reliable
         // location without any source-line provenance.
-        const nearestHeading = (content, node) => {
+        const nearestHeading = (content, range) => {
           const headings = Array.from(
             content.querySelectorAll('h2[id], h3[id], h4[id]')
           );
+          // An element startContainer addresses a position *between* its
+          // children (startOffset indexes childNodes), so compare from the
+          // child actually at that offset. Without this, a range whose start
+          // is the wrapper itself (what select-all produces) makes every
+          // heading a descendant of `node`, which is CONTAINED_BY and never
+          // FOLLOWING, and the anchor is lost.
+          let node = range.startContainer;
+          if (node.nodeType === Node.ELEMENT_NODE) {
+            node = node.childNodes[range.startOffset] ?? node.lastChild ?? node;
+          }
           let best = null;
           for (const h of headings) {
+            // A selection that starts on (or inside) a heading belongs to that
+            // heading's own section. compareDocumentPosition(h) is 0 against
+            // itself and never FOLLOWING, so without this the passage would be
+            // filed under the *previous* section.
+            if (h === node || h.contains(node)) return h;
             // compareDocumentPosition: heading precedes the selection start.
             const rel = h.compareDocumentPosition(node);
             if (rel & Node.DOCUMENT_POSITION_FOLLOWING) best = h;
           }
-          return best;
+          // A selection starting before the first heading (select-all begins
+          // at the generator comment that opens the pandoc output) has no
+          // preceding heading; the first one is still the right anchor.
+          return best ?? headings[0] ?? null;
         };
 
         const update = () => {
@@ -1121,7 +1139,7 @@ const legalLinks = [
           if (paper) {
             const text = sel.toString().trim();
             if (!text) return hide();
-            const heading = nearestHeading(content, range.startContainer);
+            const heading = nearestHeading(content, range);
             const section = heading
               ? heading.textContent.trim()
               : '';

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -1025,11 +1025,26 @@ const legalLinks = [
       document.addEventListener('astro:page-load', reanchor);
     </script>
 
-    <!-- Select lines in a doc/RFC, jump to GitHub edit at that source range.
-         Pure chrome, no hydration: one floating nldd-button wired to the
-         current text selection. Active only on pages whose content wrapper
-         carries data-edit-base (doc + RFC templates); the source line numbers
-         come from rehype-source-lines (data-line / data-line-end). -->
+    <!-- Selection affordance on prose pages. One floating nldd-button, wired
+         to the current text selection; pure chrome, no hydration.
+
+         Two modes, decided by the content wrapper's attributes:
+
+         - data-edit-base (doc + RFC templates): jump to the GitHub edit view
+           at the selected source range. Line numbers come from
+           rehype-source-lines (data-line / data-line-end).
+         - data-discuss-paper (research papers): open a prefilled "Discuss a
+           paper" issue quoting the selection. Papers are frozen published
+           artifacts, so there is nothing to edit: the reader's response is an
+           argument, and the issue form is where it goes. The location comes
+           from the nearest heading anchor, not from source lines, because the
+           paper HTML is generated (pandoc) and its line numbers point into a
+           build artifact rather than the paper's LaTeX source.
+
+           GitHub resolves ?template= against the DEFAULT BRANCH, so the link
+           only finds the form once .github/ISSUE_TEMPLATE/paper-feedback.yml
+           is on main; on a preview deployment of the branch that adds it, the
+           button lands on the blank issue form instead. -->
     <script>
       // Bound once for the document lifetime: the global listeners
       // (selectionchange, scroll, keydown) survive ClientRouter swaps, and the
@@ -1064,32 +1079,100 @@ const legalLinks = [
           wrap.hidden = true;
         };
 
+        // GitHub prefill values travel in the query string, so a long
+        // selection is truncated: an over-long URL is dropped or mangled by
+        // some browsers, and the anchor link below carries the exact location
+        // regardless. The reader can paste more into the form itself.
+        const MAX_QUOTE = 600;
+
+        // Last heading that precedes the selection start, whose id is the
+        // anchor the issue links back to. The generated paper HTML gives every
+        // heading a stable id (pandoc's sec: prefixes), so this is a reliable
+        // location without any source-line provenance.
+        const nearestHeading = (content, node) => {
+          const headings = Array.from(
+            content.querySelectorAll('h2[id], h3[id], h4[id]')
+          );
+          let best = null;
+          for (const h of headings) {
+            // compareDocumentPosition: heading precedes the selection start.
+            const rel = h.compareDocumentPosition(node);
+            if (rel & Node.DOCUMENT_POSITION_FOLLOWING) best = h;
+          }
+          return best;
+        };
+
         const update = () => {
           // Content wrapper is re-resolved every time: it lives in the swapped
           // <body>, so it changes on each ClientRouter navigation.
-          const content = document.querySelector('[data-edit-base]');
-          const editBase = content && content.getAttribute('data-edit-base');
-          if (!content || !editBase) return hide();
+          const content = document.querySelector(
+            '[data-edit-base], [data-discuss-paper]'
+          );
+          if (!content) return hide();
+          const editBase = content.getAttribute('data-edit-base');
+          const paper = content.getAttribute('data-discuss-paper');
+          if (!editBase && !paper) return hide();
 
           const sel = window.getSelection();
           if (!sel || sel.isCollapsed || sel.rangeCount === 0) return hide();
           const range = sel.getRangeAt(0);
           if (!content.contains(range.commonAncestorContainer)) return hide();
 
-          // Every data-line element the selection touches; min start / max end
-          // gives the source range even across multiple blocks.
-          let min = Infinity;
-          let max = -Infinity;
-          content.querySelectorAll('[data-line]').forEach((el) => {
-            if (!range.intersectsNode(el)) return;
-            const a = Number(el.getAttribute('data-line'));
-            const b = Number(el.getAttribute('data-line-end')) || a;
-            if (a && a < min) min = a;
-            if (b && b > max) max = b;
-          });
-          if (min === Infinity || max === -Infinity) return hide();
+          if (paper) {
+            const text = sel.toString().trim();
+            if (!text) return hide();
+            const heading = nearestHeading(content, range.startContainer);
+            const section = heading
+              ? heading.textContent.trim()
+              : '';
+            const anchor = heading
+              ? `${location.origin}${location.pathname}#${heading.id}`
+              : `${location.origin}${location.pathname}`;
+            const quote =
+              text.length > MAX_QUOTE ? `${text.slice(0, MAX_QUOTE)}…` : text;
+            // Blockquoted so the passage reads as a quotation in the issue.
+            const quoted = quote.replace(/^/gm, '> ');
+            const where = section ? `${paper} — ${section}` : paper;
+            const params = new URLSearchParams({
+              template: 'paper-feedback.yml',
+              title: `paper: ${section || paper}`,
+              // Issue-form fields, addressed by field id. GitHub applies these
+              // only when the template above resolves.
+              paper: where,
+              passage: quoted,
+              source: anchor,
+              // Same content as a plain body, for when it does not: an
+              // unresolved ?template= (the form not yet on the default branch,
+              // renamed, or removed) silently falls back to the blank issue
+              // form, which ignores field ids and would drop the passage
+              // entirely. The blank form honours `body`; the issue form
+              // ignores it. Sending both means the quote survives either way.
+              body: `${quoted}\n\n— ${where}\n${anchor}\n\n`,
+            });
+            btn.setAttribute('text', 'Discuss this passage');
+            btn.setAttribute('start-icon', 'comment');
+            btn.setAttribute(
+              'href',
+              `https://github.com/MinBZK/regelrecht/issues/new?${params}`
+            );
+          } else {
+            // Every data-line element the selection touches; min start / max
+            // end gives the source range even across multiple blocks.
+            let min = Infinity;
+            let max = -Infinity;
+            content.querySelectorAll('[data-line]').forEach((el) => {
+              if (!range.intersectsNode(el)) return;
+              const a = Number(el.getAttribute('data-line'));
+              const b = Number(el.getAttribute('data-line-end')) || a;
+              if (a && a < min) min = a;
+              if (b && b > max) max = b;
+            });
+            if (min === Infinity || max === -Infinity) return hide();
+            btn.setAttribute('text', 'Edit these lines on GitHub');
+            btn.setAttribute('start-icon', 'pencil');
+            btn.setAttribute('href', `${editBase}#L${min}-L${max}`);
+          }
 
-          btn.setAttribute('href', `${editBase}#L${min}-L${max}`);
           const rect = range.getBoundingClientRect();
           if (!rect.width && !rect.height) return hide();
           // Anchor just above the selection start, clamped into the viewport.

--- a/docs/src/pages/research/rules-as-executed.astro
+++ b/docs/src/pages/research/rules-as-executed.astro
@@ -70,7 +70,16 @@ const doiUrl = `https://doi.org/${meta.doi}`;
           <a href={doiUrl}>doi:{meta.doi}</a>
         </p>
         <p class="rr-paper-note">{meta.note}</p>
-        <Fragment set:html={paperHtml} />
+        {/*
+         * data-discuss-paper turns on the selection affordance in Base.astro:
+         * selecting text offers "Discuss this passage", which opens a
+         * prefilled issue. The value names the paper in the issue title.
+         * Scoped to the paper body so a selection in the byline above (authors,
+         * emails, DOI) does not offer to discuss a passage.
+         */}
+        <div data-discuss-paper={meta.title}>
+          <Fragment set:html={paperHtml} />
+        </div>
       </nldd-rich-text>
     </div>
   </nldd-one-third-two-thirds-section>


### PR DESCRIPTION
Op docs- en RFC-pagina's kun je tekst selecteren en krijg je "Edit these
lines on GitHub". Deze PR brengt diezelfde affordance naar de
research-pagina, maar met een andere uitkomst: "Discuss this passage",
dat een voorgevulde issue opent met de geselecteerde passage als citaat.

## Waarom niet dezelfde bewerklink

De bestaande knop werkt omdat de bron van een doc of RFC markdown in deze
repo is, en `rehype-source-lines` per blok regelnummers meegeeft. Bij een
paper gaat dat niet op:

* `docs/src/research/rules-as-executed.html` is een gegenereerd
  pandoc-artefact. De LaTeX-bron staat in een andere repo. Een
  bewerking in het artefact verdwijnt bij de volgende `just html`.
* CLAUDE.md zegt dat een gepubliceerd paper bevroren is. Een
  bewerkaffordance nodigt precies uit tot de drift die die regel
  tegenhoudt.
* Het paper is co-auteurschap en staat onder een DOI. Openzetten voor
  bewerking is geen eenzijdige keuze.

Een lezer die op een paper reageert wil ook geen typo fixen maar iets
zeggen: een tegenwerping, een vraag, een gemiste referentie. Dat is een
issue, geen pull request.

## Hoe het werkt

De selectiescript in `Base.astro` heeft nu twee modi, bepaald door het
attribuut op de content-wrapper. `data-edit-base` blijft ongewijzigd
werken op docs en RFC's. `data-discuss-paper` opent een voorgevulde issue.

De locatie komt van het dichtstbijzijnde kopanker in plaats van
regelnummers. Pandoc zet al een `sec:`-id op elke kop, dus daar is niets
voor nodig in het gegenereerde bestand.

Nieuw issueformulier `.github/ISSUE_TEMPLATE/paper-feedback.yml`
("Discuss a paper"), met label `contribution:paper` (nieuw, naar het
voorbeeld van `contribution:rfc`) en `comp:docs`.

## Twee keer dezelfde inhoud

De passage gaat mee als formuliervelden en als gewone `body`. GitHub lost
`?template=` op tegen de default branch; lukt dat niet, dan valt het stil
terug op het lege issueformulier, dat veld-ids negeert. Zonder die `body`
verdwijnt het citaat dan zonder melding. Dit is in de praktijk
tegengekomen, niet bedacht.

Gevolg voor het testen: op een preview deployment vindt de knop het
formulier nog niet, want dat leest van `main`. Daar krijg je de
body-terugval. Na merge werkt het volledige formulier.

## Getest

In de browser op de gebouwde site:

* Selectie in een paragraaf geeft de juiste sectie, een blockquote-citaat
  en een deeplink naar het kopanker.
* Selectie in de byline (auteurs, e-mail, DOI) geeft de knop niet.
* Selectie van het hele paper kapt af op 600 tekens; de URL blijft 853
  tekens en elke regel blijft geciteerd.
* Lege selectie verbergt de knop.
* RFC-pagina's houden het potlood-icoon, de oude tekst en een
  `#L<a>-L<b>`-URL. Geen regressie.

## Ontwerpsysteem

Geen extra CSS. Hergebruikt de bestaande `#rr-edit-selection`-wrapper en
`nldd-button`. Het icoon `comment` is de alias voor
`message-rectangle-text`, conform de aliasregel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RT4jW4TjpwQxTscUq6h1qZ
