### PR TITLE
fix(frontend): verrijk-knop zegt dat hij de hele wet verrijkt

### DIFF
--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -1906,7 +1906,7 @@ async function enrichLaw() {
     } else {
       enrichFeedback.value = {
         variant: 'success',
-        text: 'Verrijking gestart - je krijgt een taak zodra het resultaat klaarstaat.',
+        text: 'Verrijking van de hele wet gestart - je krijgt een taak per gewijzigd artikel zodra het resultaat klaarstaat.',
       };
     }
   } catch (e) {
@@ -2803,7 +2803,7 @@ async function handleActionSave() {
                     v-if="canEnrichLaw && isEnrichPane(view) && hasMachineReadable"
                     slot="overflow"
                     icon="ai"
-                    text="Genereer nieuw voorstel"
+                    text="Verrijk deze wet opnieuw"
                     @select="enrichLaw"
                   ></nldd-menu-item>
                 </nldd-toolbar>

--- a/frontend/src/components/MachineEmptyState.test.js
+++ b/frontend/src/components/MachineEmptyState.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import MachineEmptyState from './MachineEmptyState.vue';
+
+// Het knoplabel draagt twee dingen tegelijk die alleen in de tekst zichtbaar
+// zijn en die een volgende bewerking dus stilzwijgend kan platslaan:
+//
+//  1. de scope - de aanvraag kent alleen een wet en levert een voorstel per
+//     gewijzigd artikel op, dus het label mag geen artikel-scope suggereren;
+//  2. de vorm - gebiedende wijs waar de klik de actie hier uitvoert, heel
+//     werkwoord waar hij je eerst ergens heen brengt (login of traject).
+//
+// Geen enkele andere test raakt deze strings, terwijl de knop in vier panes
+// staat (Machine en YAML, in de editor en in de Bibliotheek).
+
+function mountEmpty(needs = '') {
+  return mount(MachineEmptyState, {
+    props: { canEnrich: true, needs },
+  });
+}
+
+function enrichLabel(wrapper) {
+  return wrapper.find('[data-testid="enrich-btn"]').attributes('text');
+}
+
+describe('MachineEmptyState', () => {
+  it('noemt de wet en niet het artikel waar de knop de actie hier uitvoert', () => {
+    const label = enrichLabel(mountEmpty(''));
+    expect(label).toBe('Verrijk deze wet');
+    expect(label).not.toMatch(/artikel/i);
+  });
+
+  it.each(['login', 'traject'])('gebruikt het hele werkwoord waar de knop routeert (%s)', (needs) => {
+    const label = enrichLabel(mountEmpty(needs));
+    expect(label).toBe('Deze wet verrijken');
+    expect(label).not.toMatch(/artikel/i);
+  });
+
+  it('zegt in de ondersteunende tekst dat de verrijking de hele wet raakt', () => {
+    const supporting = mountEmpty('')
+      .find('[data-testid="no-machine-readable"]')
+      .attributes('supporting-text');
+    expect(supporting).toContain('de hele wet');
+  });
+});

--- a/frontend/src/components/MachineEmptyState.vue
+++ b/frontend/src/components/MachineEmptyState.vue
@@ -56,8 +56,13 @@ const onLoginTriggerPointerdown = inject('onLoginTriggerPointerdown', () => {});
 // traject. Buiten een traject voert de knop de actie dus niet uit maar brengt
 // hij je ergens heen. Dat verschil zit in de tekst en in de vorm van het label:
 // gebiedende wijs waar het nu gebeurt, heel werkwoord waar je heen gaat.
+//
+// Het label noemt de wet en niet het artikel, want dat is wat de actie doet: de
+// aanvraag kent alleen een wet en levert een voorstel per gewijzigd artikel op.
+// Wie bij artikel 5 op deze knop drukte, kreeg taken terug voor artikel 3, 7 en
+// 12 zonder dat de knop dat ergens had gezegd.
 const actsHere = computed(() => !props.needs);
-const enrichLabel = computed(() => (actsHere.value ? 'Genereer een voorstel' : 'Voorstel genereren'));
+const enrichLabel = computed(() => (actsHere.value ? 'Verrijk deze wet' : 'Deze wet verrijken'));
 const IN_EEN_TRAJECT = 'Een voorstel komt in een traject te staan, want daar leg je wijzigingen vast.';
 const emptyText = computed(() => {
   if (props.needs === 'login') return `${IN_EEN_TRAJECT} Log in en kies een traject om dit artikel daar te openen.`;

--- a/frontend/src/composables/useEnrichState.js
+++ b/frontend/src/composables/useEnrichState.js
@@ -7,7 +7,7 @@
  * tonen en dus hetzelfde moeten melden. Die blokken stonden regel-voor-regel
  * dubbel en liepen uit elkaar: de ene helft kreeg wél een refresh van de
  * gedeelde takenlijst en de andere niet, waardoor de editor bij een deeplink
- * "Genereer een voorstel" aanbood terwijl er al een voorstel klaarlag.
+ * "Verrijk deze wet" aanbood terwijl er al een voorstel klaarlag.
  *
  * Bewust op useTaskActions gebouwd en niet op useTasks: dit is de niet-pollende
  * helft. Een view die een wet toont mag de 30s-poll van de takenlijst niet
@@ -47,8 +47,8 @@ export function useEnrichState({ trajectRef, lawId, articleNumber, reviewActive 
   // Ook hier op traject matchen: `running` is net als de takenlijst
   // account-breed, terwijl de 409 per (wet, traject) geldt
   // (`idx_unique_active_enrich_job`). Een verrijking die in traject A loopt
-  // zette de pane in traject B anders op "bezig" en verborg daar de "Genereer
-  // een voorstel"-knop voor een aanvraag die gewoon gehonoreerd zou worden.
+  // zette de pane in traject B anders op "bezig" en verborg daar de "Verrijk
+  // deze wet"-knop voor een aanvraag die gewoon gehonoreerd zou worden.
   const isEnriching = computed(() => {
     const traject = toValue(trajectRef);
     if (!traject) return false;
@@ -76,7 +76,7 @@ export function useEnrichState({ trajectRef, lawId, articleNumber, reviewActive 
   // Ook op traject matchen, niet alleen op wet: de takenlijst is account-breed
   // en dezelfde wet leeft in meerdere trajecten. Een open taak uit traject A
   // kaapte anders de pane in traject B - inclusief de "Beoordeel voorstel"-knop,
-  // die dan naar A navigeert en de "Genereer een voorstel"-knop van B verdringt.
+  // die dan naar A navigeert en de "Verrijk deze wet"-knop van B verdringt.
   // Zonder actief traject (globale corpus-weergave) matcht er dus niets: een
   // voorstel hoort bij een traject en valt daarbuiten niet te beoordelen.
   //

--- a/frontend/src/composables/useEnrichState.test.js
+++ b/frontend/src/composables/useEnrichState.test.js
@@ -117,8 +117,8 @@ describe('useEnrichState', () => {
   // De takenlijst is account-breed. Een open taak voor dezelfde wet in een
   // ander traject (of in een traject dat inmiddels verwijderd is, waarvan de
   // taak bleef staan) mag hier geen voorstel melden: de "Beoordelen"-knop zou
-  // naar dat andere traject navigeren en de "Genereer een voorstel"-knop van
-  // het actieve traject verdringen.
+  // naar dat andere traject navigeren en de "Verrijk deze wet"-knop van het
+  // actieve traject verdringen.
   it('negeert taken van een ander traject', async () => {
     apiFetch.mockResolvedValue(
       tasksResponse({
@@ -159,7 +159,7 @@ describe('useEnrichState', () => {
 
   // `running` is net zo account-breed als de takenlijst, terwijl de 409 op een
   // tweede aanvraag per (wet, traject) geldt. Een verrijking in traject A mag
-  // hier dus niet "bezig" melden en de "Genereer een voorstel"-knop verbergen.
+  // hier dus niet "bezig" melden en de "Verrijk deze wet"-knop verbergen.
   it('negeert een lopende verrijking van een ander traject', async () => {
     apiFetch.mockResolvedValue(
       tasksResponse({ running: [runningEnrich({ traject_ref: 'ander-traject-9f8e7d6c' })] }),


### PR DESCRIPTION
## Waarom

De knop om te verrijken staat in de Machine- of YAML-pane van één artikel, maar de actie is wet-breed: het endpoint kent alleen een `law_id` en de taak-flow zet chunking expliciet uit (`max_articles_per_run = 0`), zodat het resultaat een voorstel per gewijzigd artikel oplevert. Je klikte dus bij artikel 5 op "Genereer een voorstel" en kreeg taken terug voor artikel 3, 7 en 12.

De ondersteunende tekst onder de knop zei dat al wel ("Genereren verrijkt de hele wet en levert een voorstel per artikel op in dit traject"); het knoplabel, het menu-item en de melding na het starten liepen daar niet mee in de pas. Deze PR trekt die drie recht. De scope van het verrijken zelf verandert niet.

## Wat

- **Knoplabel in de lege Machine-/YAML-pane** (`MachineEmptyState`, die zowel de editor als de Bibliotheek gebruikt): "Verrijk deze wet" waar de actie ter plekke plaatsvindt, "Deze wet verrijken" waar hij naar login of traject routeert. Het bestaande onderscheid tussen gebiedende wijs (het gebeurt hier) en heel werkwoord (je gaat ergens heen) blijft intact.
- **Overflow-menu-item** in de pane-toolbar, dat alleen verschijnt als er al een machine-leesbare versie is: "Genereer nieuw voorstel" → "Verrijk deze wet opnieuw".
- **Succesmelding na het starten**: "Verrijking van de hele wet gestart - je krijgt een taak per gewijzigd artikel zodra het resultaat klaarstaat." Er komt vrijwel altijd meer dan één taak.

## Over de woordkeus

"Verrijk deze wet" / "Deze wet verrijken" zet het onderwerp van de actie (de wet) voorop in plaats van het resultaat (een voorstel). Dat is de kortste manier om te zeggen wat de knop doet en het sluit aan bij het woord dat de rest van de UI al gebruikt ("Er loopt al een verrijking voor deze wet"). Nadeel: "voorstel" verdwijnt uit het label, terwijl dat is wat je uiteindelijk te beoordelen krijgt. Een alternatief als "Genereer voorstellen voor de hele wet" houdt dat vast maar wordt lang voor een knop in een smalle pane. Als de UXer de andere kant op wil, zit de keuze op één plek (`enrichLabel` in `MachineEmptyState.vue`).

De ondersteunende tekst in de lege staat is bewust ongewijzigd gelaten: die klopte al. Daardoor staat er nu "Verrijk deze wet" boven een zin die met "Genereren" begint — inhoudelijk correct, maar een kandidaat om in dezelfde UX-sessie mee te nemen.

## Checks

`npm test -w frontend` (vitest): 80 bestanden, 880 tests groen. Geen test haakte aan op deze labels; wel stonden er comments in `useEnrichState.js`/`.test.js` die de knop bij zijn oude naam noemden — die zijn meegenomen zodat ze naar een bestaand label blijven verwijzen.
