### PR TITLE
fix(docs): geef de roadmapmatrix de volle breedte van het venster

### DIFF
--- a/docs/src/pages/roadmap/index.astro
+++ b/docs/src/pages/roadmap/index.astro
@@ -114,43 +114,60 @@ const pathname = '/roadmap';
   title="Roadmap · RegelRecht"
   description="Werkpakketten van RegelRecht, geordend per fase en discipline."
 >
+  {/*
+    Two measures on one page. `width="full"` drops the section's body
+    max-width, which every other docs page keeps for a readable line length;
+    the matrix needs that, because it is seven columns wide and would
+    otherwise scroll horizontally inside a measure meant for paragraphs.
+
+    Only the matrix. The heading and the filter keep the docs measure and stay
+    where they sit on every other page: .rr-roadmap__kop (roadmap.css) puts
+    the token back and centres them, so they line up with the navigation bar
+    above and the footer below, and the table alone breaks out of that column.
+    The section's own inline padding stays either way, so the table keeps a
+    gutter to the viewport edge.
+  */}
   <nldd-simple-section
+    width="full"
     sm-padding-bottom="32"
     md-padding-bottom="64"
     lg-padding-bottom="96"
   >
     <nldd-container class="rr-roadmap" gap="24">
-      <nldd-title size="1">
-        <h1>Roadmap</h1>
-        <p slot="subtitle">
-          Werkpakketten per fase en discipline. Deze weergave is read-only;
-          wijzigen gaat via een pull request op GitHub.
-        </p>
-      </nldd-title>
+      <nldd-container class="rr-roadmap__kop" gap="24">
+        <nldd-title size="1">
+          <h1>Roadmap</h1>
+          <p slot="subtitle">
+            Werkpakketten per fase en discipline. Deze weergave is read-only;
+            wijzigen gaat via een pull request op GitHub.
+          </p>
+        </nldd-title>
 
-      {/*
-        The filter works without any JavaScript of our own: nldd-checkbox-field
-        reflects `checked` onto its host element, so the :has() rules in
-        roadmap.css can read the state straight off the component. A <fieldset>
-        and <legend> group the controls, which is what a group of checkboxes
-        needs and what the design system has no component for.
-      */}
-      <fieldset class="rr-filter">
-        <legend class="rr-filter__legend">
-          <nldd-text size="sm" weight="medium" color="secondary">
-            Filter op categorie
-          </nldd-text>
-        </legend>
-        {
-          FILTER_OPTIES.map((optie) => (
-            <nldd-checkbox-field
-              class="rr-filter__option"
-              id={`rr-cat-${optie.id}`}
-              label={optie.label}
-            />
-          ))
-        }
-      </fieldset>
+        {/*
+          The filter works without any JavaScript of our own:
+          nldd-checkbox-field reflects `checked` onto its host element, so the
+          :has() rules in roadmap.css can read the state straight off the
+          component. A <fieldset> and <legend> group the controls, which is
+          what a group of checkboxes needs and what the design system has no
+          component for.
+        */}
+        <fieldset class="rr-filter">
+          <legend class="rr-filter__legend">
+            <nldd-text size="sm" weight="medium" color="secondary">
+              Filter op categorie
+            </nldd-text>
+          </legend>
+          {
+            FILTER_OPTIES.map((optie) => (
+              <nldd-checkbox-field
+                class="rr-filter__option"
+                id={`rr-cat-${optie.id}`}
+                label={optie.label}
+              />
+            ))
+          }
+        </fieldset>
+      </nldd-container>
 
       {/* tabindex + role make the horizontally scrolling matrix reachable by
           keyboard; without it axe flags scrollable-region-focusable. */}

--- a/docs/src/styles/roadmap.css
+++ b/docs/src/styles/roadmap.css
@@ -6,7 +6,7 @@
  * and nldd-text for every run of text. Those bring their own responsive
  * behaviour, so this file deliberately holds no media queries.
  *
- * What is left are the two things the design system has no component for:
+ * What is left are the things the design system has no component for:
  *
  * 1. The fase x discipline matrix. It is a real <table> so a screen reader can
  *    place a card, laid out as one CSS grid (`display: contents` on the table
@@ -16,11 +16,34 @@
  *    checkbox state, and nldd-checkbox-field keeps its <input> in shadow DOM
  *    where a page stylesheet cannot reach it. Using the component would mean
  *    adding a script; the docs site runs zero client islands on purpose.
+ * 3. Two measures on one page: the section runs full-width for the matrix,
+ *    while the heading and the filter keep the docs measure. A section has one
+ *    body width, so the narrower one is restored on a block inside it.
  *
  * Colours, spacing and radii come from NLDD tokens, which are light-dark()
  * pairs, so both blocks follow the theme toggle. Nothing here sets a font or
  * hardcodes a colour.
  */
+
+/* --- Kop ---------------------------------------------------------------- */
+
+/*
+ * The page's section runs at width="full" so the matrix can use the whole
+ * viewport. The heading and the filter are prose-shaped and would read badly
+ * that wide, so this block puts the docs measure back for them. It uses the
+ * token nldd-simple-section applies by default, so the heading lands on the
+ * same measure as every other docs page rather than on a width invented here.
+ *
+ * `margin-inline: auto` centres it, which is what puts it back where it would
+ * have been: the navigation bar and the footer centre their own content on
+ * this same token, and so does a page section that is not at width="full".
+ * Left-aligning it instead lines it up with the matrix, but then the heading
+ * sits left of the bar above it and the page reads as misaligned.
+ */
+.rr-roadmap .rr-roadmap__kop {
+  max-width: var(--semantics-page-sections-body-max-width);
+  margin-inline: auto;
+}
 
 /* --- Filter ------------------------------------------------------------- */
 


### PR DESCRIPTION
De matrix op `/roadmap` stond in de leesbreedte die elke docspagina aanhoudt (1280px) en scrolde daardoor horizontaal terwijl er scherm over was. De sectie draait nu op `width="full"`, een attribuut dat het design system zelf biedt.

Alleen de tabel. De kop, de intro en het categoriefilter houden de leesbreedte en blijven staan waar ze op elke andere pagina staan: ze lijnen uit met de navigatiebalk erboven en de kruimelpaden eronder. Een `<h1>` die over 2200px uitwaaiert leest slecht, en de filterrij met vier vinkjes zou in een leeg veld hangen.

Gemeten, op de linkerrand van kop, footer-kruimelpad en matrix:

| venster | kop | kruimelpad | matrix | scroll nodig |
|---|---|---|---|---|
| 2200 | 453 | 453 | 56, breed 2073 | 0 |
| 1600 | 153 | 153 | 56, breed 1473 | 11 |
| 1200 | 56 | 56 | 56, breed 1073 | 411 |
| 400 | 16 | 16 | 16, breed 353 | 1131 |

Onder 1280px valt alles samen en verandert er niets. Geen horizontale overflow op de pagina zelf, op geen enkele breedte.

## Extra CSS

Eén regel bovenop het ontwerpsysteem, die hier expliciet gemeld wordt:

```css
.rr-roadmap .rr-roadmap__kop {
  max-width: var(--semantics-page-sections-body-max-width);
  margin-inline: auto;
}
```

`nldd-simple-section` heeft één bodybreedte, en deze pagina heeft er twee nodig. De regel gebruikt het token dat de sectie zelf standaard toepast, dus er wordt geen breedte verzonnen. Als het ontwerpsysteem hier een nette voorziening voor wil, is dit het signaal.

## Getest

`npm run a11y`: 128/128 URLs zonder fouten, `/roadmap` inbegrepen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9AMnjJboLDjxwLafWJebV
