### PR TITLE
chore(docs): hernoem roadmapcategorie lat naar bar

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -101,7 +101,7 @@ build vallen met de naam van het werkpakket erbij.
 
 `prioriteit` — `hoog`, `midden`, `laag`, of `''`.
 `omvang` — `S`, `M`, `L`, `XL`, of `''`.
-`categorie` — `lat`, `pivot`, `bet`, of `''`.
+`categorie` — `bar`, `pivot`, `bet`, of `''`.
 `capability` — `basis`, `ontwikkelen`, `simuleren`, `publiceren`, `analyseren`,
 `implementeren`, `verifieren`, of `''`.
 

--- a/docs/src/content/roadmap/werkpakketten/413459cd-4f34-48f2-9fbd-ae4ad2dbf67b.md
+++ b/docs/src/content/roadmap/werkpakketten/413459cd-4f34-48f2-9fbd-ae4ad2dbf67b.md
@@ -5,7 +5,7 @@ faseId: wat
 disciplineId: recht
 prioriteit: hoog
 omvang: ''
-categorie: lat
+categorie: bar
 capability: basis
 capaciteit: juridisch specialist / PhD
 toelichting: >-

--- a/docs/src/content/roadmap/werkpakketten/8c0d5283-44c0-4b21-b8c9-c74e3be06a86.md
+++ b/docs/src/content/roadmap/werkpakketten/8c0d5283-44c0-4b21-b8c9-c74e3be06a86.md
@@ -5,7 +5,7 @@ faseId: wat
 disciplineId: recht
 prioriteit: hoog
 omvang: ''
-categorie: lat
+categorie: bar
 capability: ''
 capaciteit: ''
 toelichting: |-

--- a/docs/src/content/roadmap/werkpakketten/9f994802-0fe1-4b57-8cf6-e7811920e272.md
+++ b/docs/src/content/roadmap/werkpakketten/9f994802-0fe1-4b57-8cf6-e7811920e272.md
@@ -5,7 +5,7 @@ faseId: hoe
 disciplineId: mensen
 prioriteit: ''
 omvang: ''
-categorie: lat
+categorie: bar
 capability: ''
 capaciteit: ''
 toelichting: "Bijscholing. Creëren van nieuwe rollen. Organisatieverandering.\nTraining van professionals in de nieuwe methodieken en tools.\nSchalen van individuele opleidingen naar communities of practice. De 'Doing' en 'Learning' communities worden het primaire kanaal voor kennisdeling."

--- a/docs/src/content/roadmap/werkpakketten/9fbfe2b7-0eca-4812-bc6a-f516539fb568.md
+++ b/docs/src/content/roadmap/werkpakketten/9fbfe2b7-0eca-4812-bc6a-f516539fb568.md
@@ -5,7 +5,7 @@ faseId: wat
 disciplineId: ethiek
 prioriteit: ''
 omvang: ''
-categorie: lat
+categorie: bar
 capability: basis
 capaciteit: ''
 toelichting: >-

--- a/docs/src/content/roadmap/werkpakketten/ac48d98b-aaf7-406e-9bf8-11da021dc878.md
+++ b/docs/src/content/roadmap/werkpakketten/ac48d98b-aaf7-406e-9bf8-11da021dc878.md
@@ -5,7 +5,7 @@ faseId: wat
 disciplineId: recht
 prioriteit: midden
 omvang: XL
-categorie: lat
+categorie: bar
 capability: ''
 capaciteit: ''
 toelichting: >-

--- a/docs/src/content/roadmap/werkpakketten/e4307fef-21c9-4cea-bf0a-d0f75e9eb8bb.md
+++ b/docs/src/content/roadmap/werkpakketten/e4307fef-21c9-4cea-bf0a-d0f75e9eb8bb.md
@@ -5,7 +5,7 @@ faseId: wat
 disciplineId: recht
 prioriteit: ''
 omvang: ''
-categorie: lat
+categorie: bar
 capability: ''
 capaciteit: ''
 toelichting: ''

--- a/docs/src/lib/roadmap.ts
+++ b/docs/src/lib/roadmap.ts
@@ -84,7 +84,7 @@ export const getOnderzoek = (id: string) =>
 export const getBouw = (id: string) => BOUW_STANDEN.find((s) => s.id === id);
 
 export const CATEGORIEEN = [
-  { id: 'lat', label: 'Lat' },
+  { id: 'bar', label: 'Bar' },
   { id: 'pivot', label: 'Pivot' },
   { id: 'bet', label: 'Bet' },
 ] as const;

--- a/docs/src/styles/roadmap.css
+++ b/docs/src/styles/roadmap.css
@@ -57,7 +57,7 @@
  * in lib/roadmap.ts reads this file during the build and fails when the two
  * drift, so the omission cannot ship.
  *
- * DO NOT rewrite `#rr-cat-lat` as an attribute or class selector. The show
+ * DO NOT rewrite `#rr-cat-bar` as an attribute or class selector. The show
  * rules only beat the hide rule above because :has() takes the specificity
  * of its most specific argument, and an id makes these (1,3,0) against
  * (0,3,0). Level them and the rules tie, source order lets the hide rule
@@ -66,7 +66,7 @@
 .rr-roadmap:has(.rr-filter__option[checked]) .rr-wp-card {
   display: none;
 }
-.rr-roadmap:has(#rr-cat-lat[checked]) .rr-wp-card[data-categorie='lat'],
+.rr-roadmap:has(#rr-cat-bar[checked]) .rr-wp-card[data-categorie='bar'],
 .rr-roadmap:has(#rr-cat-pivot[checked]) .rr-wp-card[data-categorie='pivot'],
 .rr-roadmap:has(#rr-cat-bet[checked]) .rr-wp-card[data-categorie='bet'],
 .rr-roadmap:has(#rr-cat-geen[checked]) .rr-wp-card[data-categorie='geen'] {


### PR DESCRIPTION
De roadmapcategorie \`lat\` heet voortaan \`bar\`. Aangepast op de vier plekken waar de naam voorkomt:

- de zes werkpakketten met \`categorie: lat\`
- \`CATEGORIEEN\` in \`docs/src/lib/roadmap.ts\` (id en label)
- de filterregel in \`docs/src/styles/roadmap.css\` (\`#rr-cat-bar\` en \`data-categorie='bar'\`), zodat \`assertFilterRules\` blijft kloppen
- de veldbeschrijving in de roadmap-skill

\`just docs-build\` slaagt.