### PR TITLE
feat(docs): notities op regelrecht.rijks.app/notes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -743,6 +743,15 @@ docs-preview:
 docs-a11y:
     cd docs && npm run a11y
 
+# Preview the notes locally at http://localhost:4321/notes (same dev server as `just docs`)
+notes:
+    cd docs && npm run dev -- --open /notes
+
+# Check notes: filename/date agreement, URL stability, and that every
+# `regulations` id exists in corpus/regulation. Runs in CI as part of `docs-a11y`.
+notes-check:
+    node docs/scripts/check-notes.mjs
+
 # --- Architecture model ---
 
 # Generate the code-derived architecture model

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,9 +9,10 @@
     "preview": "astro preview",
     "check:rfc-coverage": "node scripts/check-rfc-coverage.mjs",
     "check:schema-version": "node scripts/check-schema-version.mjs",
-    "a11y": "astro build && node scripts/check-rfc-coverage.mjs && node scripts/check-roadmap-rfcs.mjs && node scripts/check-mermaid-alt.mjs && node scripts/check-heading-order.mjs && node scripts/check-links.mjs && node scripts/gen-pa11yci.mjs && start-server-and-test 'astro preview --port 4173' http://localhost:4173 'pa11y-ci'",
+    "a11y": "astro build && node scripts/check-rfc-coverage.mjs && node scripts/check-roadmap-rfcs.mjs && node scripts/check-notes.mjs && node scripts/check-mermaid-alt.mjs && node scripts/check-heading-order.mjs && node scripts/check-links.mjs && node scripts/gen-pa11yci.mjs && start-server-and-test 'astro preview --port 4173' http://localhost:4173 'pa11y-ci'",
     "nldd:imports": "node ../script/check-nldd-imports.mjs src src/nldd-components.js --write",
-    "nldd:check": "node ../script/check-nldd-imports.mjs src src/nldd-components.js"
+    "nldd:check": "node ../script/check-nldd-imports.mjs src src/nldd-components.js",
+    "check:notes": "node scripts/check-notes.mjs"
   },
   "dependencies": {
     "@astrojs/mdx": "^7.0.5",

--- a/docs/scripts/check-notes.mjs
+++ b/docs/scripts/check-notes.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/*
+ * Notes checks that the Astro build cannot make.
+ *
+ * Three of them:
+ *
+ *  1. Filename shape and date agreement. The published URL is derived from the
+ *     filename, the visible date from frontmatter; if they disagree, a post
+ *     lives at a URL that contradicts what it says.
+ *
+ *  2. URL stability. Every URL that exists on the default branch must still
+ *     exist here. `/notes/YYYY/MM/slug` is a published contract, so a rename
+ *     that would break a live link fails instead of shipping. Adding and
+ *     removing posts is fine; moving an existing one is not.
+ *
+ *  3. `regulations` ids resolve. The docs image builds from `docs/` alone
+ *     (see docs/Dockerfile), so the corpus is not there at build time — this
+ *     check has to run in CI, where the whole repository is checked out.
+ *
+ * Exit 0 when everything holds, 1 with one line per problem otherwise.
+ */
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, '..', '..');
+const NOTES_DIR = join(REPO, 'docs', 'src', 'content', 'notes');
+const CORPUS_DIR = join(REPO, 'corpus', 'regulation');
+const POST_PATTERN = /^(\d{4})-(\d{2})-(\d{2})-(.+)\.mdx?$/;
+
+const problems = [];
+const fail = (file, message) => problems.push(`${file}: ${message}`);
+
+/* Narrow frontmatter reader: the fields this script checks, nothing more.
+ * Astro's own schema validates the rest, with better errors than a
+ * hand-rolled parser would give. */
+function frontmatter(src) {
+  const block = /^---\r?\n([\s\S]*?)\r?\n---/.exec(src);
+  if (!block) return null;
+  const body = block[1];
+  const date = /^date:\s*['"]?(\d{4}-\d{2}-\d{2})['"]?\s*$/m.exec(body)?.[1];
+  const regulations = [];
+  const list = /^regulations:\s*\n((?:\s*-\s*.+\n?)+)/m.exec(body);
+  if (list) {
+    for (const line of list[1].split('\n')) {
+      const id = /^\s*-\s*['"]?([^'"\s]+)['"]?\s*$/.exec(line)?.[1];
+      if (id) regulations.push(id);
+    }
+  }
+  return { date, regulations };
+}
+
+/** Every law `$id` in this repository's corpus. */
+function corpusIds() {
+  const ids = new Set();
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) walk(path);
+      else if (entry.name.endsWith('.yaml')) {
+        // The directory name is not the id (a municipal by-law appends the
+        // municipality), so read the field rather than infer it.
+        const id = /^\$id:\s*(\S+)\s*$/m.exec(readFileSync(path, 'utf8'))?.[1];
+        if (id) ids.add(id);
+      }
+    }
+  };
+  if (existsSync(CORPUS_DIR)) walk(CORPUS_DIR);
+  return ids;
+}
+
+/** `2026-09-10-slug.md` -> `/notes/2026/09/slug`. */
+const urlFor = (filename) => {
+  const m = POST_PATTERN.exec(filename);
+  return m ? `/notes/${m[1]}/${m[2]}/${m[4]}` : null;
+};
+
+/**
+ * Post filenames on the default branch. Returns null when that cannot be
+ * established (no git, shallow clone, no remote) — a missing baseline is not
+ * a failure, it just means this run cannot check stability.
+ */
+function publishedFilenames() {
+  const dir = relative(REPO, NOTES_DIR).replaceAll('\\', '/');
+  const git = (args) =>
+    execFileSync('git', args, {
+      cwd: REPO,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  for (const ref of ['origin/main', 'main']) {
+    try {
+      git(['rev-parse', '--verify', '--quiet', ref]);
+    } catch {
+      continue; // ref not available in this checkout
+    }
+    try {
+      const out = git(['ls-tree', '--name-only', `${ref}:${dir}`]);
+      return out.split('\n').filter((n) => POST_PATTERN.test(n));
+    } catch {
+      // The ref exists but carries no notes directory: nothing published yet,
+      // so the baseline is empty rather than unknown.
+      return [];
+    }
+  }
+  return null;
+}
+
+const files = existsSync(NOTES_DIR)
+  ? readdirSync(NOTES_DIR).filter((f) => /\.mdx?$/.test(f))
+  : [];
+
+const ids = corpusIds();
+const urls = new Map();
+
+for (const file of files) {
+  if (file === 'README.md') continue;
+  const match = POST_PATTERN.exec(file);
+  if (!match) {
+    fail(file, 'must be named YYYY-MM-DD-slug.md — the URL is derived from it');
+    continue;
+  }
+  const [, year, month, day, slug] = match;
+  const url = `/notes/${year}/${month}/${slug}`;
+
+  if (urls.has(url)) {
+    fail(file, `collides with ${urls.get(url)} on ${url}`);
+  }
+  urls.set(url, file);
+
+  const data = frontmatter(readFileSync(join(NOTES_DIR, file), 'utf8'));
+  if (!data) {
+    fail(file, 'has no frontmatter block');
+    continue;
+  }
+  const filenameDate = `${year}-${month}-${day}`;
+  if (!data.date) {
+    fail(file, 'has no date in its frontmatter');
+  } else if (data.date !== filenameDate) {
+    fail(file, `date ${data.date} does not match the filename date ${filenameDate}`);
+  }
+
+  for (const id of data.regulations) {
+    if (ids.size === 0) break; // no corpus checked out; reported once below
+    if (!ids.has(id)) {
+      fail(file, `regulations: "${id}" is not a law $id in corpus/regulation`);
+    }
+  }
+}
+
+const published = publishedFilenames();
+if (published === null) {
+  console.log('check-notes: no main branch to compare against; URL stability not checked');
+} else {
+  for (const name of published) {
+    const url = urlFor(name);
+    if (url && !urls.has(url)) {
+      problems.push(
+        `${name}: ${url} is published on main but no note produces it any more — ` +
+          'note URLs are a contract; keep the filename',
+      );
+    }
+  }
+}
+
+if (ids.size === 0) {
+  console.log('check-notes: corpus/regulation not present; regulations ids not checked');
+}
+
+if (problems.length > 0) {
+  console.error('check-notes: problems found\n');
+  for (const p of problems) console.error(`  ${p}`);
+  process.exit(1);
+}
+
+console.log(
+  `check-notes: ${urls.size} note(s) OK` +
+    (published === null ? '' : `, ${published.length} published URL(s) intact`),
+);

--- a/docs/src/components/LandingSections.astro
+++ b/docs/src/components/LandingSections.astro
@@ -124,6 +124,12 @@ function exampleImage(key: string): ImageMetadata {
               start-icon="text-document"
               text={t.nav.research}
             />
+            <nldd-button
+              variant="inherit-tinted"
+              href="/notes"
+              start-icon="write"
+              text={t.nav.notes}
+            />
           </nldd-button-group>
         </nldd-hero>
 

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -124,4 +124,40 @@ const werkpakketten = defineCollection({
   }),
 });
 
-export const collections = { docs, rfcs, werkpakketten };
+/*
+ * Notes (/notes), one markdown file per post, named `YYYY-MM-DD-slug.md`.
+ *
+ * The glob only picks up date-prefixed files, so README.md can live next to
+ * the posts without being loaded as one. The filename is the source of the
+ * published URL (see lib/notes.ts); the `date` below is what the page and the
+ * feed show, and scripts/check-notes.mjs asserts the two agree.
+ */
+const notes = defineCollection({
+  loader: glob({
+    pattern: '[0-9][0-9][0-9][0-9]-*.{md,mdx}',
+    base: 'src/content/notes',
+  }),
+  schema: z.object({
+    title: z.string(),
+    // 'YYYY-MM-DD' as a string rather than z.date(), for the same reason the
+    // RFCs do it: no timezone shift between build and render.
+    date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be YYYY-MM-DD'),
+    // At least one author. `role` is required and `name` is not: a post may be
+    // published under a role alone.
+    authors: z
+      .array(
+        z.object({
+          name: z.string().optional(),
+          role: z.string(),
+        }),
+      )
+      .min(1),
+    summary: z.string(),
+    tags: z.array(z.string()).default([]),
+    // Optional: law `$id`s from corpus/regulation. When present, the post
+    // links through to each one in the public reading environment.
+    regulations: z.array(z.string()).optional(),
+  }),
+});
+
+export const collections = { docs, rfcs, werkpakketten, notes };

--- a/docs/src/content/notes/2026-09-10-voorbeeldnotitie.md
+++ b/docs/src/content/notes/2026-09-10-voorbeeldnotitie.md
@@ -1,0 +1,51 @@
+---
+title: 'Voorbeeldnotitie: zo ziet een notitie eruit'
+date: '2026-09-10'
+authors:
+  - name: Voorbeeld Auteur
+    role: ontwikkelaar
+  - role: jurist
+summary: >-
+  Een voorbeeldnotitie met verzonnen inhoud, die alle velden uit de frontmatter
+  gebruikt. Vervang of verwijder hem zodra er een echte notitie staat.
+tags:
+  - voorbeeld
+  - werkwijze
+regulations:
+  - wet_op_de_zorgtoeslag
+---
+
+Deze notitie bestaat om te laten zien hoe een notitie eruitziet. De inhoud is
+verzonnen. Wie de eerste echte schrijft, mag dit bestand weggooien.
+
+Ik schrijf hier in de ik-vorm, omdat een notitie van iemand komt en niet van een
+organisatie. Dat maakt ook makkelijker om iets te zeggen waar je nog niet
+helemaal uit bent.
+
+## Eén idee per notitie
+
+Deze notitie gaat over één ding: hoe zo'n notitie is opgebouwd. Alles wat daar
+niet bij hoort, hoort in een andere. Dat scheelt de lezer werk en het scheelt de
+schrijver een structuur bedenken.
+
+De opmaak is gewone markdown. Koppen beginnen op niveau twee, want de titel uit
+de frontmatter is al de `h1` van de pagina. Verder is er niets verplicht: geen
+vaste secties, geen sjabloon om in te vullen.
+
+## Wat de frontmatter doet
+
+De velden bovenaan dit bestand sturen vier dingen aan:
+
+- `title`, `date` en `summary` vullen het overzicht en de RSS-feed.
+- `authors` levert de regel onder de titel. De tweede auteur hierboven heeft
+  geen naam — een rol alleen mag ook.
+- `tags` staan onderaan. Er zijn geen tagpagina's; het is beschrijving, geen
+  navigatie.
+- `regulations` verwijst naar regelingen in het corpus. Deze notitie noemt de
+  [Wet op de zorgtoeslag](https://wetten.overheid.nl/BWBR0018451), en onderaan
+  staat automatisch een link naar diezelfde regeling in de leesomgeving.
+
+De bestandsnaam bepaalt de URL. Dit bestand heet
+`2026-09-10-voorbeeldnotitie.md` en staat dus op
+`/notes/2026/09/voorbeeldnotitie`. Die URL verandert niet meer, ook niet als de
+titel later wordt bijgeschaafd.

--- a/docs/src/content/notes/README.md
+++ b/docs/src/content/notes/README.md
@@ -1,0 +1,62 @@
+# Notes
+
+Notes published at <https://regelrecht.rijks.app/notes>. One markdown file per
+note, in this directory. They are built by the same Astro pipeline as the rest
+of the site — there is no CMS.
+
+Notes are written in Dutch. This README, like the rest of the repository
+documentation, is in English; the writing guidelines below are quoted in the
+language they were given in.
+
+Not to be confused with the stand-off notes of RFC-005 and RFC-018, which are
+annotations on legal text inside the editor. These are site pages.
+
+## Adding a note, in four steps
+
+1. **Create the file.** `docs/src/content/notes/YYYY-MM-DD-slug.md`. The filename
+   sets the URL: `2026-09-10-voorbeeldnotitie.md` is published at
+   `/notes/2026/09/voorbeeldnotitie`. Pick the slug once — the URL is a
+   contract and will not be changed afterwards.
+
+2. **Fill in the frontmatter.**
+
+   ```yaml
+   ---
+   title: 'Title of the note'
+   date: '2026-09-10'          # must match the date in the filename
+   authors:
+     - name: Your Name         # optional — a role on its own is fine
+       role: your role
+   summary: >-
+     One or two sentences. This is what the overview page and the RSS feed show.
+   tags:                       # optional
+     - a-tag
+   regulations:                # optional, law $id from corpus/regulation
+     - wet_op_de_zorgtoeslag
+   ---
+   ```
+
+   `regulations` links the note through to each law in the public reading
+   environment. A typo fails the build.
+
+3. **Write it.** Plain markdown. Start headings at `##` — the title is already
+   the page's `h1`. There is no template and there are no required sections.
+
+4. **Open a pull request.** `just notes` previews it locally at
+   <http://localhost:4321/notes>. Merging to `main` publishes it.
+
+## Writing guidelines
+
+Dit zijn defaults, geen regels. Je mag ervan afwijken als de post erom vraagt;
+je hoeft dat niet te verantwoorden.
+
+Bij het schrijven:
+
+- Eén idee per post
+- Ik-vorm, met naam en rol van de auteur erbij
+
+Voor publicatie, vier vinkjes:
+
+- Is elke afkorting bij eerste gebruik uitgeschreven?
+- Werken de links?
+- Is er iemand die dit had moeten zien voor publicatie? (meestal: nee)

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -92,9 +92,20 @@ if (isStatusPage) {
   const inResearch = isResearchRoot || pathname.startsWith('/research/');
   const isRoadmapRoot = pathname === '/roadmap/' || pathname === '/roadmap';
   const inRoadmap = isRoadmapRoot || pathname.startsWith('/roadmap/');
+  const isNotesRoot = pathname === '/notes' || pathname === '/notes/';
+  const inNotes = isNotesRoot || pathname.startsWith('/notes/');
   const cat = categoryForPath(pathname);
   const onCategoryPage = cat !== null && pathname === cat.prefix;
-  if (isRoadmapRoot) {
+  if (isNotesRoot) {
+    // The notes section root goes up to the site home. The posts are Dutch, so the
+    // page's own language sends it to the Dutch landing.
+    backHref = landingHome;
+    backText = t.nav.home;
+  } else if (inNotes) {
+    // A post goes up to the notes section overview.
+    backHref = '/notes';
+    backText = t.nav.notes;
+  } else if (isRoadmapRoot) {
     // The roadmap root goes up to the site home, in the page's own language.
     backHref = landingHome;
     backText = t.nav.home;
@@ -196,6 +207,20 @@ if (
     current: isResearchRoot,
   });
   if (!isResearchRoot) {
+    breadcrumbs.push({ text: pageTitle, current: true });
+  }
+} else if (
+  !isLanding &&
+  !isNotFound &&
+  (pathname === '/notes' || pathname.startsWith('/notes/'))
+) {
+  // The notes section sits next to the documentation, like /research and /roadmap:
+  // Home -> Notes -> note. Without this branch it would fall through to the
+  // docs trail below and claim to live under Documentation.
+  const isNotesRoot = pathname === '/notes' || pathname === '/notes/';
+  breadcrumbs.push({ text: homeText, href: homeHref });
+  breadcrumbs.push({ text: t.nav.notes, href: '/notes', current: isNotesRoot });
+  if (!isNotesRoot) {
     breadcrumbs.push({ text: pageTitle, current: true });
   }
 } else if (

--- a/docs/src/lib/landing-content.ts
+++ b/docs/src/lib/landing-content.ts
@@ -40,6 +40,7 @@ export interface LandingContent {
     signup: string
     docs: string
     research: string
+    notes: string
   }
   hero: { title: string; intro: string }
   whatIsIt: { title: string; lede: string; cards: { h: string; p: string }[] }
@@ -177,6 +178,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
       signup: 'Aanmelden',
       docs: 'Documentatie',
       research: 'Onderzoek',
+      notes: 'Notities',
     },
     hero: {
       title: 'Van wet naar digitale werking',
@@ -577,6 +579,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
         { label: 'Op de hoogte blijven', href: SIGNUP_NL_PATH },
         { label: 'Documentatie (Engels)', href: '/docs/' },
         { label: 'Onderzoek (Engels)', href: '/research/' },
+        { label: 'Notities', href: '/notes' },
       ],
       partOf: [
         'Bureau Architectuur',
@@ -634,6 +637,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
       signup: 'Sign up',
       docs: 'Documentation',
       research: 'Research',
+      notes: 'Notes (Dutch)',
     },
     hero: {
       title: 'From statute to digital execution',
@@ -1033,6 +1037,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
         { label: 'Stay informed', href: SIGNUP_EN_PATH },
         { label: 'Documentation', href: '/docs/' },
         { label: 'Research', href: '/research/' },
+        { label: 'Notes (Dutch)', href: '/notes' },
       ],
       partOf: [
         'Bureau Architectuur',

--- a/docs/src/lib/notes.ts
+++ b/docs/src/lib/notes.ts
@@ -1,0 +1,112 @@
+/*
+ * Notes helpers: URL shape, post ordering, and the outbound links a post can
+ * carry.
+ *
+ * The URL is the part worth being careful about. `/notes/YYYY/MM/slug` is a
+ * published contract: once a post is out, that path has to keep resolving.
+ * It is derived here, in one place, from the filename — never from a title, a
+ * counter, or anything else that can be edited later. `scripts/check-notes.mjs`
+ * pins the set of built URLs so a rename that would break a live link fails
+ * CI instead of shipping.
+ */
+
+/*
+ * The notes section is published on the apex host. `astro.config.mjs` sets `site` to
+ * the docs subdomain, and the same build serves both hostnames, so notes pages
+ * carry an explicit canonical and the feed builds absolute URLs from this
+ * constant rather than from `Astro.site`.
+ */
+export const NOTES_SITE = 'https://regelrecht.rijks.app';
+
+/* Public reading environment. `/library/<id>` redirects here, so this is the
+ * stable target of a `regulations` entry. */
+export const LAW_READER = 'https://editor.regelrecht.rijks.app/corpus-juris';
+
+export interface NoteAuthor {
+  /** Optional: a post may be published under a role alone. */
+  name?: string;
+  role: string;
+}
+
+/** Entry id as the glob loader reports it: `YYYY-MM-DD-slug` (no extension). */
+const ID_PATTERN = /^(\d{4})-(\d{2})-\d{2}-(.+)$/;
+
+/**
+ * Route for a post, derived from its filename.
+ *
+ * Year and month come from the filename rather than the `date` frontmatter so
+ * the file on disk and the published URL can never disagree — a post that is
+ * edited later keeps the URL it was published under. `check-notes.mjs` asserts
+ * the two agree at build time.
+ */
+export function postPath(id: string): string {
+  const m = ID_PATTERN.exec(id.replace(/\.mdx?$/, ''));
+  if (!m) {
+    throw new Error(
+      `Note "${id}" must be named YYYY-MM-DD-slug.md — the URL is derived from it.`,
+    );
+  }
+  const [, year, month, slug] = m;
+  return `/notes/${year}/${month}/${slug}`;
+}
+
+/** The `[...slug]` param for a post, i.e. its path without the `/notes/` prefix. */
+export function postParam(id: string): string {
+  return postPath(id).replace(/^\/notes\//, '');
+}
+
+/** Absolute URL, for the feed and the canonical link. */
+export function postUrl(id: string): string {
+  return NOTES_SITE + postPath(id);
+}
+
+/**
+ * Byline: "Name, role" per author, or just the role when a post is published
+ * anonymously. Roles carry the weight here — who was speaking matters more
+ * than which person typed it, and an author is free to leave the name out.
+ */
+export function byline(authors: NoteAuthor[]): string {
+  return authors
+    .map((a) => (a.name ? `${a.name}, ${a.role}` : a.role))
+    .join(' · ');
+}
+
+/** Dutch long date, e.g. "10 september 2026". Posts are Dutch. */
+export function formatDate(date: string): string {
+  return new Date(date + 'T00:00:00Z').toLocaleDateString('nl-NL', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+/** RFC-822 date, as RSS requires. */
+export function rfc822(date: string): string {
+  return new Date(date + 'T00:00:00Z').toUTCString();
+}
+
+/**
+ * Link to a regulation in the reading environment. The id is the law's `$id`
+ * from the corpus (e.g. `wet_op_de_zorgtoeslag`); `check-notes.mjs` verifies it
+ * exists, which cannot happen at image-build time because the docs Dockerfile
+ * copies `docs/` only.
+ */
+export function regulationUrl(id: string): string {
+  return `${LAW_READER}/${id}`;
+}
+
+/** `wet_op_de_zorgtoeslag` -> `wet op de zorgtoeslag`, for link text. */
+export function regulationLabel(id: string): string {
+  return id.replace(/_/g, ' ');
+}
+
+/** Escape the five XML entities. The feed is assembled as text. */
+export function xmlEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}

--- a/docs/src/pages/notes/[...slug].astro
+++ b/docs/src/pages/notes/[...slug].astro
@@ -1,0 +1,129 @@
+---
+/*
+ * A single note (/notes/YYYY/MM/slug).
+ *
+ * The route is a rest param so the year/month segments come from one place:
+ * postParam() derives them from the filename, the same function the overview
+ * and the feed link with. Nothing here reads the title or a counter, so a post
+ * keeps the URL it was published under even if it is edited later.
+ *
+ * The post body is plain prose. Everything the page adds around it — byline,
+ * date, tags, regulation links — sits outside the rich-text so the article's
+ * own heading structure starts at the <h1> and continues with the author's
+ * own headings, with nothing injected in between.
+ */
+import { getCollection, render } from 'astro:content';
+import Base from '~/layouts/Base.astro';
+import EditLink from '~/components/EditLink.astro';
+import {
+  NOTES_SITE,
+  byline,
+  formatDate,
+  postParam,
+  postPath,
+  regulationLabel,
+  regulationUrl,
+} from '~/lib/notes';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('notes');
+  return posts.map((entry) => ({
+    params: { slug: postParam(entry.id) },
+    props: { entry },
+  }));
+}
+
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+
+const { title, date, authors, summary, tags, regulations } = entry.data;
+const pathname = postPath(entry.id);
+---
+
+<Base
+  lang="nl"
+  kind="docs"
+  pathname={pathname}
+  title={`${title} · RegelRecht`}
+  description={summary}
+>
+  <link slot="head" rel="canonical" href={NOTES_SITE + pathname} />
+  <link
+    slot="head"
+    rel="alternate"
+    type="application/rss+xml"
+    title="RegelRecht notities"
+    href={`${NOTES_SITE}/notes/feed.xml`}
+  />
+
+  <nldd-simple-section
+    sm-padding-bottom="32"
+    md-padding-bottom="64"
+    lg-padding-bottom="96"
+  >
+    <article>
+      <nldd-title size="1">
+        <h1>{title}</h1>
+      </nldd-title>
+      <nldd-spacer size="4" />
+      {/* Byline and date, in the same shape the RFC pages use for their
+          author line. */}
+      <nldd-identity
+        text={byline(authors)}
+        supporting-text={formatDate(date)}
+      ></nldd-identity>
+      <nldd-spacer size="24" />
+
+      <nldd-rich-text>
+        <Content />
+      </nldd-rich-text>
+
+      {
+        regulations && regulations.length > 0 && (
+          <>
+            <nldd-spacer size="32" />
+            {/* h2 keeps the document outline intact: the post body's own
+                headings are h2 as well, and this section follows them. */}
+            <nldd-title size="4">
+              <h2>Regelingen in deze notitie</h2>
+            </nldd-title>
+            <nldd-spacer size="8" />
+            <nldd-list type="navigation" variant="box-tinted">
+              {regulations.map((id) => (
+                <nldd-list-item href={regulationUrl(id)}>
+                  <nldd-text-cell
+                    text={regulationLabel(id)}
+                    supporting-text="Lezen in de leesomgeving"
+                    width="full"
+                  />
+                  <nldd-spacer-cell />
+                  <nldd-icon-cell size="20" icon="chevron-right" />
+                </nldd-list-item>
+              ))}
+            </nldd-list>
+          </>
+        )
+      }
+
+      {
+        tags.length > 0 && (
+          <>
+            <nldd-spacer size="24" />
+            {/* Tags are metadata, not navigation: there are no tag pages to
+                link to, so they render as plain labels. */}
+            <nldd-container layout="wrap" gap="4" aria-label="Onderwerpen">
+              {tags.map((tag) => (
+                <nldd-tag color="neutral" size="md">
+                  {tag}
+                </nldd-tag>
+              ))}
+            </nldd-container>
+          </>
+        )
+      }
+
+      <nldd-spacer size="24" />
+      <EditLink filePath={entry.filePath} />
+    </article>
+  </nldd-simple-section>
+</Base>

--- a/docs/src/pages/notes/feed.xml.ts
+++ b/docs/src/pages/notes/feed.xml.ts
@@ -1,0 +1,63 @@
+/*
+ * RSS 2.0 feed for the notes section (/notes/feed.xml).
+ *
+ * Hand-assembled rather than pulled in from @astrojs/rss: the feed is a fixed
+ * shape over a handful of fields, and the dependency would buy nothing that
+ * this file does not already do. Everything interpolated goes through
+ * xmlEscape().
+ *
+ * Absolute URLs come from NOTES_SITE, not from Astro.site: the same build is
+ * served on both the apex and the docs subdomain, and the notes section is published on
+ * the apex.
+ */
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import { NOTES_SITE, byline, postUrl, rfc822, xmlEscape } from '~/lib/notes';
+
+const FEED_TITLE = 'RegelRecht notities';
+const FEED_DESCRIPTION =
+  'Notities van het RegelRecht-team over uitvoerbare wetgeving, het corpus en de techniek eronder.';
+
+export const GET: APIRoute = async () => {
+  const posts = (await getCollection('notes')).sort((a, b) =>
+    b.data.date.localeCompare(a.data.date),
+  );
+
+  const items = posts
+    .map((post) => {
+      const url = postUrl(post.id);
+      return `    <item>
+      <title>${xmlEscape(post.data.title)}</title>
+      <link>${xmlEscape(url)}</link>
+      <guid isPermaLink="true">${xmlEscape(url)}</guid>
+      <pubDate>${rfc822(post.data.date)}</pubDate>
+      <dc:creator>${xmlEscape(byline(post.data.authors))}</dc:creator>
+      <description>${xmlEscape(post.data.summary)}</description>
+${post.data.tags.map((t) => `      <category>${xmlEscape(t)}</category>`).join('\n')}
+    </item>`;
+    })
+    .join('\n');
+
+  // lastBuildDate follows the newest post rather than the build clock, so an
+  // unrelated rebuild does not present itself to a reader as new activity.
+  const lastBuild = posts.length > 0 ? rfc822(posts[0].data.date) : undefined;
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:atom="http://www.w3.org/2005/Atom"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>${xmlEscape(FEED_TITLE)}</title>
+    <link>${NOTES_SITE}/notes</link>
+    <description>${xmlEscape(FEED_DESCRIPTION)}</description>
+    <language>nl-NL</language>
+    <atom:link href="${NOTES_SITE}/notes/feed.xml" rel="self" type="application/rss+xml" />
+${lastBuild ? `    <lastBuildDate>${lastBuild}</lastBuildDate>\n` : ''}${items}
+  </channel>
+</rss>
+`;
+
+  return new Response(xml, {
+    headers: { 'Content-Type': 'application/rss+xml; charset=utf-8' },
+  });
+};

--- a/docs/src/pages/notes/index.astro
+++ b/docs/src/pages/notes/index.astro
@@ -1,0 +1,83 @@
+---
+/*
+ * Notes overview (/notes) — every post, newest first.
+ *
+ * Dutch: the docs are English, the posts are not, so the page carries
+ * lang="nl". It renders as a docs-kind page, which gives it the back button
+ * and the site footer without a global menu.
+ *
+ * No pagination, no tag pages, no author pages: tags are metadata on a post,
+ * not a taxonomy with its own routes to maintain.
+ */
+import { getCollection } from 'astro:content';
+import Base from '~/layouts/Base.astro';
+import { NOTES_SITE, formatDate, postPath } from '~/lib/notes';
+
+const pathname = '/notes';
+const posts = (await getCollection('notes')).sort((a, b) =>
+  b.data.date.localeCompare(a.data.date),
+);
+const description =
+  'Notities van het RegelRecht-team over uitvoerbare wetgeving, het corpus en de techniek eronder.';
+---
+
+<Base
+  lang="nl"
+  kind="docs"
+  pathname={pathname}
+  title="Notities · RegelRecht"
+  description={description}
+>
+  <link slot="head" rel="canonical" href={`${NOTES_SITE}/notes`} />
+  <link
+    slot="head"
+    rel="alternate"
+    type="application/rss+xml"
+    title="RegelRecht notities"
+    href={`${NOTES_SITE}/notes/feed.xml`}
+  />
+
+  <nldd-one-third-two-thirds-section
+    sm-padding-bottom="32"
+    md-padding-bottom="64"
+    lg-padding-bottom="96"
+  >
+    <div slot="left">
+      <nldd-title size="2">
+        <h1>Notities</h1>
+      </nldd-title>
+      <nldd-spacer />
+      <nldd-rich-text>
+        <p>{description}</p>
+        <p>
+          Losse notities, geen serie. Meelezen zonder langs te komen kan via de
+          <a href="/notes/feed.xml">RSS-feed</a>.
+        </p>
+      </nldd-rich-text>
+    </div>
+    <div slot="right">
+      {
+        posts.length === 0 ? (
+          <nldd-rich-text>
+            <p>Er staat nog niets. De eerste notitie volgt.</p>
+          </nldd-rich-text>
+        ) : (
+          <nldd-list type="navigation" variant="box-tinted">
+            {posts.map((post) => (
+              <nldd-list-item href={postPath(post.id)}>
+                <nldd-text-cell
+                  overline={formatDate(post.data.date)}
+                  text={post.data.title}
+                  supporting-text={post.data.summary}
+                  width="full"
+                />
+                <nldd-spacer-cell />
+                <nldd-icon-cell size="20" icon="chevron-right" />
+              </nldd-list-item>
+            ))}
+          </nldd-list>
+        )
+      }
+    </div>
+  </nldd-one-third-two-thirds-section>
+</Base>


### PR DESCRIPTION
Notities worden markdown in deze repo en gaan door dezelfde Astro-pipeline als de rest van de site. Geen CMS, geen tweede build, geen nieuwe dependency.

## Wat erin zit

| | |
|---|---|
| Collection | `notes`, vierde naast `docs`, `rfcs` en `werkpakketten`; bestanden in `docs/src/content/notes/` |
| Frontmatter | `title`, `date`, `authors`, `summary`, `tags`, optioneel `regulations` — zod-schema, dus een typefout laat de build vallen |
| URL | `/notes/JJJJ/MM/slug`, afgeleid uit de bestandsnaam `JJJJ-MM-DD-slug.md` |
| Pagina's | Overzicht `/blog`, post `/notes/JJJJ/MM/slug`, feed `/blog/feed.xml` |
| Navigatie | Vierde heroknop op de landing, regel in de footer, terugknop + breadcrumbs |
| Controle | `docs/scripts/check-notes.mjs`, aangehaakt op de bestaande a11y-keten in CI |
| Recepten | `just notes` (preview), `just notes-check` |

## Naamkeuze

Het heet **Notities**, op de route `/notes`. De route is Engels omdat `/docs`,
`/research` en `/roadmap` dat ook zijn — de roadmap draagt daar al Nederlandse
inhoud onder. De labels volgen de taal van de pagina.

Eén ding om te wegen: *notitie* is in deze repo al bezet. RFC-005 en RFC-018
noemen zo de stand-off annotatie op wetstekst in de editor. Dat zijn twee
verschillende oppervlakken, maar in gesprek kan "een notitie" nu twee dingen
betekenen. `/logboek` of `/proces` vermijdt dat; die wissel is mechanisch.

## Keuzes

**De URL is een contract, dus hij komt uit de bestandsnaam.** Niet uit de titel, niet uit een teller, niet uit `date`. Een notitie die later wordt bijgeschaafd houdt de URL waaronder hij is gepubliceerd. `check-notes.mjs` vergelijkt de URL's met die op `main` en faalt als er een verdwijnt; hij controleert ook dat de datum in de frontmatter gelijk is aan die in de bestandsnaam, zodat de zichtbare datum de URL niet tegenspreekt.

**`regulations` wordt in CI gecontroleerd, niet in de build.** `docs/Dockerfile` doet `COPY docs/ .`, dus het corpus is er bij de image-build niet. Het script draait daarom in de CI-baan waar de hele repo is uitgecheckt. Een id dat geen `$id` in `corpus/regulation` is, laat de check vallen.

**Nul nieuwe dependencies.** De feed is een Astro-endpoint dat de XML zelf opbouwt in plaats van `@astrojs/rss`.

**Canonical naar de apex.** Dezelfde build draait op `regelrecht.rijks.app` en `docs.regelrecht.rijks.app`. `site` in `astro.config.mjs` blijft op het docs-subdomein — dat verzetten zou elke canonical in de docs raken — en de notitiepagina's dragen in plaats daarvan een expliciete canonical naar de apex. De feed bouwt zijn absolute URL's uit dezelfde constante.

**Navigatie langs de drie plekken die de site heeft.** De landing heeft geen hoofdmenu (`globalLinks = []` voor `kind: 'landing'`), dus er valt niets aan een menu toe te voegen. Het worden: een vierde getinte heroknop naast Documentatie en Onderzoek, een regel in de footer-links, en twee takken in de bestaande terugknop- en breadcrumb-ketens (notitie → `/notes` → home). Op `/en/` heet de knop *Notes (Dutch)*, zoals de Nederlandse footer al *Documentatie (Engels)* zegt.

**Zonder JavaScript leesbaar.** De pagina's zijn statisch; de NLDD-componenten stylen, ze renderen de tekst niet.

**Vorm van het overzicht.** Datum, titel, twee zinnen — verder niets. Geen namen en geen tags in de lijst; die staan op de notitie zelf.

## Bewust niet gedaan

- **Reacties, reactieformulier of contactformulier.** Publicatie blijft één richting. De CSP (`default-src 'self'`) blokkeert externe embeds al.
- **Conceptvlag.** Zonder `draft: true` ontstaat er geen lade met halve stukken.
- **Tag- en auteurspagina's.** Tags zijn beschrijving, geen navigatie; er is niets om te onderhouden.
- **Paginering.** Pas nodig voorbij ± 50 notities.
- **Vaste secties in het sjabloon.** Er is geen sjabloon: een notitie is een titel en tekst.
- **Afbeeldingen-pipeline, leestijd, gerelateerde notities.**
- **Een sectie *Laatste berichten* op de landing.** Zou de sterkste vindbaarheid geven, maar een sectie met één notitie is slechter dan geen sectie. Losse kleine PR zodra er drie staan.

## Wat de reviewer moet weten

- **De voorbeeldnotitie is dummy-inhoud** (`2026-09-10-voorbeeldnotitie.md`) en hoort weg zodra de eerste echte notitie er is. Hij staat er om alle frontmatter-velden te tonen, inclusief een tweede auteur zonder naam.
- **De contentrichtlijnen in `docs/src/content/notes/README.md` staan er letterlijk in**, in het Nederlands, binnen een verder Engelse README. Twee dingen om te bevestigen: de kop zegt *vier vinkjes* terwijl er drie bullets onder staan, en de regel *"Ik-vorm, met naam en rol van de auteur erbij"* is strakker dan het schema, dat een naam optioneel maakt.
- **De README staat als `docs/src/content/notes/README.md`.** Buiten `docs/` zou het bestand niet in het image belanden.
- **Pagefind indexeert de notities mee** in de op Engels geforceerde index. Nederlandse notities krijgen daardoor Engelse woordafbreking; buiten de zoekfunctie vallen leek slechter.
- **Lokaal is `astro build` hier niet volledig gedraaid**: `rehype-mermaid` heeft een Chromium met systeemafhankelijkheden nodig, en die kan deze omgeving niet installeren. De build is geverifieerd met een tijdelijke config zonder die plugin (128 pagina's, notitie-uitvoer gecontroleerd), en `check-heading-order`, `check-links` en `check-notes` draaien groen. `pa11y-ci` heeft dezelfde Chromium nodig en is dus aan CI.
