### PR TITLE
feat(docs): herstructureer de roadmap-matrix met swimlanes

### DIFF
--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roadmap
-description: Onderhoudt de inhoud van de roadmap op /roadmap — werkpakketten toevoegen, wijzigen, verplaatsen of verwijderen, onderzoeksvragen schrijven en aan een sectie van het position paper koppelen, en RFC's koppelen die het ontwerp beschrijven. Gebruik dit bij "voeg een werkpakket toe", "verplaats X naar de Hoe-fase", "zet er een onderzoeksvraag bij", of het bijwerken van fases en disciplines.
+description: Onderhoudt de inhoud van de roadmap op /roadmap — werkpakketten toevoegen, wijzigen, verplaatsen of verwijderen, onderzoeksvragen schrijven en aan een sectie van het position paper koppelen, en RFC's koppelen die het ontwerp beschrijven. Gebruik dit bij "voeg een werkpakket toe", "verplaats X naar de Hoe-fase", "zet er een onderzoeksvraag bij", of het bijwerken van fases, disciplines en swimlanes.
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write
 ---
@@ -19,7 +19,7 @@ redenering erachter in de commits van PR #1317.
 
 ```
 docs/src/content/roadmap/werkpakketten/<uuid>.md   één bestand per werkpakket
-docs/src/data/roadmap-config.json                  de fases en de disciplines
+docs/src/data/roadmap-config.json                  de fases, disciplines en swimlanes
 ```
 
 De bestandsnaam ís het `id` uit de frontmatter. Dat wordt bij de build
@@ -92,9 +92,13 @@ samenhangIds: []
 
 ### Wat er in de velden mag
 
-`faseId` — een van `wat`, `wat-fase-2`, `hoe`, `waar`, `garantie`.
+`faseId` — een van `wat`, `wat-fase-2`, `hoe`, `waar`, `garantie`. Dit is een
+procesvolwassenheids-fasering (Fase I t/m V), geen tijdas: de Wat-fase is met
+opzet in twee stappen geknipt (fundering/definitie, dan verdieping/onderzoek)
+in plaats van er een aparte tijdsindeling naast te zetten — dat las als twee
+losse assen in één matrix. Zie de discussie in PR #1356.
 `disciplineId` — een van `techniek`, `recht`, `mensen`, `ethiek`,
-`service-design`.
+`service-design`, `samenwerking`, `transitie-ondersteuning`.
 
 Beide staan in `roadmap-config.json`; een waarde die daar niet in staat laat de
 build vallen met de naam van het werkpakket erbij.
@@ -255,13 +259,30 @@ zegt alleen waar het misgaat.
 ## Fases en disciplines wijzigen
 
 Die staan in `roadmap-config.json`. Een fase heeft een `volgnummer` dat de
-kolomvolgorde bepaalt; disciplines staan in de volgorde van het bestand.
+kolomvolgorde bepaalt.
+
+Disciplines zijn gegroepeerd in `swimlanes`: elke swimlane heeft een `naam` en
+een `disciplineIds`-lijst, en die volgorde — swimlane voor swimlane, en
+binnen een swimlane de volgorde van `disciplineIds` — bepaalt de rijvolgorde
+op de matrix, niet de volgorde van het `disciplines`-blok zelf. Een swimlane
+met meer dan één discipline krijgt een eigen, opvallende bannerrij erboven;
+een swimlane met precies één discipline niet — die ene rij draagt dan zelf de
+naam en de nadrukkelijke stijl van de swimlane (zie `matrixRijen` in
+`pages/roadmap/index.astro`), anders zou dezelfde naam twee keer vlak boven
+elkaar staan.
+
+**Elke discipline moet in precies één swimlane staan.** Een nieuwe discipline
+toevoegen aan `disciplines` zonder 'm ook in een `disciplineIds`-lijst te
+zetten laat de build vallen op `assertSwimlanesMatchDisciplines`
+(`lib/roadmap.ts`) — net als een `disciplineId` die niet bestaat, of die in
+twee swimlanes tegelijk staat. Dat is met opzet een harde fout: een discipline
+buiten elke swimlane zou stilzwijgend nergens renderen.
 
 Een fase of discipline verwijderen kan alleen als geen enkel werkpakket er nog
 naar wijst — anders faalt de build. Zoek eerst wie er hangt:
 
 ```bash
-grep -l 'faseId: hoe' docs/src/content/roadmap/werkpakketten/*.md
+grep -l 'faseId: garantie' docs/src/content/roadmap/werkpakketten/*.md
 ```
 
 **Een categorie toevoegen aan `CATEGORIEEN` in `docs/src/lib/roadmap.ts` is
@@ -283,6 +304,7 @@ aan zodra je `/roadmap` echt opvraagt. Vertrouw op `docs-build`.
 `docs-build` faalt met een leesbare melding bij:
 
 - een onbekende `faseId` of `disciplineId`
+- een discipline die in geen, of in meer dan één, swimlane staat
 - een `samenhangId` dat nergens heen wijst
 - twee bestanden met hetzelfde `id`, of een bestandsnaam die niet het `id` is
 - een `paper:`-anker dat niet in het paper staat

--- a/docs/src/components/RoadmapMatrixCel.astro
+++ b/docs/src/components/RoadmapMatrixCel.astro
@@ -1,0 +1,100 @@
+---
+/*
+ * One matrix cell: the stack of werkpakket-cards for a fase/discipline
+ * combination.
+ *
+ * Split out of index.astro so the (sizeable) card markup lives in one place
+ * instead of being inlined once per fase column in the matrix template.
+ */
+import {
+  GEEN_CATEGORIE,
+  getPrioriteit,
+  getCategorie,
+  getCapability,
+  type WerkpakketData,
+} from '~/lib/roadmap';
+
+interface Props {
+  cel: { data: WerkpakketData }[];
+  class?: string;
+}
+
+const { cel, class: className } = Astro.props;
+---
+
+<td class:list={['rr-matrix__cell', className]}>
+  <nldd-container gap="8">
+    {
+      cel.map((wp) => {
+        const prioriteit = getPrioriteit(wp.data.prioriteit);
+        const categorie = getCategorie(wp.data.categorie);
+        const capability = getCapability(wp.data.capability);
+        const tags = [
+          prioriteit && {
+            color: prioriteit.tagColor,
+            text: prioriteit.label,
+            label: prioriteit.label,
+          },
+          wp.data.omvang && {
+            color: 'neutral',
+            text: wp.data.omvang,
+            label: `Omvang ${wp.data.omvang}`,
+          },
+          categorie && {
+            color: 'neutral',
+            text: categorie.label,
+            label: categorie.label,
+          },
+          capability && {
+            color: 'accent',
+            text: capability.label.split(' ')[0],
+            label: capability.label,
+          },
+        ].filter(Boolean);
+        return (
+          <nldd-card
+            class="rr-wp-card"
+            href={`/roadmap/werkpakket/${wp.data.id}`}
+            accessible-label={[
+              wp.data.titel,
+              ...tags.map((t: any) => t.label),
+              ...(wp.data.rfcs.length
+                ? [`${wp.data.rfcs.length} RFC${wp.data.rfcs.length > 1 ? "'s" : ''}`]
+                : []),
+            ].join(', ')}
+            data-categorie={wp.data.categorie || GEEN_CATEGORIE}
+          >
+            {/* nldd-card leaves padding to a nested container by design;
+                without one the content sits flush against the border. */}
+            <nldd-container padding="12" gap="8">
+              <nldd-text size="sm" weight="medium">
+                {wp.data.titel}
+              </nldd-text>
+              {(tags.length > 0 || wp.data.rfcs.length > 0) && (
+                <nldd-container layout="wrap" gap="4" vertical-alignment="center">
+                  {tags.map((tag: any) => (
+                    <nldd-tag
+                      color={tag.color}
+                      text={tag.text}
+                      accessible-label={tag.label}
+                      size="sm"
+                    />
+                  ))}
+                  {/* Not a tag: the card already carries up to four, and a
+                      fifth would make the title compete with its own
+                      metadata. This is a quiet count of the design behind
+                      the werkpakket — the detail page names them. */}
+                  {wp.data.rfcs.length > 0 && (
+                    <nldd-text size="xs" color="secondary">
+                      {wp.data.rfcs.length} RFC{wp.data.rfcs.length > 1 ? "'s" : ''}
+                    </nldd-text>
+                  )}
+                </nldd-container>
+              )}
+            </nldd-container>
+          </nldd-card>
+        );
+      })
+    }
+  </nldd-container>
+</td>

--- a/docs/src/components/RoadmapMatrixCel.astro
+++ b/docs/src/components/RoadmapMatrixCel.astro
@@ -17,12 +17,14 @@ import {
 interface Props {
   cel: { data: WerkpakketData }[];
   class?: string;
+  /** Space-separated header ids: swimlane, discipline, fase — see index.astro. */
+  headers: string;
 }
 
-const { cel, class: className } = Astro.props;
+const { cel, class: className, headers } = Astro.props;
 ---
 
-<td class:list={['rr-matrix__cell', className]}>
+<td class:list={['rr-matrix__cell', className]} headers={headers}>
   <nldd-container gap="8">
     {
       cel.map((wp) => {

--- a/docs/src/content/roadmap/werkpakketten/5124234d-b9e3-4a40-940b-382e83e844c8.md
+++ b/docs/src/content/roadmap/werkpakketten/5124234d-b9e3-4a40-940b-382e83e844c8.md
@@ -1,0 +1,20 @@
+---
+id: 5124234d-b9e3-4a40-940b-382e83e844c8
+titel: Bewustwording van de opgave en de bet
+faseId: wat
+disciplineId: transitie-ondersteuning
+prioriteit: ''
+omvang: ''
+categorie: bet
+capability: ''
+capaciteit: ''
+toelichting: |-
+  Geven van demo's en faciliteren van (bestuurlijke) bijeenkomsten rondom "van
+  wet naar digitale werking".
+volgorde: 1000
+onderzoek: ''
+bouw: ''
+rfcs: []
+onderzoeksvragen: []
+samenhangIds: []
+---

--- a/docs/src/content/roadmap/werkpakketten/8713c88b-efa2-407e-902b-667691afe962.md
+++ b/docs/src/content/roadmap/werkpakketten/8713c88b-efa2-407e-902b-667691afe962.md
@@ -1,0 +1,25 @@
+---
+id: 8713c88b-efa2-407e-902b-667691afe962
+titel: Interoperabiliteit van regeltalen en analysemethoden
+faseId: wat
+disciplineId: samenwerking
+prioriteit: ''
+omvang: ''
+categorie: pivot
+capability: ''
+capaciteit: ''
+toelichting: |-
+  Interoperabiliteit: is het wenselijk en mogelijk om verschillende methoden
+  interoperabel te maken / uitwisselbaar?
+volgorde: 1000
+onderzoek: open
+bouw: ''
+rfcs: []
+onderzoeksvragen:
+  - vraag: >-
+      Is het wenselijk en mogelijk om verschillende methoden interoperabel te
+      maken / uitwisselbaar?
+    paper: sec:engines
+  - Hoe navolgbaar is het?
+samenhangIds: []
+---

--- a/docs/src/data/roadmap-config.json
+++ b/docs/src/data/roadmap-config.json
@@ -3,32 +3,32 @@
     {
       "id": "wat",
       "volgnummer": 1,
-      "naam": "Wat-fase",
-      "ondertitel": "Fundering & Definitie"
+      "naam": "Fase I",
+      "ondertitel": "Wat · Fundering en definitie"
     },
     {
       "id": "wat-fase-2",
       "volgnummer": 2,
-      "naam": "Wat-fase 2",
-      "ondertitel": ""
+      "naam": "Fase II",
+      "ondertitel": "Wat · Verdieping en onderzoek"
     },
     {
       "id": "hoe",
       "volgnummer": 3,
-      "naam": "Hoe-fase",
-      "ondertitel": "Operationalisering & Tooling"
+      "naam": "Fase III",
+      "ondertitel": "Hoe · Operationalisering en tooling"
     },
     {
       "id": "waar",
       "volgnummer": 4,
-      "naam": "Waar-fase",
-      "ondertitel": "Institutionele Verankering"
+      "naam": "Fase IV",
+      "ondertitel": "Waar · Institutionele verankering"
     },
     {
       "id": "garantie",
       "volgnummer": 5,
-      "naam": "Garantie-fase",
-      "ondertitel": "Maturiteit & Systeemwaarborging"
+      "naam": "Fase V",
+      "ondertitel": "Garantie · Maturiteit en systeemwaarborging"
     }
   ],
   "disciplines": [
@@ -56,6 +56,38 @@
       "id": "ethiek",
       "naam": "Ethiek & Waarden",
       "ondertitel": "Van principes naar toetsbare waarborgen"
+    },
+    {
+      "id": "samenwerking",
+      "naam": "Samenwerking met andere initiatieven",
+      "ondertitel": ""
+    },
+    {
+      "id": "transitie-ondersteuning",
+      "naam": "Transitie-ondersteuning",
+      "ondertitel": ""
+    }
+  ],
+  "swimlanes": [
+    {
+      "id": "invloedssfeer",
+      "naam": "Scope RegelRecht",
+      "disciplineIds": ["techniek", "service-design", "mensen"]
+    },
+    {
+      "id": "onderzoek",
+      "naam": "Onderzoek",
+      "disciplineIds": ["recht", "ethiek"]
+    },
+    {
+      "id": "samenwerking",
+      "naam": "Samenwerking met andere initiatieven",
+      "disciplineIds": ["samenwerking"]
+    },
+    {
+      "id": "transitie-ondersteuning",
+      "naam": "Transitie-ondersteuning",
+      "disciplineIds": ["transitie-ondersteuning"]
     }
   ]
 }

--- a/docs/src/lib/roadmap.ts
+++ b/docs/src/lib/roadmap.ts
@@ -29,6 +29,19 @@ export interface Discipline {
   ondertitel: string;
 }
 
+/**
+ * A swimlane: the matrix's real grouping on the vertical axis. Disciplines
+ * are the rows the matrix draws; a swimlane says which of them belong
+ * together and in which order, top to bottom. One discipline belongs to
+ * exactly one swimlane — enforced at load time, see the check below
+ * `disciplines`.
+ */
+export interface Swimlane {
+  id: string;
+  naam: string;
+  disciplineIds: string[];
+}
+
 /** A werkpakket's frontmatter, mirroring the zod schema in content.config.ts. */
 export interface WerkpakketData {
   id: string;
@@ -191,6 +204,15 @@ const configSchema = z.object({
       }),
     )
     .min(1),
+  swimlanes: z
+    .array(
+      z.object({
+        id: z.string().min(1),
+        naam: z.string().min(1),
+        disciplineIds: z.array(z.string().min(1)).min(1),
+      }),
+    )
+    .min(1),
 });
 
 const config = configSchema.parse(configJson);
@@ -199,10 +221,57 @@ export const fases: Fase[] = [...config.fases].sort(
   (a, b) => a.volgnummer - b.volgnummer,
 );
 export const disciplines: Discipline[] = config.disciplines;
+export const swimlanes: Swimlane[] = config.swimlanes;
 
 export const getFase = (id: string) => fases.find((f) => f.id === id);
 export const getDiscipline = (id: string) =>
   disciplines.find((d) => d.id === id);
+
+/**
+ * Fail the build when swimlanes and disciplines disagree about which rows
+ * exist: a disciplineId a swimlane points at but that isn't in
+ * `disciplines`, a discipline in two swimlanes at once (it would render
+ * twice), or a discipline in none (it would silently not render at all,
+ * the same failure mode `assertReferencesResolve` guards against for
+ * werkpakketten). This runs at import time, like the zod parse above,
+ * because roadmap-config.json is static — there is no per-request state
+ * that could still make it valid.
+ */
+function assertSwimlanesMatchDisciplines(): void {
+  const disciplineIds = new Set(disciplines.map((d) => d.id));
+  const gezien = new Set<string>();
+  const problems: string[] = [];
+
+  for (const lane of swimlanes) {
+    for (const id of lane.disciplineIds) {
+      if (!disciplineIds.has(id)) {
+        problems.push(
+          `swimlane "${lane.id}" verwijst naar onbekende disciplineId "${id}"`,
+        );
+        continue;
+      }
+      if (gezien.has(id)) {
+        problems.push(`disciplineId "${id}" zit in meer dan één swimlane`);
+        continue;
+      }
+      gezien.add(id);
+    }
+  }
+
+  for (const id of disciplineIds) {
+    if (!gezien.has(id)) {
+      problems.push(`discipline "${id}" zit in geen enkele swimlane`);
+    }
+  }
+
+  if (problems.length) {
+    throw new Error(
+      `roadmap-config.json: swimlanes en disciplines komen niet overeen:\n  ${problems.join('\n  ')}`,
+    );
+  }
+}
+
+assertSwimlanesMatchDisciplines();
 
 /** Placeholder wording for fields the roadmap has not filled in yet. */
 export const NIET_BEPAALD = 'Nog niet bepaald';

--- a/docs/src/pages/roadmap/index.astro
+++ b/docs/src/pages/roadmap/index.astro
@@ -72,6 +72,7 @@ assertFilterRules(roadmapCss);
 interface MatrixRow {
   discipline: Discipline;
   label: string;
+  laneId: string;
   bar?: { naam: string; rowspan: number; zichtbaar: boolean };
 }
 const matrixRijen: MatrixRow[] = swimlanes.flatMap((lane) => {
@@ -79,6 +80,7 @@ const matrixRijen: MatrixRow[] = swimlanes.flatMap((lane) => {
   return laneDisciplines.map((discipline, index) => ({
     discipline,
     label: discipline.naam,
+    laneId: lane.id,
     bar:
       index === 0
         ? {
@@ -91,6 +93,15 @@ const matrixRijen: MatrixRow[] = swimlanes.flatMap((lane) => {
         : undefined,
   }));
 });
+
+// Ids for the `headers` attribute below: with two levels of row header (the
+// swimlane bar spans several rows, the discipline header one), a screen
+// reader can no longer infer the association from `scope` alone — pa11y's
+// htmlcs runner flags exactly that ("multiple levels of th elements"). Every
+// <td> names all three headers that apply to it explicitly instead.
+const faseHeaderId = (faseId: string) => `rr-fase-${faseId}`;
+const disciplineHeaderId = (disciplineId: string) => `rr-discipline-${disciplineId}`;
+const swimlaneHeaderId = (laneId: string) => `rr-swimlane-${laneId}`;
 
 const pathname = '/roadmap';
 ---
@@ -169,7 +180,11 @@ const pathname = '/roadmap';
               ></td>
               {
                 fases.map((fase) => (
-                  <th scope="col" class="rr-matrix__header rr-matrix__header--fase">
+                  <th
+                    scope="col"
+                    id={faseHeaderId(fase.id)}
+                    class="rr-matrix__header rr-matrix__header--fase"
+                  >
                     <nldd-container gap="4" horizontal-alignment="center">
                       <nldd-text size="md" weight="bold">{fase.naam}</nldd-text>
                       {fase.ondertitel && (
@@ -190,6 +205,7 @@ const pathname = '/roadmap';
                     {rij.bar && (
                       <th
                         scope="rowgroup"
+                        id={swimlaneHeaderId(rij.laneId)}
                         rowspan={rij.bar.rowspan}
                         style={`grid-row: span ${rij.bar.rowspan}`}
                         class="rr-matrix__header rr-matrix__header--swimlanebalk"
@@ -205,6 +221,7 @@ const pathname = '/roadmap';
                     )}
                     <th
                       scope="row"
+                      id={disciplineHeaderId(rij.discipline.id)}
                       class="rr-matrix__header rr-matrix__header--discipline"
                     >
                       <nldd-container gap="4">
@@ -220,6 +237,7 @@ const pathname = '/roadmap';
                       fases.map((fase, index) => (
                         <RoadmapMatrixCel
                           class={index > 0 ? 'rr-matrix__cell--kolom-start' : undefined}
+                          headers={`${swimlaneHeaderId(rij.laneId)} ${disciplineHeaderId(rij.discipline.id)} ${faseHeaderId(fase.id)}`}
                           cel={werkpakkettenInCel(
                             werkpakketten,
                             fase.id,

--- a/docs/src/pages/roadmap/index.astro
+++ b/docs/src/pages/roadmap/index.astro
@@ -9,21 +9,30 @@
  *
  * The matrix is a real <table>: fases are columns, disciplines are rows, and a
  * screen reader needs that relationship to place a card. CSS gives it back the
- * grid layout (see roadmap.css).
+ * grid layout (see roadmap.css). Disciplines are further grouped into
+ * swimlanes (roadmap-config.json), rendered as a narrow vertical bar to the
+ * left of the row-header column, one per swimlane, spanning down over all of
+ * its rows; see `matrixRijen` below.
+ *
+ * The five fases (Fase I..V) are the Wat/Wat/Hoe/Waar/Garantie maturity
+ * staging; each fase's ondertitel names both that stage and its theme (e.g.
+ * "Wat · Fundering en definitie"). An earlier version of this page also cut
+ * the Wat-fase into its own nested time-subkolommen (nu/half-jaar/later-ooit)
+ * — a second axis stacked inside the first, which read as two unrelated
+ * dimensions in one matrix and was dropped; see the discussion on PR #1356.
  */
 import { getCollection } from 'astro:content';
 import Base from '~/layouts/Base.astro';
+import RoadmapMatrixCel from '~/components/RoadmapMatrixCel.astro';
 import {
   fases,
-  disciplines,
+  swimlanes,
+  getDiscipline,
   FILTER_OPTIES,
-  GEEN_CATEGORIE,
-  getPrioriteit,
-  getCategorie,
-  getCapability,
   werkpakkettenInCel,
   assertReferencesResolve,
   assertFilterRules,
+  type Discipline,
 } from '~/lib/roadmap';
 import '~/styles/roadmap.css';
 // The stylesheet's own text, so the filter check below can read the rules it
@@ -37,6 +46,51 @@ const werkpakketten = await getCollection('werkpakketten');
 assertReferencesResolve(werkpakketten);
 // Fails the build when a filter option has no rule to show its cards again.
 assertFilterRules(roadmapCss);
+
+/*
+ * One row per discipline, grouped under its swimlane —
+ * assertSwimlanesMatchDisciplines() (lib/roadmap.ts) guarantees every
+ * discipline is in exactly one, so this partitions all of them without
+ * dropping or duplicating a row. The first row of each swimlane carries
+ * `bar`: the swimlane's name plus how many rows (including its own) belong
+ * to it, so the template can draw one vertical cell there spanning down —
+ * the same rowspan-via-inline-grid-style technique the header uses for its
+ * fase columns. Every later row of that swimlane leaves `bar` undefined; the
+ * grid's own auto-placement skips the column there, the same way it already
+ * skips columns under a rowspan header.
+ *
+ * `bar.zichtbaar` is false when a swimlane has exactly one discipline whose
+ * name is identical to the swimlane's own — "Transitie-ondersteuning" and
+ * "Samenwerking met andere initiatieven" both name themselves twice today.
+ * The vertical bar and the row-header would then print the same word twice,
+ * once sideways, right next to each other. The `<th>` still renders (the
+ * accessible name stays, and the coloured/bordered bar keeps running the
+ * full height of the matrix, uninterrupted), only its text is visually
+ * hidden — `.rr-sr-only` in roadmap.css. Give the discipline a name distinct
+ * from its swimlane's and both show.
+ */
+interface MatrixRow {
+  discipline: Discipline;
+  label: string;
+  bar?: { naam: string; rowspan: number; zichtbaar: boolean };
+}
+const matrixRijen: MatrixRow[] = swimlanes.flatMap((lane) => {
+  const laneDisciplines = lane.disciplineIds.map((id) => getDiscipline(id)!);
+  return laneDisciplines.map((discipline, index) => ({
+    discipline,
+    label: discipline.naam,
+    bar:
+      index === 0
+        ? {
+            naam: lane.naam,
+            rowspan: laneDisciplines.length,
+            zichtbaar: !(
+              laneDisciplines.length === 1 && lane.naam === discipline.naam
+            ),
+          }
+        : undefined,
+  }));
+});
 
 const pathname = '/roadmap';
 ---
@@ -97,18 +151,26 @@ const pathname = '/roadmap';
       >
         <table class="rr-matrix" style={`--rr-fase-count: ${fases.length}`}>
           <caption class="rr-matrix__caption">
-            Werkpakketten per fase (kolommen) en discipline (rijen).
+            Werkpakketten per fase (kolommen) en discipline (rijen). De vijf
+            fases zijn Wat (in twee stappen), Hoe, Waar en Garantie. De
+            disciplines zijn gegroepeerd in vier swimlanes: Scope RegelRecht,
+            Onderzoek, Samenwerking met andere initiatieven, en
+            Transitie-ondersteuning.
           </caption>
           <thead>
+            {/* Corner spans both the swimlane-bar column and the row-header
+                column, so the fase headers start at the same column as the
+                cards below them. */}
             <tr>
-              <td class="rr-matrix__corner"></td>
+              <td
+                class="rr-matrix__corner"
+                colspan={2}
+                style="grid-column: span 2"
+              ></td>
               {
                 fases.map((fase) => (
                   <th scope="col" class="rr-matrix__header rr-matrix__header--fase">
                     <nldd-container gap="4" horizontal-alignment="center">
-                      <nldd-text size="xs" weight="medium" color="secondary">
-                        Fase {fase.volgnummer}
-                      </nldd-text>
                       <nldd-text size="md" weight="bold">{fase.naam}</nldd-text>
                       {fase.ondertitel && (
                         <nldd-text size="xs" color="secondary">
@@ -123,116 +185,50 @@ const pathname = '/roadmap';
           </thead>
           <tbody>
             {
-              disciplines.map((discipline) => (
-                <tr>
-                  <th
-                    scope="row"
-                    class="rr-matrix__header rr-matrix__header--discipline"
-                  >
-                    <nldd-container gap="4">
-                      <nldd-text size="md" weight="bold">
-                        {discipline.naam}
-                      </nldd-text>
-                      {discipline.ondertitel && (
-                        <nldd-text size="xs" color="secondary">
-                          {discipline.ondertitel}
+              matrixRijen.map((rij) => (
+                  <tr>
+                    {rij.bar && (
+                      <th
+                        scope="rowgroup"
+                        rowspan={rij.bar.rowspan}
+                        style={`grid-row: span ${rij.bar.rowspan}`}
+                        class="rr-matrix__header rr-matrix__header--swimlanebalk"
+                      >
+                        <nldd-text
+                          size="sm"
+                          weight="bold"
+                          class={rij.bar.zichtbaar ? undefined : 'rr-sr-only'}
+                        >
+                          {rij.bar.naam}
                         </nldd-text>
-                      )}
-                    </nldd-container>
-                  </th>
-                  {
-                    fases.map((fase) => {
-                      const cel = werkpakkettenInCel(
-                        werkpakketten,
-                        fase.id,
-                        discipline.id,
-                      );
-                      return (
-                        <td class="rr-matrix__cell">
-                          <nldd-container gap="8">
-                            {cel.map((wp) => {
-                              const prioriteit = getPrioriteit(wp.data.prioriteit);
-                              const categorie = getCategorie(wp.data.categorie);
-                              const capability = getCapability(wp.data.capability);
-                              const tags = [
-                                prioriteit && {
-                                  color: prioriteit.tagColor,
-                                  text: prioriteit.label,
-                                  label: prioriteit.label,
-                                },
-                                wp.data.omvang && {
-                                  color: 'neutral',
-                                  text: wp.data.omvang,
-                                  label: `Omvang ${wp.data.omvang}`,
-                                },
-                                categorie && {
-                                  color: 'neutral',
-                                  text: categorie.label,
-                                  label: categorie.label,
-                                },
-                                capability && {
-                                  color: 'accent',
-                                  text: capability.label.split(' ')[0],
-                                  label: capability.label,
-                                },
-                              ].filter(Boolean);
-                              return (
-                                <nldd-card
-                                  class="rr-wp-card"
-                                  href={`/roadmap/werkpakket/${wp.data.id}`}
-                                  accessible-label={[
-                                    wp.data.titel,
-                                    ...tags.map((t: any) => t.label),
-                                    ...(wp.data.rfcs.length
-                                      ? [`${wp.data.rfcs.length} RFC${wp.data.rfcs.length > 1 ? "'s" : ''}`]
-                                      : []),
-                                  ].join(', ')}
-                                  data-categorie={wp.data.categorie || GEEN_CATEGORIE}
-                                >
-                                  {/* nldd-card leaves padding to a nested
-                                      container by design; without one the
-                                      content sits flush against the border. */}
-                                  <nldd-container padding="12" gap="8">
-                                    <nldd-text size="sm" weight="medium">
-                                      {wp.data.titel}
-                                    </nldd-text>
-                                    {(tags.length > 0 || wp.data.rfcs.length > 0) && (
-                                      <nldd-container
-                                        layout="wrap"
-                                        gap="4"
-                                        vertical-alignment="center"
-                                      >
-                                        {tags.map((tag: any) => (
-                                          <nldd-tag
-                                            color={tag.color}
-                                            text={tag.text}
-                                            accessible-label={tag.label}
-                                            size="sm"
-                                          />
-                                        ))}
-                                        {/* Not a tag: the card already carries
-                                            up to four, and a fifth would make
-                                            the title compete with its own
-                                            metadata. This is a quiet count of
-                                            the design behind the werkpakket —
-                                            the detail page names them. */}
-                                        {wp.data.rfcs.length > 0 && (
-                                          <nldd-text size="xs" color="secondary">
-                                            {wp.data.rfcs.length} RFC{wp.data.rfcs.length > 1 ? "'s" : ''}
-                                          </nldd-text>
-                                        )}
-                                      </nldd-container>
-                                    )}
-                                  </nldd-container>
-                                </nldd-card>
-                              );
-                            })}
-                          </nldd-container>
-                        </td>
-                      );
-                    })
-                  }
-                </tr>
+                      </th>
+                    )}
+                    <th
+                      scope="row"
+                      class="rr-matrix__header rr-matrix__header--discipline"
+                    >
+                      <nldd-container gap="4">
+                        <nldd-text size="md" weight="bold">{rij.label}</nldd-text>
+                        {rij.discipline.ondertitel && (
+                          <nldd-text size="xs" color="secondary">
+                            {rij.discipline.ondertitel}
+                          </nldd-text>
+                        )}
+                      </nldd-container>
+                    </th>
+                    {
+                      fases.map((fase, index) => (
+                        <RoadmapMatrixCel
+                          class={index > 0 ? 'rr-matrix__cell--kolom-start' : undefined}
+                          cel={werkpakkettenInCel(
+                            werkpakketten,
+                            fase.id,
+                            rij.discipline.id,
+                          )}
+                        />
+                      ))
+                    }
+                  </tr>
               ))
             }
           </tbody>

--- a/docs/src/pages/roadmap/werkpakket/[id].astro
+++ b/docs/src/pages/roadmap/werkpakket/[id].astro
@@ -145,7 +145,12 @@ const kerngegevens = [
     <nldd-title slot="header" size="1">
       <h1>{wp.titel}</h1>
       <p slot="subtitle">
-        {[fase?.naam, discipline?.naam].filter(Boolean).join(' · ')}
+        {[
+          fase && (fase.ondertitel ? `${fase.naam} · ${fase.ondertitel}` : fase.naam),
+          discipline?.naam,
+        ]
+          .filter(Boolean)
+          .join(' · ')}
       </p>
     </nldd-title>
 

--- a/docs/src/styles/roadmap.css
+++ b/docs/src/styles/roadmap.css
@@ -81,12 +81,25 @@
   overflow-x: auto;
 }
 
-/* The table lays out as one grid: `display: contents` on thead/tbody/tr lifts
-   the cells into it, so the columns line up across every row while the table
-   semantics stay intact in the accessibility tree. */
+/*
+ * The table lays out as one grid: `display: contents` on thead/tbody/tr lifts
+ * the cells into it, so the columns line up across every row while the table
+ * semantics stay intact in the accessibility tree.
+ *
+ * Three fixed tracks — the swimlane bar, the row-header, and the fases,
+ * repeated to whatever count roadmap-config.json declares (--rr-fase-count).
+ *
+ * grid-column/grid-row spans on the header cells (set inline, matching their
+ * colspan/rowspan attributes) are what makes the corner and the swimlane bar
+ * line up correctly: this grid does not rely on the browser mapping HTML
+ * colspan/rowspan to grid placement on its own.
+ */
 .rr-roadmap .rr-matrix {
   display: grid;
-  grid-template-columns: 200px repeat(var(--rr-fase-count, 5), minmax(240px, 1fr));
+  grid-template-columns:
+    36px
+    200px
+    repeat(var(--rr-fase-count, 5), minmax(240px, 1fr));
   gap: var(--primitives-space-8, 0.5rem);
   border-collapse: separate;
 }
@@ -111,16 +124,41 @@
   border: 0;
 }
 
+/*
+ * Same technique as .rr-matrix__caption, generalised: content stays in the
+ * accessibility tree (an assistive technology still reads it) but is not
+ * painted. Used on a swimlane bar's label when it would otherwise repeat,
+ * word for word, the row-header sitting right next to it — see the
+ * `bar.zichtbaar` comment in index.astro.
+ */
+.rr-roadmap .rr-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 .rr-roadmap .rr-matrix__corner {
   min-height: 1px;
   padding: 0;
   border: 0;
 }
 
-/* Only the surface, the corner and the alignment: the text inside is
-   nldd-text and its spacing is nldd-container, so no font or colour here. */
+/*
+ * Only the surface, the corner and the alignment: the text inside is
+ * nldd-text and its spacing is nldd-container, so no font or colour here.
+ * `align-items: center` keeps every header's content vertically centred, so
+ * a fase with an ondertitel (three lines) and one without (two) still line
+ * up on the same baseline instead of one sitting stuck to the top.
+ */
 .rr-roadmap .rr-matrix__header {
   display: flex;
+  align-items: center;
   padding: var(--primitives-space-12, 0.75rem);
   border-radius: var(--semantics-surfaces-corner-radius, 8px);
   background: var(--semantics-surfaces-tinted-background-color);
@@ -132,9 +170,31 @@
   justify-content: center;
 }
 
+/*
+ * A hairline between every fase column, so each reads as a distinct slice of
+ * time without needing its own boxed column.
+ */
+.rr-roadmap .rr-matrix__cell--kolom-start {
+  border-inline-start: 1px solid var(--semantics-surfaces-tinted-border-color);
+}
+
 /* The discipline label sits centred against the tall row of cards beside it. */
 .rr-roadmap .rr-matrix__header--discipline {
   align-items: center;
+}
+
+/*
+ * The swimlane bar: a narrow column of its own, one cell per swimlane
+ * spanning down over all of its rows (rowspan, set inline in the template),
+ * with the name rotated to read top-to-bottom. This is the literal
+ * "swimlane" picture — a lane running the height of its group — and it costs
+ * a dedicated column rather than sharing space with the row-header.
+ */
+.rr-roadmap .rr-matrix__header--swimlanebalk {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  justify-content: center;
+  padding-inline: var(--primitives-space-4, 0.25rem);
 }
 
 .rr-roadmap .rr-matrix__cell {


### PR DESCRIPTION
## Samenvatting

De vijf fases (Wat/Wat/Hoe/Waar/Garantie) staan, elke fase-kolom heet **Fase
I** t/m **Fase V** als hoofdlabel met de oorspronkelijke identiteit en het
thema in de ondertitel ("Wat · Fundering en definitie", "Wat · Verdieping en
onderzoek", "Hoe · Operationalisering en tooling", "Waar · Institutionele
verankering", "Garantie · Maturiteit en systeemwaarborging"). Geen apart
`tijdshorizon`-veld of geneste subkolommen binnen één fase — dat bleek als
twee losse assen in één matrix te lezen; elk werkpakket heeft gewoon de fase
die bij hem past.

Disciplines zijn gegroepeerd in vier swimlanes via `swimlanes` in
`roadmap-config.json`, bewaakt door `assertSwimlanesMatchDisciplines`:
**Scope RegelRecht** (Techniek & Architectuur, Service Design, Mens &
Proces), **Onderzoek** (Recht & Instituties, Ethiek & Waarden),
**Samenwerking met andere initiatieven**, **Transitie-ondersteuning**. Elke
swimlane krijgt een smalle verticale balk die over zijn rijen doorloopt.
Kaartrendering uit `index.astro` getrokken naar een eigen
`RoadmapMatrixCel`-component.

### Update na review (anneschuth)

- **Branch opnieuw opgebouwd vanaf `main`** in plaats van de negen commits te
  rebasen: zes daarvan waren al gesquasht op main via #1332/#1333
  (add/add-conflicten op werkpakketten), en de rest miste #1347 (categorie
  `lat`→`bar`) en #1334 (outcome-mappingwerkblad eruit). De payload is nu
  precies de zes bestanden die de matrix daadwerkelijk wijzigen.
- `SKILL.md`'s `faseId`-documentatie hersteld: die verwees nog naar de
  afgeschafte `nu`/`half-jaar`/`later-ooit`-tijdas uit een tussenstap van
  deze branch die weer is teruggedraaid. Frontmatter- en grep-voorbeeld
  meegecorrigeerd.
- `RoadmapMatrixCel.astro`'s intro-comment over tijdshorizon-subkolommen
  verwijderd (die bestaan niet (meer)), en de CSS-fallback
  `--rr-fase-count` van 3 naar 5 (het werkelijke aantal fases).
- **Samenwerking met andere initiatieven** en **Transitie-ondersteuning**
  waren twee lege swimlanes (één rij ~250px hoog zonder inhoud). Beide nu
  gevuld met een eerste werkpakket; meer volgt in een aparte PR na de eerste
  teamdag.
- Swimlane- en disciplinenaam voor "samenwerking" gelijkgetrokken
  ("Samenwerking met andere initiatieven" i.p.v. het nergens op de site
  toegelichte "WWU-domein"), zodat de bestaande zichtbaar-mechaniek
  (`bar.zichtbaar` in `index.astro`) de balktekst sr-only maakt in plaats van
  een tweede naam voor hetzelfde ding te tonen.
- Caption-tikfout "Wat, Wat, Hoe, Waar en Garantie" herschreven naar "Wat (in
  twee stappen), Hoe, Waar en Garantie".
- Detailpagina toont de fase-ondertitel weer naast "Fase I" — zonder die was
  het kale volgnummer op die plek betekenisloos.

**Niet opgelost, met opzet**: de nieuwe 36px swimlane-bar-kolom duwt Fase V
op brede viewports iets verder buiten beeld dan op productie. Dat is een
tradeoff van de nieuwe kolom, geen regressie om te patchen zonder een
bredere layoutkeuze.

### Custom CSS bovenop het design system

Per CLAUDE.md expliciet gemeld:
- `.rr-matrix__cell--kolom-start` — hairline tussen elke fase-kolom.
- `.rr-sr-only` — verbergt de balktekst visueel bij een single-discipline
  swimlane zonder hem uit de accessibility tree te halen.
- `.rr-matrix__header--swimlanebalk` — `writing-mode: vertical-rl` +
  rotatie, voor de verticaal lopende swimlane-naam.
- De vaste 36px-track voor de swimlane-bar-kolom in `grid-template-columns`.

## Test plan

- [x] `npm run build` in `docs/` (incl. alle build-gates:
      `assertReferencesResolve`, `assertFilterRules`,
      `assertSwimlanesMatchDisciplines`)
- [x] `node scripts/check-roadmap-rfcs.mjs` — alle geïmplementeerde RFC's
      hangen aan een werkpakket
- [x] Lokaal handmatig doorlopen op `/roadmap` (astro dev), gescreenshot en
      afgestemd vóór het pushen: de twee voorheen lege swimlanes tonen nu
      compacte rijen i.p.v. een 250px lege balk
- [x] Detailpagina van een nieuw werkpakket handmatig gecontroleerd
      (fase-ondertitel zichtbaar in de subtitle)
