### PR TITLE
feat(docs): rfc-relaties als navigatielijst in de zijbalk

### DIFF
--- a/docs/src/content/rfcs/rfc-002.md
+++ b/docs/src/content/rfcs/rfc-002.md
@@ -1,5 +1,6 @@
 ---
 title: "RFC-002: Bevoegdheid (Authority) in Machine-Readable Law"
+short_title: Bevoegdheid
 status: Accepted
 implementation: Implemented
 date: '2025-11-21'

--- a/docs/src/content/rfcs/rfc-003.md
+++ b/docs/src/content/rfcs/rfc-003.md
@@ -1,5 +1,6 @@
 ---
 title: "RFC-003: Inversion of Control for Delegated Legislation"
+short_title: Inversion of Control
 status: Accepted
 implementation: Implemented
 date: '2026-03-15'

--- a/docs/src/content/rfcs/rfc-005.md
+++ b/docs/src/content/rfcs/rfc-005.md
@@ -1,5 +1,6 @@
 ---
 title: "RFC-005: Stand-off Notes for Legal Texts"
+short_title: Stand-off Notes
 status: Accepted
 implementation: Implemented
 date: '2025-12-16'

--- a/docs/src/content/rfcs/rfc-006.md
+++ b/docs/src/content/rfcs/rfc-006.md
@@ -1,5 +1,6 @@
 ---
 title: "RFC-006: Language Choice for Law Execution Engine"
+short_title: Engine Language Choice
 status: Accepted
 implementation: Implemented
 date: '2026-01-26'

--- a/docs/src/content/rfcs/rfc-014.md
+++ b/docs/src/content/rfcs/rfc-014.md
@@ -1,5 +1,6 @@
 ---
 title: "RFC-014: Engine Conformance Test Suite"
+short_title: Engine Conformance
 status: Accepted
 implementation: Partially implemented
 date: '2026-04-02'

--- a/docs/src/content/rfcs/rfc-018.md
+++ b/docs/src/content/rfcs/rfc-018.md
@@ -1,5 +1,6 @@
 ---
 title: "RFC-018: Note Infrastructure: Storage, Resolution, and Editor Integration"
+short_title: Note Infrastructure
 status: Accepted
 implementation: Implemented
 date: '2026-05-18'

--- a/docs/src/content/rfcs/rfc-019.md
+++ b/docs/src/content/rfcs/rfc-019.md
@@ -1,5 +1,6 @@
 ---
 title: "RFC-019: Law End Dates (valid_to) and Expired-Reference Handling"
+short_title: Law End Dates
 status: Accepted
 implementation: Implemented
 date: '2026-06-08'

--- a/docs/src/content/rfcs/rfc-020.md
+++ b/docs/src/content/rfcs/rfc-020.md
@@ -1,5 +1,6 @@
 ---
 title: "RFC-020: Date-Aware Reference Resolution (as_of)"
+short_title: Date-Aware Resolution
 status: Draft
 implementation: Not implemented
 date: '2026-06-09'

--- a/docs/src/content/rfcs/rfc-021.md
+++ b/docs/src/content/rfcs/rfc-021.md
@@ -1,5 +1,6 @@
 ---
 title: "RFC-021: Date Comparison and Difference Operations"
+short_title: Date Operations
 status: Accepted
 implementation: Implemented
 date: '2026-06-01'

--- a/docs/src/content/rfcs/rfc-022.md
+++ b/docs/src/content/rfcs/rfc-022.md
@@ -1,5 +1,6 @@
 ---
 title: "RFC-022: Chronolexogram types in the schema and the cell model"
+short_title: Chronolexogram Types
 status: Draft
 implementation: Not implemented
 date: '2026-05-26'

--- a/docs/src/lib/rfcs.ts
+++ b/docs/src/lib/rfcs.ts
@@ -44,6 +44,8 @@ export interface RfcLink {
   id: string
   /** Descriptive title, e.g. "Uniform Operation Syntax" */
   title: string
+  /** `short_title` when set, else the title — the label shown in a nav list */
+  shortTitle: string
   /** Site-relative link, e.g. "/rfcs/rfc-004" */
   link: string
 }
@@ -206,6 +208,7 @@ export function rfcRelations(): Map<
     num: r.num,
     id: r.id,
     title: r.title,
+    shortTitle: r.shortTitle,
     link: r.link,
   })
 

--- a/docs/src/pages/rfcs/[slug].astro
+++ b/docs/src/pages/rfcs/[slug].astro
@@ -21,15 +21,23 @@ const pathname = '/rfcs/' + entry.id.replace(/\.md$/, '');
 
 // RFC metadata from frontmatter. Author(s) and date render as an nldd-identity
 // under the title; status and implementation render as side-by-side nldd-tags
-// (colour via the shared rfcStatusColor so it cannot drift from the index),
-// with the cross-references as a rich-text line beneath. No bespoke CSS — the
-// tag row reuses the index's nldd-container wrap layout, and it sits outside
-// the content rich-text so the wrap flow isn't flattened by prose typography.
+// (colour via the shared rfcStatusColor so it cannot drift from the index).
+// No bespoke CSS — the tag row reuses the index's nldd-container wrap layout,
+// and it sits outside the content rich-text so the wrap flow isn't flattened
+// by prose typography.
 const { status, implementation, date, authors } = entry.data;
 // Forward (Depends on) and reverse (Required by) links, resolved against the
 // real RFC set in rfcs.ts so back-references cannot drift from the forward ones.
+// They are navigation, not prose, so they live in the sidebar next to the
+// outline, as navigation lists in the same overline + title shape the RFC
+// index uses. The short title keeps a row to one or two lines; the full title
+// travels along as the row's tooltip when the two differ.
 const rfcNum = parseInt(entry.id.match(/rfc-(\d+)/)?.[1] ?? '', 10);
 const relations = rfcRelations().get(rfcNum) ?? { dependsOn: [], requiredBy: [] };
+const relationGroups = [
+  { label: 'Depends on', items: relations.dependsOn },
+  { label: 'Required by', items: relations.requiredBy },
+].filter((g) => g.items.length > 0);
 // Edit-link base for this page (whole-file sidebar link + the per-selection
 // line-range affordance both build off it).
 const editBase = entry.filePath
@@ -75,41 +83,35 @@ const title = pageTitle + ' · RegelRecht';
         </>
       )}
     </div>
-    <nldd-container slot="sidebar" padding="16" padding-top="8">
+    {/*
+      Sections (outline, relation groups, edit link) are separated by gap
+      alone: every list row already carries its own rule, so a divider here
+      would double it.
+    */}
+    <nldd-container slot="sidebar" padding="16" padding-top="8" gap="24">
       <DocsOutline headings={headings} />
-      <nldd-spacer size="16" />
+      {relationGroups.map((group) => (
+        // The group label pattern (xs, medium, secondary) is the one the
+        // roadmap's werkpakket sidebar uses for its "Kerngegevens" labels.
+        <nldd-container gap="4">
+          <nldd-text size="xs" weight="medium" color="secondary">
+            {group.label}
+          </nldd-text>
+          <nldd-list type="navigation" variant="simple" aria-label={group.label}>
+            {group.items.map((r) => (
+              <nldd-list-item
+                href={r.link}
+                title={r.shortTitle !== r.title ? r.title : undefined}
+              >
+                <nldd-text-cell overline={r.id} text={r.shortTitle} />
+              </nldd-list-item>
+            ))}
+          </nldd-list>
+        </nldd-container>
+      ))}
       <EditLink filePath={entry.filePath} />
     </nldd-container>
     <div>
-      {(relations.dependsOn.length > 0 || relations.requiredBy.length > 0) && (
-        <>
-          <nldd-rich-text centered>
-            <dl>
-              {relations.dependsOn.length > 0 && (
-                <>
-                  <dt>Depends on</dt>
-                  <dd>
-                    {relations.dependsOn.map((r, i) => (
-                      <span>{i > 0 ? ', ' : ''}<a href={r.link}>{r.id}</a> ({r.title})</span>
-                    ))}
-                  </dd>
-                </>
-              )}
-              {relations.requiredBy.length > 0 && (
-                <>
-                  <dt>Required by</dt>
-                  <dd>
-                    {relations.requiredBy.map((r, i) => (
-                      <span>{i > 0 ? ', ' : ''}<a href={r.link}>{r.id}</a> ({r.title})</span>
-                    ))}
-                  </dd>
-                </>
-              )}
-            </dl>
-          </nldd-rich-text>
-          <nldd-spacer size="16" />
-        </>
-      )}
       <nldd-rich-text data-edit-base={editBase} centered>
         <Content />
       </nldd-rich-text>


### PR DESCRIPTION
## Wat

"Depends on" en "Required by" op een RFC-pagina stonden als een komma-gescheiden zin met volledige titels tussen haakjes boven het artikel. Dat liep over vier regels, gaf haakjes-in-haakjes (`(valid_to) ... Handling))`) en maakte alleen het RFC-nummer klikbaar.

Ze staan nu in de zijbalk onder de outline, als navigatielijsten in dezelfde vorm als het RFC-overzicht: nummer als overline, korte titel als tekst, één rij per RFC. De volledige titel gaat mee als tooltip wanneer die van de korte afwijkt.

## Hoe

- `rfcRelations()` geeft naast `title` nu ook `shortTitle` door.
- Tien RFC's met een lange titel krijgen een `short_title` (002, 003, 005, 006, 014, 018, 019, 020, 021, 022). Het linkermenu gebruikt dat veld al, dus dat wordt hiermee ook rustiger.
- De zijbalk-secties (outline, relaties, edit-link) zijn gescheiden door gap alleen. Elke lijstrij heeft al een eigen lijn, een `nldd-divider` ertussen gaf een dubbele lijn.
- Geen eigen CSS. Het groepslabel (`nldd-text` xs, medium, secondary) is het patroon dat de werkpakket-zijbalk op de roadmap al gebruikt.

Gecontroleerd met `npm run build`, de RFC-coverage-, roadmap-, heading-order- en link-checks.
