### PR TITLE
feat(docs): link vanuit een paper naar de discussie erover op GitHub

### DIFF
--- a/docs/src/pages/research/rules-as-executed.astro
+++ b/docs/src/pages/research/rules-as-executed.astro
@@ -72,6 +72,16 @@ const discussionUrl =
           variant="secondary"
         ></nldd-button>
       </nldd-button-group>
+      <nldd-spacer size="8" />
+      {/*
+       * The selection affordance (Base.astro) is invisible until text is
+       * selected, so nothing on the page says it exists; this line does.
+       */}
+      <nldd-rich-text>
+        <p class="rr-paper-note">
+          Select a passage in the paper to start a discussion about it.
+        </p>
+      </nldd-rich-text>
       <nldd-spacer size="24" sm-size="16" />
       <DocsOutline headings={headings} />
     </div>

--- a/docs/src/pages/research/rules-as-executed.astro
+++ b/docs/src/pages/research/rules-as-executed.astro
@@ -23,6 +23,18 @@ const description =
   `${meta.kind} by ${authors}: publish law execution as machine-executable ` +
   'specifications, so that decisions can be re-executed and rules analyzed.';
 const doiUrl = `https://doi.org/${meta.doi}`;
+
+// Every issue the "Discuss this passage" button (Base.astro) opens carries the
+// contribution:paper label from the issue form, and names the paper in its
+// Paper field. The label alone would list feedback on every paper; the quoted
+// title narrows it to this one, and also catches issues filed by hand from the
+// issue chooser as long as the paper is named. Open and closed both show:
+// a closed thread is still part of the discussion of a frozen paper.
+const discussionUrl =
+  'https://github.com/MinBZK/regelrecht/issues?q=' +
+  encodeURIComponent(
+    `is:issue label:contribution:paper "${meta.title}" sort:updated-desc`
+  );
 ---
 
 <Base
@@ -42,14 +54,24 @@ const doiUrl = `https://doi.org/${meta.doi}`;
       <p slot="subtitle">{meta.subtitle}</p>
     </nldd-title>
     <div slot="left">
-      <nldd-button
-        href={doiUrl}
-        text="PDF on Zenodo"
-        start-icon="external-link"
-        target="_blank"
-        rel="noopener"
-        variant="secondary"
-      ></nldd-button>
+      <nldd-button-group>
+        <nldd-button
+          href={doiUrl}
+          text="PDF on Zenodo"
+          start-icon="external-link"
+          target="_blank"
+          rel="noopener"
+          variant="secondary"
+        ></nldd-button>
+        <nldd-button
+          href={discussionUrl}
+          text="Discussion on GitHub"
+          start-icon="comment"
+          target="_blank"
+          rel="noopener"
+          variant="secondary"
+        ></nldd-button>
+      </nldd-button-group>
       <nldd-spacer size="24" sm-size="16" />
       <DocsOutline headings={headings} />
     </div>


### PR DESCRIPTION
Sinds #1345 opent een tekstselectie in een paper een voorgevulde issue, maar de discussie die daaruit ontstaat was vanaf de paperpagina zelf niet te vinden.

Naast "PDF on Zenodo" staat nu een tweede secondary-knop, "Discussion on GitHub", in een `nldd-button-group`. Hij linkt naar de issues gefilterd op:

```
is:issue label:contribution:paper "Rules as Executed" sort:updated-desc
```

Het label komt van het issueformulier. De titel tussen aanhalingstekens houdt bij een tweede paper de feedback uit elkaar; hij staat in het Paper-veld van elke issue die de selectieknop aanmaakt. Open en gesloten issues staan er allebei in.

Geen extra CSS. Er zijn nog geen issues met het label, dus de query is tegen echte data niet te controleren; de URL rendert correct in de build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQeH83n2TfLgEGwUg4Nw4E
