### PR TITLE
feat(editor): verrijking als beoordelingseenheid, één commit per verrijking

### DIFF
--- a/frontend/src/AppShell.vue
+++ b/frontend/src/AppShell.vue
@@ -103,19 +103,32 @@ function openSupport() {
   nextTick(() => supportSheet.value?.show?.());
 }
 
-// Rejecting a proposal resolves the review task and throws the seeded edit
-// away, so it asks first. Owned here because the Verwerp button lives in the
-// changes bar; EditorView keeps the actual reject logic.
+// Rejecting a proposal throws the seeded edit away, so it asks first. Owned
+// here because the Verwerp button lives in the changes bar; EditorView keeps
+// the actual reject logic.
 const rejectConfirm = ref(null);
 function confirmReject() {
   rejectConfirm.value?.hide();
   editorActions.value?.reject?.();
 }
 
+// "Rond af, neem de rest niet over" sluit de hele verrijking af zonder de
+// resterende onderdelen te bekijken - destructiever dan één verwerping, dus
+// die vraagt het ook eerst.
+const rejectRestConfirm = ref(null);
+function confirmRejectRest() {
+  rejectRestConfirm.value?.hide();
+  editorActions.value?.rejectRest?.();
+}
+
 // In review mode the bar decides on a proposal, not on your own edits, so the
-// labels say so. Outside review "Opslaan" stays what it always was.
+// labels say so. Outside review "Opslaan" stays what it always was. Het
+// oordeel gaat over één onderdeel van de verrijking en schrijft nog niets weg,
+// dus "Neem over" en niet "Sla op" - er wordt pas geschreven als alle
+// onderdelen beoordeeld zijn.
 const inReview = computed(() => !!editorChanges.value?.review);
-const saveLabel = computed(() => (inReview.value ? 'Sla voorstel op' : 'Opslaan'));
+const saveLabel = computed(() => (inReview.value ? 'Neem voorstel over' : 'Opslaan'));
+const canRejectRest = computed(() => !!editorChanges.value?.reviewCanRejectRest);
 
 // Not dismissible: the notice explains what Verwerp and Opslaan below it refer
 // to, so hiding it would leave two decision buttons without their subject. It
@@ -626,6 +639,12 @@ function onTabDismiss(e) {
                       destructive
                       @select="editorActions?.discard?.()"
                     ></nldd-menu-item>
+                    <nldd-menu-item
+                      v-if="canRejectRest"
+                      text="Rond af, neem de rest niet over"
+                      destructive
+                      @select="rejectRestConfirm?.show()"
+                    ></nldd-menu-item>
                   </nldd-menu>
                 </nldd-icon-button>
               </nldd-button-bar>
@@ -648,6 +667,13 @@ function onTabDismiss(e) {
                 text="Maak alle wijzigingen ongedaan"
                 destructive
                 @select="editorActions?.discard?.()"
+              ></nldd-menu-item>
+              <nldd-menu-item
+                v-if="canRejectRest"
+                slot="overflow"
+                text="Rond af, neem de rest niet over"
+                destructive
+                @select="rejectRestConfirm?.show()"
               ></nldd-menu-item>
             </nldd-toolbar-item>
             <!-- Review-modus zet de beslissing hier. Twee losse toolbar-items,
@@ -847,6 +873,27 @@ function onTabDismiss(e) {
       variant="destructive"
       text="Verwerp voorstel"
       @click="confirmReject"
+    ></nldd-button>
+  </nldd-modal-dialog>
+
+  <nldd-modal-dialog
+    ref="rejectRestConfirm"
+    variant="alert"
+    icon="exclamation-triangle"
+    text="Verrijking afronden?"
+    supporting-text="Wat je al hebt overgenomen wordt weggeschreven; alle onderdelen die je nog niet hebt beoordeeld worden niet overgenomen en gaan verloren."
+  >
+    <nldd-button
+      slot="actions"
+      variant="primary"
+      text="Verder beoordelen"
+      @click="rejectRestConfirm?.hide()"
+    ></nldd-button>
+    <nldd-button
+      slot="actions"
+      variant="destructive"
+      text="Rond af"
+      @click="confirmRejectRest"
     ></nldd-button>
   </nldd-modal-dialog>
 </template>

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -203,6 +203,7 @@ const {
   saving: lawSaving,
   saveError: lawSaveError,
   saveLaw,
+  reloadLaw,
   seedFromYaml,
   createLaw,
   currentEtag,
@@ -1514,16 +1515,24 @@ const lastSaveTouchedMachine = ref(false);
 // the same pane-local "current" refs a manual edit would touch), so the
 // existing dirty-tracking and Wijzigingenbalk (Opslaan/Wijzigingen-
 // ongedaan) drive the review UI the same way they drive a manual edit.
-// Seeding en opslaan zijn allebei artikel-scoped: de taak wijst het artikel
-// aan (`payload.article`), de editor seedt dat en Opslaan bewaart de splice.
-// Alleen een taak zónder artikelnummer valt terug op de hele wet, zie
-// `reviewSavesWholeLaw`.
+// Seeden is artikel-scoped: de taak wijst het artikel aan (`payload.article`)
+// en de editor toont dat.
+//
+// Opslaan schrijft niet meer. Een verrijking is de eenheid die geschreven
+// wordt, dus "Neem voorstel over" legt het oordeel over dít onderdeel vast en
+// brengt je naar het volgende; pas als elk onderdeel een oordeel heeft, gaat
+// alles in één keer naar de backend, die er één commit van maakt. Tot dat
+// moment verandert er niets aan de wet.
 const {
   reviewTask,
   proposedContent: reviewProposedContent,
-  stale: reviewStale,
   loadError: reviewLoadError,
+  partIndex: reviewPartIndex,
+  partCount: reviewPartCount,
+  undecidedParts: reviewUndecidedParts,
   loadReview,
+  decide: decideReviewPart,
+  processEnrichment,
   approveAfterSave,
   reject: rejectReviewInternal,
 } = useTaskReview();
@@ -1545,10 +1554,10 @@ const reviewArticleNumber = computed(() => {
   const number = reviewTask.value?.payload?.article;
   return number == null ? null : String(number);
 });
-// Een taak die één artikel aanwijst, slaat op als elke andere artikel-save: de
-// splice van de zichtbare pane, inclusief wat de beoordelaar er zelf nog aan
-// veranderde. Alleen een taak zonder artikelnummer committeert het voorstel in
-// zijn geheel, want daar is geen kleinere eenheid om over te beslissen.
+// Een taak die één artikel aanwijst, accordeert dat artikel zoals het in de
+// panes staat - inclusief wat de beoordelaar er zelf nog aan veranderde. Een
+// taak zonder artikelnummer accordeert het voorstel in zijn geheel, want daar
+// is geen kleinere eenheid om over te beslissen.
 const reviewSavesWholeLaw = computed(() => reviewActive.value && !reviewArticleNumber.value);
 const reviewTaskIdParam = computed(() =>
   typeof route.query.task === 'string' ? route.query.task : null,
@@ -1631,7 +1640,6 @@ const REVIEW_HIDDEN_CHANGES_NOTE = 'Zie ook het YAML-paneel voor wijzigingen bui
 const reviewBannerVariant = computed(() => {
   if (reviewLoadError.value) return 'critical';
   if (reviewIsLawCreate.value) return 'accent';
-  if (reviewStale.value) return 'warning';
   if (reviewActive.value && !reviewSeeded.value) return 'warning';
   return 'accent';
 });
@@ -1648,20 +1656,13 @@ const reviewBannerSupportingText = computed(() => {
       ? `Artikel ${reviewArticleNumber.value} wijkt niet af van het voorstel; er valt niets te wijzigen.`
       : 'Voorstel raakt alleen inhoud die hier niet zichtbaar is - bekijk het YAML-paneel.';
   }
-  if (reviewStale.value) {
-    return (
-      'Let op: de wet is intussen gewijzigd; controleer extra goed.' +
-      (reviewHasHiddenChanges.value ? ` ${REVIEW_HIDDEN_CHANGES_NOTE}` : '')
-    );
-  }
-  // Artikel-scoped: Opslaan is de gewone artikel-save, dus eigen aanpassingen
-  // gaan wél mee. Bij een voorstel voor de hele wet niet, en dat moet er dan
-  // ook staan - het is precies wat een beoordelaar niet verwacht.
+  // Artikel-scoped: het oordeel gaat over dit artikel zoals het hier staat,
+  // dus eigen aanpassingen gaan wél mee.
   if (!reviewSavesWholeLaw.value) {
-    return `Opslaan bewaart artikel ${reviewArticleNumber.value} zoals het hier staat, Verwerpen wijst het voorstel af.`;
+    return `Overnemen bewaart artikel ${reviewArticleNumber.value} zoals het hier staat, Verwerpen laat het ongemoeid.`;
   }
   return (
-    'Opslaan keurt het volledige voorstel goed (eigen aanpassingen gaan niet mee), Verwerpen wijst af.' +
+    'Overnemen neemt het volledige voorstel over (eigen aanpassingen gaan niet mee), Verwerpen wijst af.' +
     (reviewHasHiddenChanges.value ? ` ${REVIEW_HIDDEN_CHANGES_NOTE}` : '')
   );
 });
@@ -1686,8 +1687,22 @@ const reviewStatusText = computed(() => {
   const panes = reviewChangedPanes.value;
   const list =
     panes.length > 1 ? `${panes.slice(0, -1).join(', ')} en ${panes.at(-1)}` : panes[0];
-  const stale = reviewStale.value ? ' De wet is intussen gewijzigd, controleer extra goed.' : '';
-  return `${what}. Beoordeel ${list}.${stale}`;
+  return `${what}. Beoordeel ${list}.${reviewProgressNote.value}`;
+});
+
+// Waar de beoordelaar in de verrijking staat, en - zolang er nog onderdelen
+// open staan - dat de wet nog niet is bijgewerkt. Zonder die tweede zin leest
+// "Neem voorstel over" als "opgeslagen", terwijl er tot het laatste oordeel
+// niets is weggeschreven.
+const reviewProgressNote = computed(() => {
+  if (reviewIsLawCreate.value || reviewPartCount.value <= 1) return '';
+  const position =
+    reviewPartIndex.value > 0
+      ? ` Onderdeel ${reviewPartIndex.value} van ${reviewPartCount.value}.`
+      : '';
+  return reviewUndecidedParts.value.length > 1
+    ? `${position} De wet wordt pas bijgewerkt als alle onderdelen zijn beoordeeld.`
+    : `${position} Dit is het laatste onderdeel; daarna wordt de wet bijgewerkt.`;
 });
 
 // Fires once the law + its first article have finished loading (whether
@@ -1704,7 +1719,7 @@ watch(
     if (isLoading || !article || !taskId) return;
     if (reviewAttemptedForTaskId === taskId) return;
     reviewAttemptedForTaskId = taskId;
-    loadReview(taskId, currentEtag.value).then(() => {
+    loadReview(taskId).then(() => {
       if (reviewProposedContent.value) applyProposedContent(reviewProposedContent.value);
     });
   },
@@ -1723,7 +1738,7 @@ watch(
     if (!taskId || err?.status !== 404) return;
     if (reviewAttemptedForTaskId === taskId) return;
     reviewAttemptedForTaskId = taskId;
-    loadReview(taskId, null).then(() => {
+    loadReview(taskId).then(() => {
       const task = reviewTask.value;
       if (
         task?.payload?.kind === 'law_create' &&
@@ -1742,20 +1757,105 @@ watch(
   { immediate: true },
 );
 
-// "Verwerpen" in the review banner: resolve the task as rejected, throw
-// away the seeded edit (same discard the Wijzigingenbalk offers), and
-// leave review mode.
+// "Verwerpen": bij een `law_create` is er niets samen te stellen - die taak
+// staat op zichzelf en wordt direct afgehandeld. Bij een verrijking is dit een
+// oordeel over één onderdeel, net als "Overnemen".
 async function rejectReview() {
-  const wasLawCreate = reviewIsLawCreate.value;
-  await rejectReviewInternal();
-  if (wasLawCreate) {
+  if (reviewIsLawCreate.value) {
+    await rejectReviewInternal();
     // De wet bestaat niet (en komt er na verwerpen ook niet): terugroutes
     // naar de wetsroute zouden op een 404 landen, dus terug naar Home.
     router.replace(libraryTabTarget.value);
     return;
   }
+  await decideReview('rejected');
+}
+
+// "Rond af, neem de rest niet over": de vastgelegde oordelen plus "niet
+// overnemen" voor alles wat nog open staat, in één verwerking. Zonder deze weg
+// zou een verrijking van dertig artikelen dertig klikken kosten voordat er ook
+// maar iets geschreven kan worden.
+async function rejectRestOfReview() {
+  if (!reviewActive.value || reviewIsLawCreate.value) return;
+  await processReview({ rejectRemaining: true });
+}
+
+/**
+ * De inhoud die de beoordelaar met "Overnemen" accordeert.
+ *
+ * Voor een artikel-taak: het artikel zoals het nu in de panes staat - het
+ * geseede voorstel plus wat de beoordelaar er zelf nog aan veranderde. Zelfde
+ * splice-regels als `currentLawYaml`, maar dan alléén het artikel: wat dat
+ * betekent voor het bestand stelt de backend samen, want alleen daar kan het
+ * tegen precies de bytes waartegen de `If-Match` is gecontroleerd.
+ *
+ * `null` betekent "neem het ruwe voorstel over" - dat is wat de backend doet
+ * als er geen inhoud meekomt. Dat is de juiste terugval wanneer de editor het
+ * artikel niet kan tonen (het staat niet in de opgeslagen wet), want dan heeft
+ * de beoordelaar er ook niets aan kunnen veranderen.
+ */
+function acceptedReviewContent() {
+  if (reviewSavesWholeLaw.value) return reviewProposedContent.value;
+  const base = selectedArticle.value;
+  if (!base || String(base.number) !== reviewArticleNumber.value) return null;
+  const patched = { ...base, text: editedText.value };
+  if (machineReadable.value != null) {
+    patched.machine_readable = machineReadable.value;
+  } else {
+    delete patched.machine_readable;
+  }
+  try {
+    return yaml.dump(patched, dumpOpts);
+  } catch {
+    return null;
+  }
+}
+
+// Eén oordeel over het onderdeel dat nu open staat. Is het het laatste, dan
+// wordt de verrijking meteen verwerkt; anders schuift de editor door naar het
+// volgende onbeoordeelde onderdeel.
+async function decideReview(action) {
+  const { done, next } = decideReviewPart(
+    action,
+    action === 'approved' ? acceptedReviewContent() : null,
+  );
+  if (done) {
+    await processReview();
+    return;
+  }
+  // De geseede wijziging is vastgelegd in het oordeel; de panes gaan terug
+  // naar de opgeslagen wet voordat het volgende onderdeel eroverheen komt.
   discardArticle();
-  clearReviewQuery();
+  router.replace(reviewRouteForPart(next));
+}
+
+// De editor-route van een ander onderdeel van dezelfde verrijking, met de
+// taak-id als `?task=` zodat de bestemming hem oppakt.
+function reviewRouteForPart(part) {
+  const target = editorRouteFor(lawId.value, part.article ?? selectedArticleNumber.value);
+  return { ...target, query: { ...(target.query ?? {}), task: part.id } };
+}
+
+// Verwerk de verrijking: één schrijfactie, één commit, alle taken dicht. De
+// backend stelt de eindstand samen, dus de wet wordt daarna opnieuw geladen -
+// de client kent de uitkomst niet.
+const reviewProcessing = ref(false);
+const reviewProcessError = ref(null);
+async function processReview(options = {}) {
+  reviewProcessing.value = true;
+  reviewProcessError.value = null;
+  try {
+    await processEnrichment(currentEtag.value, options);
+    await reloadLaw();
+    discardArticle();
+    // De wettekst kan gewijzigd zijn, dus notities moeten opnieuw ankeren.
+    void reloadNotes();
+    clearReviewQuery();
+  } catch (e) {
+    reviewProcessError.value = e;
+  } finally {
+    reviewProcessing.value = false;
+  }
 }
 
 // --- Verrijken aanvragen (levert een job_review-taak op) -----------------
@@ -1821,18 +1921,17 @@ function dismissEnrichFeedback() {
 // the whole law YAML, so one click persists every in-memory edit for the
 // selected article regardless of which pane surfaced the button.
 //
-// Review-modus: Opslaan approves the task. Een taak die één artikel aanwijst
-// loopt langs het gewone pad - `currentLawYaml` splicet dat artikel in de
-// opgeslagen wet, en dat is precies de eenheid waarover de taak gaat. Wat de
-// verrijking elders voorstelde, blijft aan de eigen taak van dát artikel
-// hangen en gaat hier niet ongezien mee.
-//
-// Een taak zonder artikelnummer (law_create, of een voorstel dat de worker
-// niet kon opsplitsen) heeft die kleinere eenheid niet, en committeert het
-// voorstel integraal. `saveLaw` accepteert willekeurige volledige-wet-YAML
-// (zie de PUT-body in useLaw.js), dus dat is dezelfde aanroep met andere
+// Review-modus van een verrijking gaat hier NIET langs: daar is Opslaan een
+// oordeel over één onderdeel en geen schrijfactie (`decideReview`). Alleen een
+// `law_create` slaat hier nog op - die taak staat op zichzelf, de wet bestaat
+// nog niet en gaat via het create-pad (POST). `createLaw` accepteert
+// willekeurige volledige-wet-YAML, dus dat is dezelfde aanroep met andere
 // inhoud; er komt geen tweede save-pad bij.
 async function handleLawSave() {
+  if (reviewActive.value && !reviewIsLawCreate.value) {
+    await decideReview('approved');
+    return;
+  }
   const lawYaml = reviewSavesWholeLaw.value ? reviewProposedContent.value : currentLawYaml.value;
   if (!lawYaml) return;
   // Snapshot the law id before the await. saveLaw itself guards its own
@@ -1891,16 +1990,24 @@ async function handleLawSave() {
 }
 
 // Whole-law save failures surface as a single modal over the editor (not an
-// inline dialog buried in one pane). lawSaveError drives it: a new failure
-// (a fresh Error) re-opens it via the watch, a successful save (null) closes it.
+// inline dialog buried in one pane). `saveErrorText` drives it: a new failure
+// (a fresh Error) re-opens it via the watch, a successful save (null) closes
+// it. Het verwerken van een verrijking hangt er ook aan - dat is voor de
+// gebruiker dezelfde gebeurtenis (mijn wijziging kwam er niet in) en verdient
+// dezelfde melding, inclusief de 412-uitleg bij een conflict.
+const saveFailure = computed(() => reviewProcessError.value ?? lawSaveError.value);
+const saveErrorText = computed(() =>
+  saveFailure.value ? saveFailure.value.message || String(saveFailure.value) : '',
+);
 const saveErrorModalEl = ref(null);
-watch(lawSaveError, (err) => {
+watch(saveFailure, (err) => {
   const el = saveErrorModalEl.value;
   if (!el) return;
   if (err && typeof el.show === 'function') el.show();
   else if (!err && typeof el.hide === 'function') el.hide();
 });
 function dismissSaveError() {
+  reviewProcessError.value = null;
   saveErrorModalEl.value?.hide?.();
 }
 
@@ -1959,16 +2066,25 @@ registerEditorActions({
   undo: undoText,
   redo: redoText,
   reject: rejectReview,
+  rejectRest: rejectRestOfReview,
 });
 watchEffect(() => {
   setEditorChanges({
     dirty: articleDirty.value,
-    saving: lawSaving.value,
+    saving: lawSaving.value || reviewProcessing.value,
     canUndo: canUndoText.value,
     canRedo: canRedoText.value,
-    review: reviewActive.value,
+    // `reviewProcessing` telt mee zodat de balk niet halverwege het verwerken
+    // verdwijnt: `processEnrichment` sluit de review-state zodra de backend
+    // klaar is, terwijl het herladen van de wet dan nog loopt.
+    review: reviewActive.value || reviewProcessing.value,
     reviewStatus: reviewActive.value || reviewLoadError.value ? reviewStatusText.value : null,
     reviewVariant: reviewBannerVariant.value,
+    // Meer dan één onbeoordeeld onderdeel: dan is "rond af, neem de rest niet
+    // over" een echte afkorting. Bij het laatste onderdeel doet Verwerpen
+    // hetzelfde, en dan zou het een tweede knop voor dezelfde daad zijn.
+    reviewCanRejectRest:
+      reviewActive.value && !reviewIsLawCreate.value && reviewUndecidedParts.value.length > 1,
   });
 });
 
@@ -3052,7 +3168,7 @@ async function handleActionSave() {
     ref="saveErrorModalEl"
     variant="alert"
     text="Opslaan mislukt"
-    :supporting-text="lawSaveError ? (lawSaveError.message || String(lawSaveError)) : ''"
+    :supporting-text="saveErrorText"
     data-testid="save-error-modal"
     @close="dismissSaveError"
   >

--- a/frontend/src/composables/useAppChrome.js
+++ b/frontend/src/composables/useAppChrome.js
@@ -74,8 +74,11 @@ const documentTabsTrajectRef = shallowRef(null);
 // `main`: it belongs to the bar-split-view, not to the editor's own content
 // flow, so it lines up with the tab bar and the changes bar instead of
 // scrolling with the panes.
-const editorChanges = shallowRef(null); // { dirty, saving, canUndo, canRedo, review, reviewStatus, reviewVariant } | null
-const editorActions = shallowRef(null); // { save, discard, undo, redo, reject } | null
+// `reviewCanRejectRest` zegt of er meer dan één onbeoordeeld onderdeel over is;
+// dan biedt de bar "rond af, neem de rest niet over" aan, zodat een verrijking
+// af te ronden is zonder elk onderdeel langs te lopen.
+const editorChanges = shallowRef(null); // { dirty, saving, canUndo, canRedo, review, reviewStatus, reviewVariant, reviewCanRejectRest } | null
+const editorActions = shallowRef(null); // { save, discard, undo, redo, reject, rejectRest } | null
 
 // --- Library-only chrome ---
 // Whether the library has nothing curated yet (no favorites, no traject edits,

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -439,6 +439,31 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
   }
 
   /**
+   * Herlaad de open wet van de server, langs de cache heen.
+   *
+   * Voor schrijfacties waarvan de backend de eindstand zelf samenstelt en de
+   * client die dus niet kent - het verwerken van een verrijking splicet de
+   * overgenomen artikelen server-side in de wet. `saveLaw` kan zijn eigen body
+   * terugleggen, hier is er geen body om terug te leggen.
+   *
+   * Zelfde stale-guard als `saveLaw`: is de gebruiker tijdens de fetch naar een
+   * andere wet of een ander traject gesprongen, dan wordt er niets overschreven.
+   *
+   * @returns {Promise<boolean>} of deze aanroep de state daadwerkelijk bijwerkte.
+   */
+  async function reloadLaw() {
+    if (!lawId.value) return false;
+    const reloadedLawId = lawId.value;
+    const reloadedTrajectRef = currentTrajectRef;
+    const entry = await fetchLawFresh(reloadedTrajectRef, reloadedLawId);
+    if (lawId.value !== reloadedLawId || currentTrajectRef !== reloadedTrajectRef) return false;
+    law.value = entry.law;
+    rawYaml.value = entry.rawYaml;
+    currentEtag.value = entry.etag ?? null;
+    return true;
+  }
+
+  /**
    * Create a NEW law in the active traject via POST (the approve-step of a
    * `law_create` review task). Same body/etag/PR plumbing as `saveLaw`, but
    * without `If-Match` (there is nothing to be concurrent with yet); the
@@ -508,6 +533,7 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
     saving,
     saveError,
     saveLaw,
+    reloadLaw,
     seedFromYaml,
     createLaw,
     currentEtag,

--- a/frontend/src/composables/useTaskReview.js
+++ b/frontend/src/composables/useTaskReview.js
@@ -86,10 +86,16 @@ export function useTaskReview() {
   const jobParts = ref([]);
 
   const jobId = computed(() => reviewTask.value?.job_id ?? null);
+  // Waaronder de tussenstand wordt bewaard. Eén sleutel voor de hele
+  // verrijking; valt terug op de taak zelf voor een taak zonder job, want dan
+  // is die taak in zijn eentje de verrijking. Alles wat de oordelen leest of
+  // schrijft gebruikt déze sleutel - een lezer die `jobId` neemt en een
+  // schrijver die terugvalt, zouden elkaars oordelen niet zien.
+  const verdictKey = computed(() => jobId.value ?? reviewTask.value?.id ?? null);
   const openParts = computed(() => jobParts.value.filter((p) => p.status === 'open'));
   /** Onderdelen die nog op een oordeel wachten. */
   const undecidedParts = computed(() => {
-    const decided = verdictsForJob(jobId.value);
+    const decided = verdictsForJob(verdictKey.value);
     return openParts.value.filter((p) => !decided[p.id]);
   });
   /** Hoeveelste onderdeel je nu beoordeelt, 1-based (0 als het er niet bij zit). */
@@ -166,7 +172,7 @@ export function useTaskReview() {
   function decide(action, content) {
     const task = reviewTask.value;
     if (!task) return { done: false, next: null };
-    recordVerdict(jobId.value ?? task.id, task.id, action, content ?? null);
+    recordVerdict(verdictKey.value, task.id, action, content ?? null);
     const next = undecidedParts.value.find((p) => p.id !== task.id) ?? null;
     return { done: !next, next };
   }
@@ -180,7 +186,7 @@ export function useTaskReview() {
   async function processEnrichment(etag, { rejectRemaining = false } = {}) {
     const task = reviewTask.value;
     if (!task) return null;
-    const key = jobId.value ?? task.id;
+    const key = verdictKey.value;
     const decided = verdictsForJob(key);
     const decisions = openParts.value
       .map((part) => {
@@ -193,7 +199,7 @@ export function useTaskReview() {
         return rejectRemaining ? { task_id: part.id, action: 'rejected' } : null;
       })
       .filter(Boolean);
-    const result = await applyEnrichment(jobId.value ?? task.id, decisions, etag);
+    const result = await applyEnrichment(key, decisions, etag);
     clearVerdicts(key);
     reviewTask.value = null;
     proposedContent.value = null;

--- a/frontend/src/composables/useTaskReview.js
+++ b/frontend/src/composables/useTaskReview.js
@@ -1,27 +1,105 @@
 /**
  * useTaskReview - review-modus voor een job_review-taak in de editor.
  *
- * Bij ?task=<id>: haal de taakdetail op, vind het law-YAML-resultaat en
- * lever (a) de voorgestelde content, (b) een staleness-vlag (payload.
- * source_etag ≠ actuele law-ETag), en (c) approve/reject-acties.
- * Approve-volgorde (spec §5.3): éérst opslaan via het normale save-pad
- * (doet de caller), dán resolve(approved).
+ * Een verrijking levert één taak per gewijzigd artikel. Je oordeelt per
+ * artikel, maar de verrijking is de eenheid die geschreven wordt: pas als
+ * elk onderdeel een oordeel heeft, gaat alles in één keer naar de backend,
+ * die er één commit van maakt. Tot dat moment verandert er niets aan de wet.
+ *
+ * Bij ?task=<id>: haal de taakdetail op, vind het law-YAML-resultaat en lever
+ * (a) de voorgestelde content, (b) de andere onderdelen van dezelfde
+ * verrijking, en (c) de acties om een oordeel vast te leggen en de verrijking
+ * te verwerken.
+ *
+ * Er is geen staleness-vlag meer. Die vergeleek `payload.source_etag` met de
+ * actuele ETag en sloeg daardoor aan zodra een zusje van dezelfde verrijking
+ * was goedgekeurd - een waarschuwing over je eigen werk. Met één schrijfmoment
+ * hoort er ook één controle te zijn, en die zit nu op het `If-Match` van het
+ * verwerken.
  */
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { useTaskActions } from './useTasks.js';
+
+const STORAGE_KEY = 'regelrecht.enrich-verdicts';
+
+/**
+ * Vastgelegde oordelen per verrijking: `{ [jobId]: { [taskId]: { action, content } } }`.
+ *
+ * Bewust module-level en niet per component-mount: je beoordeelt artikel voor
+ * artikel en navigeert daar tussendoor, dus de tussenstand moet die navigatie
+ * overleven. sessionStorage houdt hem ook een herlaadbeurt vol; is die niet
+ * beschikbaar (quota vol, privacy-modus), dan blijft het geheugen over en is de
+ * tussenstand na een herlading weg - dan beoordeel je opnieuw, er is nog niets
+ * geschreven.
+ */
+const verdicts = ref(loadVerdicts());
+
+function loadVerdicts() {
+  try {
+    return JSON.parse(window.sessionStorage.getItem(STORAGE_KEY) ?? '{}') ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function persistVerdicts() {
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(verdicts.value));
+  } catch {
+    // Geheugen is de bron; opslag is alleen de herlaadbestendigheid.
+  }
+}
+
+export function verdictsForJob(jobId) {
+  return (jobId && verdicts.value[jobId]) || {};
+}
+
+export function recordVerdict(jobId, taskId, action, content) {
+  if (!jobId || !taskId) return;
+  verdicts.value = {
+    ...verdicts.value,
+    [jobId]: { ...verdictsForJob(jobId), [taskId]: { action, content } },
+  };
+  persistVerdicts();
+}
+
+export function clearVerdicts(jobId) {
+  if (!jobId || !verdicts.value[jobId]) return;
+  const next = { ...verdicts.value };
+  delete next[jobId];
+  verdicts.value = next;
+  persistVerdicts();
+}
 
 export function useTaskReview() {
   // useTaskActions(), not useTasks(): useTaskReview() is itself called
   // unconditionally in EditorView's setup(), so joining the polled
   // useTasks() here would start the 30s poll for every editor visitor
   // (including anonymous ones).
-  const { fetchTask, resolveTask } = useTaskActions();
+  const { fetchTask, resolveTask, fetchJobTasks, applyEnrichment } = useTaskActions();
   const reviewTask = ref(null);
   const proposedContent = ref(null);
-  const stale = ref(false);
   const loadError = ref(null);
+  // De onderdelen van deze verrijking: `[{ id, article, status, title }]`.
+  // Eén element voor een taak zonder job (of wanneer het ophalen mislukt) -
+  // dan is deze taak zelf de hele verrijking.
+  const jobParts = ref([]);
 
-  async function loadReview(taskId, currentLawEtag) {
+  const jobId = computed(() => reviewTask.value?.job_id ?? null);
+  const openParts = computed(() => jobParts.value.filter((p) => p.status === 'open'));
+  /** Onderdelen die nog op een oordeel wachten. */
+  const undecidedParts = computed(() => {
+    const decided = verdictsForJob(jobId.value);
+    return openParts.value.filter((p) => !decided[p.id]);
+  });
+  /** Hoeveelste onderdeel je nu beoordeelt, 1-based (0 als het er niet bij zit). */
+  const partIndex = computed(() => {
+    const idx = openParts.value.findIndex((p) => p.id === reviewTask.value?.id);
+    return idx < 0 ? 0 : idx + 1;
+  });
+  const partCount = computed(() => openParts.value.length);
+
+  async function loadReview(taskId) {
     try {
       const detail = await fetchTask(taskId);
       if (detail.task_type !== 'job_review' || detail.status !== 'open') {
@@ -45,27 +123,118 @@ export function useTaskReview() {
       }
       reviewTask.value = detail;
       proposedContent.value = lawFile.content;
-      stale.value = Boolean(
-        detail.payload?.source_etag &&
-          currentLawEtag &&
-          detail.payload.source_etag !== currentLawEtag
-      );
+      loadError.value = null;
+      jobParts.value = await loadJobParts(detail);
     } catch (e) {
       loadError.value = 'Taak laden mislukt.';
     }
   }
 
-  async function approveAfterSave() {
-    if (reviewTask.value) await resolveTask(reviewTask.value.id, 'approved');
+  /**
+   * De andere onderdelen van dezelfde verrijking. Mislukt dat (of hangt de
+   * taak aan geen job), dan is deze taak in zijn eentje de verrijking: dan kun
+   * je hem nog steeds beoordelen en verwerken.
+   */
+  async function loadJobParts(detail) {
+    const fallback = [
+      {
+        id: detail.id,
+        article: detail.payload?.article == null ? null : String(detail.payload.article),
+        status: 'open',
+        title: detail.title,
+      },
+    ];
+    if (!detail.job_id) return fallback;
+    try {
+      const json = await fetchJobTasks(detail.job_id);
+      const parts = Array.isArray(json?.tasks) ? json.tasks : [];
+      return parts.length > 0 ? parts : fallback;
+    } catch {
+      return fallback;
+    }
+  }
+
+  /**
+   * Leg het oordeel over het onderdeel dat nu open staat vast en zeg wat er
+   * daarna moet gebeuren: het volgende onbeoordeelde onderdeel, of - als dit
+   * de laatste was - dat de verrijking verwerkt kan worden.
+   *
+   * `content` is de inhoud die de gebruiker accordeert (het artikel zoals het
+   * in de editor staat, of de hele wet bij een onderdeel zonder artikelnummer);
+   * bij "niet overnemen" blijft hij weg.
+   */
+  function decide(action, content) {
+    const task = reviewTask.value;
+    if (!task) return { done: false, next: null };
+    recordVerdict(jobId.value ?? task.id, task.id, action, content ?? null);
+    const next = undecidedParts.value.find((p) => p.id !== task.id) ?? null;
+    return { done: !next, next };
+  }
+
+  /**
+   * Verwerk de verrijking: de vastgelegde oordelen plus, wanneer
+   * `rejectRemaining` waar is, "niet overnemen" voor alles waar nog geen
+   * oordeel over is geveld. Dat laatste is de weg om een verrijking af te
+   * ronden zonder alles één voor één langs te lopen.
+   */
+  async function processEnrichment(etag, { rejectRemaining = false } = {}) {
+    const task = reviewTask.value;
+    if (!task) return null;
+    const key = jobId.value ?? task.id;
+    const decided = verdictsForJob(key);
+    const decisions = openParts.value
+      .map((part) => {
+        const verdict = decided[part.id];
+        if (verdict) {
+          return verdict.action === 'approved'
+            ? { task_id: part.id, action: 'approved', content: verdict.content ?? undefined }
+            : { task_id: part.id, action: 'rejected' };
+        }
+        return rejectRemaining ? { task_id: part.id, action: 'rejected' } : null;
+      })
+      .filter(Boolean);
+    const result = await applyEnrichment(jobId.value ?? task.id, decisions, etag);
+    clearVerdicts(key);
     reviewTask.value = null;
     proposedContent.value = null;
+    jobParts.value = [];
+    return result;
+  }
+
+  /**
+   * Los afhandelen van één taak, zonder de wet te schrijven. Alleen nog voor
+   * het `law_create`-pad: daar bestaat de wet nog niet, dus die gaat via het
+   * aanmaakpad (POST) en niet via het verwerken van een verrijking.
+   */
+  async function approveAfterSave() {
+    if (reviewTask.value) await resolveTask(reviewTask.value.id, 'approved');
+    resetReview();
   }
 
   async function reject() {
     if (reviewTask.value) await resolveTask(reviewTask.value.id, 'rejected');
-    reviewTask.value = null;
-    proposedContent.value = null;
+    resetReview();
   }
 
-  return { reviewTask, proposedContent, stale, loadError, loadReview, approveAfterSave, reject };
+  function resetReview() {
+    reviewTask.value = null;
+    proposedContent.value = null;
+    jobParts.value = [];
+  }
+
+  return {
+    reviewTask,
+    proposedContent,
+    loadError,
+    jobParts,
+    openParts,
+    undecidedParts,
+    partIndex,
+    partCount,
+    loadReview,
+    decide,
+    processEnrichment,
+    approveAfterSave,
+    reject,
+  };
 }

--- a/frontend/src/composables/useTaskReview.test.js
+++ b/frontend/src/composables/useTaskReview.test.js
@@ -1,20 +1,42 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { useTaskReview } from './useTaskReview.js';
+import { useTaskReview, clearVerdicts } from './useTaskReview.js';
 
 const fetchTask = vi.fn();
 const resolveTask = vi.fn();
+const fetchJobTasks = vi.fn();
+const applyEnrichment = vi.fn();
 vi.mock('./useTasks.js', () => ({
-  useTaskActions: () => ({ fetchTask: (...a) => fetchTask(...a), resolveTask: (...a) => resolveTask(...a) }),
+  useTaskActions: () => ({
+    fetchTask: (...a) => fetchTask(...a),
+    resolveTask: (...a) => resolveTask(...a),
+    fetchJobTasks: (...a) => fetchJobTasks(...a),
+    applyEnrichment: (...a) => applyEnrichment(...a),
+  }),
 }));
+
+const JOB = 'job-1';
 
 function openTask(overrides = {}) {
   return {
     id: 't1',
     task_type: 'job_review',
     status: 'open',
-    payload: { law_id: 'test_wet', source_etag: 'etag-1' },
+    job_id: JOB,
+    title: 'Verrijking beoordelen: test_wet artikel 1',
+    payload: { law_id: 'test_wet', article: '1' },
     results: [{ path: 'corpus/regulation/nl/wet/test_wet/2025-01-01.yaml', content: 'proposed: yaml' }],
     ...overrides,
+  };
+}
+
+function twoParts() {
+  return {
+    job_id: JOB,
+    law_id: 'test_wet',
+    tasks: [
+      { id: 't1', article: '1', status: 'open', title: 'artikel 1' },
+      { id: 't2', article: '2', status: 'open', title: 'artikel 2' },
+    ],
   };
 }
 
@@ -22,30 +44,45 @@ describe('useTaskReview', () => {
   beforeEach(() => {
     fetchTask.mockReset();
     resolveTask.mockReset();
+    fetchJobTasks.mockReset();
+    applyEnrichment.mockReset();
+    applyEnrichment.mockResolvedValue({ accepted: 1, total: 2 });
+    clearVerdicts(JOB);
+    clearVerdicts('t1');
+    window.sessionStorage.clear();
   });
 
-  it('laadt het voorstel en zet stale wanneer de etag afwijkt', async () => {
+  it('laadt het voorstel en de andere onderdelen van dezelfde verrijking', async () => {
     fetchTask.mockResolvedValue(openTask());
-    const { reviewTask, proposedContent, stale, loadError, loadReview } = useTaskReview();
-    await loadReview('t1', 'etag-2');
+    fetchJobTasks.mockResolvedValue(twoParts());
+    const { reviewTask, proposedContent, loadError, jobParts, partIndex, partCount, loadReview } =
+      useTaskReview();
+    await loadReview('t1');
     expect(fetchTask).toHaveBeenCalledWith('t1');
+    expect(fetchJobTasks).toHaveBeenCalledWith(JOB);
     expect(reviewTask.value?.id).toBe('t1');
     expect(proposedContent.value).toBe('proposed: yaml');
-    expect(stale.value).toBe(true);
+    expect(jobParts.value).toHaveLength(2);
+    expect(partIndex.value).toBe(1);
+    expect(partCount.value).toBe(2);
     expect(loadError.value).toBeNull();
   });
 
-  it('zet stale niet wanneer de etag overeenkomt', async () => {
+  it('valt terug op de taak zelf als de onderdelen niet op te halen zijn', async () => {
     fetchTask.mockResolvedValue(openTask());
-    const { stale, loadReview } = useTaskReview();
-    await loadReview('t1', 'etag-1');
-    expect(stale.value).toBe(false);
+    fetchJobTasks.mockRejectedValue(new Error('netwerk'));
+    const { jobParts, partCount, loadReview } = useTaskReview();
+    await loadReview('t1');
+    expect(jobParts.value).toEqual([
+      { id: 't1', article: '1', status: 'open', title: 'Verrijking beoordelen: test_wet artikel 1' },
+    ]);
+    expect(partCount.value).toBe(1);
   });
 
   it('weigert een taak die al afgehandeld is', async () => {
     fetchTask.mockResolvedValue(openTask({ status: 'resolved' }));
     const { reviewTask, proposedContent, loadError, loadReview } = useTaskReview();
-    await loadReview('t1', 'etag-1');
+    await loadReview('t1');
     expect(reviewTask.value).toBeNull();
     expect(proposedContent.value).toBeNull();
     expect(loadError.value).toBe('Deze taak is al afgehandeld.');
@@ -54,7 +91,7 @@ describe('useTaskReview', () => {
   it('weigert een taak van het verkeerde type', async () => {
     fetchTask.mockResolvedValue(openTask({ task_type: 'job_failed' }));
     const { reviewTask, loadError, loadReview } = useTaskReview();
-    await loadReview('t1', 'etag-1');
+    await loadReview('t1');
     expect(reviewTask.value).toBeNull();
     expect(loadError.value).toBe('Deze taak is al afgehandeld.');
   });
@@ -62,15 +99,15 @@ describe('useTaskReview', () => {
   it('zet loadError wanneer er geen law-resultaat bij de taak zit', async () => {
     fetchTask.mockResolvedValue(openTask({ results: [{ path: '.enrichment.yaml', content: 'x' }] }));
     const { reviewTask, loadError, loadReview } = useTaskReview();
-    await loadReview('t1', 'etag-1');
+    await loadReview('t1');
     expect(reviewTask.value).toBeNull();
     expect(loadError.value).toBe('Geen resultaat gevonden bij deze taak.');
   });
 
   it('zet loadError wanneer de taak geen law_id in de payload heeft', async () => {
-    fetchTask.mockResolvedValue(openTask({ payload: { source_etag: 'etag-1' } }));
+    fetchTask.mockResolvedValue(openTask({ payload: {} }));
     const { reviewTask, loadError, loadReview } = useTaskReview();
-    await loadReview('t1', 'etag-1');
+    await loadReview('t1');
     expect(reviewTask.value).toBeNull();
     expect(loadError.value).toBe('Geen resultaat gevonden bij deze taak.');
   });
@@ -78,22 +115,23 @@ describe('useTaskReview', () => {
   it('kiest het result-bestand op payload.yaml_path, niet de eerste dot-loze file', async () => {
     fetchTask.mockResolvedValue(
       openTask({
-        payload: { law_id: 'test_wet', source_etag: 'etag-1', yaml_path: 'laws/w/law.yaml' },
+        payload: { law_id: 'test_wet', yaml_path: 'laws/w/law.yaml' },
         results: [
           { path: 'features/x.feature', content: 'Feature: ...' },
           { path: 'laws/w/law.yaml', content: 'wet: ja' },
         ],
       })
     );
+    fetchJobTasks.mockResolvedValue(twoParts());
     const { proposedContent, loadReview } = useTaskReview();
-    await loadReview('t1', 'etag-1');
+    await loadReview('t1');
     expect(proposedContent.value).toBe('wet: ja');
   });
 
   it('zet loadError wanneer de taak geen payload heeft', async () => {
     fetchTask.mockResolvedValue(openTask({ payload: undefined }));
     const { reviewTask, loadError, loadReview } = useTaskReview();
-    await loadReview('t1', 'etag-1');
+    await loadReview('t1');
     expect(reviewTask.value).toBeNull();
     expect(loadError.value).toBe('Geen resultaat gevonden bij deze taak.');
   });
@@ -101,34 +139,121 @@ describe('useTaskReview', () => {
   it('zet loadError wanneer fetchTask faalt', async () => {
     fetchTask.mockRejectedValue(new Error('netwerk'));
     const { loadError, loadReview } = useTaskReview();
-    await loadReview('t1', 'etag-1');
+    await loadReview('t1');
     expect(loadError.value).toBe('Taak laden mislukt.');
   });
 
-  it('approveAfterSave resolvet als approved en reset de review-state', async () => {
+  it('een oordeel over één onderdeel schrijft niets en wijst het volgende aan', async () => {
     fetchTask.mockResolvedValue(openTask());
-    const { reviewTask, proposedContent, loadReview, approveAfterSave } = useTaskReview();
-    await loadReview('t1', 'etag-1');
-    await approveAfterSave();
+    fetchJobTasks.mockResolvedValue(twoParts());
+    const { loadReview, decide, undecidedParts } = useTaskReview();
+    await loadReview('t1');
+
+    const { done, next } = decide('approved', 'number: "1"\n');
+    expect(done).toBe(false);
+    expect(next.id).toBe('t2');
+    expect(applyEnrichment).not.toHaveBeenCalled();
+    expect(undecidedParts.value.map((p) => p.id)).toEqual(['t2']);
+  });
+
+  it('verwerkt de verrijking in één keer zodra het laatste onderdeel is beoordeeld', async () => {
+    fetchTask.mockResolvedValue(openTask());
+    fetchJobTasks.mockResolvedValue(twoParts());
+    const first = useTaskReview();
+    await first.loadReview('t1');
+    expect(first.decide('approved', 'number: "1"\ntext: een\n').done).toBe(false);
+
+    // Het tweede onderdeel wordt als eigen review geladen (nieuwe ?task=).
+    fetchTask.mockResolvedValue(
+      openTask({ id: 't2', payload: { law_id: 'test_wet', article: '2' } })
+    );
+    const second = useTaskReview();
+    await second.loadReview('t2');
+    expect(second.decide('rejected').done).toBe(true);
+
+    await second.processEnrichment('"etag-1"');
+    expect(applyEnrichment).toHaveBeenCalledWith(
+      JOB,
+      [
+        { task_id: 't1', action: 'approved', content: 'number: "1"\ntext: een\n' },
+        { task_id: 't2', action: 'rejected' },
+      ],
+      '"etag-1"'
+    );
+    expect(second.reviewTask.value).toBeNull();
+  });
+
+  it('rondt af met de rest op niet overnemen', async () => {
+    fetchTask.mockResolvedValue(openTask());
+    fetchJobTasks.mockResolvedValue(twoParts());
+    const { loadReview, decide, processEnrichment } = useTaskReview();
+    await loadReview('t1');
+    decide('approved', 'number: "1"\n');
+
+    await processEnrichment('"etag-1"', { rejectRemaining: true });
+    expect(applyEnrichment).toHaveBeenCalledWith(
+      JOB,
+      [
+        { task_id: 't1', action: 'approved', content: 'number: "1"\n' },
+        { task_id: 't2', action: 'rejected' },
+      ],
+      '"etag-1"'
+    );
+  });
+
+  it('laat onbeoordeelde onderdelen weg zolang je niet afrondt', async () => {
+    fetchTask.mockResolvedValue(openTask());
+    fetchJobTasks.mockResolvedValue(twoParts());
+    const { loadReview, decide, processEnrichment } = useTaskReview();
+    await loadReview('t1');
+    decide('rejected');
+
+    await processEnrichment('"etag-1"');
+    expect(applyEnrichment).toHaveBeenCalledWith(
+      JOB,
+      [{ task_id: 't1', action: 'rejected' }],
+      '"etag-1"'
+    );
+  });
+
+  it('houdt de oordelen vast als het verwerken faalt', async () => {
+    fetchTask.mockResolvedValue(openTask());
+    fetchJobTasks.mockResolvedValue(twoParts());
+    applyEnrichment.mockRejectedValue(new Error('412'));
+    const { loadReview, decide, processEnrichment, reviewTask, undecidedParts } = useTaskReview();
+    await loadReview('t1');
+    decide('approved', 'number: "1"\n');
+
+    await expect(processEnrichment('"oud"', { rejectRemaining: true })).rejects.toThrow('412');
+    // Niets geschreven, dus de review blijft staan met het vastgelegde oordeel.
+    expect(reviewTask.value?.id).toBe('t1');
+    expect(undecidedParts.value.map((p) => p.id)).toEqual(['t2']);
+  });
+
+  it('approveAfterSave/reject handelen één taak af (het law_create-pad)', async () => {
+    fetchTask.mockResolvedValue(
+      openTask({ payload: { law_id: 'test_wet', kind: 'law_create' }, job_id: null })
+    );
+    const a = useTaskReview();
+    await a.loadReview('t1');
+    await a.approveAfterSave();
     expect(resolveTask).toHaveBeenCalledWith('t1', 'approved');
-    expect(reviewTask.value).toBeNull();
-    expect(proposedContent.value).toBeNull();
-  });
+    expect(a.reviewTask.value).toBeNull();
 
-  it('reject resolvet als rejected en reset de review-state', async () => {
-    fetchTask.mockResolvedValue(openTask());
-    const { reviewTask, proposedContent, loadReview, reject } = useTaskReview();
-    await loadReview('t1', 'etag-1');
-    await reject();
+    const b = useTaskReview();
+    await b.loadReview('t1');
+    await b.reject();
     expect(resolveTask).toHaveBeenCalledWith('t1', 'rejected');
-    expect(reviewTask.value).toBeNull();
-    expect(proposedContent.value).toBeNull();
+    expect(b.reviewTask.value).toBeNull();
   });
 
-  it('approveAfterSave/reject zijn een no-op zonder actieve review', async () => {
-    const { approveAfterSave, reject } = useTaskReview();
+  it('decide/approveAfterSave/reject zijn een no-op zonder actieve review', async () => {
+    const { approveAfterSave, reject, decide, processEnrichment } = useTaskReview();
+    expect(decide('approved')).toEqual({ done: false, next: null });
     await approveAfterSave();
     await reject();
+    expect(await processEnrichment('"etag"')).toBeNull();
     expect(resolveTask).not.toHaveBeenCalled();
+    expect(applyEnrichment).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/composables/useTasks.js
+++ b/frontend/src/composables/useTasks.js
@@ -43,6 +43,46 @@ async function fetchTask(taskId) {
   return res.json();
 }
 
+/**
+ * De onderdelen van één verrijking: alle review-taken van dezelfde enrich-job,
+ * met per taak het artikelnummer en de status. Levert `{ job_id, law_id, tasks }`.
+ */
+async function fetchJobTasks(jobId) {
+  const res = await apiFetch(`/api/tasks/jobs/${encodeURIComponent(jobId)}`);
+  return res.json();
+}
+
+/**
+ * Verwerk een verrijking: alle oordelen in één keer, één schrijfactie, één
+ * commit. `decisions` is een lijst `{ task_id, action, content? }`; `etag` is
+ * de ETag van de wet zoals de beoordelaar hem zag en gaat als `If-Match` mee -
+ * dát is het enige moment waarop deze flow nog op verouderdheid controleert.
+ */
+async function applyEnrichment(jobId, decisions, etag) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (etag) headers['If-Match'] = etag;
+  const res = await apiFetch(`/api/tasks/jobs/${encodeURIComponent(jobId)}/apply`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ decisions }),
+    // 412 lossen we hieronder zelf op met een uitlegbare tekst; de rest gooit.
+    allowStatuses: [412],
+    // Zelfde proxy-guard als saveLaw: alleen text/plain-bodies zijn van onze
+    // eigen editor-api, al het andere is een tussenliggende proxy.
+    errorMessage: (status, body, contentType) =>
+      contentType.startsWith('text/plain') && body ? body : `Verwerken mislukt: ${status}`,
+  });
+  if (res.status === 412) {
+    throw new Error(
+      'De wet is intussen door iemand anders gewijzigd. Herlaad de pagina om de ' +
+        'nieuwste versie te zien en beoordeel de verrijking daarna opnieuw.',
+    );
+  }
+  const json = await res.json();
+  await refresh();
+  return json;
+}
+
 async function resolveTask(taskId, action) {
   await apiFetch(`/api/tasks/${encodeURIComponent(taskId)}/resolve`, {
     method: 'POST',
@@ -102,6 +142,8 @@ export function useTasks() {
     refresh,
     fetchTask,
     resolveTask,
+    fetchJobTasks,
+    applyEnrichment,
     requestEnrich,
   };
 }
@@ -118,7 +160,16 @@ export function useTaskActions() {
   // `running` is een module-level ref, gedeeld met useTasks(). Meegeven kost
   // niets en start geen poll: een view die alleen wil weten of er iets loopt,
   // leest hem en ververst zelf na een actie of bij mount.
-  return { fetchTask, resolveTask, requestEnrich, refresh, running, tasks };
+  return {
+    fetchTask,
+    resolveTask,
+    fetchJobTasks,
+    applyEnrichment,
+    requestEnrich,
+    refresh,
+    running,
+    tasks,
+  };
 }
 
 /**

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -26,7 +26,7 @@ use regelrecht_corpus::CorpusError;
 use regelrecht_github::GithubClient;
 
 use crate::accounts::AccountRecord;
-use crate::credentials::{self, TrajectCredentials};
+use crate::credentials::{self, TrajectCredentials, WriteAuthorization};
 use crate::state::{AppState, CorpusState};
 use crate::traject_corpus::{ScenarioListEntry, TrajectCorpus, TrajectCorpusError};
 use crate::traject_index_diagnosis::{
@@ -1844,7 +1844,9 @@ async fn editor_user_from_session(session: &Session) -> Option<EditorUser> {
 /// and will hit this 403 even when the user's email *is* verified at
 /// the IdP. The message therefore nudges towards a re-login, which
 /// re-runs the OIDC callback and populates the missing claim.
-async fn require_editor_user(session: &Session) -> Result<EditorUser, (StatusCode, String)> {
+pub(crate) async fn require_editor_user(
+    session: &Session,
+) -> Result<EditorUser, (StatusCode, String)> {
     editor_user_from_session(session).await.ok_or_else(|| {
         (
             StatusCode::FORBIDDEN,
@@ -2028,8 +2030,8 @@ fn traject_write_source_id(traject: &TrajectCorpus, law: &LoadedLaw) -> String {
 /// Resolved write routing for a law in a traject: the law's index
 /// entry, the id of the source whose backend the write goes to, and an
 /// owned guard over that backend.
-struct TrajectLawWrite {
-    law: LoadedLaw,
+pub(crate) struct TrajectLawWrite {
+    pub(crate) law: LoadedLaw,
     /// Source id of the backend behind `backend`. Differs from
     /// `law.source_id` when the law comes from a federated read-only
     /// source and its writes are routed to the traject's writable-own
@@ -2040,14 +2042,14 @@ struct TrajectLawWrite {
     /// backend registration. Fed to [`TrajectCredentials::for_write`] as the
     /// explicit "has own write credential" capability instead of a runtime
     /// `is_writable()` probe.
-    write_source_writable: bool,
-    backend: tokio::sync::OwnedMutexGuard<Box<dyn RepoBackend>>,
+    pub(crate) write_source_writable: bool,
+    pub(crate) backend: tokio::sync::OwnedMutexGuard<Box<dyn RepoBackend>>,
 }
 
 /// Resolve the writable-own backend within a traject's corpus. Returns
 /// the looked-up law (for its `relative_path`), the write-target source
 /// id, and an owned guard over the traject's writable backend.
-async fn resolve_traject_law_write(
+pub(crate) async fn resolve_traject_law_write(
     traject: &Arc<TrajectCorpus>,
     law_id: &str,
 ) -> Result<TrajectLawWrite, (StatusCode, String)> {
@@ -2756,28 +2758,93 @@ pub async fn save_law(
         .await?;
     let relative_path = PathBuf::from(&write.law.relative_path);
 
+    let written = write_composed_law(
+        &traject,
+        write,
+        auth,
+        &relative_path,
+        &law_id,
+        author,
+        extract_if_match(&headers),
+        false,
+        |_current| Ok((body, format!("Update law {law_id}"))),
+    )
+    .await?;
+
+    let mut response = written.response;
+    response.etag = Some(written.etag.clone());
+    Ok(([(axum::http::header::ETAG, written.etag)], Json(response)).into_response())
+}
+
+/// Wat een geslaagde wet-schrijfactie oplevert: het save-antwoord (inclusief
+/// een eventuele PR) en de ETag van wat er nu op de branch staat, die de
+/// client als `If-Match` van de volgende save meeneemt.
+pub(crate) struct WrittenLaw {
+    pub response: SaveResponse,
+    pub etag: String,
+}
+
+/// Schrijf een wet als **één** commit naar het schrijfdoel van een traject.
+///
+/// Gedeelde kern van de gewone wet-PUT ([`save_law`]) en het verwerken van een
+/// verrijking (`enrich_review::apply`). Wat die twee onderscheidt is alleen
+/// wát er geschreven wordt en onder welke commit-message; alles eromheen — de
+/// `If-Match`-controle onder dezelfde write-lock, de commit, de
+/// read-your-writes-overlay en de changed-laws-cache — is identiek en hoort
+/// dus één keer te bestaan.
+///
+/// `compose` krijgt de huidige inhoud van het bestand op de branch (`None`
+/// wanneer het er nog niet staat) en levert het paar (body, commit-message).
+/// Het draait *binnen* de write-lock die de aanroeper via
+/// [`resolve_traject_law_write`] vasthoudt, dus de eindstand wordt samengesteld
+/// tegen precies de bytes waartegen de `If-Match` is gecontroleerd — een
+/// concurrent save kan er niet tussen glippen.
+///
+/// De huidige inhoud wordt gelezen wanneer er een `If-Match` is óf wanneer
+/// `needs_current` dat vraagt; een blinde overschrijving die zijn body al kent
+/// (de gewone PUT zonder `If-Match`) bespaart daarmee een leesronde naar
+/// GitHub.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn write_composed_law<F>(
+    traject: &Arc<TrajectCorpus>,
+    write: TrajectLawWrite,
+    auth: WriteAuthorization,
+    relative_path: &std::path::Path,
+    law_id: &str,
+    author: Option<EditorUser>,
+    if_match: Option<String>,
+    needs_current: bool,
+    compose: F,
+) -> Result<WrittenLaw, (StatusCode, String)>
+where
+    F: FnOnce(Option<&str>) -> Result<(String, String), (StatusCode, String)>,
+{
     // Optimistic concurrency, same semantics as the document PUT: a
     // present `If-Match` must equal the current content's ETag (412 on
     // mismatch), an absent header stays a permissive blind write for
     // backward compatibility. Checked while holding the write backend's
-    // mutex (acquired by `resolve_traject_law_write` above), so a
-    // concurrent save cannot slip between the check and the write.
-    if let Some(if_match) = extract_if_match(&headers) {
-        let current =
-            current_content_for_write(&traject, &write, &relative_path, "law", auth.read_token())
-                .await?;
-        check_if_match(current.as_deref(), Some(&if_match), "Wet")?;
+    // mutex (acquired by `resolve_traject_law_write`), so a concurrent
+    // save cannot slip between the check and the write.
+    let current = if if_match.is_some() || needs_current {
+        current_content_for_write(traject, &write, relative_path, "law", auth.read_token()).await?
+    } else {
+        None
+    };
+    if if_match.is_some() {
+        check_if_match(current.as_deref(), if_match.as_deref(), "Wet")?;
     }
+
+    let (body, message) = compose(current.as_deref())?;
 
     let outcome = {
         write
             .backend
-            .write_file(&relative_path, &body)
+            .write_file(relative_path, &body)
             .await
             .map_err(corpus_write_error("law"))?;
         write
             .backend
-            .persist(&auth.into_write_context(format!("Update law {}", law_id), author))
+            .persist(&auth.into_write_context(message, author))
             .await
             .map_err(corpus_write_error("law"))?
     };
@@ -2794,18 +2861,19 @@ pub async fn save_law(
     // We DO mirror into the per-traject overlay so a subsequent GET in
     // the same traject (any session) sees the new content — that is
     // the read-your-writes follow-up that used to be punted.
-    traject.record_save(law_id.clone(), body).await;
+    traject.record_save(law_id.to_string(), body).await;
 
     // This save added (or kept) this law on the traject branch — fold it
     // into the cached changed-laws diff so the sidebar's "Bewerkt in dit
     // traject" section reflects the edit on the next load, without the
     // synchronous GitHub Compare call a cache invalidation would cost
     // that load.
-    traject.record_changed_law(&law_id).await;
+    traject.record_changed_law(law_id).await;
 
-    let mut response = save_response_from_traject(outcome);
-    response.etag = Some(new_etag.clone());
-    Ok(([(axum::http::header::ETAG, new_etag)], Json(response)).into_response())
+    Ok(WrittenLaw {
+        response: save_response_from_traject(outcome),
+        etag: new_etag,
+    })
 }
 
 /// DELETE /api/trajects/{traject_id}/corpus/laws/{law_id}/scenarios/{filename}
@@ -3131,7 +3199,7 @@ struct DocumentsWriter {
 }
 
 /// Read the `If-Match` header value, trimmed. `None` when absent or empty.
-fn extract_if_match(headers: &axum::http::HeaderMap) -> Option<String> {
+pub(crate) fn extract_if_match(headers: &axum::http::HeaderMap) -> Option<String> {
     headers
         .get(axum::http::header::IF_MATCH)
         .and_then(|v| v.to_str().ok())

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -2726,27 +2726,7 @@ pub async fn save_law(
     // supporting-text and we don't want self-XSS if the dialog ever renders
     // that attribute as markup. The path law_id is already known to the
     // caller, so the generic message is sufficient.
-    validate_yaml_syntax(&body).map_err(|e| {
-        tracing::debug!(law_id = %law_id, error = %e, "save_law received malformed YAML body");
-        (
-            StatusCode::BAD_REQUEST,
-            "Body is not valid YAML".to_string(),
-        )
-    })?;
-
-    let body_id = extract_law_id(&body).ok_or_else(|| {
-        (
-            StatusCode::BAD_REQUEST,
-            "Body missing top-level `$id` field".to_string(),
-        )
-    })?;
-
-    if body_id != law_id {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "Body $id does not match path law_id".to_string(),
-        ));
-    }
+    validate_whole_law_body(&body, &law_id)?;
 
     // Resolve the write target AND keep a handle on the per-traject
     // corpus so we can mirror the saved body into its read-your-writes
@@ -2774,6 +2754,56 @@ pub async fn save_law(
     let mut response = written.response;
     response.etag = Some(written.etag.clone());
     Ok(([(axum::http::header::ETAG, written.etag)], Json(response)).into_response())
+}
+
+/// De poort voor elke body die als **hele wet** naar het corpus geschreven
+/// wordt: de PUT van de editor ([`save_law`]) en het overnemen van een
+/// whole-law-voorstel (`enrich_review::apply`). Beide zetten een door de
+/// client aangeleverd bestand integraal op de plaats van een bestaande wet,
+/// dus beide hebben dezelfde drie controles nodig — één plek, want een tweede
+/// schrijfpad dat er één vergeet is precies hoe een corpus stukgaat.
+///
+/// 1. De body moet geldige YAML zijn. [`extract_law_id`] is een regelscanner
+///    die `"$id: foo\n<rommel>"` gewoon accepteert, dus zonder deze controle
+///    landt een kapotte body op schijf.
+/// 2. De body moet een top-level `$id` hebben.
+/// 3. Dat `$id` moet gelijk zijn aan de wet die overschreven wordt. Een
+///    afwijking is óf een phantom-law (een nieuw id op een bestaand bestand)
+///    óf een verweesde wet (het oude id wordt onvindbaar).
+///
+/// Bewust géén volledige JSON-Schema-validatie: dat is een apart vervolg
+/// (spiegel van `just validate`).
+///
+/// De foutmelding echoot het aangeleverde `$id` niet terug: die tekst loopt
+/// via de frontend in de supporting-text van een dialoog, en een id uit de
+/// body daarin renderen zou self-XSS zijn zodra die attribuut-tekst ooit als
+/// markup gelezen wordt. De aanroeper kent `law_id` al.
+pub(crate) fn validate_whole_law_body(
+    body: &str,
+    law_id: &str,
+) -> Result<(), (StatusCode, String)> {
+    validate_yaml_syntax(body).map_err(|e| {
+        tracing::debug!(law_id = %law_id, error = %e, "law write received malformed YAML body");
+        (
+            StatusCode::BAD_REQUEST,
+            "Body is not valid YAML".to_string(),
+        )
+    })?;
+
+    let body_id = extract_law_id(body).ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            "Body missing top-level `$id` field".to_string(),
+        )
+    })?;
+
+    if body_id != law_id {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Body $id does not match path law_id".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 /// Wat een geslaagde wet-schrijfactie oplevert: het save-antwoord (inclusief

--- a/packages/editor-api/src/enrich_review.rs
+++ b/packages/editor-api/src/enrich_review.rs
@@ -22,6 +22,7 @@
 //! serverbeslissing.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use axum::extract::{Path, State};
 use axum::http::{HeaderMap, StatusCode};
@@ -30,12 +31,14 @@ use serde::{Deserialize, Serialize};
 use tower_sessions::Session;
 use uuid::Uuid;
 
+use regelrecht_corpus::backend::EditorUser;
 use regelrecht_pipeline::tasks::{self, BlobKind, Task, TaskStatus};
 
 use crate::accounts::AccountRecord;
-use crate::corpus_handlers::{self, SavePrInfo};
-use crate::credentials::TrajectCredentials;
+use crate::corpus_handlers::{self, SavePrInfo, TrajectLawWrite};
+use crate::credentials::{TrajectCredentials, WriteAuthorization};
 use crate::state::AppState;
+use crate::traject_corpus::TrajectCorpus;
 
 fn get_pool(state: &AppState) -> Result<&sqlx::PgPool, (StatusCode, String)> {
     state.pool.as_ref().ok_or((
@@ -203,9 +206,13 @@ struct Accepted {
 /// 3. Niets overnemen schrijft niets — geen lege commit. De taken gaan wel
 ///    dicht.
 ///
-/// De `If-Match`-header hoort de ETag te dragen van de wet zoals de beoordelaar
-/// hem zag. Dat is meteen de enige staleness-bepaling die deze flow nog kent:
-/// één schrijfmoment, één controle.
+/// De `If-Match`-header draagt de ETag van de wet zoals de beoordelaar hem
+/// zag. Dat is meteen de enige staleness-bepaling die deze flow nog kent: één
+/// schrijfmoment, één controle. Hij is daarom **verplicht** zodra er iets
+/// overgenomen wordt — de permissieve blinde write die de gewone PUT om
+/// historische redenen toestaat, zou hier de enige controle wegnemen die er
+/// nog is. Verwerken zonder overnemen schrijft niets en vraagt er dus ook niet
+/// om.
 pub async fn apply(
     State(state): State<AppState>,
     Extension(account): Extension<AccountRecord>,
@@ -322,6 +329,20 @@ pub async fn apply(
     let accepted_count = accepted.len();
     let total = open.len();
 
+    // De schrijfactie helemaal klaarzetten *voordat* de taak-transactie
+    // opengaat. Zie [`PreparedWrite`]: elke stap eronder leent zelf een
+    // verbinding uit dezelfde pool, en de write-lock op de backend hoort in
+    // dezelfde volgorde genomen te worden als `save_law` hem neemt.
+    //
+    // Alleen wanneer er iets overgenomen wordt: "niets overnemen" schrijft
+    // niet, en hoeft dus ook geen schrijfrecht, geen GitHub-koppeling en geen
+    // `If-Match`.
+    let prepared = if accepted.is_empty() {
+        None
+    } else {
+        Some(prepare_write(&state, &account, &session, &headers, &traject_ref, &law_id).await?)
+    };
+
     // --- taken dicht + schrijven, of terugrollen -------------------------
     let mut tx = pool.begin().await.map_err(db_error)?;
     let closed = tasks::resolve_tasks(&mut *tx, &approved_ids, account.id, TaskStatus::Approved)
@@ -338,29 +359,18 @@ pub async fn apply(
         ));
     }
 
-    let written = if accepted.is_empty() {
+    let written = match prepared {
         // Niets overnemen: de wet blijft zoals hij is. Een commit die niets
         // verandert zou het traject-log vervuilen met een gebeurtenis die
         // alleen in de takenlijst thuishoort.
-        None
-    } else {
-        match write_accepted(
-            &state,
-            &account,
-            &session,
-            &headers,
-            &traject_ref,
-            &law_id,
-            &accepted,
-            whole_law,
-            total,
-        )
-        .await
-        {
-            Ok(written) => Some(written),
-            Err(e) => {
-                let _ = tx.rollback().await;
-                return Err(e);
+        None => None,
+        Some(prepared) => {
+            match write_accepted(prepared, &law_id, &accepted, whole_law, total).await {
+                Ok(written) => Some(written),
+                Err(e) => {
+                    let _ = tx.rollback().await;
+                    return Err(e);
+                }
             }
         }
     };
@@ -451,18 +461,53 @@ fn article_from_proposal(proposal: &str, number: &str) -> Result<String, (Status
     })
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn write_accepted(
+/// Alles wat de schrijfactie nodig heeft, opgehaald *voordat* de
+/// taak-transactie opengaat.
+///
+/// Waarom vooraf, en niet gewoon binnen de transactie: elk van die stappen
+/// leent zelf een verbinding uit dezelfde pool waar de transactie er al een
+/// van vasthoudt (de traject-lookup, de sessie-store, de feature-flag). Dat
+/// binnen de transactie doen laat één verzoek op twee verbindingen tegelijk
+/// wachten, en de pool telt er vijf — een handvol gelijktijdige verwerkingen
+/// wacht dan op zichzelf, met een schrijfactie naar GitHub als duur van het
+/// venster.
+///
+/// En het houdt de slotvolgorde gelijk aan die van [`corpus_handlers::save_law`]:
+/// eerst de write-lock op de backend, dan de database. Andersom (transactie
+/// eerst, dan de lock) staan de twee schrijfpaden precies omgekeerd in de rij
+/// en kunnen ze elkaar vasthouden.
+///
+/// Wat er ná dit punt nog in de transactie gebeurt raakt alleen `tasks` en de
+/// git-backend.
+struct PreparedWrite {
+    traject: Arc<TrajectCorpus>,
+    write: TrajectLawWrite,
+    auth: WriteAuthorization,
+    author: Option<EditorUser>,
+    relative_path: std::path::PathBuf,
+    /// De ETag van de wet zoals de beoordelaar hem zag. Verplicht: dit is het
+    /// enige moment waarop deze flow nog op verouderdheid controleert, dus
+    /// zonder `If-Match` zou het verwerken een blinde overschrijving zijn.
+    if_match: String,
+}
+
+async fn prepare_write(
     state: &AppState,
     account: &AccountRecord,
     session: &Session,
     headers: &HeaderMap,
     traject_ref: &str,
     law_id: &str,
-    accepted: &[Accepted],
-    whole_law: bool,
-    total: usize,
-) -> Result<corpus_handlers::WrittenLaw, (StatusCode, String)> {
+) -> Result<PreparedWrite, (StatusCode, String)> {
+    // Niet 428: die code is editor-breed gereserveerd voor de
+    // GitHub-koppelflow (zie `frontend/src/lib/apiAuthGuard.js`) en zou de
+    // beoordelaar naar een koppelscherm sturen voor iets wat een herlading is.
+    let if_match = corpus_handlers::extract_if_match(headers).ok_or((
+        StatusCode::BAD_REQUEST,
+        "Verwerken vraagt om de versie van de wet zoals je hem zag. Herlaad de pagina en \
+         beoordeel de verrijking opnieuw."
+            .to_string(),
+    ))?;
     let author = Some(corpus_handlers::require_editor_user(session).await?);
     let traject =
         corpus_handlers::require_traject_corpus_from_ref(state, session, traject_ref).await?;
@@ -471,6 +516,31 @@ async fn write_accepted(
         .for_write(&**write.backend, write.write_source_writable)
         .await?;
     let relative_path = std::path::PathBuf::from(&write.law.relative_path);
+    Ok(PreparedWrite {
+        traject,
+        write,
+        auth,
+        author,
+        relative_path,
+        if_match,
+    })
+}
+
+async fn write_accepted(
+    prepared: PreparedWrite,
+    law_id: &str,
+    accepted: &[Accepted],
+    whole_law: bool,
+    total: usize,
+) -> Result<corpus_handlers::WrittenLaw, (StatusCode, String)> {
+    let PreparedWrite {
+        traject,
+        write,
+        auth,
+        author,
+        relative_path,
+        if_match,
+    } = prepared;
     let message = commit_message(law_id, accepted.len(), total, whole_law);
 
     corpus_handlers::write_composed_law(
@@ -480,7 +550,7 @@ async fn write_accepted(
         &relative_path,
         law_id,
         author,
-        corpus_handlers::extract_if_match(headers),
+        Some(if_match),
         true,
         |current| {
             if whole_law {
@@ -512,11 +582,10 @@ fn commit_message(law_id: &str, accepted: usize, total: usize, whole_law: bool) 
     if whole_law {
         return format!("Verrijking verwerkt: hele wet overgenomen in {law_id}");
     }
-    let artikelen = if accepted == 1 {
-        "artikel"
-    } else {
-        "artikelen"
-    };
+    // Het zelfstandig naamwoord hoort bij het getal dat er direct voor staat -
+    // het totaal, niet het aantal overgenomen. "1 van de 4 artikel" leest als
+    // een schrijffout in een commit-log dat je later terugleest.
+    let artikelen = if total == 1 { "artikel" } else { "artikelen" };
     format!("Verrijking verwerkt: {accepted} van de {total} {artikelen} overgenomen in {law_id}")
 }
 
@@ -675,9 +744,15 @@ mod tests {
             commit_message("test_wet", 3, 7, false),
             "Verrijking verwerkt: 3 van de 7 artikelen overgenomen in test_wet"
         );
+        // Het meervoud volgt het totaal, niet het aantal overgenomen: "1 van
+        // de 4 artikel" zou een schrijffout in het log zijn.
         assert_eq!(
             commit_message("test_wet", 1, 4, false),
-            "Verrijking verwerkt: 1 van de 4 artikel overgenomen in test_wet"
+            "Verrijking verwerkt: 1 van de 4 artikelen overgenomen in test_wet"
+        );
+        assert_eq!(
+            commit_message("test_wet", 0, 1, false),
+            "Verrijking verwerkt: 0 van de 1 artikel overgenomen in test_wet"
         );
         assert_eq!(
             commit_message("test_wet", 1, 1, true),

--- a/packages/editor-api/src/enrich_review.rs
+++ b/packages/editor-api/src/enrich_review.rs
@@ -1,0 +1,775 @@
+//! De verrijking als beoordelingseenheid.
+//!
+//! Een verrijking (één enrich-job) levert één review-taak per gewijzigd
+//! artikel. Beoordelen gebeurt per artikel — dat is de eenheid waarover een
+//! mens iets kan zeggen — maar *schrijven* hoort bij de verrijking als geheel:
+//! zeven goedgekeurde artikelen zijn één wijziging aan één wet, geen zeven
+//! losse commits met dezelfde titel.
+//!
+//! Dit is de serverkant daarvan:
+//!
+//! * [`job_tasks`] — welke onderdelen heeft deze verrijking, en wat is hun
+//!   status. De beoordelaar (en straks de beoordelingsview) leest hier wat er
+//!   nog openstaat.
+//! * [`apply`] — verwerk de verrijking: per onderdeel een oordeel, de
+//!   eindstand in één keer samengesteld, **één** `write_file` + `persist` met
+//!   één `If-Match`, en alle taken in dezelfde transactie dicht.
+//!
+//! Waarom het samenstellen hier gebeurt en niet in de browser: alleen hier kan
+//! de eindstand tegen precies de bytes gezet worden waartegen de `If-Match` is
+//! gecontroleerd, onder de write-lock die de commit erna gebruikt. De client
+//! zegt wát hij accordeert; wat dat betekent voor het bestand is een
+//! serverbeslissing.
+
+use std::collections::HashSet;
+
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::{Extension, Json};
+use serde::{Deserialize, Serialize};
+use tower_sessions::Session;
+use uuid::Uuid;
+
+use regelrecht_pipeline::tasks::{self, BlobKind, Task, TaskStatus};
+
+use crate::accounts::AccountRecord;
+use crate::corpus_handlers::{self, SavePrInfo};
+use crate::credentials::TrajectCredentials;
+use crate::state::AppState;
+
+fn get_pool(state: &AppState) -> Result<&sqlx::PgPool, (StatusCode, String)> {
+    state.pool.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "Takenopslag is niet beschikbaar".to_string(),
+    ))
+}
+
+fn db_error<E: std::fmt::Display>(e: E) -> (StatusCode, String) {
+    tracing::error!(error = %e, "verrijkings-query mislukt");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "Verrijking verwerken mislukt".to_string(),
+    )
+}
+
+/// Het artikelnummer waar een taak over gaat, `None` voor een taak die de hele
+/// wet omvat (een `law_create`, of een voorstel dat de worker niet in artikelen
+/// kon opsplitsen — zie `changed_articles` in de pipeline-worker).
+///
+/// De worker schrijft het nummer als string, maar een wet mag `number: 5`
+/// schrijven, dus een getal telt net zo goed.
+fn task_article(task: &Task) -> Option<String> {
+    scalar_to_string(task.payload.as_ref()?.get("article")?)
+}
+
+fn scalar_to_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
+fn payload_str(task: &Task, key: &str) -> Option<String> {
+    task.payload
+        .as_ref()?
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/tasks/jobs/{job_id}
+// ---------------------------------------------------------------------------
+
+/// Eén onderdeel van een verrijking, zoals de beoordelaar het ziet.
+#[derive(Serialize)]
+pub struct JobTaskSummary {
+    pub id: Uuid,
+    pub status: TaskStatus,
+    pub title: String,
+    /// Artikelnummer, of `null` wanneer dit onderdeel de hele wet is.
+    pub article: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct JobTasksResponse {
+    pub job_id: Uuid,
+    /// De wet waar deze verrijking over gaat (uit de taak-payload).
+    pub law_id: Option<String>,
+    pub tasks: Vec<JobTaskSummary>,
+}
+
+/// GET /api/tasks/jobs/{job_id} — de onderdelen van één verrijking.
+///
+/// Afgehandelde onderdelen komen mee: wie wil weten of hij klaar is, moet ook
+/// kunnen zien wat er buiten hem om al dichtging (een verwijderd traject sluit
+/// open taken, zie `dismiss_open_tasks_for_traject`).
+pub async fn job_tasks(
+    State(state): State<AppState>,
+    Extension(account): Extension<AccountRecord>,
+    Path(job_id): Path<Uuid>,
+) -> Result<Json<JobTasksResponse>, (StatusCode, String)> {
+    let pool = get_pool(&state)?;
+    let tasks = tasks::list_tasks_for_job_and_account(pool, job_id, account.id)
+        .await
+        .map_err(db_error)?;
+    if tasks.is_empty() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            "Verrijking niet gevonden".to_string(),
+        ));
+    }
+    let law_id = tasks.iter().find_map(|t| payload_str(t, "law_id"));
+    Ok(Json(JobTasksResponse {
+        job_id,
+        law_id,
+        tasks: tasks
+            .iter()
+            .map(|t| JobTaskSummary {
+                id: t.id,
+                status: t.status,
+                title: t.title.clone(),
+                article: task_article(t),
+            })
+            .collect(),
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/tasks/jobs/{job_id}/apply
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum Verdict {
+    /// Overnemen.
+    Approved,
+    /// Niet overnemen.
+    Rejected,
+}
+
+/// Het oordeel over één onderdeel van de verrijking.
+#[derive(Deserialize)]
+pub struct Decision {
+    pub task_id: Uuid,
+    pub action: Verdict,
+    /// Bij overnemen: de inhoud die de gebruiker daadwerkelijk accordeert —
+    /// het artikel zoals het na eventueel bijschaven in de editor staat, als
+    /// YAML-mapping (of de hele wet-YAML voor een onderdeel zonder
+    /// artikelnummer).
+    ///
+    /// Weggelaten betekent "neem het ruwe voorstel over": de server pakt dan
+    /// het artikel uit de opgeslagen result-blob van de job.
+    #[serde(default)]
+    pub content: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct ApplyRequest {
+    pub decisions: Vec<Decision>,
+}
+
+#[derive(Serialize)]
+pub struct ApplyResponse {
+    pub law_id: String,
+    /// Aantal overgenomen onderdelen.
+    pub accepted: usize,
+    /// Aantal onderdelen waarover een oordeel is geveld.
+    pub total: usize,
+    /// ETag van de wet na het schrijven; `null` wanneer er niets is
+    /// overgenomen en er dus niet geschreven is.
+    pub etag: Option<String>,
+    pub pr: Option<SavePrInfo>,
+}
+
+/// Wat er van één goedgekeurd onderdeel de eindstand in gaat.
+struct Accepted {
+    /// `None` = dit onderdeel is de hele wet.
+    article: Option<String>,
+    content: String,
+}
+
+/// POST /api/tasks/jobs/{job_id}/apply — verwerk een verrijking.
+///
+/// Volgorde en atomiciteit:
+///
+/// 1. De oordelen moeten alle nog-open onderdelen dekken. Ontbreekt er één,
+///    dan is de verrijking niet af en verandert er niets aan de wet.
+/// 2. De taken gaan dicht binnen een transactie die pas commit als de
+///    schrijfactie is gelukt. Faalt de `If-Match` (iemand anders wijzigde de
+///    wet), dan rolt die transactie terug: er is niets geschreven en geen
+///    enkele taak blijft afgehandeld achter.
+/// 3. Niets overnemen schrijft niets — geen lege commit. De taken gaan wel
+///    dicht.
+///
+/// De `If-Match`-header hoort de ETag te dragen van de wet zoals de beoordelaar
+/// hem zag. Dat is meteen de enige staleness-bepaling die deze flow nog kent:
+/// één schrijfmoment, één controle.
+pub async fn apply(
+    State(state): State<AppState>,
+    Extension(account): Extension<AccountRecord>,
+    session: Session,
+    Path(job_id): Path<Uuid>,
+    headers: HeaderMap,
+    Json(req): Json<ApplyRequest>,
+) -> Result<Json<ApplyResponse>, (StatusCode, String)> {
+    let pool = get_pool(&state)?;
+    let all_tasks = tasks::list_tasks_for_job_and_account(pool, job_id, account.id)
+        .await
+        .map_err(db_error)?;
+    if all_tasks.is_empty() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            "Verrijking niet gevonden".to_string(),
+        ));
+    }
+    let open: Vec<&Task> = all_tasks
+        .iter()
+        .filter(|t| t.status == TaskStatus::Open)
+        .collect();
+    if open.is_empty() {
+        return Err((
+            StatusCode::CONFLICT,
+            "Deze verrijking is al verwerkt.".to_string(),
+        ));
+    }
+
+    let law_id = open.iter().find_map(|t| payload_str(t, "law_id")).ok_or((
+        StatusCode::BAD_REQUEST,
+        "Deze taak wijst geen wet aan".to_string(),
+    ))?;
+    let traject_ref = open
+        .iter()
+        .find_map(|t| payload_str(t, "traject_ref"))
+        .ok_or((
+            StatusCode::BAD_REQUEST,
+            "Deze taak hoort niet bij een traject".to_string(),
+        ))?;
+    // Een `law_create` bestaat nog niet als bestand: die gaat langs het
+    // aanmaakpad (POST .../corpus/laws), waar het pad uit de YAML wordt
+    // afgeleid en er niets is om een `If-Match` tegen te houden. Hier
+    // binnenlaten zou een tweede aanmaakimplementatie betekenen.
+    if open
+        .iter()
+        .any(|t| payload_str(t, "kind").as_deref() == Some("law_create"))
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Een nieuwe wet wordt via het aanmaakpad opgeslagen, niet als verrijking".to_string(),
+        ));
+    }
+
+    // --- de oordelen uitpaken en tegen de open onderdelen leggen ---------
+    let mut seen: HashSet<Uuid> = HashSet::new();
+    let mut approved_ids: Vec<Uuid> = Vec::new();
+    let mut rejected_ids: Vec<Uuid> = Vec::new();
+    let mut accepted: Vec<Accepted> = Vec::new();
+    for decision in &req.decisions {
+        let task = open.iter().find(|t| t.id == decision.task_id).ok_or((
+            StatusCode::BAD_REQUEST,
+            "Een oordeel wijst een onderdeel aan dat niet (meer) openstaat".to_string(),
+        ))?;
+        if !seen.insert(decision.task_id) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Twee oordelen over hetzelfde onderdeel".to_string(),
+            ));
+        }
+        match decision.action {
+            Verdict::Rejected => rejected_ids.push(task.id),
+            Verdict::Approved => {
+                approved_ids.push(task.id);
+                accepted.push(Accepted {
+                    article: task_article(task),
+                    content: decision.content.clone().unwrap_or_default(),
+                });
+            }
+        }
+    }
+    if seen.len() != open.len() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Nog niet elk onderdeel van deze verrijking heeft een oordeel".to_string(),
+        ));
+    }
+
+    // Onderdelen zonder inhoud vallen terug op het ruwe voorstel uit de job.
+    if accepted.iter().any(|a| a.content.is_empty()) {
+        let proposal = load_proposal(pool, job_id, &open).await?;
+        for part in accepted.iter_mut().filter(|a| a.content.is_empty()) {
+            part.content = match &part.article {
+                None => proposal.clone(),
+                Some(number) => article_from_proposal(&proposal, number)?,
+            };
+        }
+    }
+
+    // Een onderdeel zonder artikelnummer is per definitie het énige onderdeel
+    // van zijn verrijking (de worker maakt óf één taak per gewijzigd artikel,
+    // óf één taak voor het geheel). Een mengeling zou betekenen dat "de hele
+    // wet" en "artikel 3" tegelijk overgenomen worden, en dan is niet te zeggen
+    // wat er wint.
+    let whole_law = accepted.iter().any(|a| a.article.is_none());
+    if whole_law && open.len() > 1 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Een voorstel voor de hele wet kan niet samen met losse artikelen worden verwerkt"
+                .to_string(),
+        ));
+    }
+
+    let accepted_count = accepted.len();
+    let total = open.len();
+
+    // --- taken dicht + schrijven, of terugrollen -------------------------
+    let mut tx = pool.begin().await.map_err(db_error)?;
+    let closed = tasks::resolve_tasks(&mut *tx, &approved_ids, account.id, TaskStatus::Approved)
+        .await
+        .map_err(db_error)?
+        + tasks::resolve_tasks(&mut *tx, &rejected_ids, account.id, TaskStatus::Rejected)
+            .await
+            .map_err(db_error)?;
+    if closed as usize != total {
+        let _ = tx.rollback().await;
+        return Err((
+            StatusCode::CONFLICT,
+            "Een onderdeel van deze verrijking is intussen afgehandeld.".to_string(),
+        ));
+    }
+
+    let written = if accepted.is_empty() {
+        // Niets overnemen: de wet blijft zoals hij is. Een commit die niets
+        // verandert zou het traject-log vervuilen met een gebeurtenis die
+        // alleen in de takenlijst thuishoort.
+        None
+    } else {
+        match write_accepted(
+            &state,
+            &account,
+            &session,
+            &headers,
+            &traject_ref,
+            &law_id,
+            &accepted,
+            whole_law,
+            total,
+        )
+        .await
+        {
+            Ok(written) => Some(written),
+            Err(e) => {
+                let _ = tx.rollback().await;
+                return Err(e);
+            }
+        }
+    };
+    tx.commit().await.map_err(db_error)?;
+
+    // Pas nu de blobs opruimen: dit was het laatste moment waarop iemand het
+    // voorstel nog nodig had. Best-effort, net als na een losse resolve — de
+    // 7-dagen-GC vangt het restje.
+    if let Err(e) = tasks::delete_blobs_for_finished_job(pool, job_id).await {
+        tracing::warn!(error = %e, job_id = %job_id, "blob-cleanup na verwerken mislukt");
+    }
+    tracing::info!(
+        job_id = %job_id,
+        law_id = %law_id,
+        accepted = accepted_count,
+        total,
+        "verrijking verwerkt"
+    );
+
+    let (etag, pr) = match written {
+        Some(w) => (Some(w.etag), w.response.pr),
+        None => (None, None),
+    };
+    Ok(Json(ApplyResponse {
+        law_id,
+        accepted: accepted_count,
+        total,
+        etag,
+        pr,
+    }))
+}
+
+/// Het voorstel van de job: de wet-YAML uit de result-blobs.
+///
+/// Zelfde keuze als de editor maakt bij het laden van een review-taak: eerst
+/// het exacte pad uit de payload, anders het eerste bestand dat geen
+/// dot-prefixed sidecar is (de worker staged ook `features/*.feature`).
+async fn load_proposal(
+    pool: &sqlx::PgPool,
+    job_id: Uuid,
+    open: &[&Task],
+) -> Result<String, (StatusCode, String)> {
+    let yaml_path = open.iter().find_map(|t| payload_str(t, "yaml_path"));
+    let blobs = tasks::load_blobs(pool, job_id, BlobKind::Result)
+        .await
+        .map_err(db_error)?;
+    blobs
+        .iter()
+        .find(|b| Some(b.path.as_str()) == yaml_path.as_deref())
+        .or_else(|| {
+            blobs
+                .iter()
+                .find(|b| !b.path.rsplit('/').next().unwrap_or("").starts_with('.'))
+        })
+        .map(|b| b.content.clone())
+        .ok_or((
+            StatusCode::GONE,
+            "Het voorstel bij deze verrijking is niet meer beschikbaar".to_string(),
+        ))
+}
+
+/// Eén artikel uit het voorstel lichten, als YAML.
+fn article_from_proposal(proposal: &str, number: &str) -> Result<String, (StatusCode, String)> {
+    let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(proposal).map_err(|e| {
+        tracing::warn!(error = %e, "voorstel is geen geldige YAML");
+        (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Het voorstel bij deze verrijking is niet leesbaar".to_string(),
+        )
+    })?;
+    let article = doc
+        .get("articles")
+        .and_then(|a| a.as_sequence())
+        .and_then(|list| {
+            list.iter()
+                .find(|a| article_number(a).as_deref() == Some(number))
+        })
+        .ok_or((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            format!("Het voorstel bevat geen artikel {number}"),
+        ))?;
+    serde_yaml_ng::to_string(article).map_err(|e| {
+        tracing::error!(error = %e, "artikel uit voorstel serialiseren mislukt");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Verrijking verwerken mislukt".to_string(),
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn write_accepted(
+    state: &AppState,
+    account: &AccountRecord,
+    session: &Session,
+    headers: &HeaderMap,
+    traject_ref: &str,
+    law_id: &str,
+    accepted: &[Accepted],
+    whole_law: bool,
+    total: usize,
+) -> Result<corpus_handlers::WrittenLaw, (StatusCode, String)> {
+    let author = Some(corpus_handlers::require_editor_user(session).await?);
+    let traject =
+        corpus_handlers::require_traject_corpus_from_ref(state, session, traject_ref).await?;
+    let write = corpus_handlers::resolve_traject_law_write(&traject, law_id).await?;
+    let auth = TrajectCredentials::new(state, account.id, headers)
+        .for_write(&**write.backend, write.write_source_writable)
+        .await?;
+    let relative_path = std::path::PathBuf::from(&write.law.relative_path);
+    let message = commit_message(law_id, accepted.len(), total, whole_law);
+
+    corpus_handlers::write_composed_law(
+        &traject,
+        write,
+        auth,
+        &relative_path,
+        law_id,
+        author,
+        corpus_handlers::extract_if_match(headers),
+        true,
+        |current| {
+            if whole_law {
+                // Eén onderdeel dat de hele wet ís: de geaccordeerde inhoud
+                // staat er integraal, er valt niets in te splicen.
+                return Ok((accepted[0].content.clone(), message));
+            }
+            let base = current.ok_or((
+                StatusCode::NOT_FOUND,
+                "De wet bestaat niet (meer) in dit traject".to_string(),
+            ))?;
+            let parts: Vec<(&str, &str)> = accepted
+                .iter()
+                .filter_map(|a| Some((a.article.as_deref()?, a.content.as_str())))
+                .collect();
+            let body = compose_enriched_law(base, &parts)
+                .map_err(|e| (StatusCode::UNPROCESSABLE_ENTITY, e))?;
+            Ok((body, message))
+        },
+    )
+    .await
+}
+
+/// De commit-message van een verwerkte verrijking. Noemt wat het was, hoeveel
+/// ervan is overgenomen en welke wet het betreft — een verrijking van zeven
+/// artikelen is één gebeurtenis, en het log hoort dat te laten zien in plaats
+/// van zeven regels `Update law <id>`.
+fn commit_message(law_id: &str, accepted: usize, total: usize, whole_law: bool) -> String {
+    if whole_law {
+        return format!("Verrijking verwerkt: hele wet overgenomen in {law_id}");
+    }
+    let artikelen = if accepted == 1 {
+        "artikel"
+    } else {
+        "artikelen"
+    };
+    format!("Verrijking verwerkt: {accepted} van de {total} {artikelen} overgenomen in {law_id}")
+}
+
+/// Het nummer van een artikel als string; `None` wanneer het ontbreekt of geen
+/// scalar is. Een wet mag `number: 5` schrijven, dus een getal telt mee.
+fn article_number(article: &serde_yaml_ng::Value) -> Option<String> {
+    match article.get("number")? {
+        serde_yaml_ng::Value::String(s) => Some(s.clone()),
+        serde_yaml_ng::Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
+/// Stel de eindstand samen: de huidige wet met de overgenomen artikelen erin.
+///
+/// Elk geaccordeerd artikel vervangt het gelijkgenummerde artikel in de wet;
+/// een nummer dat de wet niet heeft komt er achteraan bij (een verrijking die
+/// een artikel toevoegt is zeldzaam, en de plek raden zou stiller fout gaan dan
+/// het zichtbaar achteraan zetten). Het nummer in de aangeleverde inhoud moet
+/// kloppen met het onderdeel waarover geoordeeld is — anders zou een oordeel
+/// over artikel 3 een heel ander artikel kunnen wegschrijven.
+///
+/// Net als de bestaande save-paden gaat dit door een YAML-round-trip, die
+/// commentaar en sleutelvolgorde niet garandeert. Dat is dezelfde bekende
+/// beperking als in de editor (`currentLawYaml`): het corpus is
+/// harvester-gegenereerd en commentaarloos.
+fn compose_enriched_law(current: &str, accepted: &[(&str, &str)]) -> Result<String, String> {
+    let mut doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(current)
+        .map_err(|e| format!("De opgeslagen wet is geen geldige YAML: {e}"))?;
+    let articles = doc
+        .get_mut("articles")
+        .and_then(|a| a.as_sequence_mut())
+        .ok_or_else(|| "De opgeslagen wet heeft geen artikelen".to_string())?;
+
+    for (number, content) in accepted {
+        let article: serde_yaml_ng::Value = serde_yaml_ng::from_str(content)
+            .map_err(|e| format!("Artikel {number} is geen geldige YAML: {e}"))?;
+        if !article.is_mapping() {
+            return Err(format!("Artikel {number} is geen YAML-mapping"));
+        }
+        match article_number(&article) {
+            Some(found) if found == *number => {}
+            _ => {
+                return Err(format!(
+                    "De aangeleverde inhoud hoort niet bij artikel {number}"
+                ))
+            }
+        }
+        match articles
+            .iter()
+            .position(|a| article_number(a).as_deref() == Some(*number))
+        {
+            Some(idx) => articles[idx] = article,
+            None => articles.push(article),
+        }
+    }
+
+    serde_yaml_ng::to_string(&doc).map_err(|e| format!("Eindstand serialiseren mislukt: {e}"))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    const CURRENT: &str = "$id: test_wet\n\
+                           articles:\n\
+                           - number: '1'\n  text: een\n\
+                           - number: '2'\n  text: twee\n";
+
+    fn articles_of(yaml: &str) -> Vec<(String, String)> {
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(yaml).unwrap();
+        doc.get("articles")
+            .unwrap()
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .map(|a| {
+                (
+                    article_number(a).unwrap(),
+                    a.get("text")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn splices_an_accepted_article_in_place() {
+        let out =
+            compose_enriched_law(CURRENT, &[("2", "number: '2'\ntext: twee verrijkt\n")]).unwrap();
+        assert_eq!(
+            articles_of(&out),
+            vec![
+                ("1".to_string(), "een".to_string()),
+                ("2".to_string(), "twee verrijkt".to_string()),
+            ]
+        );
+        // De rest van de wet blijft staan.
+        assert!(out.contains("test_wet"));
+    }
+
+    #[test]
+    fn leaves_the_law_alone_when_nothing_is_accepted() {
+        let out = compose_enriched_law(CURRENT, &[]).unwrap();
+        assert_eq!(articles_of(&out), articles_of(CURRENT));
+    }
+
+    #[test]
+    fn appends_an_article_the_law_does_not_have_yet() {
+        let out = compose_enriched_law(CURRENT, &[("3", "number: '3'\ntext: drie\n")]).unwrap();
+        assert_eq!(
+            articles_of(&out)
+                .iter()
+                .map(|(n, _)| n.clone())
+                .collect::<Vec<_>>(),
+            vec!["1", "2", "3"]
+        );
+    }
+
+    #[test]
+    fn matches_an_unquoted_article_number() {
+        let current = "$id: test_wet\narticles:\n- number: 2\n  text: twee\n";
+        let out = compose_enriched_law(current, &[("2", "number: 2\ntext: verrijkt\n")]).unwrap();
+        assert_eq!(
+            articles_of(&out),
+            vec![("2".to_string(), "verrijkt".to_string())]
+        );
+    }
+
+    #[test]
+    fn refuses_content_whose_number_does_not_match_the_verdict() {
+        let err =
+            compose_enriched_law(CURRENT, &[("2", "number: '1'\ntext: sluipt\n")]).unwrap_err();
+        assert!(err.contains("artikel 2"), "onverwachte fout: {err}");
+    }
+
+    #[test]
+    fn refuses_content_that_is_not_a_mapping() {
+        let err = compose_enriched_law(CURRENT, &[("2", "- een lijst\n")]).unwrap_err();
+        assert!(err.contains("mapping"), "onverwachte fout: {err}");
+    }
+
+    #[test]
+    fn refuses_a_law_without_articles() {
+        let err = compose_enriched_law("$id: test_wet\n", &[]).unwrap_err();
+        assert!(err.contains("geen artikelen"), "onverwachte fout: {err}");
+    }
+
+    #[test]
+    fn commit_message_names_the_enrichment_the_count_and_the_law() {
+        assert_eq!(
+            commit_message("test_wet", 3, 7, false),
+            "Verrijking verwerkt: 3 van de 7 artikelen overgenomen in test_wet"
+        );
+        assert_eq!(
+            commit_message("test_wet", 1, 4, false),
+            "Verrijking verwerkt: 1 van de 4 artikel overgenomen in test_wet"
+        );
+        assert_eq!(
+            commit_message("test_wet", 1, 1, true),
+            "Verrijking verwerkt: hele wet overgenomen in test_wet"
+        );
+    }
+
+    #[test]
+    fn takes_the_article_from_the_proposal_when_the_client_sends_none() {
+        let proposal = "$id: test_wet\narticles:\n- number: '1'\n  text: voorstel een\n";
+        let article = article_from_proposal(proposal, "1").unwrap();
+        assert!(article.contains("voorstel een"), "kreeg: {article}");
+        assert_eq!(
+            article_from_proposal(proposal, "9").unwrap_err().0,
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+    }
+
+    /// De verrijkings-routes hangen onder `/api/tasks/`, waar `{task_id}` al
+    /// een parameter op dezelfde plek is als het statische `jobs`. Dat mág van
+    /// de router, maar het is precies het soort ding dat stil verkeerd gaat:
+    /// slokt `{task_id}` het pad op, dan komt een verrijking als taak-detail
+    /// binnen en verdwijnt het verwerken zonder foutmelding.
+    #[tokio::test]
+    async fn the_enrichment_routes_are_not_swallowed_by_the_task_id_route() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use axum::routing::{get, post};
+        use tower::ServiceExt;
+
+        async fn code(status: StatusCode) -> StatusCode {
+            status
+        }
+        let app = axum::Router::new()
+            .route(
+                "/api/tasks/{task_id}",
+                get(|| code(StatusCode::IM_A_TEAPOT)),
+            )
+            .route(
+                "/api/tasks/{task_id}/resolve",
+                post(|| code(StatusCode::ACCEPTED)),
+            )
+            .route("/api/tasks/jobs/{job_id}", get(|| code(StatusCode::OK)))
+            .route(
+                "/api/tasks/jobs/{job_id}/apply",
+                post(|| code(StatusCode::CREATED)),
+            );
+
+        let hit = |method: &'static str, path: String| {
+            let app = app.clone();
+            async move {
+                app.oneshot(
+                    Request::builder()
+                        .method(method)
+                        .uri(path)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+                .status()
+            }
+        };
+        let id = Uuid::new_v4();
+        assert_eq!(
+            hit("GET", format!("/api/tasks/{id}")).await,
+            StatusCode::IM_A_TEAPOT
+        );
+        assert_eq!(
+            hit("POST", format!("/api/tasks/{id}/resolve")).await,
+            StatusCode::ACCEPTED
+        );
+        assert_eq!(
+            hit("GET", format!("/api/tasks/jobs/{id}")).await,
+            StatusCode::OK
+        );
+        assert_eq!(
+            hit("POST", format!("/api/tasks/jobs/{id}/apply")).await,
+            StatusCode::CREATED
+        );
+    }
+
+    #[test]
+    fn verdict_deserializes_lowercase_and_rejects_anything_else() {
+        assert_eq!(
+            serde_json::from_str::<Verdict>("\"approved\"").unwrap(),
+            Verdict::Approved
+        );
+        assert_eq!(
+            serde_json::from_str::<Verdict>("\"rejected\"").unwrap(),
+            Verdict::Rejected
+        );
+        assert!(serde_json::from_str::<Verdict>("\"dismissed\"").is_err());
+    }
+}

--- a/packages/editor-api/src/enrich_review.rs
+++ b/packages/editor-api/src/enrich_review.rs
@@ -206,6 +206,17 @@ struct Accepted {
 /// 3. Niets overnemen schrijft niets — geen lege commit. De taken gaan wel
 ///    dicht.
 ///
+/// Wat die transactie **niet** kan: de git-commit terugdraaien. Twee systemen
+/// zonder gedeelde transactie hebben één moment waarop ze uiteen kunnen lopen,
+/// en hier ligt dat tussen een geslaagde `persist` en `tx.commit()`. Valt de
+/// databaseverbinding precies dáár weg, dan staat de wijziging in de wet
+/// terwijl de taken open blijven; de beoordelaar ziet de verrijking dan
+/// opnieuw in zijn lijst. Dat is de kant waar deze volgorde bewust op faalt —
+/// een verrijking die nog een keer beoordeeld moet worden is te herstellen,
+/// een taak die dicht staat terwijl er niets geschreven is niet, want dan is
+/// het voorstel weg. Die uitkomst wordt hard gelogd, want hij is aan niets
+/// anders te zien.
+///
 /// De `If-Match`-header draagt de ETag van de wet zoals de beoordelaar hem
 /// zag. Dat is meteen de enige staleness-bepaling die deze flow nog kent: één
 /// schrijfmoment, één controle. Hij is daarom **verplicht** zodra er iets
@@ -326,6 +337,20 @@ pub async fn apply(
         ));
     }
 
+    // Een whole-law-onderdeel zet de aangeleverde inhoud integraal op de
+    // plaats van de wet — precies wat de PUT doet, dus precies dezelfde poort.
+    // De artikel-route heeft hem niet nodig: daar wordt in de opgeslagen wet
+    // gespliced, dus blijven `$id` en de rest van het bestand van de server.
+    //
+    // Dat de editor hier in de praktijk het onbewerkte voorstel terugstuurt,
+    // is geen bescherming: het endpoint accepteert geaccordeerde inhoud (dat
+    // is het punt van criterium 2) en moet zelf weten wat het aanneemt.
+    if whole_law {
+        for part in accepted.iter().filter(|a| a.article.is_none()) {
+            corpus_handlers::validate_whole_law_body(&part.content, &law_id)?;
+        }
+    }
+
     let accepted_count = accepted.len();
     let total = open.len();
 
@@ -344,6 +369,18 @@ pub async fn apply(
     };
 
     // --- taken dicht + schrijven, of terugrollen -------------------------
+    //
+    // Deze transactie blijft openstaan over de schrijfactie heen, en houdt dus
+    // één poolverbinding vast zolang GitHub erover doet. Dat is de prijs van
+    // "alle taken in dezelfde transactie als de write": zonder die overlap kan
+    // een mislukte `If-Match` de al afgehandelde taken niet meer terugdraaien.
+    //
+    // Wat de prijs begrenst is de volgorde hierboven. De write-lock op de
+    // backend wordt vóór deze transactie genomen, dus twee verwerkingen op
+    // hetzelfde traject staan op die mutex te wachten en niet op een
+    // verbinding. Wat er tegelijk openstaat is daarmee hooguit één transactie
+    // per traject dat op dit moment geschreven wordt — niet één per
+    // beoordelaar.
     let mut tx = pool.begin().await.map_err(db_error)?;
     let closed = tasks::resolve_tasks(&mut *tx, &approved_ids, account.id, TaskStatus::Approved)
         .await
@@ -374,7 +411,22 @@ pub async fn apply(
             }
         }
     };
-    tx.commit().await.map_err(db_error)?;
+    if let Err(e) = tx.commit().await {
+        // Het enige punt waarop wet en takenlijst uiteen kunnen lopen: is er
+        // geschreven, dan staat die commit er en komt hij hier niet meer weg.
+        // Loggen op error-niveau, met de wet erbij — aan de takenlijst alleen
+        // is niet te zien dat het voorstel al geland is.
+        if written.is_some() {
+            tracing::error!(
+                error = %e,
+                job_id = %job_id,
+                law_id = %law_id,
+                "verrijking is weggeschreven maar de taken bleven open staan; \
+                 de wet is bijgewerkt, de beoordelaar ziet de verrijking opnieuw"
+            );
+        }
+        return Err(db_error(e));
+    }
 
     // Pas nu de blobs opruimen: dit was het laatste moment waarop iemand het
     // voorstel nog nodig had. Best-effort, net als na een losse resolve — de

--- a/packages/editor-api/src/lib.rs
+++ b/packages/editor-api/src/lib.rs
@@ -10,6 +10,7 @@ pub mod config;
 pub mod corpus_handlers;
 pub mod credentials;
 pub mod crypto;
+pub mod enrich_review;
 pub mod feature_flags;
 pub mod github_oauth;
 pub mod state;

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -22,6 +22,7 @@ mod config;
 mod corpus_handlers;
 mod credentials;
 mod crypto;
+mod enrich_review;
 mod favorites;
 mod feature_flags;
 mod github_oauth;
@@ -309,6 +310,7 @@ async fn main() {
     let tasks_reader_routes = Router::new()
         .route("/api/tasks", get(tasks_api::list))
         .route("/api/tasks/{task_id}", get(tasks_api::detail))
+        .route("/api/tasks/jobs/{job_id}", get(enrich_review::job_tasks))
         .route_layer(axum_middleware::from_fn_with_state(
             app_state.clone(),
             accounts::account_middleware,
@@ -322,6 +324,10 @@ async fn main() {
         .route(
             "/api/tasks/{task_id}/resolve",
             axum::routing::post(tasks_api::resolve),
+        )
+        .route(
+            "/api/tasks/jobs/{job_id}/apply",
+            axum::routing::post(enrich_review::apply),
         )
         .route_layer(axum_middleware::from_fn_with_state(
             app_state.clone(),

--- a/packages/editor-api/tests/enrich_review_apply_test.rs
+++ b/packages/editor-api/tests/enrich_review_apply_test.rs
@@ -1,0 +1,614 @@
+//! De verrijking als beoordelingseenheid: `enrich_review::apply` verwerkt
+//! álle onderdelen van één enrich-job in één schrijfactie.
+//!
+//! Wat hier vastligt is de eenheid, niet de vormgeving: één verrijking is één
+//! commit, en tot het moment van verwerken verandert er niets aan de wet. De
+//! scenario's dekken alles overnemen, deels overnemen, niets overnemen, een
+//! `If-Match`-conflict tijdens het verwerken en een verrijking die uit één
+//! whole-law-onderdeel bestaat.
+//!
+//! Zelfde hermetische opzet als `traject_reads_test.rs`: lokale
+//! writable-own bron, geen GitHub, geen netwerk, handlers rechtstreeks
+//! aangeroepen met inline `axum`-extractors.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use axum::extract::{Extension, Path, State};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::Json;
+use pretty_assertions::assert_eq;
+use sqlx::PgPool;
+use tokio::sync::{Mutex, RwLock};
+use tower_sessions::Session;
+use tower_sessions_memory_store::MemoryStore;
+use uuid::Uuid;
+
+use regelrecht_auth::handlers::{
+    SESSION_KEY_EMAIL, SESSION_KEY_EMAIL_VERIFIED, SESSION_KEY_NAME, SESSION_KEY_SUB,
+};
+use regelrecht_editor_api::accounts::AccountRecord;
+use regelrecht_editor_api::config::AppConfig;
+use regelrecht_editor_api::corpus_handlers::get_traject_corpus_law;
+use regelrecht_editor_api::enrich_review::{apply, job_tasks};
+use regelrecht_editor_api::state::{AppState, CorpusState};
+use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
+
+use regelrecht_pipeline::test_utils::TestDb;
+
+const LAW_ID: &str = "wet_op_de_zorgtoeslag";
+const LAW_FILE: &str = "2025-01-01.yaml";
+
+/// De wet zoals hij op de branch staat vóór het verwerken.
+const SAVED_LAW: &str = r#"$id: wet_op_de_zorgtoeslag
+name: Testwet
+articles:
+- number: '1'
+  text: artikel een
+- number: '2'
+  text: artikel twee
+"#;
+
+/// Het voorstel dat de verrijking opleverde: beide artikelen aangeraakt.
+const PROPOSAL: &str = r#"$id: wet_op_de_zorgtoeslag
+name: Testwet
+articles:
+- number: '1'
+  text: artikel een verrijkt
+- number: '2'
+  text: artikel twee verrijkt
+"#;
+
+fn empty_state(pool: PgPool) -> AppState {
+    AppState {
+        corpus: Arc::new(RwLock::new(CorpusState::empty())),
+        oidc_client: None,
+        end_session_url: None,
+        config: Arc::new(AppConfig {
+            oidc: None,
+            base_url: None,
+            github_oauth: None,
+            task_enrich_provider: "claude".to_string(),
+        }),
+        http_client: regelrecht_auth::http_client(),
+        pool: Some(pool),
+        pipeline_api_url: None,
+        harvest_admin_url: None,
+        reload_lock: Arc::new(Mutex::new(())),
+        integrity: Default::default(),
+        trajects: Arc::new(TrajectCorpusCache::new()),
+    }
+}
+
+async fn seed_account(pool: &PgPool, email: &str) -> (Uuid, String) {
+    let sub = format!("sub-{email}");
+    let (id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO accounts (person_sub, email, name) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(&sub)
+    .bind(email)
+    .bind("Test User")
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    (id, sub)
+}
+
+fn law_path(corpus_dir: &std::path::Path) -> std::path::PathBuf {
+    corpus_dir.join("wet").join(LAW_ID).join(LAW_FILE)
+}
+
+fn write_law(corpus_dir: &std::path::Path, content: &str) {
+    let path = law_path(corpus_dir);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, content).unwrap();
+}
+
+fn read_law_file(corpus_dir: &std::path::Path) -> String {
+    std::fs::read_to_string(law_path(corpus_dir)).unwrap()
+}
+
+async fn local_traject(pool: &PgPool, owner_id: Uuid, corpus_dir: &std::path::Path) -> Uuid {
+    let (traject_id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, description, scope, created_by)
+         VALUES ('Test', '', '', $1) RETURNING id",
+    )
+    .bind(owner_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_members (traject_id, account_id, role)
+         VALUES ($1, $2, 'owner')",
+    )
+    .bind(traject_id)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'local', 'Local', 'local'::corpus_source_type, $2,
+                 0, '[]'::jsonb, TRUE)",
+    )
+    .bind(traject_id)
+    .bind(corpus_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+    traject_id
+}
+
+fn traject_ref(traject_id: Uuid) -> String {
+    format!("test-{}", &traject_id.to_string()[..8])
+}
+
+async fn session_for(sub: &str) -> Session {
+    let session = Session::new(None, Arc::new(MemoryStore::default()), None);
+    session.insert(SESSION_KEY_SUB, sub).await.unwrap();
+    session.insert(SESSION_KEY_NAME, "Test User").await.unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL, "alice@test.local")
+        .await
+        .unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL_VERIFIED, true)
+        .await
+        .unwrap();
+    session
+}
+
+fn account_record(id: Uuid) -> AccountRecord {
+    AccountRecord {
+        id,
+        person_sub: "test-sub".to_string(),
+        email: "alice@test.local".to_string(),
+        name: "Test User".to_string(),
+    }
+}
+
+fn if_match_headers(etag: &str) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::IF_MATCH,
+        HeaderValue::from_str(etag).unwrap(),
+    );
+    headers
+}
+
+/// Een afgeronde enrich-job met het voorstel als result-blob.
+async fn seed_job(pool: &PgPool, proposal: &str) -> Uuid {
+    let (job_id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO jobs (job_type, law_id, status, payload)
+         VALUES ('enrich'::job_type, $1, 'completed'::job_status, '{}'::jsonb)
+         RETURNING id",
+    )
+    .bind(LAW_ID)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO job_blobs (job_id, kind, path, content) VALUES ($1, 'result', $2, $3)",
+    )
+    .bind(job_id)
+    .bind(format!("wet/{LAW_ID}/{LAW_FILE}"))
+    .bind(proposal)
+    .execute(pool)
+    .await
+    .unwrap();
+    job_id
+}
+
+/// Eén review-taak van die job. `article = None` modelleert het
+/// whole-law-onderdeel (een voorstel dat de worker niet kon opsplitsen).
+async fn seed_task(
+    pool: &PgPool,
+    job_id: Uuid,
+    account_id: Uuid,
+    traject_id: Uuid,
+    tref: &str,
+    article: Option<&str>,
+) -> Uuid {
+    let mut payload = serde_json::json!({
+        "law_id": LAW_ID,
+        "yaml_path": format!("wet/{LAW_ID}/{LAW_FILE}"),
+        "traject_ref": tref,
+    });
+    if let Some(number) = article {
+        payload["article"] = serde_json::json!(number);
+    }
+    let (task_id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO tasks (task_type, assignee_account_id, traject_id, job_id, title, payload)
+         VALUES ('job_review', $1, $2, $3, $4, $5) RETURNING id",
+    )
+    .bind(account_id)
+    .bind(traject_id)
+    .bind(job_id)
+    .bind(format!(
+        "Verrijking beoordelen: {LAW_ID} {}",
+        article.unwrap_or("hele wet")
+    ))
+    .bind(&payload)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    task_id
+}
+
+async fn task_status(pool: &PgPool, task_id: Uuid) -> String {
+    let (status,): (String,) = sqlx::query_as("SELECT status::text FROM tasks WHERE id = $1")
+        .bind(task_id)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    status
+}
+
+async fn blob_count(pool: &PgPool, job_id: Uuid) -> i64 {
+    let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM job_blobs WHERE job_id = $1")
+        .bind(job_id)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    count
+}
+
+/// De huidige ETag van de wet, zoals de beoordelaar hem meekrijgt op de GET.
+async fn law_etag(state: AppState, session: Session, tref: &str, account: AccountRecord) -> String {
+    let (status, headers, _body) = get_traject_corpus_law(
+        State(state),
+        Extension(account),
+        session,
+        Path((tref.to_string(), LAW_ID.to_string())),
+        HeaderMap::new(),
+    )
+    .await
+    .expect("law GET must succeed");
+    assert_eq!(status, StatusCode::OK);
+    headers
+        .iter()
+        .find(|(name, _)| name == axum::http::header::ETAG)
+        .map(|(_, value)| value.clone())
+        .expect("law GET must carry an ETag")
+}
+
+fn decision(task_id: Uuid, action: &str, content: Option<&str>) -> serde_json::Value {
+    let mut d = serde_json::json!({ "task_id": task_id, "action": action });
+    if let Some(c) = content {
+        d["content"] = serde_json::json!(c);
+    }
+    d
+}
+
+/// De volledige opzet die elke test deelt: account, traject met een lokale
+/// writable-own bron, de opgeslagen wet, en een afgeronde verrijking.
+struct Fixture {
+    db: TestDb,
+    state: AppState,
+    corpus: tempfile::TempDir,
+    sub: String,
+    account: AccountRecord,
+    tref: String,
+    job_id: Uuid,
+}
+
+impl Fixture {
+    async fn new() -> Self {
+        let db = TestDb::new().await;
+        let state = empty_state(db.pool.clone());
+        let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+        let corpus = tempfile::tempdir().unwrap();
+        write_law(corpus.path(), SAVED_LAW);
+        let traject_id = local_traject(&db.pool, owner, corpus.path()).await;
+        let tref = traject_ref(traject_id);
+        let job_id = seed_job(&db.pool, PROPOSAL).await;
+        Self {
+            db,
+            state,
+            corpus,
+            sub,
+            account: account_record(owner),
+            tref,
+            job_id,
+        }
+    }
+
+    async fn traject_id(&self) -> Uuid {
+        let (id,): (Uuid,) = sqlx::query_as("SELECT id FROM trajects LIMIT 1")
+            .fetch_one(&self.db.pool)
+            .await
+            .unwrap();
+        id
+    }
+
+    async fn task(&self, article: Option<&str>) -> Uuid {
+        let traject_id = self.traject_id().await;
+        seed_task(
+            &self.db.pool,
+            self.job_id,
+            self.account.id,
+            traject_id,
+            &self.tref,
+            article,
+        )
+        .await
+    }
+
+    async fn etag(&self) -> String {
+        law_etag(
+            self.state.clone(),
+            session_for(&self.sub).await,
+            &self.tref,
+            self.account.clone(),
+        )
+        .await
+    }
+
+    async fn apply(
+        &self,
+        headers: HeaderMap,
+        decisions: Vec<serde_json::Value>,
+    ) -> Result<serde_json::Value, (StatusCode, String)> {
+        let body = serde_json::from_value(serde_json::json!({ "decisions": decisions })).unwrap();
+        let Json(response) = apply(
+            State(self.state.clone()),
+            Extension(self.account.clone()),
+            session_for(&self.sub).await,
+            Path(self.job_id),
+            headers,
+            Json(body),
+        )
+        .await?;
+        Ok(serde_json::to_value(response).unwrap())
+    }
+
+    fn law(&self) -> String {
+        read_law_file(self.corpus.path())
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn job_tasks_lists_every_part_with_its_article_and_status() {
+    let f = Fixture::new().await;
+    let one = f.task(Some("1")).await;
+    let two = f.task(Some("2")).await;
+
+    let Json(response) = job_tasks(
+        State(f.state.clone()),
+        Extension(f.account.clone()),
+        Path(f.job_id),
+    )
+    .await
+    .expect("job_tasks must succeed");
+
+    let value = serde_json::to_value(&response).unwrap();
+    assert_eq!(value["law_id"], serde_json::json!(LAW_ID));
+    let tasks = value["tasks"].as_array().unwrap();
+    assert_eq!(tasks.len(), 2);
+    let ids: Vec<&str> = tasks.iter().map(|t| t["id"].as_str().unwrap()).collect();
+    assert!(ids.contains(&one.to_string().as_str()));
+    assert!(ids.contains(&two.to_string().as_str()));
+    let articles: Vec<&str> = tasks
+        .iter()
+        .map(|t| t["article"].as_str().unwrap())
+        .collect();
+    assert_eq!(articles, vec!["1", "2"]);
+    assert!(tasks.iter().all(|t| t["status"] == "open"));
+}
+
+#[tokio::test]
+async fn accepting_everything_writes_the_whole_enrichment_at_once() {
+    let f = Fixture::new().await;
+    let one = f.task(Some("1")).await;
+    let two = f.task(Some("2")).await;
+    let etag = f.etag().await;
+
+    let response = f
+        .apply(
+            if_match_headers(&etag),
+            vec![
+                decision(
+                    one,
+                    "approved",
+                    Some("number: '1'\ntext: artikel een verrijkt\n"),
+                ),
+                decision(
+                    two,
+                    "approved",
+                    Some("number: '2'\ntext: artikel twee verrijkt\n"),
+                ),
+            ],
+        )
+        .await
+        .expect("apply must succeed");
+
+    assert_eq!(response["accepted"], serde_json::json!(2));
+    assert_eq!(response["total"], serde_json::json!(2));
+    let law = f.law();
+    assert!(law.contains("artikel een verrijkt"), "kreeg: {law}");
+    assert!(law.contains("artikel twee verrijkt"), "kreeg: {law}");
+    assert_eq!(task_status(&f.db.pool, one).await, "approved");
+    assert_eq!(task_status(&f.db.pool, two).await, "approved");
+    // Dit was het laatste moment waarop iemand het voorstel nodig had.
+    assert_eq!(blob_count(&f.db.pool, f.job_id).await, 0);
+}
+
+#[tokio::test]
+async fn a_rejected_part_leaves_its_article_untouched() {
+    let f = Fixture::new().await;
+    let one = f.task(Some("1")).await;
+    let two = f.task(Some("2")).await;
+    let etag = f.etag().await;
+
+    let response = f
+        .apply(
+            if_match_headers(&etag),
+            vec![
+                decision(
+                    one,
+                    "approved",
+                    Some("number: '1'\ntext: artikel een verrijkt\n"),
+                ),
+                decision(two, "rejected", None),
+            ],
+        )
+        .await
+        .expect("apply must succeed");
+
+    assert_eq!(response["accepted"], serde_json::json!(1));
+    let law = f.law();
+    assert!(law.contains("artikel een verrijkt"), "kreeg: {law}");
+    assert!(law.contains("artikel twee"), "kreeg: {law}");
+    assert!(!law.contains("artikel twee verrijkt"), "kreeg: {law}");
+    assert_eq!(task_status(&f.db.pool, one).await, "approved");
+    assert_eq!(task_status(&f.db.pool, two).await, "rejected");
+}
+
+#[tokio::test]
+async fn accepting_nothing_writes_nothing_but_closes_the_parts() {
+    let f = Fixture::new().await;
+    let one = f.task(Some("1")).await;
+    let two = f.task(Some("2")).await;
+    let etag = f.etag().await;
+
+    let response = f
+        .apply(
+            if_match_headers(&etag),
+            vec![
+                decision(one, "rejected", None),
+                decision(two, "rejected", None),
+            ],
+        )
+        .await
+        .expect("apply must succeed");
+
+    assert_eq!(response["accepted"], serde_json::json!(0));
+    // Geen lege commit: de wet staat er nog bij zoals hij stond.
+    assert_eq!(f.law(), SAVED_LAW);
+    assert_eq!(response["etag"], serde_json::Value::Null);
+    assert_eq!(task_status(&f.db.pool, one).await, "rejected");
+    assert_eq!(task_status(&f.db.pool, two).await, "rejected");
+    assert_eq!(blob_count(&f.db.pool, f.job_id).await, 0);
+}
+
+#[tokio::test]
+async fn a_part_without_a_verdict_blocks_the_whole_enrichment() {
+    let f = Fixture::new().await;
+    let one = f.task(Some("1")).await;
+    let two = f.task(Some("2")).await;
+    let etag = f.etag().await;
+
+    let (status, _message) = f
+        .apply(
+            if_match_headers(&etag),
+            vec![decision(
+                one,
+                "approved",
+                Some("number: '1'\ntext: artikel een verrijkt\n"),
+            )],
+        )
+        .await
+        .expect_err("een onvolledig oordeel hoort geweigerd te worden");
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    // Goedkeuren van één artikel schrijft niet meer direct.
+    assert_eq!(f.law(), SAVED_LAW);
+    assert_eq!(task_status(&f.db.pool, one).await, "open");
+    assert_eq!(task_status(&f.db.pool, two).await, "open");
+}
+
+#[tokio::test]
+async fn an_if_match_conflict_leaves_no_part_resolved() {
+    let f = Fixture::new().await;
+    let one = f.task(Some("1")).await;
+    let two = f.task(Some("2")).await;
+
+    let (status, _message) = f
+        .apply(
+            if_match_headers("\"een-verouderde-etag\""),
+            vec![
+                decision(
+                    one,
+                    "approved",
+                    Some("number: '1'\ntext: artikel een verrijkt\n"),
+                ),
+                decision(two, "rejected", None),
+            ],
+        )
+        .await
+        .expect_err("een verouderde If-Match hoort 412 te geven");
+
+    assert_eq!(status, StatusCode::PRECONDITION_FAILED);
+    assert_eq!(f.law(), SAVED_LAW);
+    assert_eq!(task_status(&f.db.pool, one).await, "open");
+    assert_eq!(task_status(&f.db.pool, two).await, "open");
+    // Het voorstel blijft staan: er valt nog steeds iets te beoordelen.
+    assert_eq!(blob_count(&f.db.pool, f.job_id).await, 1);
+}
+
+#[tokio::test]
+async fn a_whole_law_part_is_taken_over_in_one_piece() {
+    let f = Fixture::new().await;
+    let whole = f.task(None).await;
+    let etag = f.etag().await;
+
+    // Geen inhoud meegestuurd: dan geldt het ruwe voorstel uit de job.
+    let response = f
+        .apply(
+            if_match_headers(&etag),
+            vec![decision(whole, "approved", None)],
+        )
+        .await
+        .expect("apply must succeed");
+
+    assert_eq!(response["accepted"], serde_json::json!(1));
+    assert_eq!(f.law(), PROPOSAL);
+    assert_eq!(task_status(&f.db.pool, whole).await, "approved");
+}
+
+#[tokio::test]
+async fn an_article_without_content_falls_back_to_the_proposal() {
+    let f = Fixture::new().await;
+    let one = f.task(Some("1")).await;
+    let two = f.task(Some("2")).await;
+    let etag = f.etag().await;
+
+    f.apply(
+        if_match_headers(&etag),
+        vec![
+            decision(one, "approved", None),
+            decision(two, "rejected", None),
+        ],
+    )
+    .await
+    .expect("apply must succeed");
+
+    let law = f.law();
+    assert!(law.contains("artikel een verrijkt"), "kreeg: {law}");
+    assert!(!law.contains("artikel twee verrijkt"), "kreeg: {law}");
+}
+
+#[tokio::test]
+async fn a_second_verwerking_of_the_same_enrichment_is_a_conflict() {
+    let f = Fixture::new().await;
+    let one = f.task(Some("1")).await;
+    let etag = f.etag().await;
+
+    f.apply(
+        if_match_headers(&etag),
+        vec![decision(one, "rejected", None)],
+    )
+    .await
+    .expect("apply must succeed");
+
+    let (status, _message) = f
+        .apply(HeaderMap::new(), vec![decision(one, "rejected", None)])
+        .await
+        .expect_err("een verwerkte verrijking hoort niet nog eens te kunnen");
+    assert_eq!(status, StatusCode::CONFLICT);
+}

--- a/packages/editor-api/tests/enrich_review_apply_test.rs
+++ b/packages/editor-api/tests/enrich_review_apply_test.rs
@@ -571,6 +571,43 @@ async fn a_whole_law_part_is_taken_over_in_one_piece() {
     assert_eq!(task_status(&f.db.pool, whole).await, "approved");
 }
 
+/// Een whole-law-onderdeel zet de aangeleverde inhoud integraal op de plaats
+/// van de wet. Dezelfde daad als de PUT, dus dezelfde poort: kapotte YAML of
+/// een `$id` dat een andere wet aanwijst hoort er niet langs te komen. De
+/// artikel-route heeft dat niet nodig - daar splicet de server in de
+/// opgeslagen wet en blijft `$id` van hem.
+#[tokio::test]
+async fn een_whole_law_onderdeel_met_onbruikbare_inhoud_wordt_geweigerd() {
+    for (label, content) in [
+        (
+            "kapotte YAML",
+            "$id: wet_op_de_zorgtoeslag\narticles: [oops\n",
+        ),
+        (
+            "ander $id",
+            "$id: een_andere_wet\narticles:\n- number: '1'\n  text: x\n",
+        ),
+        ("geen $id", "articles:\n- number: '1'\n  text: x\n"),
+    ] {
+        let f = Fixture::new().await;
+        let whole = f.task(None).await;
+        let etag = f.etag().await;
+
+        let (status, _message) = f
+            .apply(
+                if_match_headers(&etag),
+                vec![decision(whole, "approved", Some(content))],
+            )
+            .await
+            .err()
+            .unwrap_or_else(|| panic!("{label} hoort geweigerd te worden"));
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{label}");
+        assert_eq!(f.law(), SAVED_LAW, "{label}");
+        assert_eq!(task_status(&f.db.pool, whole).await, "open", "{label}");
+    }
+}
+
 #[tokio::test]
 async fn an_article_without_content_falls_back_to_the_proposal() {
     let f = Fixture::new().await;

--- a/packages/editor-api/tests/enrich_review_apply_test.rs
+++ b/packages/editor-api/tests/enrich_review_apply_test.rs
@@ -612,3 +612,98 @@ async fn a_second_verwerking_of_the_same_enrichment_is_a_conflict() {
         .expect_err("een verwerkte verrijking hoort niet nog eens te kunnen");
     assert_eq!(status, StatusCode::CONFLICT);
 }
+
+/// Zonder `If-Match` zou het verwerken een blinde overschrijving zijn. Dat is
+/// precies de controle die deze flow nog heeft: de staleness-vlag per taak is
+/// weg omdat er nog maar één schrijfmoment is, dus dat ene moment moet hem
+/// dragen.
+#[tokio::test]
+async fn overnemen_zonder_if_match_schrijft_niet_en_handelt_niets_af() {
+    let f = Fixture::new().await;
+    let one = f.task(Some("1")).await;
+    let two = f.task(Some("2")).await;
+
+    let (status, _message) = f
+        .apply(
+            HeaderMap::new(),
+            vec![
+                decision(
+                    one,
+                    "approved",
+                    Some("number: '1'\ntext: artikel een verrijkt\n"),
+                ),
+                decision(two, "rejected", None),
+            ],
+        )
+        .await
+        .expect_err("verwerken zonder If-Match hoort geweigerd te worden");
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(f.law(), SAVED_LAW);
+    assert_eq!(task_status(&f.db.pool, one).await, "open");
+    assert_eq!(task_status(&f.db.pool, two).await, "open");
+}
+
+/// Niets overnemen schrijft niet, en vraagt dus ook niet om een `If-Match`:
+/// er is geen eindstand om tegen iets af te zetten.
+#[tokio::test]
+async fn niets_overnemen_mag_zonder_if_match() {
+    let f = Fixture::new().await;
+    let one = f.task(Some("1")).await;
+
+    let response = f
+        .apply(HeaderMap::new(), vec![decision(one, "rejected", None)])
+        .await
+        .expect("niets overnemen hoort te lukken");
+
+    assert_eq!(response["accepted"], serde_json::json!(0));
+    assert_eq!(f.law(), SAVED_LAW);
+    assert_eq!(task_status(&f.db.pool, one).await, "rejected");
+}
+
+/// Een verrijking van iemand anders bestaat niet voor jou - niet om te lezen
+/// en niet om te verwerken. De account-filter zit in de query, dus een vreemd
+/// account krijgt een lege lijst en daarmee een 404, niet andermans taken.
+#[tokio::test]
+async fn de_verrijking_van_een_ander_account_is_onvindbaar() {
+    let f = Fixture::new().await;
+    let one = f.task(Some("1")).await;
+    let etag = f.etag().await;
+    let (intruder_id, intruder_sub) = seed_account(&f.db.pool, "mallory@test.local").await;
+    let intruder = AccountRecord {
+        id: intruder_id,
+        person_sub: intruder_sub.clone(),
+        email: "mallory@test.local".to_string(),
+        name: "Test User".to_string(),
+    };
+
+    let (read_status, _) = job_tasks(
+        State(f.state.clone()),
+        Extension(intruder.clone()),
+        Path(f.job_id),
+    )
+    .await
+    .err()
+    .expect("de onderdelen van andermans verrijking horen niet leesbaar te zijn");
+    assert_eq!(read_status, StatusCode::NOT_FOUND);
+
+    let body = serde_json::from_value(
+        serde_json::json!({ "decisions": [decision(one, "approved", None)] }),
+    )
+    .unwrap();
+    let (status, _message) = apply(
+        State(f.state.clone()),
+        Extension(intruder),
+        session_for(&intruder_sub).await,
+        Path(f.job_id),
+        if_match_headers(&etag),
+        Json(body),
+    )
+    .await
+    .err()
+    .expect("andermans verrijking hoort niet verwerkt te kunnen worden");
+
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(f.law(), SAVED_LAW);
+    assert_eq!(task_status(&f.db.pool, one).await, "open");
+}

--- a/packages/pipeline/src/tasks.rs
+++ b/packages/pipeline/src/tasks.rs
@@ -181,6 +181,64 @@ pub async fn get_task_for_account(
     Ok(task)
 }
 
+/// Alle taken van één job voor dit account, oudste eerst — de onderdelen van
+/// één verrijking. Afgehandelde taken blijven meekomen: wie een verrijking
+/// verwerkt moet kunnen zien dat een zusje al dicht is (bijvoorbeeld omdat
+/// het traject eronder verdween, zie [`dismiss_open_tasks_for_traject`]).
+///
+/// Zelfde account-gating als [`get_task_for_account`]: een job van iemand
+/// anders levert een lege lijst, niet andermans taken.
+pub async fn list_tasks_for_job_and_account(
+    pool: &PgPool,
+    job_id: Uuid,
+    account_id: Uuid,
+) -> Result<Vec<Task>> {
+    let query = format!(
+        "SELECT {RETURNING} FROM tasks \
+         WHERE job_id = $1 AND assignee_account_id = $2 \
+         ORDER BY created_at, id",
+    );
+    let tasks = sqlx::query_as::<_, Task>(&query)
+        .bind(job_id)
+        .bind(account_id)
+        .fetch_all(pool)
+        .await?;
+    Ok(tasks)
+}
+
+/// Handel een reeks taken in één keer af en lever het aantal rijen dat
+/// daadwerkelijk dichtging. Generiek over de executor, zodat het verwerken van
+/// een hele verrijking (alle onderdelen tegelijk) in dezelfde transactie past
+/// als de schrijfactie die eruit volgt.
+///
+/// De aanroeper hoort te controleren of het aantal klopt: is het lager dan wat
+/// hij aanbood, dan was een taak niet meer open (race of vreemd account) en
+/// hoort de hele verwerking terug te rollen in plaats van half te landen.
+/// Dezelfde WHERE-voorwaarden als [`resolve_task`] doen dat werk.
+pub async fn resolve_tasks<'e, E>(
+    executor: E,
+    task_ids: &[Uuid],
+    account_id: Uuid,
+    new_status: TaskStatus,
+) -> Result<u64>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    if task_ids.is_empty() || new_status == TaskStatus::Open {
+        return Ok(0);
+    }
+    let result = sqlx::query(
+        "UPDATE tasks SET status = $3, resolved_at = now(), resolved_by = $2 \
+         WHERE id = ANY($1) AND assignee_account_id = $2 AND status = 'open'",
+    )
+    .bind(task_ids)
+    .bind(account_id)
+    .bind(new_status)
+    .execute(executor)
+    .await?;
+    Ok(result.rows_affected())
+}
+
 /// Handel een taak af. Alleen de assignee mag dat, en alleen vanuit 'open':
 /// beide voorwaarden zitten in de WHERE zodat een race of vreemd account
 /// simpelweg `None` oplevert (geen aparte foutklasse nodig).

--- a/packages/pipeline/tests/tasks_tests.rs
+++ b/packages/pipeline/tests/tasks_tests.rs
@@ -368,6 +368,109 @@ async fn test_dismiss_open_tasks_for_traject_scopes_and_dedupes() {
     assert_eq!(status, TaskStatus::Approved);
 }
 
+#[tokio::test]
+async fn test_list_tasks_for_job_returns_every_part_of_one_enrichment() {
+    let db = TestDb::new().await;
+    let (account_id, traject_id) = seed_account_and_traject(&db).await;
+    let job = job_queue::create_job(&db.pool, CreateJobRequest::new(JobType::Enrich, "wet_a"))
+        .await
+        .unwrap();
+    let other_job =
+        job_queue::create_job(&db.pool, CreateJobRequest::new(JobType::Enrich, "wet_b"))
+            .await
+            .unwrap();
+    let article_1 = seed_open_task(&db, account_id, traject_id, Some(job.id)).await;
+    let article_2 = seed_open_task(&db, account_id, traject_id, Some(job.id)).await;
+    let elsewhere = seed_open_task(&db, account_id, traject_id, Some(other_job.id)).await;
+
+    // Een afgehandeld onderdeel komt mee: wie de verrijking verwerkt moet
+    // kunnen zien dat een zusje buiten hem om al dichtging.
+    tasks::resolve_task(&db.pool, article_2.id, account_id, TaskStatus::Rejected)
+        .await
+        .unwrap()
+        .expect("assignee mag resolven");
+
+    let parts = tasks::list_tasks_for_job_and_account(&db.pool, job.id, account_id)
+        .await
+        .unwrap();
+    let ids: Vec<uuid::Uuid> = parts.iter().map(|t| t.id).collect();
+    assert_eq!(ids, vec![article_1.id, article_2.id]);
+    assert!(!ids.contains(&elsewhere.id), "andere job hoort er niet bij");
+    assert_eq!(parts[1].status, TaskStatus::Rejected);
+
+    // Andermans account ziet niets, ook niet van een job die bestaat.
+    assert!(
+        tasks::list_tasks_for_job_and_account(&db.pool, job.id, uuid::Uuid::new_v4())
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn test_resolve_tasks_closes_a_whole_enrichment_and_counts_what_it_closed() {
+    let db = TestDb::new().await;
+    let (account_id, traject_id) = seed_account_and_traject(&db).await;
+    let job = job_queue::create_job(&db.pool, CreateJobRequest::new(JobType::Enrich, "wet_a"))
+        .await
+        .unwrap();
+    let article_1 = seed_open_task(&db, account_id, traject_id, Some(job.id)).await;
+    let article_2 = seed_open_task(&db, account_id, traject_id, Some(job.id)).await;
+    let article_3 = seed_open_task(&db, account_id, traject_id, Some(job.id)).await;
+
+    let approved = tasks::resolve_tasks(
+        &db.pool,
+        &[article_1.id, article_2.id],
+        account_id,
+        TaskStatus::Approved,
+    )
+    .await
+    .unwrap();
+    assert_eq!(approved, 2);
+
+    // Al dicht, of van een ander account: die tellen niet mee, en dat is
+    // precies het signaal waarop de aanroeper de hele verwerking terugrolt.
+    let again = tasks::resolve_tasks(
+        &db.pool,
+        &[article_1.id, article_3.id],
+        account_id,
+        TaskStatus::Rejected,
+    )
+    .await
+    .unwrap();
+    assert_eq!(again, 1);
+    assert_eq!(
+        tasks::resolve_tasks(&db.pool, &[], account_id, TaskStatus::Rejected)
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        tasks::resolve_tasks(
+            &db.pool,
+            &[article_1.id],
+            uuid::Uuid::new_v4(),
+            TaskStatus::Rejected
+        )
+        .await
+        .unwrap(),
+        0
+    );
+
+    let parts = tasks::list_tasks_for_job_and_account(&db.pool, job.id, account_id)
+        .await
+        .unwrap();
+    let statuses: Vec<TaskStatus> = parts.iter().map(|t| t.status).collect();
+    assert_eq!(
+        statuses,
+        vec![
+            TaskStatus::Approved,
+            TaskStatus::Approved,
+            TaskStatus::Rejected
+        ]
+    );
+}
+
 /// Open `job_review`-taak met de minimale velden die deze test nodig heeft.
 async fn seed_open_task(
     db: &TestDb,


### PR DESCRIPTION
## Wat

Een verrijking is nu ook de eenheid van **beoordelen**, niet alleen van uitvoeren.

Eén enrich-job levert een review-taak per gewijzigd artikel op. Tot nu toe deed elke goedkeuring een eigen `PUT` op de wet: zeven verrijkte artikelen werden zeven losse commits, allemaal met de titel `Update law <id>`. En omdat `source_etag` één keer bij de aanvraag werd gezet en naar elke artikel-taak gekopieerd, maakte de eerste goedkeuring alle zusjes "verouderd" — een waarschuwing over je eigen werk.

Je oordeelt nog steeds per artikel. Er wordt alleen pas geschreven als over elk onderdeel een oordeel is geveld, en dan in **één** commit met een message die zegt wat het was.

## Backend

- `GET /api/tasks/jobs/{job_id}` — de onderdelen van één verrijking, met per taak het artikelnummer en de status.
- `POST /api/tasks/jobs/{job_id}/apply` — ontvangt per onderdeel het oordeel (`approved`/`rejected`) en bij overnemen de artikelinhoud die de gebruiker accordeert. De server stelt de eindstand samen (huidige wet + overgenomen artikelen), schrijft één keer met één `If-Match` en zet alle taken in dezelfde transactie weg.
  - De oordelen moeten álle nog-open onderdelen dekken; ontbreekt er één, dan verandert er niets aan de wet.
  - Faalt de `If-Match`, dan rolt de transactie terug: niets geschreven, geen taak afgehandeld.
  - Niets overnemen schrijft niets — geen lege commit; de taken gaan wel dicht.
  - Onderdelen zonder aangeleverde inhoud vallen terug op het ruwe voorstel uit de job.
- De commit heet nu bijvoorbeeld `Verrijking verwerkt: 3 van de 7 artikelen overgenomen in <wet>`.
- Het samenstellen hoort server-side: alleen daar kan het tegen precies de bytes waartegen de `If-Match` is gecontroleerd, onder de write-lock die de commit erna gebruikt.
- `save_law` en het verwerken delen één schrijfkern (`write_composed_law`), zodat de `If-Match`-controle, de commit, de read-your-writes-overlay en de changed-laws-cache maar één keer bestaan.

Een `law_create` blijft langs het aanmaakpad (POST) lopen: die wet bestaat nog niet, dus er is geen `If-Match` en niets samen te stellen.

## Frontend

- "Neem voorstel over" / "Verwerpen" leggen het oordeel over dít onderdeel vast en schuiven door naar het volgende onbeoordeelde onderdeel. Pas bij het laatste oordeel gaat alles in één keer naar de backend.
- De review-balk zegt erbij hoeveel onderdelen er zijn en dat de wet nog niet is bijgewerkt — "Neem voorstel over" mag niet als "opgeslagen" lezen zolang er niets staat.
- "Rond af, neem de rest niet over" (in het acties-menu van de wijzigingenbalk, met bevestiging) verwerkt de verrijking zonder elk onderdeel langs te lopen.
- De tussenstand leeft per verrijking in `sessionStorage`, zodat het navigeren tussen artikelen — en een herlaadbeurt — hem niet weggooit.
- De staleness-vlag op `payload.source_etag` is weg. Eén schrijfmoment betekent één controle, en die zit op het `If-Match` van het verwerken; een 412 landt in dezelfde "Opslaan mislukt"-melding als een gewone save.

Vormgeving blijft zoals hij is: dit gaat over wanneer er geschreven wordt, niet over hoe het eruitziet.

## Tests

- `packages/editor-api/tests/enrich_review_apply_test.rs`: alles overnemen, deels overnemen, niets overnemen, een ontbrekend oordeel, een `If-Match`-conflict (geen taak afgehandeld, blobs blijven staan), een job met één whole-law-taak, terugval op het ruwe voorstel, en dubbel verwerken.
- Unit tests op het samenstellen (in-place splice, onbekend artikelnummer, weigeren van inhoud die niet bij het oordeel hoort), op de commit-message en op de route-ordening (`/api/tasks/jobs/…` mag niet door `{task_id}` opgeslokt worden).
- `packages/pipeline/tests/tasks_tests.rs`: de taken van één job ophalen en een hele verrijking in één keer afsluiten, inclusief het aantal dat werkelijk dichtging.
- `frontend/src/composables/useTaskReview.test.js`: een oordeel schrijft niets, verwerken bij het laatste onderdeel, afronden met de rest op niet overnemen, en oordelen blijven staan als het verwerken faalt.

Groen: `cargo fmt --check`, `cargo clippy --workspace`, `cargo check --workspace`, de editor-api- en pipeline-testsuites, `vitest run` (876 tests) en de frontend-build.

## Vervolg

De beoordelingsview met overzicht en herkomst, en het draaien van scenario's op de werkkopie, komen apart — die wachten op een UX-sessie. Dit ticket raakt bewust geen vormgeving.
