### PR TITLE
fix(editor): collectieparameter uit RFC-016 ook in de scenario-editor

### DIFF
--- a/frontend/src/components/DataSourceTable.keyless.test.js
+++ b/frontend/src/components/DataSourceTable.keyless.test.js
@@ -1,0 +1,33 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import DataSourceTable from './DataSourceTable.vue';
+import ScenarioParameterInput from './ScenarioParameterInput.vue';
+
+// The elements of a collection-valued parameter (RFC-016) edit in the same
+// table as a data source, but a collection has no key column.
+describe('DataSourceTable without a key field', () => {
+  const mountKeyless = (rows) =>
+    mount(DataSourceTable, {
+      props: {
+        title: 'medebewoners',
+        keyField: null,
+        fields: [{ name: 'leeftijd', type: 'string', unit: null }],
+        modelValue: rows,
+        drilledIn: true,
+      },
+    });
+
+  it('renders only the declared columns', () => {
+    const w = mountKeyless([{ _id: 1, leeftijd: '25' }]);
+    const names = w.findAllComponents(ScenarioParameterInput).map((c) => c.props('name'));
+    expect(names).toEqual(['leeftijd']);
+    expect(w.html()).not.toContain('bsn');
+  });
+
+  it('adds a row without a key cell', async () => {
+    const w = mountKeyless([]);
+    await w.find('nldd-button[start-icon="plus-small"]').trigger('click');
+    const row = w.emitted('update:modelValue').at(-1)[0][0];
+    expect(Object.keys(row).sort()).toEqual(['_id', 'leeftijd']);
+  });
+});

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -6,6 +6,8 @@ let nextRowId = 0;
 
 const props = defineProps({
   title: { type: String, required: true },
+  // The key column of a data source. `null` for a table that has no key,
+  // such as the elements of a collection-valued parameter (RFC-016).
   keyField: { type: String, default: 'bsn' },
   fields: { type: Array, required: true },
   modelValue: { type: Array, default: () => [] },
@@ -31,9 +33,11 @@ function toggleExpand() {
 
 function addRow() {
   const newRow = { _id: ++nextRowId };
-  newRow[props.keyField] = rows.value.length > 0
-    ? rows.value[0][props.keyField] || ''
-    : '';
+  if (props.keyField) {
+    newRow[props.keyField] = rows.value.length > 0
+      ? rows.value[0][props.keyField] || ''
+      : '';
+  }
   for (const field of props.fields) {
     if (!(field.name in newRow)) {
       newRow[field.name] = defaultForType(field.type);
@@ -83,8 +87,10 @@ const allColumns = computed(() => {
   const cols = [];
   const seen = new Set();
 
-  seen.add(props.keyField);
-  cols.push({ name: props.keyField, type: 'string', unit: null, isKey: true });
+  if (props.keyField) {
+    seen.add(props.keyField);
+    cols.push({ name: props.keyField, type: 'string', unit: null, isKey: true });
+  }
 
   for (const field of props.fields) {
     if (!seen.has(field.name)) {

--- a/frontend/src/components/ExecutionTraceView.vue
+++ b/frontend/src/components/ExecutionTraceView.vue
@@ -32,6 +32,12 @@ function outputParts(name) {
   );
 }
 
+// A collection or record output renders as JSON; de-snaking its keys would
+// change the text, so humanize only a scalar.
+function humanizeOutput(text) {
+  return /^[[{]/.test(text) ? text : humanize(text);
+}
+
 const hasContent = computed(() =>
   props.result || props.traceText || props.error,
 );
@@ -100,7 +106,7 @@ const overallStatus = computed(() => {
             size="md"
             horizontal-alignment="right"
             width="100px"
-            :text="humanize(outputParts(name).text)"
+            :text="humanizeOutput(outputParts(name).text)"
             :supporting-text="outputParts(name).supportingText"
           ></nldd-text-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -108,9 +108,10 @@ const isDirty = ref(false);
 const selectedScenarioIndex = ref(null);
 const scenarioSheetEl = ref(null);
 
-// Name of the data source the active ScenarioForm is drilled into (null =
-// scenario overview). Reported by ScenarioForm via @drill-change; the
-// top-title-bar back button uses it to pop one level back out.
+// Name of the data source or collection parameter the active ScenarioForm
+// is drilled into (null = scenario overview). Reported by ScenarioForm via
+// @drill-change; the top-title-bar back button uses it to pop one level
+// back out.
 const drilledSourceName = ref(null);
 
 watch(selectedScenarioIndex, async (idx) => {

--- a/frontend/src/components/ScenarioForm.collections.test.js
+++ b/frontend/src/components/ScenarioForm.collections.test.js
@@ -1,0 +1,90 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import ScenarioForm from './ScenarioForm.vue';
+import DataSourceTable from './DataSourceTable.vue';
+import ScenarioParameterInput from './ScenarioParameterInput.vue';
+
+// A collection-valued parameter (RFC-016) as formMapper hands it to the form:
+// records plus the column list.
+const setup = () => ({
+  calculationDate: '2025-01-01',
+  parameters: [
+    { name: 'leeftijd', value: 35 },
+    { name: 'medebewoners', value: [{ leeftijd: 25 }, { leeftijd: 19 }], columns: ['leeftijd'] },
+  ],
+  dataSources: [],
+});
+
+const fakeEngine = () => ({
+  clearDataSources: vi.fn(),
+  registerDataSource: vi.fn(),
+  executeWithTrace: vi.fn(() => ({ outputs: { aantal: 2 }, trace_text: '' })),
+});
+
+const mountForm = (engine = null) =>
+  mount(ScenarioForm, {
+    props: {
+      scenario: { assertions: [], execution: { outputName: 'aantal', lawId: 'participatiewet' } },
+      setup: setup(),
+      lawId: 'participatiewet',
+      engine,
+      ready: !!engine,
+    },
+  });
+
+describe('ScenarioForm collection parameters', () => {
+  it('shows a collection as a drill-in row, not as a scalar control', () => {
+    const w = mountForm();
+    const scalarNames = w.findAllComponents(ScenarioParameterInput).map((c) => c.props('name'));
+    expect(scalarNames).toContain('leeftijd');
+    expect(scalarNames).not.toContain('medebewoners');
+    const row = w.find('[data-testid="coll-row-0"]');
+    expect(row.exists()).toBe(true);
+    expect(row.html()).toContain('medebewoners');
+    expect(row.html()).toContain('text="2"');
+  });
+
+  it('drills into a keyless table of the elements and reports the drill', async () => {
+    const w = mountForm();
+    await w.find('[data-testid="coll-row-0"]').trigger('click');
+    const table = w.findComponent(DataSourceTable);
+    expect(table.exists()).toBe(true);
+    expect(table.props('keyField')).toBeNull();
+    expect(table.props('fields').map((f) => f.name)).toEqual(['leeftijd']);
+    expect(table.props('modelValue')).toEqual([{ _id: 0, leeftijd: 25 }, { _id: 1, leeftijd: 19 }]);
+    expect(w.emitted('drill-change').at(-1)).toEqual(['medebewoners']);
+  });
+
+  it('passes the collection to the engine as an array of typed records', () => {
+    const engine = fakeEngine();
+    const w = mountForm(engine);
+    w.vm.execute();
+    const params = engine.executeWithTrace.mock.calls[0][2];
+    expect(params.leeftijd).toBe(35);
+    expect(params.medebewoners).toEqual([{ leeftijd: 25 }, { leeftijd: 19 }]);
+  });
+
+  it('passes an emptied collection as an empty array, not as a missing input', async () => {
+    const engine = fakeEngine();
+    const w = mountForm(engine);
+    await w.find('[data-testid="coll-row-0"]').trigger('click');
+    w.findComponent(DataSourceTable).vm.$emit('update:modelValue', []);
+    await w.vm.$nextTick();
+    w.vm.execute();
+    const params = engine.executeWithTrace.mock.calls.at(-1)[2];
+    expect(params.medebewoners).toEqual([]);
+  });
+
+  it('hands the edited collection back through getFormValues', async () => {
+    const w = mountForm();
+    await w.find('[data-testid="coll-row-0"]').trigger('click');
+    w.findComponent(DataSourceTable).vm.$emit('update:modelValue', [{ _id: 0, leeftijd: '40' }]);
+    await w.vm.$nextTick();
+    const values = w.vm.getFormValues();
+    expect(values.collections).toEqual([
+      { name: 'medebewoners', columns: [{ name: 'leeftijd', type: 'string', unit: null }], rows: [{ _id: 0, leeftijd: '40' }] },
+    ]);
+    expect(values.parameterValues).toEqual({ leeftijd: 35 });
+    expect(w.emitted('change')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/ScenarioForm.collections.test.js
+++ b/frontend/src/components/ScenarioForm.collections.test.js
@@ -66,7 +66,7 @@ describe('ScenarioForm collection parameters', () => {
     expect(table.exists()).toBe(true);
     expect(table.props('keyField')).toBeNull();
     expect(table.props('fields').map((f) => f.name)).toEqual(['leeftijd']);
-    expect(table.props('modelValue')).toEqual([{ _id: 0, leeftijd: 25 }, { _id: 1, leeftijd: 19 }]);
+    expect(table.props('modelValue')).toEqual([{ _id: 'init-0', leeftijd: 25 }, { _id: 'init-1', leeftijd: 19 }]);
     expect(w.emitted('drill-change').at(-1)).toEqual(['medebewoners']);
   });
 
@@ -77,6 +77,16 @@ describe('ScenarioForm collection parameters', () => {
     const params = engine.executeWithTrace.mock.calls[0][2];
     expect(params.leeftijd).toBe(35);
     expect(params.medebewoners).toEqual([{ leeftijd: 25 }, { leeftijd: 19 }]);
+  });
+
+  it('passes an untouched new cell as null, the value the saved table carries', async () => {
+    const engine = fakeEngine();
+    const w = mountForm(engine);
+    await w.find('[data-testid="coll-row-0"]').trigger('click');
+    w.findComponent(DataSourceTable).vm.$emit('update:modelValue', [{ _id: 7, leeftijd: '' }]);
+    await w.vm.$nextTick();
+    w.vm.execute();
+    expect(engine.executeWithTrace.mock.calls.at(-1)[2].medebewoners).toEqual([{ leeftijd: null }]);
   });
 
   it('passes an emptied collection as an empty array, not as a missing input', async () => {

--- a/frontend/src/components/ScenarioForm.collections.test.js
+++ b/frontend/src/components/ScenarioForm.collections.test.js
@@ -44,6 +44,21 @@ describe('ScenarioForm collection parameters', () => {
     expect(row.html()).toContain('text="2"');
   });
 
+  it('shows a background collection overridden by the scenario once, with the scenario rows', () => {
+    // getEffectiveSetup() concatenates background and scenario parameters,
+    // so an override lists the same name twice; the form shows the last.
+    const merged = setup();
+    merged.parameters = [
+      { name: 'medebewoners', value: [{ leeftijd: 25 }, { leeftijd: 19 }, { leeftijd: 50 }], columns: ['leeftijd'] },
+      ...merged.parameters,
+    ];
+    const w = mount(ScenarioForm, {
+      props: { scenario: { assertions: [] }, setup: merged, lawId: 'participatiewet' },
+    });
+    expect(w.findAll('[data-testid^="coll-row-"]')).toHaveLength(1);
+    expect(w.vm.getFormValues().collections.map((c) => c.rows.length)).toEqual([2]);
+  });
+
   it('drills into a keyless table of the elements and reports the drill', async () => {
     const w = mountForm();
     await w.find('[data-testid="coll-row-0"]').trigger('click');

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed, watch, onBeforeUnmount, useId } from 'vue';
 import { quotedValue, tableCellValue } from '../gherkin/actions.js';
+import { isCollectionValue, collectionColumns } from '../gherkin/formMapper.js';
 import { formatValue, normalizeForCompare, matchStatus as _matchStatus, humanize } from '../utils/outputFormat.js';
 import DataSourceTable from './DataSourceTable.vue';
 import ScenarioParameterInput from './ScenarioParameterInput.vue';
@@ -43,9 +44,31 @@ const emit = defineEmits(['show-details', 'executed', 'change', 'drill-change'])
 // --- Form state (initialized from scenario setup) ---
 const calculationDate = ref(props.setup.calculationDate || new Date().toISOString().slice(0, 10));
 
+// Scalar parameters edit as one control each; a collection-valued parameter
+// (RFC-016, `Given parameter "x" is the collection:`) is a table and gets
+// the same drill-in treatment as a data source. The two are kept apart so
+// the control loop below never meets an array.
+const scalarParams = () => (props.setup.parameters || []).filter((p) => !isCollectionValue(p.value));
+
 const parameterValues = ref(
-  Object.fromEntries((props.setup.parameters || []).map((p) => [p.name, p.value ?? ''])),
+  Object.fromEntries(scalarParams().map((p) => [p.name, p.value ?? ''])),
 );
+
+// Convert collection parameters to DataSourceTable format. A collection has
+// no key field; the element fields are not typed by the law (an `array`
+// input declares no item shape), so cells are typed by content at run time,
+// the same rule the runner applies to the saved table.
+function initCollections() {
+  return (props.setup.parameters || [])
+    .filter((p) => isCollectionValue(p.value))
+    .map((p) => ({
+      name: p.name,
+      columns: collectionColumns(p).map((c) => ({ name: c, type: 'string', unit: null })),
+      rows: p.value.map((record, i) => ({ _id: i, ...record })),
+    }));
+}
+
+const collections = ref(initCollections());
 
 // Convert scenario data sources to DataSourceTable format
 function initDataSources() {
@@ -69,9 +92,15 @@ const dataSources = ref(initDataSources());
 // ActionSheet-style breadcrumb rows would be overkill), so the parent needs
 // to know the drilled source name and be able to pop back out.
 const selectedSource = ref(null);
+// Same, for a collection parameter (index into `collections`). At most one
+// of the two is non-null.
+const selectedCollection = ref(null);
+
+const drilledIn = computed(() => selectedSource.value !== null || selectedCollection.value !== null);
 
 function clearDrill() {
   selectedSource.value = null;
+  selectedCollection.value = null;
 }
 
 // Data-source names render human-readable AND sentence-cased ("personal_data"
@@ -81,8 +110,10 @@ function sourceLabel(name) {
   return h ? h.charAt(0).toUpperCase() + h.slice(1) : h;
 }
 
-watch(selectedSource, (idx) => {
-  emit('drill-change', idx == null ? null : (dataSources.value[idx]?.sourceName ?? null));
+watch([selectedSource, selectedCollection], ([src, coll]) => {
+  if (src != null) emit('drill-change', dataSources.value[src]?.sourceName ?? null);
+  else if (coll != null) emit('drill-change', collections.value[coll]?.name ?? null);
+  else emit('drill-change', null);
 });
 
 // Expectations from scenario assertions
@@ -119,10 +150,12 @@ const errorTraceText = ref(null);
 function discardEdits() {
   calculationDate.value = props.setup.calculationDate || new Date().toISOString().slice(0, 10);
   parameterValues.value = Object.fromEntries(
-    (props.setup.parameters || []).map((p) => [p.name, p.value ?? '']),
+    scalarParams().map((p) => [p.name, p.value ?? '']),
   );
+  collections.value = initCollections();
   dataSources.value = initDataSources();
   selectedSource.value = null;
+  selectedCollection.value = null;
   expectations.value = Object.fromEntries(
     (props.scenario.assertions || [])
       .filter((a) => a.outputName && a.value !== null && a.value !== undefined)
@@ -197,6 +230,18 @@ function execute() {
         params[k] = typeof v === 'string' ? quotedValue(v) : v;
       }
     }
+    // A collection is passed whole, an empty one included: "no elements" is
+    // a value (no medebewoners), not a missing input.
+    for (const coll of collections.value) {
+      params[coll.name] = coll.rows.map((row) => {
+        const record = {};
+        for (const c of coll.columns) {
+          const v = row[c.name];
+          record[c.name] = v === undefined || v === null ? null : typeof v === 'string' ? tableCellValue(v) : v;
+        }
+        return record;
+      });
+    }
 
     const execResult = engine.executeWithTrace(
       props.lawId,
@@ -249,6 +294,7 @@ function getFormValues() {
     parameterValues: { ...parameterValues.value },
     calculationDate: calculationDate.value,
     dataSources: [...dataSources.value],
+    collections: [...collections.value],
   };
 }
 
@@ -257,7 +303,7 @@ defineExpose({ execute, getExecutionData, getFormValues, clearDrill, discardEdit
 // --- Auto-re-execute when input values change ---
 let executeTimer = null;
 watch(
-  [parameterValues, calculationDate, dataSources],
+  [parameterValues, calculationDate, dataSources, collections],
   () => {
     if (!props.engine || !props.ready) return;
     clearTimeout(executeTimer);
@@ -274,6 +320,13 @@ function updateDataSourceRows(index, rows) {
   const updated = [...dataSources.value];
   updated[index] = { ...updated[index], rows };
   dataSources.value = updated;
+  emit('change');
+}
+
+function updateCollectionRows(index, rows) {
+  const updated = [...collections.value];
+  updated[index] = { ...updated[index], rows };
+  collections.value = updated;
   emit('change');
 }
 
@@ -303,7 +356,7 @@ const dateErrorId = useId();
 <template>
   <div class="sf-root">
     <!-- Scenario overview -->
-    <template v-if="selectedSource === null">
+    <template v-if="!drilledIn">
       <!-- Expected outputs -->
       <template v-if="hasExpectations">
         <nldd-title size="5"><h2>Verwachte uitkomsten</h2></nldd-title>
@@ -370,6 +423,22 @@ const dateErrorId = useId();
             />
           </nldd-cell>
         </nldd-list-item>
+        <!-- Collection parameters: a row per collection, drill in one level
+             deeper to edit the elements, the same way a data source works. -->
+        <nldd-list-item
+          v-for="(coll, i) in collections"
+          :key="coll.name"
+          size="md"
+          button
+          :data-testid="`coll-row-${i}`"
+          @click="selectedCollection = i"
+        >
+          <nldd-text-cell :text="coll.name" :supporting-text="articleMap?.paramToArticle?.get(coll.name) ? `Artikel ${articleMap.paramToArticle.get(coll.name)}` : undefined" min-width="120px" max-width="200px"></nldd-text-cell>
+          <nldd-spacer-cell size="12"></nldd-spacer-cell>
+          <nldd-text-cell horizontal-alignment="right" :text="coll.rows.length ? String(coll.rows.length) : ''"></nldd-text-cell>
+          <nldd-spacer-cell size="12"></nldd-spacer-cell>
+          <nldd-icon-cell size="20"><nldd-icon name="chevron-right"></nldd-icon></nldd-icon-cell>
+        </nldd-list-item>
       </nldd-list>
 
       <!-- Data sources: a row per source, drill in one level deeper -->
@@ -397,7 +466,7 @@ const dateErrorId = useId();
     <!-- One level deeper: a single data source's table. Back to the scenario
          overview is the sheet's top-title-bar back button (driven by the
          parent via clearDrill / drill-change). -->
-    <template v-else>
+    <template v-else-if="selectedSource !== null">
       <DataSourceTable
         :key="dataSources[selectedSource].sourceName"
         :title="sourceLabel(dataSources[selectedSource].sourceName)"
@@ -406,6 +475,19 @@ const dateErrorId = useId();
         :model-value="dataSources[selectedSource].rows"
         :drilled-in="true"
         @update:model-value="updateDataSourceRows(selectedSource, $event)"
+      />
+    </template>
+
+    <!-- A collection parameter's elements: the same table, without a key column. -->
+    <template v-else>
+      <DataSourceTable
+        :key="collections[selectedCollection].name"
+        :title="collections[selectedCollection].name"
+        :key-field="null"
+        :fields="collections[selectedCollection].columns"
+        :model-value="collections[selectedCollection].rows"
+        :drilled-in="true"
+        @update:model-value="updateCollectionRows(selectedCollection, $event)"
       />
     </template>
 

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed, watch, onBeforeUnmount, useId } from 'vue';
 import { quotedValue, tableCellValue } from '../gherkin/actions.js';
-import { isCollectionValue, collectionColumns, collectionCell } from '../gherkin/formMapper.js';
+import { isCollectionValue, collectionColumns, formCollectionToState } from '../gherkin/formMapper.js';
 import { formatValue, normalizeForCompare, matchStatus as _matchStatus, humanize } from '../utils/outputFormat.js';
 import DataSourceTable from './DataSourceTable.vue';
 import ScenarioParameterInput from './ScenarioParameterInput.vue';
@@ -239,16 +239,10 @@ function execute() {
       }
     }
     // A collection is passed whole, an empty one included: "no elements" is
-    // a value (no medebewoners), not a missing input. An empty cell is null,
-    // the same value the saved table carries (formatCell writes `null`).
+    // a value (no medebewoners), not a missing input. The same conversion
+    // that a save applies, so the engine runs what the file will say.
     for (const coll of collections.value) {
-      params[coll.name] = coll.rows.map((row) => {
-        const record = {};
-        for (const c of coll.columns) {
-          record[c.name] = collectionCell(row[c.name]);
-        }
-        return record;
-      });
+      params[coll.name] = formCollectionToState(coll).records;
     }
 
     const execResult = engine.executeWithTrace(

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -58,14 +58,20 @@ const parameterValues = ref(
 // no key field; the element fields are not typed by the law (an `array`
 // input declares no item shape), so cells are typed by content at run time,
 // the same rule the runner applies to the saved table.
+//
+// The setup is the merged background plus scenario list, so a scenario that
+// overrides a background collection lists the name twice. Last wins, the
+// same rule `Object.fromEntries` applies to the scalars above.
 function initCollections() {
-  return (props.setup.parameters || [])
-    .filter((p) => isCollectionValue(p.value))
-    .map((p) => ({
-      name: p.name,
-      columns: collectionColumns(p).map((c) => ({ name: c, type: 'string', unit: null })),
-      rows: p.value.map((record, i) => ({ _id: i, ...record })),
-    }));
+  const byName = new Map();
+  for (const p of props.setup.parameters || []) {
+    if (isCollectionValue(p.value)) byName.set(p.name, p);
+  }
+  return [...byName.values()].map((p) => ({
+    name: p.name,
+    columns: collectionColumns(p).map((c) => ({ name: c, type: 'string', unit: null })),
+    rows: p.value.map((record, i) => ({ _id: i, ...record })),
+  }));
 }
 
 const collections = ref(initCollections());

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed, watch, onBeforeUnmount, useId } from 'vue';
 import { quotedValue, tableCellValue } from '../gherkin/actions.js';
-import { isCollectionValue, collectionColumns } from '../gherkin/formMapper.js';
+import { isCollectionValue, collectionColumns, collectionCell } from '../gherkin/formMapper.js';
 import { formatValue, normalizeForCompare, matchStatus as _matchStatus, humanize } from '../utils/outputFormat.js';
 import DataSourceTable from './DataSourceTable.vue';
 import ScenarioParameterInput from './ScenarioParameterInput.vue';
@@ -70,7 +70,7 @@ function initCollections() {
   return [...byName.values()].map((p) => ({
     name: p.name,
     columns: collectionColumns(p).map((c) => ({ name: c, type: 'string', unit: null })),
-    rows: p.value.map((record, i) => ({ _id: i, ...record })),
+    rows: p.value.map((record, i) => ({ _id: `init-${i}`, ...record })),
   }));
 }
 
@@ -82,8 +82,10 @@ function initDataSources() {
     sourceName: ds.sourceName,
     keyField: ds.keyField,
     fields: ds.headers.filter((h) => h !== ds.keyField).map((h) => typeField(h)),
+    // A string id: DataSourceTable.addRow numbers new rows from a counter
+    // of its own, and an integer here would collide with it in `:key`.
     rows: ds.rows.map((row, i) => {
-      const obj = { _id: i };
+      const obj = { _id: `init-${i}` };
       ds.headers.forEach((h, j) => { obj[h] = row[j] ?? ''; });
       return obj;
     }),
@@ -237,13 +239,13 @@ function execute() {
       }
     }
     // A collection is passed whole, an empty one included: "no elements" is
-    // a value (no medebewoners), not a missing input.
+    // a value (no medebewoners), not a missing input. An empty cell is null,
+    // the same value the saved table carries (formatCell writes `null`).
     for (const coll of collections.value) {
       params[coll.name] = coll.rows.map((row) => {
         const record = {};
         for (const c of coll.columns) {
-          const v = row[c.name];
-          record[c.name] = v === undefined || v === null ? null : typeof v === 'string' ? tableCellValue(v) : v;
+          record[c.name] = collectionCell(row[c.name]);
         }
         return record;
       });

--- a/frontend/src/gherkin/formMapper.collections.test.js
+++ b/frontend/src/gherkin/formMapper.collections.test.js
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { parseFeature } from './parser.js';
+import { mapFeatureToForm, getEffectiveSetup, formStateToGherkin, syncEditedValues } from './formMapper.js';
+
+// A collection-valued parameter (RFC-016): `Given parameter "x" is the
+// collection:` with a header row and one row per element. Before this was
+// handled the step landed in unmatchedSteps, so the editor ran the scenario
+// without the parameter while the Rust runner passed it.
+describe('collection parameters', () => {
+  const FEATURE = `Feature: Kostendelersnorm
+
+  Background:
+    Given parameter "bsn" is "999993653"
+    Given parameter "medebewoners" is the collection:
+      | leeftijd | naam  |
+      | 25       | Alice |
+      | 19       | Bob   |
+
+  Scenario: Three flatmates
+    Given parameter "leeftijd" is 35
+    Given parameter "medebewoners" is the collection:
+      | leeftijd |
+      | 25       |
+      | 19       |
+      | 34       |
+    When I evaluate "aantal_kostendelende_medebewoners" of "participatiewet"
+    Then output "aantal_kostendelende_medebewoners" equals 3
+
+  Scenario: Inherits the background collection
+    When I evaluate "aantal_kostendelende_medebewoners" of "participatiewet"
+    Then output "aantal_kostendelende_medebewoners" equals 2
+`;
+
+  it('maps the table to one typed record per element, keeping the columns', () => {
+    const form = mapFeatureToForm(parseFeature(FEATURE));
+    const bg = form.background.parameters.find((p) => p.name === 'medebewoners');
+    expect(bg.columns).toEqual(['leeftijd', 'naam']);
+    expect(bg.value).toEqual([
+      { leeftijd: 25, naam: 'Alice' },
+      { leeftijd: 19, naam: 'Bob' },
+    ]);
+    expect(form.background.unmatchedSteps).toHaveLength(0);
+
+    const sc = form.scenarios[0].setup.parameters.find((p) => p.name === 'medebewoners');
+    expect(sc.value.map((r) => r.leeftijd)).toEqual([25, 19, 34]);
+    expect(form.scenarios[0].unmatchedSteps).toHaveLength(0);
+  });
+
+  it('keeps the header of a collection without elements', () => {
+    const form = mapFeatureToForm(parseFeature(`
+Feature: Empty
+
+  Scenario: Nobody
+    Given parameter "medebewoners" is the collection:
+      | leeftijd |
+    When I evaluate "aantal_kostendelende_medebewoners" of "participatiewet"
+`));
+    const p = form.scenarios[0].setup.parameters[0];
+    expect(p.value).toEqual([]);
+    expect(p.columns).toEqual(['leeftijd']);
+    expect(formStateToGherkin(form)).toContain(
+      'Given parameter "medebewoners" is the collection:\n      | leeftijd |\n',
+    );
+  });
+
+  it('merges the background collection into a scenario that does not override it', () => {
+    const form = mapFeatureToForm(parseFeature(FEATURE));
+    const second = getEffectiveSetup(form, 1);
+    const coll = second.parameters.filter((p) => p.name === 'medebewoners');
+    expect(coll).toHaveLength(1);
+    expect(coll[0].value).toHaveLength(2);
+  });
+
+  it('round-trips through Gherkin unchanged', () => {
+    const form = mapFeatureToForm(parseFeature(FEATURE));
+    const text = formStateToGherkin(form);
+    expect(text).toContain(
+      'Given parameter "medebewoners" is the collection:\n' +
+      '      | leeftijd | naam |\n' +
+      '      | 25 | Alice |\n' +
+      '      | 19 | Bob |\n',
+    );
+    const again = mapFeatureToForm(parseFeature(text));
+    expect(again.background.parameters).toEqual(form.background.parameters);
+    expect(again.scenarios[0].setup.parameters).toEqual(form.scenarios[0].setup.parameters);
+    // Serialising twice is a fixed point.
+    expect(formStateToGherkin(again)).toBe(text);
+  });
+
+  it('writes a null cell for a missing value and reads it back', () => {
+    const form = mapFeatureToForm(parseFeature(`
+Feature: Null cell
+
+  Scenario: Unknown age
+    Given parameter "medebewoners" is the collection:
+      | leeftijd | naam |
+      | null     | Bob  |
+    When I evaluate "x" of "law"
+`));
+    expect(form.scenarios[0].setup.parameters[0].value).toEqual([{ leeftijd: null, naam: 'Bob' }]);
+    expect(formStateToGherkin(form)).toContain('| null | Bob |');
+  });
+
+  describe('syncEditedValues', () => {
+    // Form format as ScenarioForm.getFormValues() hands it back: typed
+    // columns and rows carrying an `_id`.
+    const twoColumns = [{ name: 'leeftijd' }, { name: 'naam' }];
+    const backgroundRows = [
+      { _id: 0, leeftijd: '25', naam: 'Alice' },
+      { _id: 1, leeftijd: '19', naam: 'Bob' },
+    ];
+
+    it('updates a scenario-level collection in place, dropping _id and typing cells', () => {
+      const form = mapFeatureToForm(parseFeature(FEATURE));
+      syncEditedValues(form, 0, {
+        parameterValues: { leeftijd: '35' },
+        calculationDate: null,
+        collections: [{
+          name: 'medebewoners',
+          columns: [{ name: 'leeftijd', type: 'string', unit: null }],
+          rows: [{ _id: 0, leeftijd: '40' }, { _id: 1, leeftijd: '41' }],
+        }],
+      });
+      const p = form.scenarios[0].setup.parameters.find((x) => x.name === 'medebewoners');
+      expect(p.value).toEqual([{ leeftijd: 40 }, { leeftijd: 41 }]);
+      expect(p.columns).toEqual(['leeftijd']);
+      expect(form.scenarios[0].setup.parameters).toHaveLength(2);
+    });
+
+    it('adds a scenario override when the background collection is changed', () => {
+      const form = mapFeatureToForm(parseFeature(FEATURE));
+      syncEditedValues(form, 1, {
+        parameterValues: {},
+        calculationDate: null,
+        collections: [{ name: 'medebewoners', columns: twoColumns, rows: backgroundRows.slice(0, 1) }],
+      });
+      expect(form.scenarios[1].setup.parameters).toEqual([
+        { name: 'medebewoners', value: [{ leeftijd: 25, naam: 'Alice' }], columns: ['leeftijd', 'naam'] },
+      ]);
+      expect(form.background.parameters.find((p) => p.name === 'medebewoners').value).toHaveLength(2);
+    });
+
+    it('does not add an override when the collection still matches the background', () => {
+      const form = mapFeatureToForm(parseFeature(FEATURE));
+      syncEditedValues(form, 1, {
+        parameterValues: {},
+        calculationDate: null,
+        collections: [{ name: 'medebewoners', columns: twoColumns, rows: backgroundRows }],
+      });
+      expect(form.scenarios[1].setup.parameters).toHaveLength(0);
+    });
+
+    it('removes a scenario override that is edited back to the background value', () => {
+      const form = mapFeatureToForm(parseFeature(FEATURE));
+      syncEditedValues(form, 0, {
+        parameterValues: { leeftijd: '35' },
+        calculationDate: null,
+        collections: [{ name: 'medebewoners', columns: twoColumns, rows: backgroundRows }],
+      });
+      expect(form.scenarios[0].setup.parameters.map((p) => p.name)).toEqual(['leeftijd']);
+    });
+  });
+});

--- a/frontend/src/gherkin/formMapper.collections.test.js
+++ b/frontend/src/gherkin/formMapper.collections.test.js
@@ -101,6 +101,41 @@ Feature: Null cell
     expect(formStateToGherkin(form)).toContain('| null | Bob |');
   });
 
+  it('escapes a pipe and a backslash in a cell and in a header, and reads them back', () => {
+    const form = mapFeatureToForm(parseFeature(`
+Feature: Escapes
+
+  Scenario: Odd cells
+    Given parameter "items" is the collection:
+      | naam    | pad\\|x |
+      | a\\|b    | c\\\\d   |
+    When I evaluate "x" of "law"
+`));
+    const p = form.scenarios[0].setup.parameters[0];
+    expect(p.columns).toEqual(['naam', 'pad|x']);
+    expect(p.value).toEqual([{ naam: 'a|b', 'pad|x': 'c\\d' }]);
+    const text = formStateToGherkin(form);
+    expect(text).toContain('| naam | pad\\|x |');
+    expect(text).toContain('| a\\|b | c\\\\d |');
+    expect(mapFeatureToForm(parseFeature(text)).scenarios[0].setup.parameters).toEqual(form.scenarios[0].setup.parameters);
+  });
+
+  it('types numeric cells by content, the same rule as a data-source table', () => {
+    const form = mapFeatureToForm(parseFeature(`
+Feature: Numbers
+
+  Scenario: Numeric strings
+    Given parameter "items" is the collection:
+      | code | bedrag |
+      | 007  | 1.0    |
+    When I evaluate "x" of "law"
+`));
+    // 007 and 1.0 are numbers to the runner too; the leading zero and the
+    // trailing .0 do not survive a save, and that is the documented rule.
+    expect(form.scenarios[0].setup.parameters[0].value).toEqual([{ code: 7, bedrag: 1 }]);
+    expect(formStateToGherkin(form)).toContain('| 7 | 1 |');
+  });
+
   describe('syncEditedValues', () => {
     // Form format as ScenarioForm.getFormValues() hands it back: typed
     // columns and rows carrying an `_id`.

--- a/frontend/src/gherkin/formMapper.coverage.test.js
+++ b/frontend/src/gherkin/formMapper.coverage.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { GRAMMAR } from './grammar.generated.js';
+import { parseFeature } from './parser.js';
+import { mapFeatureToForm, formStateToGherkin } from './formMapper.js';
+
+// The mapper consumes the `core` tier of the grammar. A core entry it does
+// not extract falls through to unmatchedSteps: the step is written back on
+// save, but the editor runs the scenario without it and says nothing. That
+// is how `set_parameter_collection` (RFC-016) shipped in the grammar, the
+// Rust runner and actions.js while the editor kept dropping it. This test
+// synthesizes one step per core entry from its own template and demands
+// that the mapper recognizes each, so a grammar extension without a mapper
+// case fails here instead of in a colleague's editor.
+const CORE = GRAMMAR.filter((e) => e.tier === 'core');
+
+const sampleArg = (type, i) => (type === 'number' ? String(10 + i) : `arg${i}`);
+
+function stepFor(entry) {
+  const args = entry.argTypes.map(sampleArg);
+  const keyword = entry.keyword.charAt(0).toUpperCase() + entry.keyword.slice(1);
+  const lines = [`    ${keyword} ${entry.template(args)}`];
+  if (entry.datatable) {
+    // Two columns, one data row - a shape every table-taking step accepts.
+    lines.push('      | arg1 | col |');
+    lines.push('      | 1    | x   |');
+  }
+  return lines.join('\n');
+}
+
+describe('formMapper covers every core grammar entry', () => {
+  it.each(CORE.map((e) => [e.id, e]))('recognizes %s', (_id, entry) => {
+    const form = mapFeatureToForm(parseFeature(`Feature: Coverage\n\n  Scenario: One step\n${stepFor(entry)}\n`));
+    expect(form.scenarios[0].unmatchedSteps.map((s) => s.text)).toEqual([]);
+  });
+
+  it('writes every core entry back out as a step the mapper recognizes again', () => {
+    const text = `Feature: Coverage\n\n  Scenario: All steps\n${CORE.map(stepFor).join('\n')}\n`;
+    const form = mapFeatureToForm(parseFeature(text));
+    const again = mapFeatureToForm(parseFeature(formStateToGherkin(form)));
+    expect(again.scenarios[0].unmatchedSteps).toEqual([]);
+    // The round trip preserves what the form carries: the setup, the
+    // execution and the assertions.
+    expect(again.scenarios[0].setup).toEqual(form.scenarios[0].setup);
+    expect(again.scenarios[0].execution).toEqual(form.scenarios[0].execution);
+    expect(again.scenarios[0].assertions).toEqual(form.scenarios[0].assertions);
+  });
+});

--- a/frontend/src/gherkin/formMapper.js
+++ b/frontend/src/gherkin/formMapper.js
@@ -297,7 +297,7 @@ function formDataSourceToState(ds) {
  * Form format:  `{ name, columns: [{name, type}], rows: [{_id, [col]: v}] }`
  * State format: `{ columns: string[], records: object[] }`
  */
-function formCollectionToState(coll) {
+export function formCollectionToState(coll) {
   const columns = (coll.columns || []).map((c) => c.name);
   const records = (coll.rows || []).map((row) => {
     const record = {};

--- a/frontend/src/gherkin/formMapper.js
+++ b/frontend/src/gherkin/formMapper.js
@@ -121,6 +121,16 @@ export function isCollectionValue(value) {
   return Array.isArray(value);
 }
 
+/**
+ * Type one cell of a collection as edited in the form: an empty or absent
+ * cell is null (what formatCell writes and the runner reads back), a string
+ * is typed by content, anything else is already typed.
+ */
+export function collectionCell(v) {
+  if (v === undefined || v === null || v === '') return null;
+  return typeof v === 'string' ? tableCellValue(v) : v;
+}
+
 /** Column names of a collection parameter: the recorded header, or the keys of the first element. */
 export function collectionColumns(param) {
   if (param.columns?.length) return param.columns;
@@ -292,8 +302,7 @@ function formCollectionToState(coll) {
   const records = (coll.rows || []).map((row) => {
     const record = {};
     for (const c of columns) {
-      const v = row[c];
-      record[c] = v === undefined || v === null ? null : typeof v === 'string' ? tableCellValue(v) : v;
+      record[c] = collectionCell(row[c]);
     }
     return record;
   });
@@ -522,7 +531,7 @@ function writeSetupSteps(lines, setup, indent) {
     if (isCollectionValue(param.value)) {
       lines.push(`${indent}${KW.set_parameter_collection} ${TPL.set_parameter_collection([param.name])}`);
       const columns = collectionColumns(param);
-      lines.push(`${indent}  | ${columns.join(' | ')} |`);
+      lines.push(`${indent}  | ${columns.map(formatCell).join(' | ')} |`);
       for (const record of param.value) {
         const cells = columns.map((c) => formatCell(record[c]));
         lines.push(`${indent}  | ${cells.join(' | ')} |`);

--- a/frontend/src/gherkin/formMapper.js
+++ b/frontend/src/gherkin/formMapper.js
@@ -43,6 +43,13 @@ function extractFragment(entry, match, step) {
       };
     case 'set_parameters_table':
       return { type: 'parameterTable', parameters: tableToParams(step.dataTable) };
+    case 'set_parameter_collection': {
+      // A collection-valued parameter (RFC-016): header row plus one row per
+      // element. The columns are kept next to the records so a collection
+      // without elements still serializes with its header.
+      const { columns, records } = tableToCollection(step.dataTable);
+      return { type: 'parameter', name: match[1], value: records, columns };
+    }
     case 'set_data_source':
       return {
         type: 'dataSource',
@@ -91,6 +98,36 @@ function tableToParams(dataTable) {
     }));
 }
 
+// A `Given parameter "x" is the collection:` table has a header row and one
+// row per element (mirror of Rust `rows_to_records`): every element becomes
+// an object keyed by the column names, cells typed by content. Lenient on a
+// short row - a missing cell reads as null - so one ragged row does not
+// take the whole feature down in the editor.
+function tableToCollection(dataTable) {
+  if (!dataTable || dataTable.length === 0) return { columns: [], records: [] };
+  const columns = dataTable[0].map((h) => h.trim());
+  const records = dataTable.slice(1).map((row) => {
+    const record = {};
+    columns.forEach((h, i) => {
+      record[h] = i < row.length ? tableCellValue(row[i]) : null;
+    });
+    return record;
+  });
+  return { columns, records };
+}
+
+/** True when a parameter value is a collection (array of records). */
+export function isCollectionValue(value) {
+  return Array.isArray(value);
+}
+
+/** Column names of a collection parameter: the recorded header, or the keys of the first element. */
+export function collectionColumns(param) {
+  if (param.columns?.length) return param.columns;
+  const first = (param.value || [])[0];
+  return first ? Object.keys(first) : [];
+}
+
 function classifyStep(step) {
   const text = step.text;
   for (const entry of CORE_ENTRIES) {
@@ -128,7 +165,11 @@ function classifySteps(steps) {
         setup.dependencies.push(classified.lawId);
         break;
       case 'parameter':
-        setup.parameters.push({ name: classified.name, value: classified.value });
+        setup.parameters.push(
+          classified.columns
+            ? { name: classified.name, value: classified.value, columns: classified.columns }
+            : { name: classified.name, value: classified.value },
+        );
         break;
       case 'parameterTable':
         setup.parameters.push(...classified.parameters);
@@ -238,6 +279,39 @@ function formDataSourceToState(ds) {
   return { sourceName: ds.sourceName, keyField: ds.keyField, headers, rows };
 }
 
+/**
+ * Convert a collection as edited in the form to the formState parameter
+ * value: the column names plus one record per row, `_id` dropped and cells
+ * typed by content (the same rule the runner applies to the saved table).
+ *
+ * Form format:  `{ name, columns: [{name, type}], rows: [{_id, [col]: v}] }`
+ * State format: `{ columns: string[], records: object[] }`
+ */
+function formCollectionToState(coll) {
+  const columns = (coll.columns || []).map((c) => c.name);
+  const records = (coll.rows || []).map((row) => {
+    const record = {};
+    for (const c of columns) {
+      const v = row[c];
+      record[c] = v === undefined || v === null ? null : typeof v === 'string' ? tableCellValue(v) : v;
+    }
+    return record;
+  });
+  return { columns, records };
+}
+
+/**
+ * Equality for two parameter values, scalar or collection. A collection is
+ * compared record by record; `String()` on an array would flatten every
+ * collection to "[object Object]" and call them all equal.
+ */
+function parameterValuesEqual(a, b) {
+  if (isCollectionValue(a) || isCollectionValue(b)) {
+    return isCollectionValue(a) && isCollectionValue(b) && JSON.stringify(a) === JSON.stringify(b);
+  }
+  return String(a) === String(b);
+}
+
 /** Deep equality check for two state-format data sources. */
 function dataSourcesEqual(a, b) {
   if (!a || !b) return false;
@@ -278,7 +352,7 @@ export function syncEditedValues(formState, scenarioIndex, values) {
   const scenario = formState.scenarios[scenarioIndex];
   if (!scenario) return;
 
-  const { parameterValues, calculationDate, dataSources } = values;
+  const { parameterValues, calculationDate, dataSources, collections } = values;
 
   // --- Parameters ---
   const scenarioParamMap = new Map(
@@ -287,29 +361,38 @@ export function syncEditedValues(formState, scenarioIndex, values) {
   const bgParams = formState.background?.parameters || [];
   const bgParamMap = new Map(bgParams.map((p) => [p.name, p]));
 
+  // Scalar parameters and collections share the override rule: a value that
+  // lives in the scenario is updated in place, a background value that was
+  // changed becomes a scenario-level override. `columns` only exists on a
+  // collection.
+  const applyParameter = (name, value, columns) => {
+    const entry = columns ? { name, value, columns } : { name, value };
+    if (scenarioParamMap.has(name)) {
+      Object.assign(scenario.setup.parameters[scenarioParamMap.get(name)], entry);
+    } else if (bgParamMap.has(name)) {
+      if (!parameterValuesEqual(bgParamMap.get(name).value, value)) {
+        scenario.setup.parameters.push(entry);
+      }
+    }
+  };
+
   for (const [name, rawValue] of Object.entries(parameterValues)) {
     // Same rule as reading a step: the content decides. An input control hands
     // back a raw string, and leaving it at that would write `is "50000"` where
     // the scenario said `is 50000`.
-    const value = quotedValue(rawValue);
+    applyParameter(name, quotedValue(rawValue));
+  }
 
-    if (scenarioParamMap.has(name)) {
-      // Update existing scenario-level parameter
-      scenario.setup.parameters[scenarioParamMap.get(name)].value = value;
-    } else if (bgParamMap.has(name)) {
-      // Background param - add scenario override only if value differs
-      const bgValue = bgParamMap.get(name).value;
-      if (String(bgValue) !== String(value)) {
-        scenario.setup.parameters.push({ name, value });
-      }
-    }
+  for (const coll of collections || []) {
+    const { columns, records } = formCollectionToState(coll);
+    applyParameter(coll.name, records, columns);
   }
 
   // Drop scenario-level overrides that now match the background - otherwise
   // a save/edit/save cycle accumulates redundant `Given parameter ...` steps.
   scenario.setup.parameters = scenario.setup.parameters.filter((p) => {
     if (!bgParamMap.has(p.name)) return true;
-    return String(bgParamMap.get(p.name).value) !== String(p.value);
+    return !parameterValuesEqual(bgParamMap.get(p.name).value, p.value);
   });
 
   // --- Data sources ---
@@ -433,7 +516,15 @@ function writeSetupSteps(lines, setup, indent) {
   }
 
   for (const param of setup.parameters || []) {
-    if (typeof param.value === 'number') {
+    if (isCollectionValue(param.value)) {
+      lines.push(`${indent}${KW.set_parameter_collection} ${TPL.set_parameter_collection([param.name])}`);
+      const columns = collectionColumns(param);
+      lines.push(`${indent}  | ${columns.join(' | ')} |`);
+      for (const record of param.value) {
+        const cells = columns.map((c) => formatCell(record[c]));
+        lines.push(`${indent}  | ${cells.join(' | ')} |`);
+      }
+    } else if (typeof param.value === 'number') {
       lines.push(`${indent}${KW.set_parameter_number} ${TPL.set_parameter_number([param.name, formatValue(param.value)])}`);
     } else {
       lines.push(`${indent}${KW.set_parameter_string} ${TPL.set_parameter_string([param.name, formatValue(param.value)])}`);

--- a/frontend/src/gherkin/formMapper.js
+++ b/frontend/src/gherkin/formMapper.js
@@ -306,6 +306,9 @@ function formCollectionToState(coll) {
  * collection to "[object Object]" and call them all equal.
  */
 function parameterValuesEqual(a, b) {
+  // Key order counts: an override that lists the same columns in another
+  // order never collapses into the background. That keeps a step, it never
+  // loses one, so it is left as is.
   if (isCollectionValue(a) || isCollectionValue(b)) {
     return isCollectionValue(a) && isCollectionValue(b) && JSON.stringify(a) === JSON.stringify(b);
   }

--- a/frontend/src/utils/outputFormat.js
+++ b/frontend/src/utils/outputFormat.js
@@ -6,6 +6,9 @@
 export function formatValue(value) {
   if (value === null || value === undefined) return 'null';
   if (typeof value === 'boolean') return value ? 'ja' : 'nee';
+  // A collection (RFC-016) or a record reaches the trace as an array or an
+  // object; String() would render every element as "[object Object]".
+  if (typeof value === 'object') return JSON.stringify(value);
   return String(value);
 }
 

--- a/frontend/src/utils/outputFormat.test.js
+++ b/frontend/src/utils/outputFormat.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatOutputValue, formatOutputValueParts } from './outputFormat.js';
+import { formatOutputValue, formatOutputValueParts, formatValue } from './outputFormat.js';
 
 // Intl renders the euro sign followed by a non-breaking space; matching on the
 // digits keeps the assertions readable and independent of that whitespace.
@@ -46,5 +46,19 @@ describe('formatOutputValue', () => {
   it('returns the bare value without a monetary unit', () => {
     expect(formatOutputValue(150000, null)).toBe('150000');
     expect(formatOutputValue(150000, 'eurocenten')).toBe('150000');
+  });
+});
+
+describe('formatValue', () => {
+  it('renders a collection as JSON instead of [object Object]', () => {
+    expect(formatValue([{ leeftijd: 25 }, { leeftijd: 19 }])).toBe('[{"leeftijd":25},{"leeftijd":19}]');
+    expect(formatValue({ leeftijd: 25 })).toBe('{"leeftijd":25}');
+    expect(formatValue([])).toBe('[]');
+  });
+
+  it('keeps scalars as they were', () => {
+    expect(formatValue(true)).toBe('ja');
+    expect(formatValue(null)).toBe('null');
+    expect(formatValue(42)).toBe('42');
   });
 });


### PR DESCRIPTION
Luc meldde dat FOREACH werkt, maar dat de scenario's in de editor niet lopen. Dat klopt, en de oorzaak is inderdaad formMapper.js.

## Wat er misging

De stap `Given parameter "x" is the collection:` kwam in #1343 in `bdd/grammar.yaml`, in de Rust-runner en in `actions.js`. In `formMapper.js` kwam hij niet. Dat bestand vertaalt een feature-bestand naar de formuliertoestand waaruit de editor het scenario tegen de WASM-engine draait. Een stap die de mapper niet kent gaat naar `unmatchedSteps`. Bij opslaan wordt hij letterlijk teruggeschreven, dus het bestand blijft heel, maar de run mist de parameter. `kostendelersnorm.feature` slaagde daardoor onder `just bdd` en faalde in de editor op een ontbrekende `medebewoners`.

## Wat er verandert

- De mapper leest de tabel als records plus kolomnamen en schrijft hem in dezelfde vorm terug. De kolommen gaan apart mee, anders verliest een collectie zonder elementen zijn header.
- De background-override-regel in `syncEditedValues` werkt nu ook voor collecties. De oude vergelijking deed `String(a) !== String(b)`, en dat maakt van elke array `[object Object]`, waardoor elke gewijzigde collectie als "gelijk aan de background" was weggegooid.
- In `ScenarioForm.vue` staat een collectie als drill-in rij onder Invoer, met hetzelfde tabelwidget als een bron. `DataSourceTable` kreeg daarvoor een optionele sleutelkolom (`keyField: null`). Geen extra CSS.
- De engine krijgt de collectie als array van records. Een leeggemaakte collectie gaat mee als `[]`, want "geen medebewoners" is een waarde en geen ontbrekende invoer.
- Een scenario dat een background-collectie overschrijft, toonde de parameter twee keer (de scalars dedupliceerden op naam, de collecties niet). Nu wint de laatste.
- In de trace-weergave stond de collectie-resolve als `[object Object],[object Object]`. `formatValue` geeft arrays en objecten nu als JSON weer.

## Waarom dit niet nog een keer gebeurt

`formMapper.coverage.test.js` bouwt uit elke `tier: core`-ingang van de grammatica een stap op basis van zijn eigen template en eist dat de mapper hem herkent, heen en terug. Tegen de mapper van main faalt die test op precies `set_parameter_collection`. De volgende grammatica-uitbreiding zonder mapper-case wordt dus hier rood en niet in iemands editor.

## Gecontroleerd

Alle twaalf asserties uit `kostendelersnorm.feature` slagen via mapper plus de gebouwde WASM-engine in Node, langs hetzelfde pad als `ScenarioForm.execute()`. De frontend-suite staat op 866 groen.

Wat nog open staat: de editor zegt nog steeds niets als een stap in `unmatchedSteps` belandt. Dat is een aparte UX-keuze.
