### PR TITLE
ci: bump zad-actions naar v4.1.1 voor de environment-delete-fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -315,7 +315,7 @@ jobs:
 
       - name: Deploy to ZAD (Preview)
         id: deploy
-        uses: RijksICTGilde/zad-actions/deploy@cd577345a3c4ae025d61bb75aa67dba25a8ddc11  # v4.1.0 + env-delete fixes (zad-actions#57)
+        uses: RijksICTGilde/zad-actions/deploy@272713bbf86e8516ab436804c8fef4a534a971ee  # v4.1.1
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
           project-id: ${{ env.ZAD_PROJECT }}
@@ -450,7 +450,7 @@ jobs:
       # de bestaande config en moeten daar niet door een deploy verschuiven.
       - name: Deploy to ZAD (Production)
         id: deploy
-        uses: RijksICTGilde/zad-actions/deploy@cd577345a3c4ae025d61bb75aa67dba25a8ddc11  # v4.1.0 + env-delete fixes (zad-actions#57)
+        uses: RijksICTGilde/zad-actions/deploy@272713bbf86e8516ab436804c8fef4a534a971ee  # v4.1.1
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
           project-id: ${{ env.ZAD_PROJECT }}
@@ -507,7 +507,7 @@ jobs:
 
     steps:
       - name: Cleanup ZAD deployment and container images
-        uses: RijksICTGilde/zad-actions/cleanup@cd577345a3c4ae025d61bb75aa67dba25a8ddc11  # v4.1.0 + env-delete fixes (zad-actions#57)
+        uses: RijksICTGilde/zad-actions/cleanup@272713bbf86e8516ab436804c8fef4a534a971ee  # v4.1.1
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
           project-id: ${{ env.ZAD_PROJECT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -315,7 +315,7 @@ jobs:
 
       - name: Deploy to ZAD (Preview)
         id: deploy
-        uses: RijksICTGilde/zad-actions/deploy@b844c76eba3502b40a19be868cdf0586e322f4b8  # v4.1.0
+        uses: RijksICTGilde/zad-actions/deploy@cd577345a3c4ae025d61bb75aa67dba25a8ddc11  # v4.1.0 + env-delete fixes (zad-actions#57)
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
           project-id: ${{ env.ZAD_PROJECT }}
@@ -450,7 +450,7 @@ jobs:
       # de bestaande config en moeten daar niet door een deploy verschuiven.
       - name: Deploy to ZAD (Production)
         id: deploy
-        uses: RijksICTGilde/zad-actions/deploy@b844c76eba3502b40a19be868cdf0586e322f4b8  # v4.1.0
+        uses: RijksICTGilde/zad-actions/deploy@cd577345a3c4ae025d61bb75aa67dba25a8ddc11  # v4.1.0 + env-delete fixes (zad-actions#57)
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
           project-id: ${{ env.ZAD_PROJECT }}
@@ -507,7 +507,7 @@ jobs:
 
     steps:
       - name: Cleanup ZAD deployment and container images
-        uses: RijksICTGilde/zad-actions/cleanup@b844c76eba3502b40a19be868cdf0586e322f4b8  # v4.1.0
+        uses: RijksICTGilde/zad-actions/cleanup@cd577345a3c4ae025d61bb75aa67dba25a8ddc11  # v4.1.0 + env-delete fixes (zad-actions#57)
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
           project-id: ${{ env.ZAD_PROJECT }}

--- a/.github/workflows/scheduled-cleanup.yml
+++ b/.github/workflows/scheduled-cleanup.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 1
 
       - name: Cleanup stale ZAD deployments and GitHub environments
-        uses: RijksICTGilde/zad-actions/scheduled-cleanup@b844c76eba3502b40a19be868cdf0586e322f4b8  # v4.1.0
+        uses: RijksICTGilde/zad-actions/scheduled-cleanup@cd577345a3c4ae025d61bb75aa67dba25a8ddc11  # v4.1.0 + env-delete fixes (zad-actions#57)
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
           project-id: ${{ env.ZAD_PROJECT }}

--- a/.github/workflows/scheduled-cleanup.yml
+++ b/.github/workflows/scheduled-cleanup.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 1
 
       - name: Cleanup stale ZAD deployments and GitHub environments
-        uses: RijksICTGilde/zad-actions/scheduled-cleanup@cd577345a3c4ae025d61bb75aa67dba25a8ddc11  # v4.1.0 + env-delete fixes (zad-actions#57)
+        uses: RijksICTGilde/zad-actions/scheduled-cleanup@272713bbf86e8516ab436804c8fef4a534a971ee  # v4.1.1
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
           project-id: ${{ env.ZAD_PROJECT }}


### PR DESCRIPTION
Bumpt alle vier de zad-actions-pins van v4.1.0 (`b844c76`) naar **v4.1.1** (`272713b`).

## Waarom

v4.1.0 bevat de `%0A`-encodingbug: de environmentnaam werd met trailing newline ge-URL-encodeerd, waardoor `DELETE /environments/pr123%0A` altijd 404'de — met elk token. Daardoor liet elke gesloten PR z'n GitHub-environment achter (#1213). v4.1.1 (RijksICTGilde/zad-actions#57) fixt dat, plus de hardening eromheen: statusregel-parsing van `gh api`, 404-verificatie met het leestoken zodat een mis-scoped admin-token niet als 'already deleted' telt, eerlijke `cleaned-count`, en environment/image blijven staan zolang de ZAD-delete niet slaagde.

Closes #1213.