### PR TITLE
docs: verwijs vanuit de RFC's naar het position paper

### DIFF
--- a/docs/src/content/rfcs/rfc-002.md
+++ b/docs/src/content/rfcs/rfc-002.md
@@ -92,4 +92,5 @@ competent_authority:
 - Issue #7: Good enough Language for 1st fase Editor and Engine
 - PR #30 Discussion
 - Art. 1:1 Awb (definition of administrative body (*bestuursorgaan*))
+- [Rules as Executed, section 4.3](/research/rules-as-executed#sec:whochooses), the position paper on who interprets the law for execution and who publishes that interpretation
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-007.md
+++ b/docs/src/content/rfcs/rfc-007.md
@@ -631,4 +631,6 @@ This matters for multi-output evaluation: when a caller requests specific output
 - Vreemdelingenwet artikel 69: https://wetten.overheid.nl/BWBR0011823/2024-01-01#Artikel69
 - KB gelijkgestelde dagen 2026-2028: https://zoek.officielebekendmakingen.nl/stcrt-2025-24713.html
 - KB gelijkgestelde dagen 2023-2025: https://zoek.officielebekendmakingen.nl/stcrt-2022-7812.html
+- [Rules as Executed, section 4.9](/research/rules-as-executed#sec:modes), the position paper on the four execution modes
+- [Rules as Executed, section 4.6](/research/rules-as-executed#sec:overrides), the position paper on overrides and discretion
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-008.md
+++ b/docs/src/content/rfcs/rfc-008.md
@@ -471,6 +471,7 @@ Decision (*besluit*) state is external (passed in, returned out), which is compa
 - [PG Awb - Bestuurlijke lus (8:51a-8:51d)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-8/8-2-behandeling-van-het-beroep/8-2-2a-bestuurlijke-lus/)
 - [PG Awb - Afdeling 3.4 UOV](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-3/3-4-uniforme-openbare-voorbereidingsprocedure/)
 - [PG Awb - Artikel 7:1a (rechtstreeks beroep)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-7/7-1-bezwaar-voorafgaand-aan-beroep-bij-de-administratieve-rechter/artikel-71a/)
+- [Rules as Executed, section 4.10](/research/rules-as-executed#sec:lifecycle), the position paper on procedure as a staged lifecycle, and on the objection term running from *bekendmaking*
 - [Glossary of Dutch Legal Terms](/reference/glossary)
 
 ---

--- a/docs/src/content/rfcs/rfc-009.md
+++ b/docs/src/content/rfcs/rfc-009.md
@@ -586,4 +586,6 @@ The data layer, how engines obtain input data, which registries they connect to,
 - [Federated Service Connectivity (FSC) Core specification](https://gitdocumentatie.logius.nl/publicatie/fsc/core/), service discovery, contract-based connectivity, and mTLS authentication
 - [Logboek Dataverwerkingen](https://logius-standaarden.github.io/logboek-dataverwerkingen/), each org logs its own data processing; logs are not exchanged between orgs; citizen can request their logs from each org
 - [W3C Trace Context](https://www.w3.org/TR/trace-context/), standard for propagating trace identifiers across service boundaries
+- [Rules as Executed, section 4.11](/research/rules-as-executed#sec:crossorg), the position paper on executing across organizations
+- [Rules as Executed, section 4.12](/research/rules-as-executed#sec:relying), the position paper on relying on another body's decision
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-011.md
+++ b/docs/src/content/rfcs/rfc-011.md
@@ -128,4 +128,5 @@ ineligible_reason(Person, "te jong") :-
 - [PyDatalog](https://github.com/pcarbonn/pyDatalog): Python Datalog implementation
 - [RuleSpeak](http://www.rulespeak.com/): controlled natural language for business rules
 - [SBVR](https://www.omg.org/spec/SBVR/): Semantics of Business Vocabulary and Rules
+- [Rules as Executed, sections 10.1 and 10.2](/research/rules-as-executed#sec:cnl), the position paper on why controlled natural language and linked data were not chosen
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-012.md
+++ b/docs/src/content/rfcs/rfc-012.md
@@ -135,4 +135,5 @@ Ordering is layer 1 → 2 → 3. Each layer is independently useful.
 
 - [RFC-003: Inversion of Control](/rfcs/rfc-003), IoC pattern for cross-law references
 - [RFC-007: Reactive Execution](/rfcs/rfc-007), hooks and overrides mechanism
+- [Rules as Executed, section 5.4](/research/rules-as-executed#sec:untranslatables), the position paper on publishing what the format cannot yet say
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-013.md
+++ b/docs/src/content/rfcs/rfc-013.md
@@ -404,4 +404,6 @@ See [RFC-007](/rfcs/rfc-007#output-provenance) for the hook provenance model.
 - [W3C PROV Data Model](https://www.w3.org/TR/prov-dm/), provenance standard (Execution Receipt draws on Entity/Activity/Agent model)
 - [Logboek Dataverwerkingen](https://logius-standaarden.github.io/logboek-dataverwerkingen/), Dutch standard for per-organization data processing logs
 - [MDTO](https://www.nationaalarchief.nl/archiveren/mdto), Dutch government metadata standard for durable information access
+- [Rules as Executed, section 4.4](/research/rules-as-executed#sec:attestation), the position paper on attestation: which version ran, on which inputs
+- [Rules as Executed, section 4.5](/research/rules-as-executed#sec:traceaccess), the position paper on the recipient re-executing their own decision
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-014.md
+++ b/docs/src/content/rfcs/rfc-014.md
@@ -325,4 +325,5 @@ A new CI job `conformance` runs alongside the existing `test` job. It uses the `
 - [RFC-013: Execution Provenance](/rfcs/rfc-013), Execution Receipt format (provenance conformance tests)
 - [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite), model for language-agnostic conformance testing
 - [W3C Web Platform Tests](https://web-platform-tests.org/), model for multi-implementation conformance testing at scale
+- [Rules as Executed, section 9.1](/research/rules-as-executed#sec:engines), the position paper on multiple engines and semantic equivalence
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-016.md
+++ b/docs/src/content/rfcs/rfc-016.md
@@ -382,3 +382,4 @@ scaffolding sits unused is a decision to keep laws unmodeled that need not be.
 - Participatiewet, artikel 22a: https://wetten.overheid.nl/BWBR0015703/2022-03-15#Artikel22a
 - Algemene wet inkomensafhankelijke regelingen, artikel 7: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel7
 - Wet op het kindgebonden budget, artikel 2: https://wetten.overheid.nl/BWBR0022751/2025-01-01#Artikel2
+- [Rules as Executed, section 9.2](/research/rules-as-executed#sec:opset), the position paper on the restricted operation set. It describes the engine as it stood before this RFC, without aggregation over collections, and argues the set should grow only explicitly, versioned and in public. This RFC is such a growth

--- a/docs/src/content/rfcs/rfc-019.md
+++ b/docs/src/content/rfcs/rfc-019.md
@@ -296,4 +296,5 @@ case in the **Temporal** conformance level ([RFC-014](/rfcs/rfc-014)).
   [BWBR0005730](https://wetten.overheid.nl/BWBR0005730), deep links via
   [kcbr.nl](https://www.kcbr.nl) - 6.24 (vervallen uitvoeringsregelingen; explicit mede-intrekking
   since 2018), 6.25 (uitgewerkte regelingen), old 243 (pre-2018: van rechtswege vervallen)
+- [Rules as Executed, section 4.8](/research/rules-as-executed#sec:versionedartifact), the position paper on law as a version-managed artifact
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-020.md
+++ b/docs/src/content/rfcs/rfc-020.md
@@ -320,4 +320,5 @@ Plus `as_of` cases in the **Temporal** conformance level ([RFC-014](/rfcs/rfc-01
   [RFC-008](/rfcs/rfc-008) Awb Administrative Procedures · [RFC-013](/rfcs/rfc-013) Execution
   Provenance · [RFC-014](/rfcs/rfc-014) Conformance · [RFC-015](/rfcs/rfc-015) Engine Policy
 - Law, jurisprudence and drafting conventions: see the Grounding table above.
+- [Rules as Executed, section 9.4](/research/rules-as-executed#sec:versioning), the position paper on version management and temporal consistency: resolving each dependency at the version in force on the date in question
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-024.md
+++ b/docs/src/content/rfcs/rfc-024.md
@@ -253,4 +253,5 @@ vocabulary and the legal-default policy; the engine track decides the computatio
 - Issue #304: "engine hardcodes eurocent rounding, should be law-controlled"
 - Issue #444: `type_spec.precision` parsed but not enforced
 - PR #791: engine boundary-rounding track
+- [Rules as Executed, section 9.2](/research/rules-as-executed#sec:opset), the position paper on modeling statutory rounding explicitly rather than leaving it to the engine
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/pages/rfcs/index.astro
+++ b/docs/src/pages/rfcs/index.astro
@@ -40,10 +40,9 @@ const rfcs = getRfcs();
         <p>
           The position paper{' '}
           <a href="/research/rules-as-executed">Rules as Executed</a> sets out
-          the constitutional case these decisions are made against: why law
-          execution should be published, and what that demands of the format.
-          It was written after most of these RFCs and argues for the shape they
-          gave the system.
+          the constitutional case behind these decisions: why law execution
+          should be published, and what that demands of the format. Individual
+          RFCs link to the sections that bear on them.
         </p>
       </nldd-rich-text>
       <nldd-spacer size="24" sm-size="16" />

--- a/docs/src/pages/rfcs/index.astro
+++ b/docs/src/pages/rfcs/index.astro
@@ -37,6 +37,14 @@ const rfcs = getRfcs();
         <p>
           See <a href="/rfcs/rfc-000">RFC-000</a> for the process and template.
         </p>
+        <p>
+          The position paper{' '}
+          <a href="/research/rules-as-executed">Rules as Executed</a> sets out
+          the constitutional case these decisions are made against: why law
+          execution should be published, and what that demands of the format.
+          It was written after most of these RFCs and argues for the shape they
+          gave the system.
+        </p>
       </nldd-rich-text>
       <nldd-spacer size="24" sm-size="16" />
       <EditLink filePath="src/pages/rfcs/index.astro" />


### PR DESCRIPTION
Dertien concept- en guide-pagina's verwezen al naar 'Rules as Executed',
met deeplinks naar de sectie die erover gaat. De RFC's waren het enige
deel van de site dat dat niet deed: geen van de 35 verwees ernaar. (De
verwijzing in RFC-022 gaat over een ander position paper, dat van
Chronolexografie.)

Twaalf RFC's krijgen er nu een regel bij in hun bestaande
References-sectie, in dezelfde vorm als de andere verwijzingen daar.

## Welke, en waarom die

Sterk, de RFC bouwt of verfijnt iets waar het paper expliciet over
argumenteert:

* **013** attestatie (4.4) en de hercontrole door de ontvanger (4.5)
* **009** uitvoering over organisaties heen (4.11, 4.12)
* **016** de beperkte operatieset (9.2)
* **012** publiceren wat het formaat nog niet kan zeggen (5.4)
* **007** de vier uitvoeringsmodi (4.9) en overrides (4.6)
* **024** afronding als expliciete modellering (9.2)
* **014** meerdere engines en semantische gelijkwaardigheid (9.1)

Verwant genoeg dat een lezer er iets aan heeft:

* **002** wie interpreteert en wie publiceert (4.3)
* **008** procedure als gefaseerde levensloop (4.10)
* **011** de niet-gekozen alternatieven, CNL en linked data (10.1, 10.2)
* **019**, **020** wet als versiebeheerd artefact (4.8, 9.4)

Niet gelinkt: de overige RFC's raken het paper hooguit thematisch. Een
verwijzing die overal staat zegt niets meer.

## De overzichtspagina

/rfcs krijgt een alinea over wat het paper is: het constitutionele betoog
achter deze ontwerpkeuzes, met de opmerking dat de RFC's zelf naar de
relevante secties linken. Dat leek me waardevoller dan een `paper:`-veld
in de frontmatter, dat maar op een handvol RFC's gevuld zou zijn.

## Richting van de verwijzing

Het paper is bevroren. Bij 016 en 024 beschrijft het de engine van voor
die RFC (het zegt in zoveel woorden dat aggregatie over collecties
ontbreekt, wat 016 juist toevoegt). Die verwijzingen zeggen dat er dus
bij: het paper bepleitte de groei, de RFC is waar die landde. Nergens
staat het als correctie op het paper.

## Gecontroleerd

Alle vijftien ankers bestaan in het gegenereerde paper, geverifieerd
tegen de id's in de HTML. Build draait door, 126 pagina's. Het paper zelf is niet
aangeraakt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RT4jW4TjpwQxTscUq6h1qZ
