### PR TITLE
feat: chronolexografie-simulator met cel, kroniekstore en scenario-loader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `packages/editor-api/` - Rust backend API for the editor frontend
 - `packages/corpus/` - Shared library for working with YAML regulation files
 - `packages/shared/` - Common types/utilities across packages
+- `packages/simulator/` - Chronolexografie testopstelling (RFC-022): cellen met een privé kroniekstore, lexostatus-reducties en een scenario-loader
 - `packages/tui/` - Terminal UI dashboard
 - `packages/grafana/` - Grafana monitoring with provisioned dashboards
 - `frontend/` - Law editor (Vue/Vite + editor-api backend)

--- a/Justfile
+++ b/Justfile
@@ -74,6 +74,15 @@ validate-annotations *FILES:
 conformance:
     cd packages && {{ci_flags}} cargo test -p regelrecht-engine --features validate --test conformance
 
+# Draai één chronolexografie-scenario (RFC-022) en druk het verslag af. De
+# scenario's zelf dragen hun assertie, dus `just test` dekt ze al; deze recipe is
+# voor het lezen van de uitkomst tijdens het schrijven van een scenario. Het pad
+# is relatief aan de repo-wortel, niet aan packages/. Zie
+# packages/simulator/README.md.
+[doc("Draai een chronolexografie-scenario en druk het verslag af")]
+simulate SCENARIO='packages/simulator/scenarios/toeslagen_zorgtoeslag.yaml':
+    cd packages && cargo run -q -p regelrecht-simulator --bin run-scenario -- {{justfile_directory()}}/{{SCENARIO}}
+
 # Pins the deploy filters against the real cargo graph. Node's built-in test
 # runner, so no dependency for one file. Needs `cargo metadata`, not a build.
 [doc("Check the deploy filters against the real cargo dependency graph")]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -52,7 +52,7 @@ RUN set -eu; \
 # When adding a new workspace member that this image does NOT build, add it
 # to this exclusion list as well; otherwise chef will fail to find its source.
 RUN grep -qE '^members = \[$' Cargo.toml && \
-    sed -i '/"admin"/d; /"arch-extract"/d; /"auth"/d; /"corpus"/d; /"editor-api"/d; /"github"/d; /"harvester"/d; /"pipeline"/d; /"tui"/d' Cargo.toml
+    sed -i '/"admin"/d; /"arch-extract"/d; /"auth"/d; /"corpus"/d; /"editor-api"/d; /"github"/d; /"harvester"/d; /"pipeline"/d; /"simulator"/d; /"tui"/d' Cargo.toml
 COPY packages/engine/ engine/
 COPY packages/law-model/ law-model/
 COPY packages/shared/ shared/
@@ -115,7 +115,7 @@ COPY packages/Cargo.lock packages/Cargo.toml ./
 # When adding a new workspace member that this image does NOT build, add it
 # to this exclusion list as well; otherwise chef will fail to find its source.
 RUN grep -qE '^members = \[$' Cargo.toml && \
-    sed -i '/"admin"/d; /"arch-extract"/d; /"tui"/d' Cargo.toml
+    sed -i '/"admin"/d; /"arch-extract"/d; /"simulator"/d; /"tui"/d' Cargo.toml
 COPY packages/auth/ auth/
 COPY packages/editor-api/ editor-api/
 COPY packages/corpus/ corpus/

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -4302,6 +4302,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regelrecht-simulator"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "regelrecht-engine",
+ "serde",
+ "serde_yaml_ng",
+ "thiserror 2.0.20",
+ "walkdir",
+]
+
+[[package]]
 name = "regelrecht-tui"
 version = "0.1.0"
 dependencies = [

--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "law-model",
     "pipeline",
     "shared",
+    "simulator",
     "tui",
 ]
 

--- a/packages/admin/Dockerfile
+++ b/packages/admin/Dockerfile
@@ -42,7 +42,7 @@ COPY packages/Cargo.lock packages/Cargo.toml ./
 # When adding a new workspace member that this image does NOT build, add it
 # to this exclusion list as well; otherwise chef will fail to find its source.
 RUN grep -qE '^members = \[$' Cargo.toml && \
-    sed -i '/"arch-extract"/d; /"editor-api"/d; /"tui"/d' Cargo.toml
+    sed -i '/"arch-extract"/d; /"editor-api"/d; /"simulator"/d; /"tui"/d' Cargo.toml
 COPY packages/admin/ admin/
 COPY packages/auth/ auth/
 COPY packages/corpus/ corpus/

--- a/packages/arch-extract/prose/crate-simulator.md
+++ b/packages/arch-extract/prose/crate-simulator.md
@@ -1,0 +1,14 @@
+---
+node: crate:simulator
+fingerprint: b04e82b7689561ab
+---
+**Wat.** De testopstelling voor chronolexografie: cellen die hun eigen kronieken
+houden, daarover reduceren tot een lexostatus, en een scenario-loader die zo'n
+wereld uit YAML optuigt en bevraagt.
+
+**Waarom.** Het decentrale principe moet gebouwd én weerlegd kunnen worden, en
+dat lukt alleen als de grens tussen cellen in het typesysteem zit in plaats van
+in een afspraak: een cel bezit haar kroniekstore privé en biedt alleen
+gepubliceerde lexostatussen aan. De crate leunt op de engine (één service met
+alleen de eigen wetten per cel) en raakt die niet aan, zodat een latere
+promotie naar een echte cel-crate een verplaatsing is en geen herschrijving.

--- a/packages/arch-extract/tests/model_validation.rs
+++ b/packages/arch-extract/tests/model_validation.rs
@@ -105,6 +105,7 @@ fn product_crates_present() {
         "law-model",
         "pipeline",
         "shared",
+        "simulator",
         "tui",
     ]
     .iter()

--- a/packages/pipeline/Dockerfile
+++ b/packages/pipeline/Dockerfile
@@ -53,7 +53,7 @@ COPY packages/Cargo.lock packages/Cargo.toml ./
 # When adding a new workspace member that this image does NOT build, add it
 # to this exclusion list as well; otherwise chef will fail to find its source.
 RUN grep -qE '^members = \[$' Cargo.toml && \
-    sed -i '/"admin"/d; /"arch-extract"/d; /"auth"/d; /"editor-api"/d; /"tui"/d' Cargo.toml
+    sed -i '/"admin"/d; /"arch-extract"/d; /"auth"/d; /"editor-api"/d; /"simulator"/d; /"tui"/d' Cargo.toml
 COPY packages/corpus/ corpus/
 COPY packages/github/ github/
 COPY packages/engine/ engine/

--- a/packages/simulator/Cargo.toml
+++ b/packages/simulator/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "regelrecht-simulator"
+version = "0.1.0"
+edition = "2021"
+authors = ["MinBZK <noreply@minbzk.nl>"]
+description = "RegelRecht chronolexografie simulator - cells, chronicle stores and scenario runner"
+license = "EUPL-1.2"
+repository = "https://github.com/MinBZK/regelrecht"
+homepage = "https://github.com/MinBZK/regelrecht"
+keywords = ["law", "legal", "simulation", "dutch", "regelrecht"]
+categories = ["simulation"]
+
+[dependencies]
+regelrecht-engine = { path = "../engine" }
+chrono.workspace = true
+serde.workspace = true
+serde_yaml_ng.workspace = true
+thiserror.workspace = true
+walkdir.workspace = true
+
+[[bin]]
+name = "run-scenario"
+path = "src/bin/run_scenario.rs"
+
+[lints]
+workspace = true

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -8,6 +8,28 @@ Deze eerste versie is bewust krap: één cel per scenario, geen verkeer tussen
 cellen. Wat er wel al staat, is de grens — en die is met opzet een taalgrens en
 geen afspraak.
 
+## De drie chronolexogrammen, en waar ze hier zitten
+
+De paper onderscheidt drie soorten chronolexogram (RFC-022 §1.1–§1.2). Deze
+crate kent ze alle drie bij naam, maar legt er nog maar één zelf vast — de kaart
+van paper naar code:
+
+- **Lexogram** — generiek en compile-time: het recht zelf. Hier is dat elk
+  versiebestand onder `laws`. De map met `valid_from`-versies van een regeling
+  *is* de lexogram-kroniek; de engine kiest daarin op `op_moment`. Niemand
+  noemde dat hier eerder zo, maar het is precies wat RFC-022 §1.1 beschrijft.
+- **Executogram** — de vastgelegde vaststelling van een feit. Dat is wat een
+  `ChronicleEvent` wil worden: een veldwaarde op een moment. Wat er nog aan
+  ontbreekt is de procesrelatieve kant (wie stelde het vast, op welke
+  grondslag, in welke intake).
+- **Decretogram** — individueel en operationeel: het besluit. Dat wordt hier
+  nog nergens vastgelegd; zie [Wat hier nog niet staat](#wat-hier-nog-niet-staat).
+
+En de vierde term, de **reductie**: de huidige vorm (één uitkomst van één eigen
+regeling, per veld wint de laatste vastlegging) is een eerste benadering van wat
+de paper en RFC-022 §4.1 bedoelen, namelijk filteren en aggregeren over
+kronieken.
+
 ## Wat een cel is
 
 Een cel is een *containment- en autonomiedomein*, en verder niets:
@@ -56,10 +78,15 @@ Lexostatus-definities zijn dan ook **data en geen Rust**: ze staan in de
 cel-configuratie van het scenario. Een nieuwe lexostatus is een blok YAML, geen
 nieuwe functie.
 
-De `output` in de definitie stuurt de evaluatie aan maar begrenst het antwoord
-niet. Een lexostatus is een rechtstoestand, dus het antwoord draagt alles wat de
-engine onderweg naar die uitkomst berekende — het meegeleverde scenario
-controleert daarom naast `heeft_recht_op_zorgtoeslag` ook `hoogte_zorgtoeslag`.
+Gedocumenteerd geldt aan beide kanten. De `output` in de definitie stuurt de
+evaluatie aan, maar begrenst het antwoord niet: de engine levert bij een
+gevraagde uitkomst ook de uitkomsten die er causaal mee meekomen. Wat de cel
+naar buiten geeft, staat daarom apart in `outputs`, en `Cell::reduce` laat de
+rest weg. Berekend is niet gepubliceerd — anders krijgt een consument
+`hoogte_zorgtoeslag` mee zonder dat de cel dat ooit beloofd heeft. Het
+meegeleverde scenario publiceert die uitkomst dus expliciet. Een naam in
+`outputs` die de regeling niet kent, wordt geweigerd bij het optuigen van de
+cel, net als een reductie over een vreemde regeling.
 
 `op_moment` is het moment waarop gevraagd wordt, altijd expliciet en nooit de
 wandklok. Feiten die pas later in de cel zijn vastgelegd, bestaan voor dat
@@ -100,6 +127,8 @@ cells:
         inputs:                                 # de gedocumenteerde parameters
           - name: bsn
             type: string                        # string | number | boolean
+        outputs:                                # wat het antwoord mag dragen;
+          - heeft_toeslagpartner                # leeg = alleen reduction.output
         reduction:                              # hoe de cel reduceert
           regulation: algemene_wet_inkomensafhankelijke_regelingen
           output: heeft_toeslagpartner
@@ -134,6 +163,19 @@ inputs van de eigen regelingen invullen. Twee stromen met dezelfde naam worden
 geweigerd: de stroomnaam is tevens de naam van de databron, dus daar zou de
 tweede de eerste stil schaduwen.
 
+Dat "per veld wint de laatste vastlegging" is een **bewuste vereenvoudiging**,
+geen eigenschap om trots op te zijn. Het is een toestandsmerge: de velden van
+verschillende vastleggingen, op verschillende momenten, worden over elkaar
+gelegd tot één record dat als vastlegging nooit bestaan heeft. Dat gebeurt omdat
+de engine records als databron wil. De paper legt de nadruk op het omgekeerde —
+niet de resulterende toestand opslaan, maar de procesrelatieve vaststelling ("op
+moment T heeft actor X vastgesteld dat …") en bij hergebruik expliciet
+herinterpreteren. Wat samen ontstond hoort samen te blijven; wat apart ontstond
+hoort niet stil samengevoegd te worden. De echte vorm kan pas als een
+vastlegging `recording_actor`, `grondslag`, `intake` en een moment draagt
+(RFC-022 §1.3) en de reductie daarover filtert en aggregeert in plaats van
+alleen te overschrijven.
+
 De dag is de fijnste korrel van de tijdas. Twee vastleggingen op hetzelfde
 `op_moment` vallen daar niet uit elkaar te houden; dan beslist de volgorde in het
 bestand, en de laatste wint. Wie ze wél wil ordenen heeft een fijnere tijdas
@@ -164,6 +206,22 @@ Het corpus wordt standaard naast de crate gezocht (`corpus/regulation`);
 `REGULATION_PATH` overschrijft dat.
 
 ## Wat hier nog niet staat
+
+**De cel legt nooit zelf iets vast.** Haar kroniekstore wordt bij het optuigen
+gevuld en daarna alleen gelezen; alles hierboven is de leeshelft. In
+chronolexografie is vastleggen juist de *productieve* activiteit, en de lus is
+informeren → concluderen → **vastleggen**. Een reductie die
+`heeft_recht_op_zorgtoeslag: true` oplevert is een besluit, en dat hoort als
+decretogram (BESCHIKKING, met moment en `zaakkenmerk`) in de eigen kroniek te
+landen (RFC-022 §1.2), zodat een latere vraag *op dat moment* het besluit
+terugvindt in plaats van het opnieuw uit te rekenen onder een mogelijk andere
+wetsversie. Precies dat verschil — decretogram tegenover lexogram — is wat deze
+opstelling wil laten zien, en zonder vastleggen valt het niet te demonstreren;
+"een besluit van een andere bevoegde organisatie accepteren" heeft er evengoed
+een vastgelegd besluit voor nodig. De eerstvolgende stap is daarom een
+**vastleg-pad naast `reduce`**, alleen aanroepbaar door de cel zelf: het is
+haar eigen kroniek, dus geen consument mag erin schrijven, net zomin als eruit
+lezen.
 
 Verkeer tussen cellen (`CellTransport`), de veiligheidscontext, het
 observatielog, meerdere cellen in één scenario en asynchrone intake met een

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -1,0 +1,155 @@
+# regelrecht-simulator
+
+Testopstelling voor chronolexografie ([RFC-022](../../docs/src/content/rfcs/rfc-022.md)).
+De crate simuleert een wereld van **cellen** en laat een scenario die wereld
+optuigen en bevragen.
+
+Deze eerste versie is bewust krap: één cel per scenario, geen verkeer tussen
+cellen. Wat er wel al staat, is de grens — en die is met opzet een taalgrens en
+geen afspraak.
+
+## Wat een cel is
+
+Een cel is een *containment- en autonomiedomein*, en verder niets:
+
+- ze houdt haar eigen **kronieken** (de feiten die zij zelf vastlegde);
+- ze laadt haar eigen **regelingen**;
+- ze **reduceert** over die eigen feiten tot een **lexostatus**: de
+  rechtstoestand vanuit een gevraagd perspectief, op de feiten die zij kent.
+
+## Wat een cel níet is
+
+Precies de drie dingen die er in de praktijk bij gedacht worden (RFC-022 §2):
+
+- **Geen sleutels.** Ondertekening, trust material en de autorisatie waaronder
+  een vraag beantwoord wordt, zitten in de veiligheidscontext, niet in de cel.
+- **Geen bevoegd gezag.** `competent_authority` (RFC-002) is een juridisch feit
+  van het besluit, geen eigenschap van de opslag. Een cel houdt kronieken van
+  besluiten waarvoor een ander bevoegd is.
+- **Geen synthese.** Een reductie raakt uitsluitend de eigen kronieken.
+  Combineren over cellen heen doet een consument, nooit een cel.
+
+Twee dingen dwingen dat af in code in plaats van in proza:
+
+1. `Cell` houdt haar `ChronicleStore` in een **privéveld** zonder accessor. Er
+   is geen `pub fn store()` en die komt er ook niet: dat een andere cel niet bij
+   deze feiten kan, moet een compileerfout zijn.
+2. De reductie mag alleen een regeling gebruiken die de cel zélf laadt. Een
+   definitie die naar een vreemde regeling wijst, wordt geweigerd bij het
+   optuigen van de cel — niet pas bij de eerste vraag.
+
+## De publieke ingang
+
+Een consument heeft er precies één:
+
+```rust,ignore
+cell.reduce(lexostatus_naam, &params, op_moment) -> Result<Lexostatus>
+```
+
+Hij kiest een **gepubliceerde naam** en levert de **gedocumenteerde
+parameters**. Een onbekende naam levert een fout die opsomt wat de cel wél
+publiceert; een ontbrekende, onbekende of verkeerd getypeerde parameter wordt
+geweigerd. Een eigen reductie meesturen kan niet — daar is geen parameter voor
+(RFC-022 §4.1).
+
+Lexostatus-definities zijn dan ook **data en geen Rust**: ze staan in de
+cel-configuratie van het scenario. Een nieuwe lexostatus is een blok YAML, geen
+nieuwe functie.
+
+`op_moment` is het moment waarop gevraagd wordt, altijd expliciet en nooit de
+wandklok. Feiten die pas later in de cel zijn vastgelegd, bestaan voor dat
+antwoord niet, en de engine kiest op datzelfde moment de regelingversie.
+
+## Scenarioformaat
+
+Een scenario is één YAML-bestand met twee blokken: `cells` (de wereld) en
+`queries` (de vragen plus wat ze moeten opleveren). De assertie hoort bij het
+scenario, niet bij Rust: een nieuw testgeval is een nieuw bestand.
+
+```yaml
+name: korte naam van het scenario
+description: waarom dit scenario bestaat        # optioneel
+
+cells:
+  - id: toeslagen                               # het cel-id
+    laws:                                       # regelingen bij $id; de loader
+      - wet_op_de_zorgtoeslag                   # laadt alle versies uit de map
+      - regeling_standaardpremie
+
+    chronicles:                                 # de eigen feiten van de cel
+      - stream: relaties                        # naam van de kroniekstroom
+        key: bsn                                # veld waarop gegroepeerd wordt
+        events:
+          - op_moment: 2023-01-01               # wanneer dit feit feit werd
+            fields:                             # veldnamen = input-namen in de wet
+              bsn: '999993653'
+              partnerschap_type: HUWELIJK
+          - op_moment: 2024-07-01               # latere vastlegging wint
+            fields:
+              bsn: '999993653'
+              partnerschap_type: GEEN
+
+    lexostatus_definitions:                     # wat de cel publiceert
+      - name: toeslagpartnerschap
+        doc: vrije toelichting                  # optioneel
+        inputs:                                 # de gedocumenteerde parameters
+          - name: bsn
+            type: string                        # string | number | boolean
+        reduction:                              # hoe de cel reduceert
+          regulation: algemene_wet_inkomensafhankelijke_regelingen
+          output: heeft_toeslagpartner
+          parameters:
+            bsn: $bsn                           # $naam verwijst naar een input;
+                                                # alles zonder $ is letterlijk
+
+queries:
+  - description: vrije omschrijving             # optioneel
+    cell: toeslagen
+    lexostatus: toeslagpartnerschap
+    params:
+      bsn: '999993653'
+    op_moment: 2025-01-01
+    expect:                                     # wat het antwoord moet bevatten
+      heeft_toeslagpartner: false               # uitkomsten die hier niet staan,
+                                                # worden niet gecontroleerd
+```
+
+Onbekende velden worden geweigerd, zodat een typfout niet stil verdwijnt.
+
+### Kroniekstromen en tijd
+
+Per stroom geldt: alleen vastleggingen met `op_moment <= ` het gevraagde moment
+tellen mee, en van de rest wint per sleutelwaarde en per veld de laatste
+vastlegging. Een vraag over een moment in het verleden levert dus het beeld van
+toen. De stromen worden aan de engine aangeboden als databronnen, waar ze de
+inputs van de eigen regelingen invullen.
+
+Feiten die in de echte wereld van een andere organisatie komen, staan hier als
+binnengekomen feit in de eigen kroniek. Zolang er geen transport tussen cellen
+is, is dat het eerlijke model: de cel kan niets ophalen wat ze niet zelf heeft.
+Vraag je een moment op waarop een binnengekomen feit nog niet vastlag, dan valt
+de engine terug op kruisverwijzing en faalt de reductie met "Law not found" —
+de cel reikt niet buiten zichzelf.
+
+## Een scenario draaien
+
+```bash
+# los, met verslag op de terminal; exitcode 1 als een verwachting niet uitkwam.
+# Zonder argument draait het scenario hieronder.
+just simulate packages/simulator/scenarios/toeslagen_zorgtoeslag.yaml
+
+# als test: draait elk bestand in scenarios/ en controleert alle verwachtingen
+# (zit ook in `just test`)
+cd packages && cargo test -p regelrecht-simulator
+```
+
+Het corpus wordt standaard naast de crate gezocht (`corpus/regulation`);
+`REGULATION_PATH` overschrijft dat.
+
+## Wat hier nog niet staat
+
+Verkeer tussen cellen (`CellTransport`), de veiligheidscontext, het
+observatielog, meerdere cellen in één scenario en asynchrone intake met een
+echte tijdlijn volgen apart. De indeling anticipeert erop: de reductielogica
+woont in [`src/cell/`](src/cell/) en niet in de scenario-runner, zodat een
+latere `packages/cell` een verplaatsing is en geen herschrijving.

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -56,6 +56,11 @@ Lexostatus-definities zijn dan ook **data en geen Rust**: ze staan in de
 cel-configuratie van het scenario. Een nieuwe lexostatus is een blok YAML, geen
 nieuwe functie.
 
+De `output` in de definitie stuurt de evaluatie aan maar begrenst het antwoord
+niet. Een lexostatus is een rechtstoestand, dus het antwoord draagt alles wat de
+engine onderweg naar die uitkomst berekende — het meegeleverde scenario
+controleert daarom naast `heeft_recht_op_zorgtoeslag` ook `hoogte_zorgtoeslag`.
+
 `op_moment` is het moment waarop gevraagd wordt, altijd expliciet en nooit de
 wandklok. Feiten die pas later in de cel zijn vastgelegd, bestaan voor dat
 antwoord niet, en de engine kiest op datzelfde moment de regelingversie.
@@ -114,7 +119,10 @@ queries:
                                                 # worden niet gecontroleerd
 ```
 
-Onbekende velden worden geweigerd, zodat een typfout niet stil verdwijnt.
+Onbekende velden worden geweigerd, zodat een typfout niet stil verdwijnt. Elke
+vraag heeft minstens één verwachting: een vraag zonder `expect` slaagt altijd en
+zou als `ok` in het verslag komen, wat op bewijs lijkt en het niet is. De loader
+weigert zo'n scenario.
 
 ### Kroniekstromen en tijd
 
@@ -122,14 +130,23 @@ Per stroom geldt: alleen vastleggingen met `op_moment <= ` het gevraagde moment
 tellen mee, en van de rest wint per sleutelwaarde en per veld de laatste
 vastlegging. Een vraag over een moment in het verleden levert dus het beeld van
 toen. De stromen worden aan de engine aangeboden als databronnen, waar ze de
-inputs van de eigen regelingen invullen.
+inputs van de eigen regelingen invullen. Twee stromen met dezelfde naam worden
+geweigerd: de stroomnaam is tevens de naam van de databron, dus daar zou de
+tweede de eerste stil schaduwen.
+
+De dag is de fijnste korrel van de tijdas. Twee vastleggingen op hetzelfde
+`op_moment` vallen daar niet uit elkaar te houden; dan beslist de volgorde in het
+bestand, en de laatste wint. Wie ze wél wil ordenen heeft een fijnere tijdas
+nodig, geen andere schrijfvolgorde.
 
 Feiten die in de echte wereld van een andere organisatie komen, staan hier als
 binnengekomen feit in de eigen kroniek. Zolang er geen transport tussen cellen
 is, is dat het eerlijke model: de cel kan niets ophalen wat ze niet zelf heeft.
-Vraag je een moment op waarop een binnengekomen feit nog niet vastlag, dan valt
-de engine terug op kruisverwijzing en faalt de reductie met "Law not found" —
-de cel reikt niet buiten zichzelf.
+Vraag je een moment op waarop een binnengekomen feit nog niet vastlag, dan faalt
+de reductie: bij een input met een `source` naar een regeling die deze cel niet
+laadt met "Law not found", en anders met "Variable not found". Beide zeggen
+hetzelfde — de cel reikt niet buiten zichzelf, en levert dus geen antwoord in
+plaats van een geraden antwoord.
 
 ## Een scenario draaien
 

--- a/packages/simulator/scenarios/toeslagen_zorgtoeslag.yaml
+++ b/packages/simulator/scenarios/toeslagen_zorgtoeslag.yaml
@@ -32,6 +32,13 @@ cells:
 
       # Feiten die van buiten binnenkwamen en die de cel als eigen feit heeft
       # vastgelegd: verzekeringsstatus, inkomen en vermogen.
+      #
+      # `wet_op_de_zorgtoeslag` noemt deze drie als input met een
+      # `source.regulation` naar een andere regeling. Deze stroom overschaduwt
+      # die verwijzingen bewust: een kroniekstroom is een databron en wint op
+      # tier 1 van de resolutievolgorde (RFC-022 §4.2), dus de cross-law-vraag
+      # komt niet aan bod. Dat is hier de bedoeling — het zijn binnengekomen
+      # feiten — maar het gebeurt stil.
       - stream: intake
         key: bsn
         events:
@@ -52,6 +59,11 @@ cells:
         inputs:
           - name: bsn
             type: string
+        outputs:
+          # Wat de cel onder deze naam publiceert. De engine berekent onderweg
+          # meer; wat hier niet staat, verlaat de cel niet.
+          - heeft_recht_op_zorgtoeslag
+          - hoogte_zorgtoeslag
         reduction:
           regulation: wet_op_de_zorgtoeslag
           output: heeft_recht_op_zorgtoeslag

--- a/packages/simulator/scenarios/toeslagen_zorgtoeslag.yaml
+++ b/packages/simulator/scenarios/toeslagen_zorgtoeslag.yaml
@@ -1,0 +1,107 @@
+---
+name: toeslagen reduceert over eigen feiten
+description: >-
+  Eén cel, geen verkeer tussen cellen. De cel `toeslagen` laadt haar eigen drie
+  regelingen en houdt de feiten die ze nodig heeft in haar eigen kronieken —
+  ook de feiten die in de echte wereld van een andere organisatie komen. Die
+  zijn hier vastgelegd als binnengekomen feit, niet als vraag aan een buurcel:
+  zolang er geen transport is, is dat het eerlijke model.
+
+cells:
+  - id: toeslagen
+    laws:
+      - wet_op_de_zorgtoeslag
+      - algemene_wet_inkomensafhankelijke_regelingen
+      - regeling_standaardpremie
+
+    chronicles:
+      # Wat de cel over de relatievorm van deze persoon heeft vastgelegd (AWIR
+      # art. 3). Twee vastleggingen: de tweede vervangt de eerste vanaf haar
+      # eigen moment, wat de tijdreductie zichtbaar maakt.
+      - stream: relaties
+        key: bsn
+        events:
+          - op_moment: 2023-01-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: HUWELIJK
+          - op_moment: 2024-07-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: GEEN
+
+      # Feiten die van buiten binnenkwamen en die de cel als eigen feit heeft
+      # vastgelegd: verzekeringsstatus, inkomen en vermogen.
+      - stream: intake
+        key: bsn
+        events:
+          - op_moment: 2024-11-15
+            fields:
+              bsn: '999993653'
+              is_verzekerde: true
+              verzamelinkomen: 79547
+              buitenlands_inkomen: 0
+              vermogen: 0
+
+    lexostatus_definitions:
+      - name: zorgtoeslag_rechtstoestand
+        doc: >-
+          De zorgtoeslagpositie van één persoon op één moment, op de feiten die
+          deze cel kent. Wie iets anders wil weten, moet een andere lexostatus
+          gepubliceerd zien te krijgen — een eigen reductie meesturen kan niet.
+        inputs:
+          - name: bsn
+            type: string
+        reduction:
+          regulation: wet_op_de_zorgtoeslag
+          output: heeft_recht_op_zorgtoeslag
+          parameters:
+            bsn: $bsn
+
+      - name: toeslagpartnerschap
+        doc: >-
+          Of deze persoon op het gevraagde moment een toeslagpartner had (AWIR
+          art. 3), op de relatiefeiten die deze cel kent.
+        inputs:
+          - name: bsn
+            type: string
+        reduction:
+          regulation: algemene_wet_inkomensafhankelijke_regelingen
+          output: heeft_toeslagpartner
+          parameters:
+            bsn: $bsn
+
+queries:
+  - description: >-
+      Alleenstaande met een actieve polis en een laag toetsingsinkomen; op
+      2025-01-01 zijn alle vastleggingen bekend en geldt de versie 2025 van de
+      standaardpremie.
+    cell: toeslagen
+    lexostatus: zorgtoeslag_rechtstoestand
+    params:
+      bsn: '999993653'
+    op_moment: 2025-01-01
+    expect:
+      heeft_recht_op_zorgtoeslag: true
+      hoogte_zorgtoeslag: 209692
+
+  # Dezelfde cel, dezelfde persoon, twee momenten: het antwoord verschilt omdat
+  # de vastlegging van 2024-07-01 er op het eerste moment nog niet was. Dat
+  # `op_moment` geen versiering is, staat of valt met dit paar.
+  - description: op 2024-06-01 gold nog de vastlegging HUWELIJK
+    cell: toeslagen
+    lexostatus: toeslagpartnerschap
+    params:
+      bsn: '999993653'
+    op_moment: 2024-06-01
+    expect:
+      heeft_toeslagpartner: true
+
+  - description: na de vastlegging van 2024-07-01 is er geen toeslagpartner meer
+    cell: toeslagen
+    lexostatus: toeslagpartnerschap
+    params:
+      bsn: '999993653'
+    op_moment: 2025-01-01
+    expect:
+      heeft_toeslagpartner: false

--- a/packages/simulator/src/bin/run_scenario.rs
+++ b/packages/simulator/src/bin/run_scenario.rs
@@ -1,0 +1,43 @@
+//! Draai één scenariobestand en druk het verslag af.
+//!
+//! ```text
+//! cargo run -p regelrecht-simulator --bin run-scenario -- \
+//!     packages/simulator/scenarios/toeslagen_zorgtoeslag.yaml
+//! ```
+//!
+//! Exitcode 0 als alle verwachtingen uitkwamen, 1 als er één niet uitkwam of
+//! als het scenario niet gedraaid kon worden.
+
+use regelrecht_simulator::{regulation_root, Scenario};
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let Some(path) = std::env::args_os().nth(1).map(PathBuf::from) else {
+        eprintln!("gebruik: run-scenario <scenario.yaml>");
+        return ExitCode::FAILURE;
+    };
+
+    let scenario = match Scenario::load(&path) {
+        Ok(scenario) => scenario,
+        Err(err) => {
+            eprintln!("{err}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match scenario.run(&regulation_root()) {
+        Ok(run) => {
+            print!("{}", run.report());
+            if run.passed() {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::FAILURE
+            }
+        }
+        Err(err) => {
+            eprintln!("{err}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/packages/simulator/src/cell/chronicle.rs
+++ b/packages/simulator/src/cell/chronicle.rs
@@ -12,7 +12,7 @@ use crate::error::{Result, SimulatorError};
 use chrono::NaiveDate;
 use regelrecht_engine::Value;
 use serde::Deserialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Eén vastlegging in een kroniekstroom.
 #[derive(Debug, Clone, Deserialize)]
@@ -61,9 +61,18 @@ impl ChronicleStore {
     /// Bouw een store uit de stromen van een celconfiguratie.
     ///
     /// Faalt als een vastlegging het sleutelveld van haar stroom mist: dan valt
-    /// niet vast te stellen over welk onderwerp het feit gaat.
-    pub(crate) fn from_streams(streams: Vec<ChronicleStream>) -> Result<Self> {
+    /// niet vast te stellen over welk onderwerp het feit gaat. Faalt ook op twee
+    /// stromen met dezelfde naam: die naam is tevens de naam van de databron in
+    /// de engine, en daar zou de tweede de eerste stil schaduwen.
+    pub(crate) fn from_streams(cell: &str, streams: Vec<ChronicleStream>) -> Result<Self> {
+        let mut seen: BTreeSet<&str> = BTreeSet::new();
         for stream in &streams {
+            if !seen.insert(stream.stream.as_str()) {
+                return Err(SimulatorError::DuplicateStream {
+                    cell: cell.to_string(),
+                    stream: stream.stream.clone(),
+                });
+            }
             for event in &stream.events {
                 if !event
                     .fields
@@ -87,6 +96,13 @@ impl ChronicleStore {
     /// vraag niet, en van de rest wint per sleutel en per veld de laatste
     /// vastlegging. Een vraag over een moment in het verleden levert dus het
     /// beeld van toen, niet het beeld van nu.
+    ///
+    /// Twee vastleggingen op hetzelfde moment kunnen niet op de tijdas uit
+    /// elkaar gehouden worden. De volgorde in de configuratie beslist dan, en de
+    /// laatste wint — `sort_by_key` is stabiel, dus dat is een vastgelegde
+    /// eigenschap en geen toeval. De dag is in deze versie de fijnste korrel;
+    /// wie twee vastleggingen op één dag wil ordenen, heeft een fijnere tijdas
+    /// nodig en niet een andere sorteersleutel.
     pub(crate) fn reduce_to(&self, op_moment: NaiveDate) -> Vec<ReducedStream> {
         self.streams
             .iter()
@@ -148,11 +164,14 @@ mod tests {
     }
 
     fn store(events: Vec<ChronicleEvent>) -> ChronicleStore {
-        ChronicleStore::from_streams(vec![ChronicleStream {
-            stream: "relatie".to_string(),
-            key: "bsn".to_string(),
-            events,
-        }])
+        ChronicleStore::from_streams(
+            "toeslagen",
+            vec![ChronicleStream {
+                stream: "relatie".to_string(),
+                key: "bsn".to_string(),
+                events,
+            }],
+        )
         .unwrap_or_default()
     }
 
@@ -212,15 +231,73 @@ mod tests {
 
     #[test]
     fn vastlegging_zonder_sleutel_wordt_geweigerd() {
-        let err = ChronicleStore::from_streams(vec![ChronicleStream {
-            stream: "relatie".to_string(),
-            key: "bsn".to_string(),
-            events: vec![event("2024-01-01", &[("partnerschap_type", Value::Null)])],
-        }])
+        let err = ChronicleStore::from_streams(
+            "toeslagen",
+            vec![ChronicleStream {
+                stream: "relatie".to_string(),
+                key: "bsn".to_string(),
+                events: vec![event("2024-01-01", &[("partnerschap_type", Value::Null)])],
+            }],
+        )
         .expect_err("een vastlegging zonder sleutelveld hoort te falen");
         assert!(matches!(
             err,
             SimulatorError::ChronicleEventWithoutKey { .. }
         ));
+    }
+
+    #[test]
+    fn twee_stromen_met_dezelfde_naam_worden_geweigerd() {
+        let stream = |events| ChronicleStream {
+            stream: "relatie".to_string(),
+            key: "bsn".to_string(),
+            events,
+        };
+        let err = ChronicleStore::from_streams(
+            "toeslagen",
+            vec![
+                stream(vec![event(
+                    "2024-01-01",
+                    &[("bsn", Value::String("1".to_string()))],
+                )]),
+                stream(vec![event(
+                    "2024-02-01",
+                    &[("bsn", Value::String("1".to_string()))],
+                )]),
+            ],
+        )
+        .expect_err("twee stromen met dezelfde naam horen te falen");
+        assert!(
+            matches!(err, SimulatorError::DuplicateStream { .. }),
+            "verwachtte DuplicateStream, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn bij_gelijk_moment_wint_de_laatste_uit_de_configuratie() {
+        let store = store(vec![
+            event(
+                "2024-07-01",
+                &[
+                    ("bsn", Value::String("1".to_string())),
+                    ("partnerschap_type", Value::String("HUWELIJK".to_string())),
+                ],
+            ),
+            event(
+                "2024-07-01",
+                &[
+                    ("bsn", Value::String("1".to_string())),
+                    ("partnerschap_type", Value::String("GEEN".to_string())),
+                ],
+            ),
+        ]);
+
+        let reduced = store.reduce_to(date("2025-01-01"));
+        assert_eq!(
+            reduced[0].records[0].get("partnerschap_type"),
+            Some(&Value::String("GEEN".to_string())),
+            "de tijdas kan twee vastleggingen op één dag niet ordenen; \
+             dan beslist de volgorde in de configuratie"
+        );
     }
 }

--- a/packages/simulator/src/cell/chronicle.rs
+++ b/packages/simulator/src/cell/chronicle.rs
@@ -1,0 +1,226 @@
+//! De kroniekstore van een cel: de feiten die de cel zélf bijhoudt.
+//!
+//! Een kroniekstroom is een tijdgeordende groepering van vastleggingen over
+//! hetzelfde soort onderwerp, gesleuteld op één veld (meestal een BSN). Elke
+//! vastlegging draagt het moment waarop het feit feit werd — de as waarop een
+//! reductie ordent (RFC-022 §4.1).
+//!
+//! De store is bewust *niet* publiek bereikbaar vanaf een cel: zie
+//! [`crate::cell::Cell`].
+
+use crate::error::{Result, SimulatorError};
+use chrono::NaiveDate;
+use regelrecht_engine::Value;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+/// Eén vastlegging in een kroniekstroom.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChronicleEvent {
+    /// Het moment waarop dit feit in deze cel feit werd.
+    pub op_moment: NaiveDate,
+    /// De vastgelegde velden. Veldnamen komen overeen met de `input`-namen van
+    /// de regelingen van de cel; de engine matcht hoofdletterongevoelig.
+    pub fields: BTreeMap<String, Value>,
+}
+
+/// Een tijdgeordende groepering van vastleggingen, gesleuteld op één veld.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChronicleStream {
+    /// Naam van de stroom; dient tevens als naam van de databron in de engine.
+    pub stream: String,
+    /// Het veld waarop vastleggingen gegroepeerd worden (bijvoorbeeld `bsn`).
+    pub key: String,
+    /// De vastleggingen, in willekeurige volgorde; de store ordent zelf.
+    #[serde(default)]
+    pub events: Vec<ChronicleEvent>,
+}
+
+/// De feiten van één cel.
+///
+/// Alleen te bevragen via een reductie van de cel die haar bezit — er is geen
+/// weg van buiten naar binnen (invariant: geen gedeelde state).
+#[derive(Debug, Default)]
+pub struct ChronicleStore {
+    streams: Vec<ChronicleStream>,
+}
+
+/// Eén stroom, teruggebracht tot de feiten die op een moment bekend waren.
+pub(crate) struct ReducedStream {
+    /// Naam van de stroom.
+    pub(crate) stream: String,
+    /// Het sleutelveld van de stroom.
+    pub(crate) key: String,
+    /// Per sleutelwaarde één samengevoegd record.
+    pub(crate) records: Vec<BTreeMap<String, Value>>,
+}
+
+impl ChronicleStore {
+    /// Bouw een store uit de stromen van een celconfiguratie.
+    ///
+    /// Faalt als een vastlegging het sleutelveld van haar stroom mist: dan valt
+    /// niet vast te stellen over welk onderwerp het feit gaat.
+    pub(crate) fn from_streams(streams: Vec<ChronicleStream>) -> Result<Self> {
+        for stream in &streams {
+            for event in &stream.events {
+                if !event
+                    .fields
+                    .keys()
+                    .any(|f| f.eq_ignore_ascii_case(&stream.key))
+                {
+                    return Err(SimulatorError::ChronicleEventWithoutKey {
+                        stream: stream.stream.clone(),
+                        key: stream.key.clone(),
+                        op_moment: event.op_moment.to_string(),
+                    });
+                }
+            }
+        }
+        Ok(Self { streams })
+    }
+
+    /// De feiten zoals ze op `op_moment` in deze cel bekend waren.
+    ///
+    /// Dit is de tijdreductie: vastleggingen ná `op_moment` bestaan voor deze
+    /// vraag niet, en van de rest wint per sleutel en per veld de laatste
+    /// vastlegging. Een vraag over een moment in het verleden levert dus het
+    /// beeld van toen, niet het beeld van nu.
+    pub(crate) fn reduce_to(&self, op_moment: NaiveDate) -> Vec<ReducedStream> {
+        self.streams
+            .iter()
+            .map(|stream| {
+                let mut events: Vec<&ChronicleEvent> = stream
+                    .events
+                    .iter()
+                    .filter(|event| event.op_moment <= op_moment)
+                    .collect();
+                events.sort_by_key(|event| event.op_moment);
+
+                let mut per_key: BTreeMap<String, BTreeMap<String, Value>> = BTreeMap::new();
+                for event in events {
+                    let Some(key) = record_key(&event.fields, &stream.key) else {
+                        continue;
+                    };
+                    per_key.entry(key).or_default().extend(
+                        event
+                            .fields
+                            .iter()
+                            .map(|(name, value)| (name.clone(), value.clone())),
+                    );
+                }
+
+                ReducedStream {
+                    stream: stream.stream.clone(),
+                    key: stream.key.clone(),
+                    records: per_key.into_values().collect(),
+                }
+            })
+            .collect()
+    }
+}
+
+/// De sleutelwaarde van een vastlegging, hoofdletterongevoelig opgezocht.
+fn record_key(fields: &BTreeMap<String, Value>, key: &str) -> Option<String> {
+    fields
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case(key))
+        .map(|(_, value)| value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn date(text: &str) -> NaiveDate {
+        NaiveDate::parse_from_str(text, "%Y-%m-%d").unwrap_or_default()
+    }
+
+    fn event(op_moment: &str, fields: &[(&str, Value)]) -> ChronicleEvent {
+        ChronicleEvent {
+            op_moment: date(op_moment),
+            fields: fields
+                .iter()
+                .map(|(name, value)| ((*name).to_string(), value.clone()))
+                .collect(),
+        }
+    }
+
+    fn store(events: Vec<ChronicleEvent>) -> ChronicleStore {
+        ChronicleStore::from_streams(vec![ChronicleStream {
+            stream: "relatie".to_string(),
+            key: "bsn".to_string(),
+            events,
+        }])
+        .unwrap_or_default()
+    }
+
+    #[test]
+    fn latere_vastlegging_overschrijft_eerdere() {
+        let store = store(vec![
+            event(
+                "2024-01-01",
+                &[
+                    ("bsn", Value::String("1".to_string())),
+                    ("partnerschap_type", Value::String("GEEN".to_string())),
+                ],
+            ),
+            event(
+                "2024-06-01",
+                &[
+                    ("bsn", Value::String("1".to_string())),
+                    ("partnerschap_type", Value::String("HUWELIJK".to_string())),
+                ],
+            ),
+        ]);
+
+        let reduced = store.reduce_to(date("2025-01-01"));
+        assert_eq!(reduced.len(), 1);
+        assert_eq!(reduced[0].records.len(), 1);
+        assert_eq!(
+            reduced[0].records[0].get("partnerschap_type"),
+            Some(&Value::String("HUWELIJK".to_string()))
+        );
+    }
+
+    #[test]
+    fn feiten_van_na_het_moment_tellen_niet_mee() {
+        let store = store(vec![
+            event(
+                "2024-01-01",
+                &[
+                    ("bsn", Value::String("1".to_string())),
+                    ("partnerschap_type", Value::String("GEEN".to_string())),
+                ],
+            ),
+            event(
+                "2024-06-01",
+                &[
+                    ("bsn", Value::String("1".to_string())),
+                    ("partnerschap_type", Value::String("HUWELIJK".to_string())),
+                ],
+            ),
+        ]);
+
+        let reduced = store.reduce_to(date("2024-03-01"));
+        assert_eq!(
+            reduced[0].records[0].get("partnerschap_type"),
+            Some(&Value::String("GEEN".to_string()))
+        );
+    }
+
+    #[test]
+    fn vastlegging_zonder_sleutel_wordt_geweigerd() {
+        let err = ChronicleStore::from_streams(vec![ChronicleStream {
+            stream: "relatie".to_string(),
+            key: "bsn".to_string(),
+            events: vec![event("2024-01-01", &[("partnerschap_type", Value::Null)])],
+        }])
+        .expect_err("een vastlegging zonder sleutelveld hoort te falen");
+        assert!(matches!(
+            err,
+            SimulatorError::ChronicleEventWithoutKey { .. }
+        ));
+    }
+}

--- a/packages/simulator/src/cell/chronicle.rs
+++ b/packages/simulator/src/cell/chronicle.rs
@@ -176,7 +176,7 @@ mod tests {
                 events,
             }],
         )
-        .unwrap_or_default()
+        .unwrap_or_else(|e| panic!("teststore moet op te bouwen zijn: {e}"))
     }
 
     #[test]

--- a/packages/simulator/src/cell/chronicle.rs
+++ b/packages/simulator/src/cell/chronicle.rs
@@ -149,8 +149,12 @@ fn record_key(fields: &BTreeMap<String, Value>, key: &str) -> Option<String> {
 mod tests {
     use super::*;
 
+    /// Faalt luid op een onleesbare datum: deze tests gáán over de tijdas, dus
+    /// een typfout die stil op de standaarddatum uitkomt zou een gebroken test
+    /// achter een onschuldige assertie verstoppen.
     fn date(text: &str) -> NaiveDate {
-        NaiveDate::parse_from_str(text, "%Y-%m-%d").unwrap_or_default()
+        NaiveDate::parse_from_str(text, "%Y-%m-%d")
+            .unwrap_or_else(|e| panic!("testdatum '{text}' moet leesbaar zijn: {e}"))
     }
 
     fn event(op_moment: &str, fields: &[(&str, Value)]) -> ChronicleEvent {

--- a/packages/simulator/src/cell/config.rs
+++ b/packages/simulator/src/cell/config.rs
@@ -1,0 +1,208 @@
+//! De celconfiguratie: welke wetten een cel laadt, welke feiten ze houdt en
+//! welke lexostatussen ze publiceert.
+//!
+//! Lexostatus-definities zijn **data**, geen Rust. Ze staan in de configuratie
+//! van de cel, worden gelezen door de loader en zijn verder onveranderlijk. Een
+//! consument kan dus geen eigen reductie injecteren; hij kan alleen een
+//! gepubliceerde naam opvragen met gedocumenteerde parameters (RFC-022 §4.1).
+
+use crate::cell::chronicle::ChronicleStream;
+use crate::error::{Result, SimulatorError};
+use regelrecht_engine::Value;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+/// Alles wat nodig is om één cel op te tuigen.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CellConfig {
+    /// Het cel-id, bijvoorbeeld `toeslagen`.
+    pub id: String,
+    /// De regelingen die deze cel zelf laadt, bij `$id`.
+    pub laws: Vec<String>,
+    /// De kroniekstromen met de eigen feiten van de cel.
+    #[serde(default)]
+    pub chronicles: Vec<ChronicleStream>,
+    /// De lexostatussen die de cel naar buiten publiceert.
+    #[serde(default)]
+    pub lexostatus_definitions: Vec<LexostatusDefinition>,
+}
+
+/// Eén gepubliceerde lexostatus met haar gedocumenteerde parameters en reductie.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LexostatusDefinition {
+    /// De naam waarmee een consument deze lexostatus opvraagt.
+    pub name: String,
+    /// Vrije toelichting; verschijnt niet in het antwoord, wel in de config.
+    #[serde(default)]
+    pub doc: Option<String>,
+    /// De gedocumenteerde parameters. Een vraag die hiervan afwijkt, faalt.
+    #[serde(default)]
+    pub inputs: Vec<LexostatusInput>,
+    /// Hoe de cel over haar eigen feiten reduceert.
+    pub reduction: Reduction,
+}
+
+/// Eén gedocumenteerde parameter van een lexostatus.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LexostatusInput {
+    /// Parameternaam, waarnaar de reductie met `$naam` verwijst.
+    pub name: String,
+    /// Het verwachte type van de meegegeven waarde.
+    #[serde(rename = "type")]
+    pub value_type: ParameterType,
+}
+
+/// De typen die een lexostatus-parameter kan hebben.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ParameterType {
+    /// Tekst, bijvoorbeeld een BSN.
+    String,
+    /// Geheel of decimaal getal.
+    Number,
+    /// Waar of niet waar.
+    Boolean,
+}
+
+impl ParameterType {
+    /// De naam zoals die in foutmeldingen verschijnt.
+    fn label(self) -> &'static str {
+        match self {
+            Self::String => "string",
+            Self::Number => "number",
+            Self::Boolean => "boolean",
+        }
+    }
+
+    /// Past deze waarde bij het gedocumenteerde type?
+    fn accepts(self, value: &Value) -> bool {
+        match self {
+            Self::String => matches!(value, Value::String(_)),
+            Self::Number => matches!(value, Value::Int(_) | Value::Decimal(_)),
+            Self::Boolean => matches!(value, Value::Bool(_)),
+        }
+    }
+}
+
+/// De chronolexoreductie: welke uitkomst van welke eigen regeling de cel over
+/// haar eigen feiten berekent, en met welke parameters.
+///
+/// In deze eerste versie is de reductie precies één uitkomst van één eigen
+/// regeling. Rijkere vormen (filteren en aggregeren over meerdere kronieken)
+/// passen in dezelfde plek in de configuratie zonder dat de publieke ingang van
+/// de cel verandert.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Reduction {
+    /// De regeling, bij `$id`. Moet in `laws` van dezelfde cel staan.
+    pub regulation: String,
+    /// De uitkomst van die regeling die de reductie oplevert.
+    pub output: String,
+    /// De parameters voor de regeling. Een waarde `$naam` verwijst naar een
+    /// gedocumenteerde parameter van de lexostatus; elke andere waarde is een
+    /// letterlijke tekst.
+    #[serde(default)]
+    pub parameters: BTreeMap<String, String>,
+}
+
+impl LexostatusDefinition {
+    /// Controleer de definitie tegen de cel waarin ze staat.
+    ///
+    /// Twee dingen moeten kloppen voordat een consument er ooit bij kan: de
+    /// reductie mag alleen een eigen regeling van de cel raken, en elke
+    /// `$`-verwijzing moet een gedocumenteerde parameter zijn.
+    pub(crate) fn validate(&self, cell: &str, own_laws: &[String]) -> Result<()> {
+        if !own_laws.contains(&self.reduction.regulation) {
+            return Err(SimulatorError::ForeignRegulation {
+                cell: cell.to_string(),
+                lexostatus: self.name.clone(),
+                regulation: self.reduction.regulation.clone(),
+            });
+        }
+
+        for reference in self
+            .reduction
+            .parameters
+            .values()
+            .filter_map(|binding| binding_name(binding))
+        {
+            if !self.inputs.iter().any(|input| input.name == reference) {
+                return Err(SimulatorError::UnknownReference {
+                    cell: cell.to_string(),
+                    lexostatus: self.name.clone(),
+                    reference: reference.to_string(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Zet de vraag van een consument om in parameters voor de engine.
+    ///
+    /// Weigert een ontbrekende parameter, een niet-gedocumenteerde parameter en
+    /// een parameter van het verkeerde type. Dat is wat "gedocumenteerde
+    /// parameters" waard maakt: de cel accepteert precies wat ze publiceert.
+    pub(crate) fn bind(
+        &self,
+        cell: &str,
+        params: &BTreeMap<String, Value>,
+    ) -> Result<BTreeMap<String, Value>> {
+        for supplied in params.keys() {
+            if !self.inputs.iter().any(|input| &input.name == supplied) {
+                return Err(SimulatorError::UndocumentedParameter {
+                    cell: cell.to_string(),
+                    lexostatus: self.name.clone(),
+                    parameter: supplied.clone(),
+                    documented: self.documented_parameters(),
+                });
+            }
+        }
+
+        for input in &self.inputs {
+            let Some(value) = params.get(&input.name) else {
+                return Err(SimulatorError::MissingParameter {
+                    cell: cell.to_string(),
+                    lexostatus: self.name.clone(),
+                    parameter: input.name.clone(),
+                });
+            };
+            if !input.value_type.accepts(value) {
+                return Err(SimulatorError::ParameterType {
+                    cell: cell.to_string(),
+                    lexostatus: self.name.clone(),
+                    parameter: input.name.clone(),
+                    expected: input.value_type.label(),
+                    actual: value.type_name(),
+                });
+            }
+        }
+
+        let mut bound = BTreeMap::new();
+        for (name, binding) in &self.reduction.parameters {
+            let value = match binding_name(binding) {
+                Some(reference) => params.get(reference).cloned().unwrap_or(Value::Null),
+                None => Value::String(binding.clone()),
+            };
+            bound.insert(name.clone(), value);
+        }
+        Ok(bound)
+    }
+
+    /// Komma-gescheiden lijst van gedocumenteerde parameters, voor foutmeldingen.
+    fn documented_parameters(&self) -> String {
+        self.inputs
+            .iter()
+            .map(|input| input.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+/// `"$bsn"` → `Some("bsn")`; alles zonder `$` is een letterlijke waarde.
+fn binding_name(binding: &str) -> Option<&str> {
+    binding.strip_prefix('$')
+}

--- a/packages/simulator/src/cell/config.rs
+++ b/packages/simulator/src/cell/config.rs
@@ -99,7 +99,12 @@ impl ParameterType {
 pub struct Reduction {
     /// De regeling, bij `$id`. Moet in `laws` van dezelfde cel staan.
     pub regulation: String,
-    /// De uitkomst van die regeling die de reductie oplevert.
+    /// De uitkomst van die regeling die de reductie moet opleveren.
+    ///
+    /// Dit stuurt de evaluatie aan; het begrenst het antwoord niet. Een
+    /// lexostatus is een rechtstoestand, en de engine levert alle uitkomsten die
+    /// ze onderweg naar deze berekende. Een scenario mag daar dus ook op
+    /// controleren.
     pub output: String,
     /// De parameters voor de regeling. Een waarde `$naam` verwijst naar een
     /// gedocumenteerde parameter van de lexostatus; elke andere waarde is een

--- a/packages/simulator/src/cell/config.rs
+++ b/packages/simulator/src/cell/config.rs
@@ -10,7 +10,7 @@ use crate::cell::chronicle::ChronicleStream;
 use crate::error::{Result, SimulatorError};
 use regelrecht_engine::Value;
 use serde::Deserialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Alles wat nodig is om één cel op te tuigen.
 #[derive(Debug, Clone, Deserialize)]
@@ -40,6 +40,14 @@ pub struct LexostatusDefinition {
     /// De gedocumenteerde parameters. Een vraag die hiervan afwijkt, faalt.
     #[serde(default)]
     pub inputs: Vec<LexostatusInput>,
+    /// De gedocumenteerde uitkomsten: wat de cel onder deze naam publiceert.
+    ///
+    /// Wat hier niet staat, komt niet in het antwoord, ook al berekende de
+    /// engine het onderweg. Leeg of afwezig betekent: alleen
+    /// [`Reduction::output`]. Die uitkomst hoort er altijd bij — ze *is* de
+    /// lexostatus — dus deze lijst breidt uit, ze perkt niet in.
+    #[serde(default)]
+    pub outputs: Vec<String>,
     /// Hoe de cel over haar eigen feiten reduceert.
     pub reduction: Reduction,
 }
@@ -101,10 +109,10 @@ pub struct Reduction {
     pub regulation: String,
     /// De uitkomst van die regeling die de reductie moet opleveren.
     ///
-    /// Dit stuurt de evaluatie aan; het begrenst het antwoord niet. Een
-    /// lexostatus is een rechtstoestand, en de engine levert alle uitkomsten die
-    /// ze onderweg naar deze berekende. Een scenario mag daar dus ook op
-    /// controleren.
+    /// Dit stuurt de evaluatie aan. Wat het antwoord draagt, bepaalt
+    /// [`LexostatusDefinition::outputs`]: de engine levert ook de uitkomsten
+    /// die causaal met deze meekomen, en die zijn daarmee nog niet
+    /// gepubliceerd.
     pub output: String,
     /// De parameters voor de regeling. Een waarde `$naam` verwijst naar een
     /// gedocumenteerde parameter van de lexostatus; elke andere waarde is een
@@ -114,18 +122,73 @@ pub struct Reduction {
 }
 
 impl LexostatusDefinition {
+    /// De uitkomsten die deze lexostatus publiceert.
+    ///
+    /// Altijd [`Reduction::output`], plus wat [`Self::outputs`] noemt. Een
+    /// consument krijgt precies deze namen te zien.
+    pub fn published_outputs(&self) -> BTreeSet<&str> {
+        std::iter::once(self.reduction.output.as_str())
+            .chain(self.outputs.iter().map(String::as_str))
+            .collect()
+    }
+
+    /// Laat van het antwoord van de engine alleen de gepubliceerde uitkomsten
+    /// over.
+    ///
+    /// De engine levert bij een gevraagde uitkomst ook de uitkomsten die
+    /// causaal met haar meekomen. Die zijn berekend, niet gepubliceerd, en
+    /// horen dus niet in het antwoord van de cel.
+    pub(crate) fn project(&self, outputs: BTreeMap<String, Value>) -> BTreeMap<String, Value> {
+        let published = self.published_outputs();
+        outputs
+            .into_iter()
+            .filter(|(name, _)| published.contains(name.as_str()))
+            .collect()
+    }
+
     /// Controleer de definitie tegen de cel waarin ze staat.
     ///
-    /// Twee dingen moeten kloppen voordat een consument er ooit bij kan: de
-    /// reductie mag alleen een eigen regeling van de cel raken, en elke
-    /// `$`-verwijzing moet een gedocumenteerde parameter zijn.
-    pub(crate) fn validate(&self, cell: &str, own_laws: &[String]) -> Result<()> {
+    /// Drie dingen moeten kloppen voordat een consument er ooit bij kan: de
+    /// reductie mag alleen een eigen regeling van de cel raken, elke
+    /// gepubliceerde uitkomst moet een uitkomst zijn die die regeling kent, en
+    /// elke `$`-verwijzing moet een gedocumenteerde parameter zijn.
+    ///
+    /// `known_outputs` bevat per regeling de uitkomstnamen van álle geladen
+    /// versies. Een definitie afkeuren om een naam die alleen in de nieuwste
+    /// versie ontbreekt, zou een scenario over een ouder moment onterecht
+    /// blokkeren.
+    pub(crate) fn validate(
+        &self,
+        cell: &str,
+        own_laws: &[String],
+        known_outputs: &BTreeMap<String, BTreeSet<String>>,
+    ) -> Result<()> {
         if !own_laws.contains(&self.reduction.regulation) {
             return Err(SimulatorError::ForeignRegulation {
                 cell: cell.to_string(),
                 lexostatus: self.name.clone(),
                 regulation: self.reduction.regulation.clone(),
             });
+        }
+
+        let known = known_outputs
+            .get(&self.reduction.regulation)
+            .cloned()
+            .unwrap_or_default();
+        for published in self.published_outputs() {
+            if !known.contains(published) {
+                return Err(SimulatorError::UnknownOutput {
+                    cell: cell.to_string(),
+                    lexostatus: self.name.clone(),
+                    regulation: self.reduction.regulation.clone(),
+                    output: published.to_string(),
+                    known: known
+                        .iter()
+                        .map(String::as_str)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                });
+            }
         }
 
         for reference in self

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -192,7 +192,8 @@ lexostatus_definitions:
     }
 
     fn moment() -> NaiveDate {
-        NaiveDate::from_ymd_opt(2025, 1, 1).unwrap_or_default()
+        NaiveDate::from_ymd_opt(2025, 1, 1)
+            .unwrap_or_else(|| panic!("2025-01-01 moet een geldige datum zijn"))
     }
 
     #[test]

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -1,0 +1,262 @@
+//! De cel: een containment- en autonomiedomein, en verder niets.
+//!
+//! Een cel houdt kronieken, reduceert daarover en biedt het resultaat aan als
+//! lexostatus. Ze houdt geen sleutels, geen bevoegdheid en geen transport —
+//! dat zijn eigen assen (RFC-022 §2).
+//!
+//! De reductielogica woont hier, niet in de scenario-runner. De runner leest
+//! configuratie en stelt vragen; wat een reductie inhoudt, weet alleen de cel.
+
+mod chronicle;
+mod config;
+
+pub use chronicle::{ChronicleEvent, ChronicleStore, ChronicleStream};
+pub use config::{CellConfig, LexostatusDefinition, LexostatusInput, ParameterType, Reduction};
+
+use crate::corpus;
+use crate::error::{Result, SimulatorError};
+use chrono::NaiveDate;
+use regelrecht_engine::{LawExecutionService, Value};
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Het antwoord van een cel: de rechtstoestand vanuit een gevraagd perspectief,
+/// op de feiten die in die cel bekend zijn.
+#[derive(Debug, Clone)]
+pub struct Lexostatus {
+    /// De cel die geantwoord heeft.
+    pub cell: String,
+    /// De gepubliceerde naam die gevraagd werd.
+    pub name: String,
+    /// Het moment waarop gevraagd is; het antwoord geldt op dat moment.
+    pub op_moment: NaiveDate,
+    /// De waarden die de reductie opleverde.
+    pub values: BTreeMap<String, Value>,
+}
+
+/// Eén chronolexocel.
+///
+/// De cel bezit haar feiten. Er is met opzet geen `pub fn store()` en geen
+/// publiek veld: dat een andere cel niet bij deze kronieken kan, is een
+/// compileerfout en geen afspraak. De enige publieke ingang voor een consument
+/// is [`Cell::reduce`].
+pub struct Cell {
+    /// Het cel-id, alleen voor foutmeldingen en herkomst in het antwoord.
+    id: String,
+    /// Engine met uitsluitend de eigen wetten van deze cel geladen.
+    ///
+    /// In een `RefCell`, omdat elke reductie de zichtbare feiten opnieuw op het
+    /// gevraagde moment zet; naar buiten toe blijft bevragen een leesactie.
+    service: RefCell<LawExecutionService>,
+    /// De eigen feiten. Privé, en dat is het punt.
+    chronicles: ChronicleStore,
+    /// De gepubliceerde lexostatussen, op naam.
+    published: BTreeMap<String, LexostatusDefinition>,
+}
+
+impl Cell {
+    /// Tuig een cel op uit haar configuratie.
+    ///
+    /// Laadt uitsluitend de eigen wetten (alle versies, zodat de engine zelf op
+    /// het gevraagde moment de juiste kiest) en controleert de gepubliceerde
+    /// lexostatussen voordat er ook maar één vraag gesteld kan worden.
+    pub fn from_config(config: &CellConfig, regulation_root: &Path) -> Result<Self> {
+        let mut service = LawExecutionService::new();
+        for law in &config.laws {
+            for document in corpus::regulation_versions(regulation_root, law)? {
+                service.load_law(&document)?;
+            }
+        }
+
+        let mut published: BTreeMap<String, LexostatusDefinition> = BTreeMap::new();
+        for definition in &config.lexostatus_definitions {
+            definition.validate(&config.id, &config.laws)?;
+            if published
+                .insert(definition.name.clone(), definition.clone())
+                .is_some()
+            {
+                return Err(SimulatorError::DuplicateLexostatus {
+                    cell: config.id.clone(),
+                    name: definition.name.clone(),
+                });
+            }
+        }
+
+        Ok(Self {
+            id: config.id.clone(),
+            service: RefCell::new(service),
+            chronicles: ChronicleStore::from_streams(config.chronicles.clone())?,
+            published,
+        })
+    }
+
+    /// Reduceer over de eigen feiten en lever de gevraagde lexostatus.
+    ///
+    /// Dit is de enige ingang die een consument heeft. Hij kiest een
+    /// gepubliceerde naam en levert de gedocumenteerde parameters; hoe er
+    /// gereduceerd wordt, bepaalt de cel. Een onbekende naam is een nette fout
+    /// die opsomt wat de cel wél publiceert.
+    ///
+    /// `op_moment` is het moment waarop gevraagd wordt: feiten die pas later in
+    /// deze cel zijn vastgelegd, bestaan voor dit antwoord niet.
+    pub fn reduce(
+        &self,
+        lexostatus: &str,
+        params: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Result<Lexostatus> {
+        let definition =
+            self.published
+                .get(lexostatus)
+                .ok_or_else(|| SimulatorError::UnknownLexostatus {
+                    cell: self.id.clone(),
+                    requested: lexostatus.to_string(),
+                    published: self
+                        .published
+                        .keys()
+                        .map(String::as_str)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                })?;
+
+        let bound = definition.bind(&self.id, params)?;
+
+        let mut service = self.service.borrow_mut();
+        service.clear_data_sources();
+        for stream in self.chronicles.reduce_to(op_moment) {
+            service.register_dict_source(&stream.stream, &stream.key, stream.records)?;
+        }
+
+        let result = service.evaluate_law_output(
+            &definition.reduction.regulation,
+            &definition.reduction.output,
+            bound,
+            &op_moment.format("%Y-%m-%d").to_string(),
+        )?;
+
+        Ok(Lexostatus {
+            cell: self.id.clone(),
+            name: definition.name.clone(),
+            op_moment,
+            values: result.outputs,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::corpus::regulation_root;
+
+    fn config(yaml: &str) -> CellConfig {
+        serde_yaml_ng::from_str(yaml).unwrap_or_else(|e| panic!("testconfig moet parsen: {e}"))
+    }
+
+    fn toeslagen() -> Cell {
+        let config = config(
+            r"
+id: toeslagen
+laws:
+  - algemene_wet_inkomensafhankelijke_regelingen
+chronicles:
+  - stream: relaties
+    key: bsn
+    events:
+      - op_moment: 2024-01-01
+        fields:
+          bsn: '999993653'
+          partnerschap_type: GEEN
+lexostatus_definitions:
+  - name: toeslagpartnerschap
+    inputs:
+      - name: bsn
+        type: string
+    reduction:
+      regulation: algemene_wet_inkomensafhankelijke_regelingen
+      output: heeft_toeslagpartner
+      parameters:
+        bsn: $bsn
+",
+        );
+        Cell::from_config(&config, &regulation_root())
+            .unwrap_or_else(|e| panic!("cel moet op te tuigen zijn: {e}"))
+    }
+
+    fn bsn() -> BTreeMap<String, Value> {
+        BTreeMap::from([("bsn".to_string(), Value::String("999993653".to_string()))])
+    }
+
+    fn moment() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2025, 1, 1).unwrap_or_default()
+    }
+
+    #[test]
+    fn onbekende_lexostatus_noemt_wat_de_cel_wel_publiceert() {
+        let err = toeslagen()
+            .reduce("openstaande_vorderingen", &bsn(), moment())
+            .expect_err("een niet-gepubliceerde naam hoort te falen");
+        let SimulatorError::UnknownLexostatus { published, .. } = &err else {
+            panic!("verwachtte UnknownLexostatus, kreeg {err}");
+        };
+        assert_eq!(published, "toeslagpartnerschap");
+    }
+
+    #[test]
+    fn niet_gedocumenteerde_parameter_wordt_geweigerd() {
+        let mut params = bsn();
+        params.insert("peiljaar".to_string(), Value::Int(2025));
+        let err = toeslagen()
+            .reduce("toeslagpartnerschap", &params, moment())
+            .expect_err("een ongedocumenteerde parameter hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UndocumentedParameter { .. }),
+            "verwachtte UndocumentedParameter, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn parameter_van_het_verkeerde_type_wordt_geweigerd() {
+        let params = BTreeMap::from([("bsn".to_string(), Value::Int(999_993_653))]);
+        let err = toeslagen()
+            .reduce("toeslagpartnerschap", &params, moment())
+            .expect_err("een verkeerd getypeerde parameter hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::ParameterType { .. }),
+            "verwachtte ParameterType, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn reductie_over_een_vreemde_regeling_wordt_geweigerd() {
+        let config = config(
+            r"
+id: toeslagen
+laws:
+  - algemene_wet_inkomensafhankelijke_regelingen
+lexostatus_definitions:
+  - name: vermogen
+    inputs: []
+    reduction:
+      regulation: wet_inkomstenbelasting_2001
+      output: rendementsgrondslag
+",
+        );
+        let err = Cell::from_config(&config, &regulation_root())
+            .expect_err("een reductie over een vreemde regeling hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::ForeignRegulation { .. }),
+            "verwachtte ForeignRegulation, kreeg {err}"
+        );
+    }
+}
+
+impl std::fmt::Debug for Cell {
+    /// Toont bewust geen kronieken: ook een debugregel is een lek.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Cell")
+            .field("id", &self.id)
+            .field("published", &self.published.keys().collect::<Vec<_>>())
+            .finish_non_exhaustive()
+    }
+}

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -32,6 +32,10 @@ pub struct Lexostatus {
     /// Het moment waarop gevraagd is; het antwoord geldt op dat moment.
     pub op_moment: NaiveDate,
     /// De waarden die de reductie opleverde.
+    ///
+    /// Niet alleen de uitkomst die de definitie noemt: een lexostatus is een
+    /// rechtstoestand, dus alles wat de engine onderweg naar die uitkomst
+    /// berekende hoort erbij.
     pub values: BTreeMap<String, Value>,
 }
 
@@ -86,7 +90,7 @@ impl Cell {
         Ok(Self {
             id: config.id.clone(),
             service: RefCell::new(service),
-            chronicles: ChronicleStore::from_streams(config.chronicles.clone())?,
+            chronicles: ChronicleStore::from_streams(&config.id, config.chronicles.clone())?,
             published,
         })
     }

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -18,7 +18,7 @@ use crate::error::{Result, SimulatorError};
 use chrono::NaiveDate;
 use regelrecht_engine::{LawExecutionService, Value};
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 /// Het antwoord van een cel: de rechtstoestand vanuit een gevraagd perspectief,
@@ -33,9 +33,9 @@ pub struct Lexostatus {
     pub op_moment: NaiveDate,
     /// De waarden die de reductie opleverde.
     ///
-    /// Niet alleen de uitkomst die de definitie noemt: een lexostatus is een
-    /// rechtstoestand, dus alles wat de engine onderweg naar die uitkomst
-    /// berekende hoort erbij.
+    /// Uitsluitend de uitkomsten die de definitie publiceert. De engine levert
+    /// bij een gevraagde uitkomst ook wat er causaal mee meekomt; berekend is
+    /// niet gepubliceerd, dus dat blijft binnen de cel.
     pub values: BTreeMap<String, Value>,
 }
 
@@ -73,9 +73,11 @@ impl Cell {
             }
         }
 
+        let known_outputs = outputs_per_regulation(&service);
+
         let mut published: BTreeMap<String, LexostatusDefinition> = BTreeMap::new();
         for definition in &config.lexostatus_definitions {
-            definition.validate(&config.id, &config.laws)?;
+            definition.validate(&config.id, &config.laws, &known_outputs)?;
             if published
                 .insert(definition.name.clone(), definition.clone())
                 .is_some()
@@ -101,6 +103,10 @@ impl Cell {
     /// gepubliceerde naam en levert de gedocumenteerde parameters; hoe er
     /// gereduceerd wordt, bepaalt de cel. Een onbekende naam is een nette fout
     /// die opsomt wat de cel wél publiceert.
+    ///
+    /// Het antwoord draagt uitsluitend de uitkomsten die de definitie
+    /// publiceert. Gedocumenteerd geldt dus aan beide kanten: de vraag mag
+    /// alleen wat de definitie noemt, en het antwoord geeft niet meer dan dat.
     ///
     /// `op_moment` is het moment waarop gevraagd wordt: feiten die pas later in
     /// deze cel zijn vastgelegd, bestaan voor dit antwoord niet.
@@ -143,9 +149,31 @@ impl Cell {
             cell: self.id.clone(),
             name: definition.name.clone(),
             op_moment,
-            values: result.outputs,
+            values: definition.project(result.outputs),
         })
     }
+}
+
+/// De uitkomstnamen per regeling, over alle geladen versies heen.
+///
+/// De engine indexeert uitkomsten alleen voor de nieuwste geladen versie,
+/// terwijl een cel elke versie laadt en een vraag over een ouder moment op een
+/// oudere versie landt. Voor de vraag "kent deze regeling deze uitkomst?" telt
+/// daarom elke versie mee.
+fn outputs_per_regulation(service: &LawExecutionService) -> BTreeMap<String, BTreeSet<String>> {
+    let mut per_regulation: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for law in service.resolver().all_law_versions() {
+        let known = per_regulation.entry(law.id.clone()).or_default();
+        for article in &law.articles {
+            let Some(execution) = article.get_execution_spec() else {
+                continue;
+            };
+            for output in execution.output.iter().flatten() {
+                known.insert(output.name.clone());
+            }
+        }
+    }
+    per_regulation
 }
 
 #[cfg(test)]
@@ -229,6 +257,96 @@ lexostatus_definitions:
         assert!(
             matches!(err, SimulatorError::ParameterType { .. }),
             "verwachtte ParameterType, kreeg {err}"
+        );
+    }
+
+    /// Een cel over de zorgtoeslag, met alle feiten die die wet nodig heeft.
+    ///
+    /// `published` wordt letterlijk in de definitie geplakt, zodat elke test
+    /// alleen het `outputs`-blok varieert.
+    fn zorgtoeslag(published: &str) -> CellConfig {
+        config(&format!(
+            r"
+id: toeslagen
+laws:
+  - wet_op_de_zorgtoeslag
+  - algemene_wet_inkomensafhankelijke_regelingen
+  - regeling_standaardpremie
+chronicles:
+  - stream: intake
+    key: bsn
+    events:
+      - op_moment: 2024-11-15
+        fields:
+          bsn: '999993653'
+          partnerschap_type: GEEN
+          is_verzekerde: true
+          verzamelinkomen: 79547
+          buitenlands_inkomen: 0
+          vermogen: 0
+lexostatus_definitions:
+  - name: zorgtoeslag_rechtstoestand
+{published}
+    inputs:
+      - name: bsn
+        type: string
+    reduction:
+      regulation: wet_op_de_zorgtoeslag
+      output: heeft_recht_op_zorgtoeslag
+      parameters:
+        bsn: $bsn
+"
+        ))
+    }
+
+    #[test]
+    fn een_niet_gepubliceerde_uitkomst_blijft_binnen_de_cel() {
+        let cell = Cell::from_config(&zorgtoeslag(""), &regulation_root())
+            .unwrap_or_else(|e| panic!("cel moet op te tuigen zijn: {e}"));
+        let answer = cell
+            .reduce("zorgtoeslag_rechtstoestand", &bsn(), moment())
+            .unwrap_or_else(|e| panic!("de reductie moet slagen: {e}"));
+
+        assert_eq!(
+            answer.values.get("heeft_recht_op_zorgtoeslag"),
+            Some(&Value::Bool(true)),
+            "de gepubliceerde uitkomst hoort in het antwoord"
+        );
+        assert!(
+            !answer.values.contains_key("hoogte_zorgtoeslag"),
+            "de engine berekent de hoogte mee, maar de cel publiceert haar niet; kreeg {:?}",
+            answer.values
+        );
+    }
+
+    #[test]
+    fn een_gepubliceerde_uitkomst_komt_er_wel_bij() {
+        let cell = Cell::from_config(
+            &zorgtoeslag("    outputs:\n      - hoogte_zorgtoeslag"),
+            &regulation_root(),
+        )
+        .unwrap_or_else(|e| panic!("cel moet op te tuigen zijn: {e}"));
+        let answer = cell
+            .reduce("zorgtoeslag_rechtstoestand", &bsn(), moment())
+            .unwrap_or_else(|e| panic!("de reductie moet slagen: {e}"));
+
+        assert!(
+            answer.values.contains_key("hoogte_zorgtoeslag"),
+            "een uitkomst die in `outputs` staat hoort in het antwoord; kreeg {:?}",
+            answer.values
+        );
+    }
+
+    #[test]
+    fn een_uitkomst_die_de_regeling_niet_kent_wordt_geweigerd() {
+        let err = Cell::from_config(
+            &zorgtoeslag("    outputs:\n      - hoogte_huurtoeslag"),
+            &regulation_root(),
+        )
+        .expect_err("een uitkomst die de regeling niet kent hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownOutput { .. }),
+            "verwachtte UnknownOutput, kreeg {err}"
         );
     }
 

--- a/packages/simulator/src/corpus.rs
+++ b/packages/simulator/src/corpus.rs
@@ -62,7 +62,12 @@ pub(crate) fn regulation_versions(root: &Path, regulation: &str) -> Result<Vec<S
                     path: path.clone(),
                     source,
                 })?;
-            let parsed: RegulationId = serde_yaml_ng::from_str(&text)?;
+            let parsed: RegulationId = serde_yaml_ng::from_str(&text).map_err(|source| {
+                SimulatorError::RegulationParse {
+                    path: path.clone(),
+                    source,
+                }
+            })?;
             if parsed.id != regulation {
                 return Err(SimulatorError::RegulationIdMismatch {
                     path,

--- a/packages/simulator/src/corpus.rs
+++ b/packages/simulator/src/corpus.rs
@@ -1,0 +1,112 @@
+//! Regelingen uit het corpus opzoeken.
+//!
+//! Een cel noemt haar wetten bij `$id`. In het corpus is dat de naam van de map
+//! (`corpus/regulation/<land>/<soort>/<id>/<valid_from>.yaml`); elk bestand in
+//! die map is één versie van dezelfde regeling. De simulator laadt ze allemaal,
+//! zodat de engine zelf op `op_moment` de juiste versie kiest.
+
+use crate::error::{Result, SimulatorError};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+/// Waar het regelingcorpus staat.
+///
+/// `REGULATION_PATH` wint, anders `corpus/regulation` naast deze crate. Zelfde
+/// afspraak als de integratietests van de engine, zodat een checkout op een
+/// andere plek met één env-var werkt.
+pub fn regulation_root() -> PathBuf {
+    std::env::var("REGULATION_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("..")
+                .join("..")
+                .join("corpus")
+                .join("regulation")
+        })
+}
+
+/// Alleen de `$id` uit een regelingdocument; de rest laat de engine parseren.
+#[derive(Deserialize)]
+struct RegulationId {
+    #[serde(rename = "$id")]
+    id: String,
+}
+
+/// Lees alle versies van één regeling als YAML-teksten, op pad gesorteerd.
+///
+/// Faalt als de map niet bestaat, leeg is, of een document bevat waarvan de
+/// `$id` niet met de mapnaam overeenkomt — dan zou de cel iets anders laden dan
+/// ze denkt te laden, en dat is geen fout om stil te slikken.
+pub(crate) fn regulation_versions(root: &Path, regulation: &str) -> Result<Vec<String>> {
+    let mut documents: Vec<(PathBuf, String)> = Vec::new();
+
+    for entry in WalkDir::new(root)
+        .follow_links(true)
+        .into_iter()
+        .filter_map(std::result::Result::ok)
+        .filter(|e| e.file_type().is_dir() && e.file_name() == regulation)
+    {
+        for file in std::fs::read_dir(entry.path())
+            .into_iter()
+            .flatten()
+            .flatten()
+        {
+            let path = file.path();
+            if !path.is_file() || path.extension().is_none_or(|ext| ext != "yaml") {
+                continue;
+            }
+            let text =
+                std::fs::read_to_string(&path).map_err(|source| SimulatorError::FileRead {
+                    path: path.clone(),
+                    source,
+                })?;
+            let parsed: RegulationId = serde_yaml_ng::from_str(&text)?;
+            if parsed.id != regulation {
+                return Err(SimulatorError::RegulationIdMismatch {
+                    path,
+                    expected: regulation.to_string(),
+                    found: parsed.id,
+                });
+            }
+            documents.push((path, text));
+        }
+    }
+
+    if documents.is_empty() {
+        return Err(SimulatorError::RegulationNotFound {
+            regulation: regulation.to_string(),
+            root: root.to_path_buf(),
+        });
+    }
+
+    documents.sort_by(|(a, _), (b, _)| a.cmp(b));
+    Ok(documents.into_iter().map(|(_, text)| text).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vindt_alle_versies_van_een_regeling() {
+        let versions = regulation_versions(&regulation_root(), "regeling_standaardpremie")
+            .unwrap_or_else(|e| panic!("standaardpremie moet in het corpus staan: {e}"));
+        assert!(
+            versions.len() >= 2,
+            "standaardpremie heeft meerdere jaarversies, kreeg {}",
+            versions.len()
+        );
+    }
+
+    #[test]
+    fn onbekende_regeling_geeft_nette_fout() {
+        let err = regulation_versions(&regulation_root(), "wet_op_de_niet_bestaande_dingen")
+            .expect_err("een niet-bestaande regeling mag niet slagen");
+        assert!(
+            matches!(err, SimulatorError::RegulationNotFound { .. }),
+            "verwachtte RegulationNotFound, kreeg {err}"
+        );
+    }
+}

--- a/packages/simulator/src/error.rs
+++ b/packages/simulator/src/error.rs
@@ -138,11 +138,41 @@ pub enum SimulatorError {
         op_moment: String,
     },
 
+    /// Twee kroniekstromen met dezelfde naam in één cel.
+    ///
+    /// De stroomnaam is tevens de naam van de databron in de engine. Twee
+    /// stromen met dezelfde naam schaduwen elkaar daar stil; dat is een
+    /// configuratiefout en geen keuze.
+    #[error("cel '{cell}' definieert kroniekstroom '{stream}' twee keer")]
+    DuplicateStream {
+        /// Cel waarin het dubbel staat.
+        cell: String,
+        /// De dubbele stroomnaam.
+        stream: String,
+    },
+
     /// Twee cellen met hetzelfde id in één scenario.
     #[error("scenario definieert cel '{cell}' twee keer")]
     DuplicateCell {
         /// Het dubbele cel-id.
         cell: String,
+    },
+
+    /// Een vraag in het scenario legt niets vast wat ze moet opleveren.
+    ///
+    /// De assertie hoort bij het scenario. Een vraag zonder `expect` slaagt
+    /// altijd en bewijst niets; dat mag geen groen opleveren.
+    #[error(
+        "scenario '{scenario}': vraag naar '{cell}.{lexostatus}' heeft geen `expect` \
+         en bewijst dus niets"
+    )]
+    QueryWithoutExpectation {
+        /// Het scenario waarin de vraag staat.
+        scenario: String,
+        /// De bevraagde cel.
+        cell: String,
+        /// De gevraagde lexostatus.
+        lexostatus: String,
     },
 
     /// Een vraag richt zich tot een cel die het scenario niet kent.
@@ -173,6 +203,18 @@ pub enum SimulatorError {
     /// Het scenario is geen geldige YAML of mist verplichte velden.
     #[error("kon scenario niet lezen: {0}")]
     ScenarioParse(#[from] serde_yaml_ng::Error),
+
+    /// Een regelingdocument uit het corpus is geen geldige YAML of mist `$id`.
+    ///
+    /// Eigen variant, want zonder pad wijst de melding de lezer naar het
+    /// scenariobestand terwijl het bestand in het corpus stuk is.
+    #[error("kon regelingdocument '{path}' niet lezen: {source}")]
+    RegulationParse {
+        /// Het gelezen bestand.
+        path: PathBuf,
+        /// De onderliggende YAML-fout.
+        source: serde_yaml_ng::Error,
+    },
 
     /// De engine kon een regeling niet laden of uitvoeren.
     #[error("engine: {0}")]

--- a/packages/simulator/src/error.rs
+++ b/packages/simulator/src/error.rs
@@ -1,0 +1,183 @@
+//! Fouten van de simulator.
+//!
+//! De teksten zijn Nederlands, net als de rest van de gebruikersgerichte
+//! uitvoer in deze repo; identifiers blijven Engels.
+
+use std::path::PathBuf;
+
+/// Alles wat er mis kan gaan bij het optuigen of bevragen van een cel.
+#[derive(Debug, thiserror::Error)]
+pub enum SimulatorError {
+    /// Een consument vroeg een lexostatus op die de cel niet publiceert.
+    ///
+    /// Dit is het enige "niet gevonden" dat een consument kan zien: de cel
+    /// biedt uitsluitend gepubliceerde namen aan (RFC-022 §4.1).
+    #[error("cel '{cell}' publiceert geen lexostatus '{requested}' (wel: {published})")]
+    UnknownLexostatus {
+        /// Cel waaraan gevraagd werd.
+        cell: String,
+        /// De gevraagde naam.
+        requested: String,
+        /// Komma-gescheiden lijst van namen die de cel wél publiceert.
+        published: String,
+    },
+
+    /// Een gedocumenteerde parameter ontbreekt in de vraag.
+    #[error("lexostatus '{cell}.{lexostatus}' vereist parameter '{parameter}'")]
+    MissingParameter {
+        /// Cel waaraan gevraagd werd.
+        cell: String,
+        /// De gevraagde lexostatus.
+        lexostatus: String,
+        /// De ontbrekende parameter.
+        parameter: String,
+    },
+
+    /// De vraag bevat een parameter die de lexostatus niet documenteert.
+    #[error(
+        "lexostatus '{cell}.{lexostatus}' kent geen parameter '{parameter}' \
+         (gedocumenteerd: {documented})"
+    )]
+    UndocumentedParameter {
+        /// Cel waaraan gevraagd werd.
+        cell: String,
+        /// De gevraagde lexostatus.
+        lexostatus: String,
+        /// De onbekende parameter.
+        parameter: String,
+        /// Komma-gescheiden lijst van gedocumenteerde parameters.
+        documented: String,
+    },
+
+    /// Een parameter heeft een ander type dan gedocumenteerd.
+    #[error(
+        "parameter '{parameter}' van lexostatus '{cell}.{lexostatus}' is {actual}, \
+         verwacht {expected}"
+    )]
+    ParameterType {
+        /// Cel waaraan gevraagd werd.
+        cell: String,
+        /// De gevraagde lexostatus.
+        lexostatus: String,
+        /// De parameter met het verkeerde type.
+        parameter: String,
+        /// Het gedocumenteerde type.
+        expected: &'static str,
+        /// Het aangeboden type.
+        actual: &'static str,
+    },
+
+    /// De reductie verwijst met `$naam` naar een niet-gedocumenteerde parameter.
+    #[error(
+        "cel '{cell}': reductie van '{lexostatus}' verwijst naar '${reference}', \
+         maar dat is geen gedocumenteerde parameter"
+    )]
+    UnknownReference {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// De lexostatus met de kapotte verwijzing.
+        lexostatus: String,
+        /// De naam waarnaar verwezen wordt.
+        reference: String,
+    },
+
+    /// Twee lexostatussen met dezelfde naam in één cel.
+    #[error("cel '{cell}' definieert lexostatus '{name}' twee keer")]
+    DuplicateLexostatus {
+        /// Cel waarin het dubbel staat.
+        cell: String,
+        /// De dubbele naam.
+        name: String,
+    },
+
+    /// Een reductie grijpt naar een regeling die deze cel niet zelf geladen heeft.
+    ///
+    /// Een reductie raakt uitsluitend de eigen feiten van de cel; combineren over
+    /// cellen heen is synthese en hoort bij een consument (RFC-022 §4.1).
+    #[error(
+        "cel '{cell}': reductie van '{lexostatus}' gebruikt regeling '{regulation}', \
+         die deze cel niet zelf geladen heeft"
+    )]
+    ForeignRegulation {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// De lexostatus met de vreemde regeling.
+        lexostatus: String,
+        /// De regeling waarnaar verwezen wordt.
+        regulation: String,
+    },
+
+    /// Geen regelingmap met deze naam in het corpus.
+    #[error("regeling '{regulation}' niet gevonden onder {root}")]
+    RegulationNotFound {
+        /// De gezochte regeling.
+        regulation: String,
+        /// De corpus-wortel waarin gezocht is.
+        root: PathBuf,
+    },
+
+    /// De map heet anders dan de `$id` in het document.
+    #[error("{path}: document heeft $id '{found}', maar staat in map '{expected}'")]
+    RegulationIdMismatch {
+        /// Het gelezen bestand.
+        path: PathBuf,
+        /// De naam van de map (en dus van de wet in de celconfiguratie).
+        expected: String,
+        /// De `$id` die het document zelf opgeeft.
+        found: String,
+    },
+
+    /// Een kroniekgebeurtenis mist het sleutelveld van haar stroom.
+    #[error("kroniekstroom '{stream}': gebeurtenis van {op_moment} mist sleutelveld '{key}'")]
+    ChronicleEventWithoutKey {
+        /// De stroom waarin de gebeurtenis staat.
+        stream: String,
+        /// Het sleutelveld dat de stroom declareert.
+        key: String,
+        /// Het moment van de gebeurtenis.
+        op_moment: String,
+    },
+
+    /// Twee cellen met hetzelfde id in één scenario.
+    #[error("scenario definieert cel '{cell}' twee keer")]
+    DuplicateCell {
+        /// Het dubbele cel-id.
+        cell: String,
+    },
+
+    /// Een vraag richt zich tot een cel die het scenario niet kent.
+    #[error("scenario kent geen cel '{cell}'")]
+    UnknownCell {
+        /// Het onbekende cel-id.
+        cell: String,
+    },
+
+    /// Het scenariobestand kon niet gelezen worden.
+    #[error("kon scenario '{path}' niet lezen: {source}")]
+    ScenarioRead {
+        /// Het pad dat gelezen werd.
+        path: PathBuf,
+        /// De onderliggende I/O-fout.
+        source: std::io::Error,
+    },
+
+    /// Een YAML-bestand kon niet gelezen worden.
+    #[error("kon '{path}' niet lezen: {source}")]
+    FileRead {
+        /// Het pad dat gelezen werd.
+        path: PathBuf,
+        /// De onderliggende I/O-fout.
+        source: std::io::Error,
+    },
+
+    /// Het scenario is geen geldige YAML of mist verplichte velden.
+    #[error("kon scenario niet lezen: {0}")]
+    ScenarioParse(#[from] serde_yaml_ng::Error),
+
+    /// De engine kon een regeling niet laden of uitvoeren.
+    #[error("engine: {0}")]
+    Engine(#[from] regelrecht_engine::EngineError),
+}
+
+/// Resultaattype van de simulator.
+pub type Result<T> = std::result::Result<T, SimulatorError>;

--- a/packages/simulator/src/error.rs
+++ b/packages/simulator/src/error.rs
@@ -107,6 +107,29 @@ pub enum SimulatorError {
         regulation: String,
     },
 
+    /// Een lexostatus publiceert een uitkomst die haar regeling niet kent.
+    ///
+    /// Wat een cel publiceert is een belofte aan de consument; een naam die
+    /// geen enkele geladen versie van de regeling oplevert, kan die belofte
+    /// niet waarmaken. Dat blijkt bij het optuigen, net als bij
+    /// [`SimulatorError::ForeignRegulation`], en niet pas bij de eerste vraag.
+    #[error(
+        "cel '{cell}': lexostatus '{lexostatus}' publiceert uitkomst '{output}', \
+         maar regeling '{regulation}' kent die niet (wel: {known})"
+    )]
+    UnknownOutput {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// De lexostatus met de onbekende uitkomst.
+        lexostatus: String,
+        /// De regeling waarover gereduceerd wordt.
+        regulation: String,
+        /// De uitkomstnaam die niet bestaat.
+        output: String,
+        /// Komma-gescheiden lijst van uitkomsten die de regeling wél kent.
+        known: String,
+    },
+
     /// Geen regelingmap met deze naam in het corpus.
     #[error("regeling '{regulation}' niet gevonden onder {root}")]
     RegulationNotFound {

--- a/packages/simulator/src/lib.rs
+++ b/packages/simulator/src/lib.rs
@@ -1,0 +1,37 @@
+//! Testopstelling voor chronolexografie (RFC-022).
+//!
+//! Deze crate bouwt een gesimuleerde wereld van *cellen*. Een cel houdt haar
+//! eigen kronieken, laadt haar eigen wetten en reduceert daarover tot een
+//! *lexostatus*. Wat een cel niet is: ze houdt geen sleutels, ze heeft geen
+//! bevoegd gezag en ze combineert niets over cellen heen (RFC-022 §2, §4.1).
+//!
+//! Deze eerste versie kent één cel per scenario en geen verkeer tussen cellen.
+//! De grens ligt er wel al: een cel bezit haar [`ChronicleStore`] privé, en
+//! [`Cell::reduce`] is de enige publieke ingang voor een consument.
+//!
+//! ```no_run
+//! use regelrecht_simulator::{regulation_root, Scenario};
+//! use std::path::Path;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let scenario = Scenario::load(Path::new("scenarios/toeslagen_zorgtoeslag.yaml"))?;
+//! let run = scenario.run(&regulation_root())?;
+//! println!("{}", run.report());
+//! # Ok(())
+//! # }
+//! ```
+
+#![deny(missing_docs)]
+
+pub mod cell;
+mod corpus;
+pub mod error;
+pub mod scenario;
+
+pub use cell::{
+    Cell, CellConfig, ChronicleEvent, ChronicleStore, ChronicleStream, Lexostatus,
+    LexostatusDefinition, LexostatusInput, ParameterType, Reduction,
+};
+pub use corpus::regulation_root;
+pub use error::{Result, SimulatorError};
+pub use scenario::{ExpectationFailure, Query, QueryOutcome, Scenario, ScenarioRun};

--- a/packages/simulator/src/scenario.rs
+++ b/packages/simulator/src/scenario.rs
@@ -1,0 +1,245 @@
+//! Het scenario: de cellen van een run, de vragen die gesteld worden en wat
+//! die vragen moeten opleveren.
+//!
+//! Een scenario is data. De assertie hoort erbij: wat een run moet opleveren
+//! staat in het scenariobestand, niet in Rust. Zo blijft een testgeval een
+//! bestand dat iemand kan lezen en wijzigen zonder de crate te kennen.
+
+use crate::cell::{Cell, CellConfig, Lexostatus};
+use crate::error::{Result, SimulatorError};
+use chrono::NaiveDate;
+use regelrecht_engine::Value;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::path::Path;
+
+/// Een volledig scenario.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Scenario {
+    /// Korte naam van het scenario.
+    pub name: String,
+    /// Waarom dit scenario bestaat; vrije tekst.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// De cellen in deze run.
+    pub cells: Vec<CellConfig>,
+    /// De vragen die een consument stelt.
+    #[serde(default)]
+    pub queries: Vec<Query>,
+}
+
+/// Eén vraag van een consument aan één cel.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Query {
+    /// Vrije omschrijving, verschijnt in het verslag.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// De cel waaraan gevraagd wordt.
+    pub cell: String,
+    /// De gepubliceerde lexostatus.
+    pub lexostatus: String,
+    /// De gedocumenteerde parameters.
+    #[serde(default)]
+    pub params: BTreeMap<String, Value>,
+    /// Het moment waarop gevraagd wordt. Expliciet, nooit de wandklok.
+    pub op_moment: NaiveDate,
+    /// De verwachte waarden in het antwoord. Waarden die hier niet staan,
+    /// worden niet gecontroleerd.
+    #[serde(default)]
+    pub expect: BTreeMap<String, Value>,
+}
+
+/// Eén verwachting die niet uitkwam.
+#[derive(Debug, Clone)]
+pub struct ExpectationFailure {
+    /// De uitkomst waarover de verwachting ging.
+    pub output: String,
+    /// Wat het scenario verwachtte.
+    pub expected: Value,
+    /// Wat de reductie opleverde; `None` als de uitkomst ontbrak.
+    pub actual: Option<Value>,
+}
+
+/// Het resultaat van één vraag.
+#[derive(Debug, Clone)]
+pub struct QueryOutcome {
+    /// De cel waaraan gevraagd is.
+    pub cell: String,
+    /// De gevraagde lexostatus.
+    pub lexostatus: String,
+    /// Het antwoord van de cel.
+    pub lexostatus_value: Lexostatus,
+    /// De verwachtingen die niet uitkwamen; leeg is goed.
+    pub failures: Vec<ExpectationFailure>,
+}
+
+/// Het resultaat van een hele run.
+#[derive(Debug, Clone)]
+pub struct ScenarioRun {
+    /// De naam van het scenario dat gedraaid heeft.
+    pub name: String,
+    /// De uitkomsten, in de volgorde van het scenario.
+    pub outcomes: Vec<QueryOutcome>,
+}
+
+impl ScenarioRun {
+    /// Kwamen alle verwachtingen uit?
+    pub fn passed(&self) -> bool {
+        self.outcomes.iter().all(|o| o.failures.is_empty())
+    }
+
+    /// Leesbaar verslag van de run, geschikt voor een terminal of een testfout.
+    pub fn report(&self) -> String {
+        let mut out = format!("scenario '{}':\n", self.name);
+        for outcome in &self.outcomes {
+            let mark = if outcome.failures.is_empty() {
+                "ok"
+            } else {
+                "FOUT"
+            };
+            let _ = writeln!(
+                out,
+                "  [{mark}] {}.{} op {}",
+                outcome.cell, outcome.lexostatus, outcome.lexostatus_value.op_moment
+            );
+            for failure in &outcome.failures {
+                let actual = match &failure.actual {
+                    Some(value) => value.to_string(),
+                    None => "(niet in het antwoord)".to_string(),
+                };
+                let _ = writeln!(
+                    out,
+                    "        {}: verwacht {}, kreeg {actual}",
+                    failure.output, failure.expected
+                );
+            }
+        }
+        out
+    }
+}
+
+impl Scenario {
+    /// Lees een scenario uit YAML.
+    pub fn from_yaml(yaml: &str) -> Result<Self> {
+        Ok(serde_yaml_ng::from_str(yaml)?)
+    }
+
+    /// Lees een scenario van schijf.
+    pub fn load(path: &Path) -> Result<Self> {
+        let text =
+            std::fs::read_to_string(path).map_err(|source| SimulatorError::ScenarioRead {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        Self::from_yaml(&text)
+    }
+
+    /// Tuig de cellen op en stel alle vragen.
+    ///
+    /// De runner combineert niets: hij geeft elk antwoord terug zoals de cel het
+    /// gaf. Combineren over cellen heen is synthese en hoort bij een consument.
+    pub fn run(&self, regulation_root: &Path) -> Result<ScenarioRun> {
+        let mut cells: BTreeMap<String, Cell> = BTreeMap::new();
+        for config in &self.cells {
+            if cells.contains_key(&config.id) {
+                return Err(SimulatorError::DuplicateCell {
+                    cell: config.id.clone(),
+                });
+            }
+            cells.insert(
+                config.id.clone(),
+                Cell::from_config(config, regulation_root)?,
+            );
+        }
+
+        let mut outcomes = Vec::with_capacity(self.queries.len());
+        for query in &self.queries {
+            let cell = cells
+                .get(&query.cell)
+                .ok_or_else(|| SimulatorError::UnknownCell {
+                    cell: query.cell.clone(),
+                })?;
+
+            let answer = cell.reduce(&query.lexostatus, &query.params, query.op_moment)?;
+            let failures = check_expectations(&query.expect, &answer.values);
+
+            outcomes.push(QueryOutcome {
+                cell: query.cell.clone(),
+                lexostatus: query.lexostatus.clone(),
+                lexostatus_value: answer,
+                failures,
+            });
+        }
+
+        Ok(ScenarioRun {
+            name: self.name.clone(),
+            outcomes,
+        })
+    }
+}
+
+/// Vergelijk de verwachtingen met wat de reductie opleverde.
+fn check_expectations(
+    expect: &BTreeMap<String, Value>,
+    actual: &BTreeMap<String, Value>,
+) -> Vec<ExpectationFailure> {
+    expect
+        .iter()
+        .filter_map(|(output, expected)| {
+            let found = actual.get(output);
+            match found {
+                Some(value) if equivalent(expected, value) => None,
+                _ => Some(ExpectationFailure {
+                    output: output.clone(),
+                    expected: expected.clone(),
+                    actual: found.cloned(),
+                }),
+            }
+        })
+        .collect()
+}
+
+/// Gelijkheid met één versoepeling: getallen vergelijken op waarde, niet op
+/// variant. YAML kent geen verschil tussen `1` en `1.0`, de engine wel.
+fn equivalent(expected: &Value, actual: &Value) -> bool {
+    match (expected.as_decimal(), actual.as_decimal()) {
+        (Some(left), Some(right)) => left == right,
+        _ => expected == actual,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn onbekend_veld_in_scenario_wordt_geweigerd() {
+        let yaml = r"
+name: typfout
+cells: []
+queeries: []
+";
+        assert!(
+            Scenario::from_yaml(yaml).is_err(),
+            "een onbekend veld hoort te falen, anders verdwijnt een typfout stil"
+        );
+    }
+
+    #[test]
+    fn getallen_vergelijken_op_waarde() {
+        assert!(equivalent(&Value::Int(1), &Value::Int(1)));
+        assert!(!equivalent(&Value::Int(1), &Value::Int(2)));
+        assert!(!equivalent(&Value::Int(1), &Value::String("1".to_string())));
+    }
+
+    #[test]
+    fn ontbrekende_uitkomst_is_een_gemiste_verwachting() {
+        let expect = BTreeMap::from([("hoogte".to_string(), Value::Int(1))]);
+        let failures = check_expectations(&expect, &BTreeMap::new());
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].actual.is_none());
+    }
+}

--- a/packages/simulator/src/scenario.rs
+++ b/packages/simulator/src/scenario.rs
@@ -46,8 +46,9 @@ pub struct Query {
     pub params: BTreeMap<String, Value>,
     /// Het moment waarop gevraagd wordt. Expliciet, nooit de wandklok.
     pub op_moment: NaiveDate,
-    /// De verwachte waarden in het antwoord. Waarden die hier niet staan,
-    /// worden niet gecontroleerd.
+    /// De verwachte waarden in het antwoord. Uitkomsten die hier niet staan,
+    /// worden niet gecontroleerd — maar minstens één verwachting is verplicht,
+    /// anders bewijst de vraag niets.
     #[serde(default)]
     pub expect: BTreeMap<String, Value>,
 }
@@ -123,8 +124,31 @@ impl ScenarioRun {
 
 impl Scenario {
     /// Lees een scenario uit YAML.
+    ///
+    /// Weigert meteen een scenario dat niets vastlegt: zie [`Scenario::validate`].
     pub fn from_yaml(yaml: &str) -> Result<Self> {
-        Ok(serde_yaml_ng::from_str(yaml)?)
+        let scenario: Self = serde_yaml_ng::from_str(yaml)?;
+        scenario.validate()?;
+        Ok(scenario)
+    }
+
+    /// Controleer dat elke vraag ook iets vastlegt.
+    ///
+    /// De assertie hoort bij het scenario, en dat werkt alleen als een vraag
+    /// zonder assertie geen groen kan opleveren. Zonder deze controle draait een
+    /// scenariobestand dat niets verwacht mee in de suite en meldt het `ok` —
+    /// het duurste soort groen, want het lijkt op bewijs.
+    fn validate(&self) -> Result<()> {
+        for query in &self.queries {
+            if query.expect.is_empty() {
+                return Err(SimulatorError::QueryWithoutExpectation {
+                    scenario: self.name.clone(),
+                    cell: query.cell.clone(),
+                    lexostatus: query.lexostatus.clone(),
+                });
+            }
+        }
+        Ok(())
     }
 
     /// Lees een scenario van schijf.
@@ -225,6 +249,23 @@ queeries: []
         assert!(
             Scenario::from_yaml(yaml).is_err(),
             "een onbekend veld hoort te falen, anders verdwijnt een typfout stil"
+        );
+    }
+
+    #[test]
+    fn vraag_zonder_verwachting_wordt_geweigerd() {
+        let yaml = r"
+name: bewijst niets
+cells: []
+queries:
+  - cell: toeslagen
+    lexostatus: toeslagpartnerschap
+    op_moment: 2025-01-01
+";
+        let err = Scenario::from_yaml(yaml).expect_err("een vraag zonder `expect` hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::QueryWithoutExpectation { .. }),
+            "verwachtte QueryWithoutExpectation, kreeg {err}"
         );
     }
 

--- a/packages/simulator/tests/scenarios.rs
+++ b/packages/simulator/tests/scenarios.rs
@@ -1,0 +1,45 @@
+//! Draait elk scenariobestand in `scenarios/`.
+//!
+//! De assertie staat in het scenario, niet hier: deze test controleert alleen
+//! dat elk bestand draait en dat geen enkele verwachting mist. Een nieuw
+//! testgeval is dus een nieuw YAML-bestand, geen nieuwe Rust.
+
+use regelrecht_simulator::{regulation_root, Scenario};
+use std::path::{Path, PathBuf};
+
+fn scenario_files() -> Vec<PathBuf> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("scenarios");
+    let mut files: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("kan {} niet lezen: {e}", dir.display()))
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "yaml"))
+        .collect();
+    files.sort();
+    files
+}
+
+#[test]
+fn er_is_minstens_een_scenario() {
+    assert!(
+        !scenario_files().is_empty(),
+        "zonder scenario bewijst deze suite niets"
+    );
+}
+
+#[test]
+fn alle_scenarios_voldoen_aan_hun_eigen_verwachtingen() {
+    for path in scenario_files() {
+        let scenario = Scenario::load(&path).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+        let run = scenario
+            .run(&regulation_root())
+            .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+
+        assert!(run.passed(), "{}:\n{}", path.display(), run.report());
+        assert!(
+            !run.outcomes.is_empty(),
+            "{}: een scenario zonder vragen bewijst niets",
+            path.display()
+        );
+    }
+}


### PR DESCRIPTION
Nieuwe crate `packages/simulator`: de fundering van een testopstelling waarin
organisaties als losse **cellen** gesimuleerd worden. Doel is dat het decentrale
principe uit [RFC-022](https://github.com/MinBZK/regelrecht/blob/main/docs/src/content/rfcs/rfc-022.md)
niet alleen beweerd maar ook gebouwd én weerlegd kan worden. Deze eerste stap
levert één cel, zonder verkeer tussen cellen.

## Wat er staat

- **`Cell`** houdt een `LawExecutionService` met uitsluitend haar eigen wetten en
  een `ChronicleStore` met haar eigen feiten. Het store-veld is privé en heeft
  geen accessor — dat een andere cel er niet bij kan, is een compileerfout en
  geen afspraak.
- **Eén publieke ingang** voor consumenten: `reduce(lexostatus, params,
  op_moment)`. Een onbekende naam levert een nette fout die opsomt wat de cel wél
  publiceert; een ontbrekende, onbekende of verkeerd getypeerde parameter wordt
  geweigerd.
- **Lexostatus-definities zijn data, geen Rust.** Ze staan in de cel-configuratie
  van het scenario, met gedocumenteerde parameters, zodat een consument geen
  eigen reductie kan injecteren (RFC-022 §4.1). Een reductie mag alleen een
  regeling raken die de cel zélf geladen heeft; dat wordt geweigerd bij het
  optuigen van de cel, niet pas bij de eerste vraag.
- **Gedocumenteerd geldt aan beide kanten.** Naast haar parameters documenteert
  een definitie ook haar uitkomsten (`outputs`), en `reduce` projecteert het
  antwoord daarop. De engine levert bij een gevraagde uitkomst ook wat er
  causaal mee meekomt; berekend is niet gepubliceerd, dus dat blijft binnen de
  cel. Een uitkomstnaam die de regeling niet kent, wordt net als een vreemde
  regeling geweigerd bij het optuigen.
- **Kroniekstore met tijdas.** Per stroom tellen alleen vastleggingen tot en met
  het gevraagde moment mee; daarvan wint per sleutel en per veld de laatste. Geen
  wandklok, dus reproduceerbaar.
- **Scenarioformaat (YAML)** met `cells` en `queries`, plus een loader en een
  runner. De assertie hoort bij het scenario: een nieuw testgeval is een bestand,
  geen nieuwe Rust. Het formaat staat in de crate-README.

Het meegeleverde scenario tuigt de cel `toeslagen` op (zorgtoeslag + AWIR +
standaardpremie) en controleert drie vragen. De eerste levert dezelfde
zorgtoeslag als de bestaande BDD-scenario's van diezelfde wet; het tweede paar
stelt dezelfde vraag op twee momenten en laat zien dat `op_moment` bepaalt welke
feiten zichtbaar zijn.

Draaien kan met `just simulate [pad]`; `just test` draait elk scenario in
`packages/simulator/scenarios/` mee.

## Wat er bewust niet staat

Verkeer tussen cellen, veiligheidscontext, observatielog, meerdere cellen in één
scenario en een echte tijdlijn met asynchrone intake. `packages/engine` is
ongewijzigd. De nieuwe crate wordt in geen enkel image gebouwd en is daarom uit
de Rust-Dockerfiles weggeknipt, zoals de andere niet-gedeployde crates.

## Checks

`just format`, `just lint`, `just build-check`, `just validate` en
`just test-no-docker` zijn groen; ook de node-poorten `deploy-filters-test` en
`dockerfile-consistency-test`.
