### PR TITLE
fix(demo): laat de grafieken op de simulatiepagina weer renderen

### DIFF
--- a/frontend-demo/vite.config.js
+++ b/frontend-demo/vite.config.js
@@ -37,14 +37,30 @@ export default defineConfig({
     outDir: 'dist',
     rolldownOptions: {
       output: {
-        // Keep echarts (only the simulation tab needs it) out of the entry
-        // graph; same grouping as the editor, see frontend/vite.config.js.
+        // Group echarts into its own chunk, as the editor does (see
+        // frontend/vite.config.js).
+        //
+        // Deliberately WITHOUT the editor's `includeDependenciesRecursively:
+        // false`. That option keeps the chunk out of the entry graph entirely,
+        // but here it also leaves a shared helper behind that the chunk still
+        // calls, and every chart then dies on `TypeError: <helper> is not a
+        // function`. Vue's async-component boundary swallows that error, so the
+        // build succeeds, the page loads, and only the charts stay blank — which
+        // is exactly how it reached production unnoticed. The editor gets away
+        // with the option because it imports echarts straight from
+        // node_modules; here it arrives through SimBarChart.vue, whose helpers
+        // the dependency walk would have to carry along.
+        //
+        // The cost is that echarts is modulepreloaded on first paint (~570 kB
+        // over the entry). A working simulation is worth more than that; if the
+        // first load has to come down, the fix is to make the chart component
+        // reachable only through its own async chunk, not to switch this option
+        // back on.
         codeSplitting: {
           groups: [
             {
               name: 'echarts',
               test: /node_modules[\\/](echarts|zrender|vue-echarts)[\\/]/,
-              includeDependenciesRecursively: false,
             },
           ],
         },


### PR DESCRIPTION
De simulatiepagina op `demo.regelrecht.rijks.app` bleef leeg. De pagina laadde, de simulatie rekende door en de bedragen verschenen, maar er kwam geen enkele grafiek.

## Wat er misging

De oorzaak zat in de chunkindeling, niet in de uitrol. Met `includeDependenciesRecursively: false` blijft een gedeelde helper buiten de echarts-chunk terwijl die chunk hem wel aanroept. De eerste aanroep sneuvelt op `TypeError: <helper> is not a function`.

Die fout is stil: Vue's async-grens vangt hem op, de build slaagt, de pagina laadt, en alleen de grafieken blijven leeg. Precies daardoor is dit ongemerkt in productie beland.

De editor gebruikt dezelfde optie zonder problemen, omdat hij echarts rechtstreeks uit `node_modules` importeert. In de demo loopt het via `SimBarChart.vue`, en dan zou de afhankelijkheidswandeling de helpers van dat component moeten meenemen.

Reproduceerbaar op de gebouwde versie (`vite preview`), niet op de dev-server, waar niet gechunkt wordt. Dat verschil verklaart waarom het lokaal altijd goed leek.

## De afweging

Echarts wordt nu bij de eerste lading opgehaald, ongeveer 570 kB bovenop de entry. Een werkende simulatie weegt zwaarder dan die opstarttijd.

Wil de eerste lading omlaag, dan is de route om het grafiekcomponent alleen via een eigen async-chunk bereikbaar te maken. Ik heb dat geprobeerd, in twee varianten, en met deze bouwer lukt het niet om beide doelen tegelijk te halen: `SimBarChart.vue` in de chunkgroep trekken haalt de grafieken weer onderuit zodra de afhankelijkheidswandeling wordt afgekapt. Dat is werk apart. De afweging staat in de configuratie zelf, zodat de volgende lezer de optie niet terugzet.

## Getest

- Op de gebouwde versie draait de simulatie en levert twee grafieken, gelijk aan de dev-server.
- 115 frontend-tests groen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EfA9URMnyAnbW62Ha2FK5
