### PR TITLE
fix(guard): de leak-guard keek niet naar de site-inhoud, en niet naar machine-sporen

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -162,8 +162,15 @@ repos:
         files: ^(script/(report-advisories(\.test)?|audit-advisories)\.sh|\.github/workflows/security-advisories\.yml)$
 
       - id: skills-no-casus
-        name: Skills blijven dossier-agnostisch (geen casus-inhoud)
+        name: Methode-teksten blijven dossier-agnostisch (geen casus- of machine-inhoud)
         entry: script/check-skills-no-casus.sh
         language: system
         pass_filenames: false
-        files: ^\.claude/skills/
+        files: ^(\.claude/skills/|docs/src/content/)
+
+      - id: skills-no-casus-tests
+        name: De leak-guard vangt wat hij belooft (negatieve test)
+        entry: script/check-skills-no-casus.test.sh
+        language: system
+        pass_filenames: false
+        files: ^script/check-skills-no-casus(\.test)?\.sh$

--- a/docs/src/content/rfcs/rfc-010.md
+++ b/docs/src/content/rfcs/rfc-010.md
@@ -141,9 +141,9 @@ A source without scopes (like the central corpus) delivers laws without jurisdic
 ```yaml
 scopes:
   - type: provincie_code
-    value: "PV27"
+    value: "<provincie-code>"
   - type: waterschap_code
-    value: "WS0155"
+    value: "<waterschap-code>"
 ```
 
 **Priority:**

--- a/script/check-skills-no-casus.sh
+++ b/script/check-skills-no-casus.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
-# Leak-guard voor de dossier-agnostische skills.
+# Leak-guard voor de dossier-agnostische methode-teksten.
 #
-# De skills onder .claude/skills/ beschrijven de regelrecht-METHODE en moeten
-# dossier-agnostisch blijven. Deze repo is publiek; casus-specifieke inhoud mag
-# hier nooit in belanden: de naam van een specifieke overheidsorganisatie
-# (gemeente, provincie, waterschap, ministerie, uitvoeringsorganisatie, …), een
-# persoonsidentificerend nummer met echte waarde (BSN, KvK-nummer, A-nummer,
-# zaaknummer, …), een private repo-naam, of een trace-fragment met echte data.
+# De skills onder .claude/skills/ en de site-inhoud onder docs/src/content/
+# beschrijven de regelrecht-METHODE en moeten dossier-agnostisch blijven. Deze
+# repo is publiek; casus-specifieke inhoud mag hier nooit in belanden: de naam
+# van een specifieke overheidsorganisatie (gemeente, provincie, waterschap,
+# ministerie, uitvoeringsorganisatie, …), een persoonsidentificerend nummer met
+# echte waarde (BSN, KvK-nummer, A-nummer, zaaknummer, …), een private
+# repo-naam, of een trace-fragment met echte data.
+#
+# Sinds 2026-09-08 ook: sporen van de máchine waarop geschreven is. Een absoluut
+# pad lekt een gebruikersnaam en een mappenstructuur ook wanneer de inhoud
+# verder volledig dossier-agnostisch is, en het valt bij het lezen niet op omdat
+# het op een gewone verwijzing lijkt.
 #
 # Twee lagen (hybride), zodat de guard geen gevoelige inhoud zélf hoeft te
 # publiceren:
@@ -20,21 +26,51 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-SKILLS="$ROOT/.claude/skills"
-[ -d "$SKILLS" ] || exit 0
+
+# Bewaakte paden. Bewust NIET de hele repo: de laag-2-patronen zijn sector- en
+# casuswoorden, en die komen in het publieke corpus volkomen legitiem voor — een
+# wet óver waterschappen is publiek recht. Repo-breed scannen zou dus vals alarm
+# geven op wettekst, en een guard die vals alarm geeft wordt uitgezet. Bewaakt
+# wordt alleen wat wij zelf als methode-tekst schrijven.
+GUARDED_RELPATHS=(
+  ".claude/skills"
+  "docs/src/content"
+)
+
+GUARDED=()
+for rel in "${GUARDED_RELPATHS[@]}"; do
+    [ -d "$ROOT/$rel" ] && GUARDED+=("$ROOT/$rel")
+done
+[ ${#GUARDED[@]} -gt 0 ] || exit 0
 
 # Laag 1 — publieke, domein-loze structuur-vormen (geen concrete naam/suffix).
 # Eén extended-regex per regel. Bewust géén sector-woord of dossiernaam.
 #   - private corpus-repo-naamvorm: vaste project-prefix + willekeurig suffix
 #     (vangt elk huidig én toekomstig corpus-dossier zonder er één te noemen)
+#   - absolute home-paden, Windows-paden en file-URL's: lekken de gebruikersnaam
+#     en de mappenstructuur van de schrijver
+#   - agent-scratchpads en sessielinks: lekken waar en wanneer er gewerkt is
+#
+# NB bewust NIET in deze lijst: `~/.claude/`. Dat komt legitiem voor — skills
+# instrueren de lezer een hook in zijn éigen `~/.claude/` te installeren. En
+# bewust géén kale gebruikersnaam: het woord alleen geeft vals alarm op
+# wettekst. Een persoonsnaam hoort aan zijn padvorm te hangen, in laag 2.
 PUBLIC_PATTERNS=(
   'regelrecht-corpus-[A-Z][A-Za-z0-9-]*'
+  '/(Users|home)/[A-Za-z0-9._-]+/'
+  '[A-Za-z]:\\Users\\'
+  'file:///'
+  '/(private/)?tmp/claude-[0-9]+'
+  'claude\.ai/code/session_'
 )
 
 # Laag 2 — optioneel git-ignored aanvulbestand (één extended-regex per regel,
 # '#'-commentaar en lege regels toegestaan). In CI via een secret naar dit pad
 # geschreven. Ontbreekt het → alleen laag 1 draait; veilig, want laag 1 is nooit
-# leeg. De concrete casus-/sector-patronen horen HIER, niet in dit publieke script.
+# leeg. De concrete casus-/sector-patronen horen HIER, niet in dit publieke
+# script. Denk daarbij ook aan verwijzingen die er onschuldig uitzien omdat ze
+# relatief zijn: een pad naar een map die alleen in een private repo bestaat
+# heeft geen `/Users/` ervoor en is met een domein-loos patroon niet te vangen.
 SUPPLEMENT="${SKILLS_CASUS_DENYLIST_FILE:-$ROOT/script/.skills-casus-denylist.local}"
 
 PATTERNS_FILE="$(mktemp)"
@@ -46,13 +82,14 @@ if [ -f "$SUPPLEMENT" ]; then
     grep -vE '^[[:space:]]*(#|$)' "$SUPPLEMENT" >> "$PATTERNS_FILE" || true
 fi
 
-if grep -rEnIf "$PATTERNS_FILE" "$SKILLS" > "$HITS_FILE" 2>/dev/null; then
-    echo "LEAK-GUARD: casus-specifieke inhoud gevonden in dossier-agnostische skills:" >&2
+if grep -rEnIf "$PATTERNS_FILE" "${GUARDED[@]}" > "$HITS_FILE" 2>/dev/null; then
+    echo "LEAK-GUARD: casus- of machine-specifieke inhoud gevonden in dossier-agnostische methode-teksten:" >&2
     sed "s#${ROOT}/##" "$HITS_FILE" >&2
     echo "" >&2
-    echo "Skills moeten dossier-agnostisch blijven (deze repo is publiek)." >&2
-    echo "Verwijder de verwijzing of generaliseer 'm. Een bewust casus-/sector-" >&2
-    echo "patroon hoort in het git-ignored aanvulbestand, niet in dit publieke script." >&2
+    echo "Skills en site-inhoud moeten dossier-agnostisch blijven (deze repo is publiek)." >&2
+    echo "Verwijder de verwijzing of generaliseer 'm — maak een pad relatief, of baseer" >&2
+    echo "het voorbeeld op het publieke corpus. Een bewust casus-/sector-patroon hoort" >&2
+    echo "in het git-ignored aanvulbestand, niet in dit publieke script." >&2
     exit 1
 fi
 exit 0

--- a/script/check-skills-no-casus.test.sh
+++ b/script/check-skills-no-casus.test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Dekt elk pad dat groen of rood beslist in script/check-skills-no-casus.sh.
+#
+# Waarom deze test er is: een leak-guard die niets vangt is niet te onderscheiden
+# van een die werkt — beide zijn groen. Alleen een negatieve test bewijst dat de
+# patronen werkelijk dekken wat ze beloven. En omdat laag 2 (het git-ignored
+# aanvulbestand) op de meeste machines ontbreekt, is een groene lokale run
+# zonder deze test helemaal geen uitspraak.
+#
+# Elke casus draait tegen een eigen nep-boom in $TMPDIR, zodat de test nooit
+# leunt op de echte repo-inhoud én nooit een aanvulbestand van de ontwikkelaar
+# meepakt (ROOT is de nep-boom, dus het default-pad wijst daar naartoe).
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+gate="$here/check-skills-no-casus.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+mk_root() { # $1 = naam → echoot het pad van een verse nep-boom
+    local r="$tmp/$1"
+    mkdir -p "$r/script" "$r/.claude/skills" "$r/docs/src/content" "$r/corpus"
+    cp "$gate" "$r/script/check-skills-no-casus.sh"
+    printf 'Een gewone methode-tekst zonder sporen.\n' > "$r/.claude/skills/SKILL.md"
+    printf 'Een gewone conceptpagina.\n' > "$r/docs/src/content/page.md"
+    echo "$r"
+}
+
+check() { # $1 = naam, $2 = verwachte exitcode, $3 = root, $4 = optioneel aanvulbestand
+    local naam="$1" want="$2" root="$3" supp="${4:-}"
+    local out st
+    if [ -n "$supp" ]; then
+        out="$(SKILLS_CASUS_DENYLIST_FILE="$supp" bash "$root/script/check-skills-no-casus.sh" 2>&1)"
+    else
+        out="$(bash "$root/script/check-skills-no-casus.sh" 2>&1)"
+    fi
+    st=$?
+    if [ "$st" -eq "$want" ]; then
+        pass=$((pass + 1))
+        printf '  ok   %s\n' "$naam"
+    else
+        fail=$((fail + 1))
+        printf '  FOUT %s — exit %s, verwacht %s\n' "$naam" "$st" "$want"
+        [ -n "$out" ] && printf '       %s\n' "$out"
+    fi
+}
+
+echo "leak-guard:"
+
+# 1. Schone boom laat door.
+r="$(mk_root schoon)"
+check "schone boom → groen" 0 "$r"
+
+# 2-4. Machine-sporen in een bewaakt pad worden gevangen.
+r="$(mk_root homepad)"
+printf 'zie /Users/iemand/projecten/x voor het voorbeeld\n' >> "$r/.claude/skills/SKILL.md"
+check "absoluut home-pad in een skill → rood" 1 "$r"
+
+r="$(mk_root winpad)"
+printf 'zie C:\\Users\\iemand\\x\n' >> "$r/docs/src/content/page.md"
+check "windows-pad in site-inhoud → rood" 1 "$r"
+
+r="$(mk_root sessie)"
+printf 'zie https://claude.ai/code/session_ABC123\n' >> "$r/docs/src/content/page.md"
+check "sessielink → rood" 1 "$r"
+
+r="$(mk_root scratch)"
+printf 'geschreven in /private/tmp/claude-000/werkmap\n' >> "$r/.claude/skills/SKILL.md"
+check "agent-scratchpad → rood" 1 "$r"
+
+# 5. De private corpus-repo-vorm (het oorspronkelijke patroon) blijft werken.
+r="$(mk_root corpusnaam)"
+printf 'kloon regelrecht-corpus-Voorbeeld ernaast\n' >> "$r/.claude/skills/SKILL.md"
+check "private corpus-repo-naam → rood" 1 "$r"
+
+# 6. Site-inhoud is nieuw in de scope; zonder deze regel gleed een RFC er langs.
+r="$(mk_root rfc)"
+mkdir -p "$r/docs/src/content/rfcs"
+printf 'pad: /home/iemand/repo\n' > "$r/docs/src/content/rfcs/rfc-999.md"
+check "machine-pad in een RFC → rood" 1 "$r"
+
+# 7. Buiten de bewaakte paden blijft het stil — anders geeft de guard vals alarm
+#    op publieke wettekst en zet iemand hem uit.
+r="$(mk_root buiten_scope)"
+printf 'pad: /Users/iemand/x\n' > "$r/corpus/wet.yaml"
+printf 'pad: /Users/iemand/x\n' > "$r/README.md"
+check "zelfde spoor buiten de bewaakte paden → groen" 0 "$r"
+
+# 8. `~/.claude/` is legitiem: skills instrueren de lezer een hook in zijn eigen
+#    map te installeren. Vangen we dat, dan breekt bestaande inhoud.
+r="$(mk_root tilde)"
+printf 'installeer de hook in ~/.claude/hooks/\n' >> "$r/.claude/skills/SKILL.md"
+check "~/.claude/ in een skill → groen" 0 "$r"
+
+# 9. Laag 2 doet mee als het aanvulbestand er is — en alleen dan.
+r="$(mk_root laag2)"
+printf 'de Voorbeeldschap-regeling\n' >> "$r/.claude/skills/SKILL.md"
+check "casus-woord zonder aanvulbestand → groen (alleen laag 1)" 0 "$r"
+printf '# commentaar wordt genegeerd\n\nVoorbeeldschap\n' > "$tmp/denylist"
+check "casus-woord mét aanvulbestand → rood" 1 "$r" "$tmp/denylist"
+
+# 10. Geen bewaakte paden aanwezig (deelcheckout) → geen uitspraak, geen fout.
+r="$tmp/leeg"
+mkdir -p "$r/script"
+cp "$gate" "$r/script/check-skills-no-casus.sh"
+check "geen bewaakte paden → groen" 0 "$r"
+
+echo ""
+echo "$pass geslaagd, $fail mislukt"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
De leak-guard scande uitsluitend `.claude/skills/`. Een RFC of conceptpagina op de docs-site werd door niets gecontroleerd, terwijl daar net zo goed methode-tekst staat die dossier-agnostisch moet blijven. En laag 1 kende geen enkel patroon voor sporen van de máchine waarop geschreven is: een absoluut home-pad lekt een gebruikersnaam en een mappenstructuur ook wanneer de inhoud verder schoon is, en het valt bij het lezen niet op omdat het op een gewone verwijzing lijkt.

## Wat er verandert

- **Bewaakte paden:** `.claude/skills/` én `docs/src/content/`. Bewust niet repo-breed — de laag-2-patronen zijn sector- en casuswoorden, en die komen in het publieke corpus legitiem voor. Een guard die vals alarm geeft op wettekst wordt uitgezet.
- **Laag 1 erbij:** absolute home-paden, Windows-paden, `file:///`, agent-scratchpads en sessielinks.
- **Bewust géén patroon** voor `~/.claude/` (staat legitiem in twee skills die de lezer vragen daar zelf een hook te installeren) en géén kale gebruikersnaam (geeft vals alarm op wettekst).
- **Een negatieve test.** Een guard die niets vangt is niet te onderscheiden van een die werkt; beide zijn groen. Twaalf gevallen, inclusief de grenzen: buiten de bewaakte paden blijft het stil, `~/.claude/` blijft toegestaan, en laag 2 doet alleen mee als het aanvulbestand er is.

## Wat de eerste run vond

Eén treffer in de verbrede scope: een waterschapscode in het scope-voorbeeld van RFC-010. Laag 2 verbiedt de vorm, niet die ene waarde, dus daar staat nu een placeholder. De gemeentecodes elders in die RFC blijven staan — die illustreren en wijzen geen dossier aan.

## Bijwerking om te wegen

De guard draait vanaf nu bij elke docs-wijziging, met de laag-2-denylist erbij. Het bereik van dat bestand wordt daarmee groter. Zolang de patronen codes beschrijven gaat dat goed — dat bleek ook: alleen de code lichtte op, terwijl het woord "waterschap" tientallen keren legitiem in de docs staat. Staat er ooit een kaal sectorwoord in, dan kleurt de halve docs-site rood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)