### PR TITLE
fix(demo): vijf oneffenheden in het portaal en de presentatie

### DIFF
--- a/corpus/demo/demo-config.yaml
+++ b/corpus/demo/demo-config.yaml
@@ -18,7 +18,7 @@ profiles:
     # Graaf: the laws that tell this persona's story (detentie -> verzekerd -> zorgtoeslag)
     graph_laws: [penitentiaire_beginselenwet, zvw, zorgtoeslagwet]
     zaaksysteem_service: TOESLAGEN
-    portal_tab_label: Burger.nl
+    portal_tab_label: Mijn overheid
     portal_heading: Waar heb ik recht op? Wat zijn mijn plichten?
     portal_subtitle: >-
       Bekijk hier uw toeslagen, uitkeringen, aangiften, en andere regelingen van de overheid.
@@ -67,7 +67,7 @@ profiles:
       - handelsregisterwet
       - handelsregisterwet/bedrijfsgegevens
     zaaksysteem_service: GEMEENTE_ROTTERDAM
-    portal_tab_label: Overheid.nl
+    portal_tab_label: Mijn onderneming
     portal_heading: Welke regelingen passen bij mijn bedrijf?
     portal_subtitle: >-
       Bekijk beschikbare subsidies, rapportageverplichtingen, vergunningen, wetten en andere

--- a/frontend-demo/src/App.vue
+++ b/frontend-demo/src/App.vue
@@ -58,7 +58,7 @@ const tabs = computed(() => [
   { name: 'graaf', text: 'Graaf', icon: 'centralized-network', to: '/graaf' },
   { name: 'scenarios', text: "Scenario's", icon: 'checklist', to: '/scenarios' },
   { name: 'simulatie', text: 'Simulatie', icon: 'chart-x-y-axis-line', to: '/simulatie' },
-  { name: 'portaal', text: profile.value?.portal_tab_label ?? 'Burger.nl', icon: 'person', to: '/portaal' },
+  { name: 'portaal', text: profile.value?.portal_tab_label ?? 'Mijn overheid', icon: 'person', to: '/portaal' },
   { name: 'zaaksysteem', text: 'Zaaksysteem', icon: 'inbox', to: '/zaaksysteem' },
 ]);
 

--- a/frontend-demo/src/components/EditValueSheet.vue
+++ b/frontend-demo/src/components/EditValueSheet.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed, nextTick, ref, shallowRef, watch } from 'vue';
 import OrgLogo from './OrgLogo.vue';
-import { fieldSpec, formatValue, humanize } from '../data/format.js';
+import { fieldSpec, formatValue, humanize, isUnknown } from '../data/format.js';
 import { columnKind as columnKindOf, decimalsFor, editKind, emptyRow, parseCell, parseDutchNumber, stepFor, tableColumns, unitLabel, valueKind } from '../data/editKinds.js';
 import { useDemo } from '../store/demoStore.js';
 
@@ -109,7 +109,14 @@ watch(
     reason.value = '';
     hardship.value = '';
     evidence.value = null;
-    const v = props.node?.value;
+    // An unknown value (RFC-036) carries no value to edit: the engine does not
+    // have the fact. It arrives as `{__unknown: true, missing: [...]}`, so
+    // without this the box would open on the literal text "[object Object]".
+    // The field then starts from nothing, like an absent value does, and the
+    // citizen fills in what the register lacks. (A number field renders that
+    // as 0, which is the design system's own empty state.)
+    const raw = props.node?.value;
+    const v = isUnknown(raw) ? null : raw;
     if (kind.value === 'amount' && typeof v === 'number') newValue.value = (v / 100).toFixed(2).replace('.', ',');
     else if (kind.value === 'boolean') newValue.value = v ? 'true' : 'false';
     else if (kind.value === 'rows') rows.value = (v ?? []).map((r) => ({ ...r }));

--- a/frontend-demo/src/components/LawTile.vue
+++ b/frontend-demo/src/components/LawTile.vue
@@ -198,14 +198,24 @@ const statusTag = computed(() => {
     </nldd-container>
 
     <!-- wrap, not row: in a narrow tile (three-column grid) a whole button moves to a
-         second line, right-aligned with the other secondary actions, instead of a
-         button breaking its label. The buttons stay direct children: a nested
-         container has size containment and so no intrinsic width in a flex line. -->
-    <nldd-container slot="footer" padding="16" layout="wrap" gap="8" vertical-alignment="center" horizontal-alignment="right">
+         second line instead of a button breaking its label. The buttons stay direct
+         children: a nested container has size containment and so no intrinsic width
+         in a flex line.
+         No flexible spacer between the primary and the secondary actions. It ate
+         every leftover pixel, so a long primary label ("Gegevens aanvullen") pushed
+         the row over its width and dropped "Wettekst" alone onto a second line,
+         while a short one ("Aanvragen") kept all three together. The footer then
+         looked different from tile to tile for no reason the reader can see. Left
+         alignment with a plain gap wraps the same way for every label length.
+         The primary label is kept short for the same reason: "Gegevens aanvullen"
+         made the three buttons 374px wide in a 384px footer, so padding and gaps
+         pushed "Wettekst" onto a second line while every neighbouring tile kept
+         its buttons on one. The heading above the button already says which data
+         is missing. -->
+    <nldd-container slot="footer" padding="16" layout="wrap" gap="8" vertical-alignment="center">
       <nldd-button v-if="currentCase" variant="secondary" size="sm" start-icon="file-text" text="Mijn aanvraag" @click="apply"></nldd-button>
-      <nldd-button v-else-if="evaluation && missingInputs.length && produces?.legal_character === 'BESCHIKKING'" variant="primary" size="sm" start-icon="edit" text="Gegevens aanvullen" @click="apply"></nldd-button>
+      <nldd-button v-else-if="evaluation && missingInputs.length && produces?.legal_character === 'BESCHIKKING'" variant="primary" size="sm" start-icon="edit" text="Aanvullen" @click="apply"></nldd-button>
       <nldd-button v-else-if="canApply" variant="primary" size="sm" start-icon="paper-plane" text="Aanvragen" @click="apply"></nldd-button>
-      <nldd-spacer size="flexible" direction="horizontal"></nldd-spacer>
       <nldd-button v-if="evaluation?.ok" variant="neutral-transparent" size="sm" start-icon="list" text="Berekening" @click="showTrace = true"></nldd-button>
       <nldd-button variant="neutral-transparent" size="sm" start-icon="book" text="Wettekst" @click="router.push(`/wetten/${encodeURIComponent(law.id)}`)"></nldd-button>
     </nldd-container>

--- a/frontend-demo/src/data/editKinds.js
+++ b/frontend-demo/src/data/editKinds.js
@@ -14,7 +14,7 @@
  * an array of plain values is a list.
  */
 
-import { isAmountSpec } from './format.js';
+import { isAmountSpec, isUnknown } from './format.js';
 
 /** True for a non-empty array whose elements are all plain objects: a table. */
 export function isRecordArray(value) {
@@ -34,6 +34,10 @@ export function isRecordArray(value) {
  */
 export function editKind(value, spec = null) {
   const declared = spec?.type;
+  // An unknown value (RFC-036) is a marker object, not a value: reading its
+  // shape would make every unknown field a record editor. The declaration
+  // decides, exactly as it does for an absent value.
+  if (isUnknown(value)) value = null;
   // The declaration wins: it holds for an absent value too, where the value
   // itself says nothing.
   if (declared === 'boolean' || typeof value === 'boolean') return 'boolean';

--- a/frontend-demo/src/data/editKinds.test.js
+++ b/frontend-demo/src/data/editKinds.test.js
@@ -178,3 +178,23 @@ describe('numbers', () => {
     expect(editKind(67.25, { type: 'number', type_spec: { unit: 'years', precision: 2 } })).toBe('number');
   });
 });
+
+// RFC-036: an unknown value is a marker object, not a value. The edit box used
+// to seed its field from it, so a citizen opening "Woonlandfactor" was shown
+// the literal text "[object Object]" to correct.
+describe('an unknown value', () => {
+  const unknown = { __unknown: true, missing: [{ law: 'wkb', name: 'kinderen_woonlanden', kind: 'no_data' }] };
+
+  it('follows the declared type, like an absent value does', () => {
+    expect(editKind(unknown, { type: 'number' })).toBe('number');
+    expect(editKind(unknown, { type: 'date' })).toBe('date');
+    expect(editKind(unknown, { type: 'boolean' })).toBe('boolean');
+    expect(editKind(unknown, { type: 'amount', type_spec: { unit: 'eurocent' } })).toBe('amount');
+  });
+
+  it('is never read as a record, whatever its shape', () => {
+    expect(editKind(unknown)).toBe('text');
+    expect(editKind(unknown, { type: 'object' })).toBe('record');
+    expect(valueKind(unknown)).toBe('text');
+  });
+});

--- a/frontend-demo/src/presentation/PresentationDeck.vue
+++ b/frontend-demo/src/presentation/PresentationDeck.vue
@@ -103,6 +103,14 @@ function saveName(e) {
  * palette is the Rijkshuisstijl (donkerblauw #154273, lintblauw #01689b), the
  * type is RijksoverheidSerif for titles and RijksSans for the rest. */
 .deck {
+  /* Size the type against the deck's own box, not the viewport: the deck is a
+     40vw rail on a demo slide and the whole screen on an intro, so a viewport
+     unit would be wrong in one of the two. `container-type: size` makes 1cqmin
+     one percent of the deck's shorter side, and every size below is a multiple
+     of it, so a short window shrinks the text instead of pushing it past the
+     bottom edge. */
+  container-type: size;
+  --slide-unit: 1cqmin;
   position: fixed;
   inset: 0 auto 0 0;
   width: 36vw;
@@ -119,22 +127,28 @@ function saveName(e) {
 }
 .deck.full {
   width: 100vw;
-  padding: 4rem clamp(3rem, 9vw, 10rem) 2rem;
+  padding: clamp(1.25rem, calc(4 * var(--slide-unit, 1vw)), 4rem) clamp(3rem, 9vw, 10rem) clamp(0.75rem, calc(2 * var(--slide-unit, 1vw)), 2rem);
 }
 
+/* A slide never scrolls. Scrolling hides the bottom of an argument behind a
+ * gesture nobody makes while presenting, and on a projector the speaker cannot
+ * see that there is more. The type shrinks with the slide instead: every size
+ * below scales on the smaller of width and height (`min(1vw, …)`-style through
+ * `--slide-unit`), so a short window makes the text smaller rather than taller
+ * than the slide. `clamp()` keeps a floor, so it never becomes unreadable. */
 .content {
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   min-height: 0;
-  overflow: auto;
+  overflow: hidden;
 }
 .content-main {
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 1.4rem;
+  gap: clamp(0.5rem, calc(1.4 * var(--slide-unit, 1vw)), 1.4rem);
 }
 .content-foot {
   flex: 0 0 auto;
@@ -144,7 +158,7 @@ function saveName(e) {
 }
 
 .overline {
-  font-size: clamp(1rem, 1.5vw, 1.6rem);
+  font-size: clamp(0.7rem, calc(1.5 * var(--slide-unit, 1vw)), 1.6rem);
   font-weight: 600;
   letter-spacing: 0.02em;
   color: rgba(255, 255, 255, 0.72);
@@ -152,16 +166,16 @@ function saveName(e) {
 .title {
   font-family: 'RijksoverheidSerif', Georgia, serif;
   font-weight: 700;
-  font-size: clamp(2.4rem, 4.2vw, 5.4rem);
+  font-size: clamp(1.15rem, calc(4.2 * var(--slide-unit, 1vw)), 5.4rem);
   line-height: 1.08;
   margin: 0;
   color: #fff;
 }
 .title-hero {
-  font-size: clamp(3.2rem, 7vw, 9rem);
+  font-size: clamp(1.5rem, calc(7 * var(--slide-unit, 1vw)), 9rem);
 }
 .statement {
-  font-size: clamp(2rem, 3.8vw, 5rem);
+  font-size: clamp(1.05rem, calc(3.8 * var(--slide-unit, 1vw)), 5rem);
   line-height: 1.2;
   font-weight: 400;
 }
@@ -175,7 +189,7 @@ function saveName(e) {
   font-weight: 700;
 }
 .lead {
-  font-size: clamp(1.3rem, 2vw, 2.3rem);
+  font-size: clamp(0.8rem, calc(2 * var(--slide-unit, 1vw)), 2.3rem);
   line-height: 1.4;
   margin: 0;
   font-weight: 500;
@@ -184,17 +198,17 @@ function saveName(e) {
   font-family: 'RijksoverheidSerif', Georgia, serif;
   font-style: italic;
   font-weight: 400;
-  font-size: clamp(1.6rem, 3vw, 3.6rem);
+  font-size: clamp(0.9rem, calc(3 * var(--slide-unit, 1vw)), 3.6rem);
   color: rgba(255, 255, 255, 0.9);
 }
 .bullets {
-  font-size: clamp(1.15rem, 1.75vw, 2rem);
+  font-size: clamp(0.75rem, calc(1.75 * var(--slide-unit, 1vw)), 2rem);
   line-height: 1.45;
   margin: 0;
   padding-left: 1.3rem;
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
+  gap: clamp(0.3rem, calc(0.9 * var(--slide-unit, 1vw)), 0.9rem);
   color: rgba(255, 255, 255, 0.96);
 }
 .bullets li::marker {
@@ -203,7 +217,7 @@ function saveName(e) {
 .bullets-plain {
   list-style: none;
   padding-left: 0;
-  font-size: clamp(1.4rem, 2.4vw, 2.8rem);
+  font-size: clamp(0.85rem, calc(2.4 * var(--slide-unit, 1vw)), 2.8rem);
 }
 .bullets :deep(strong) {
   font-weight: 700;

--- a/frontend-demo/src/views/PortaalView.vue
+++ b/frontend-demo/src/views/PortaalView.vue
@@ -63,17 +63,14 @@ const loadFailureText = computed(() => loadFailures.value.map((f) => `${f.id} ($
 
 <template>
   <nldd-page>
-    <nldd-container slot="header" padding="0">
-      <nldd-container padding-inline="24" padding-block="12" background="base">
-        <nldd-toolbar size="md" :label="profile?.portal_tab_label ?? 'Burger.nl'">
-          <nldd-toolbar-title slot="start" :text="profile?.portal_tab_label ?? 'Burger.nl'" supporting-text="Demo, geen echte overheidsdienst"></nldd-toolbar-title>
-        </nldd-toolbar>
-      </nldd-container>
-    </nldd-container>
-
+    <!-- No title bar above the heading: it repeated the portal's name right on
+         top of the page heading that follows, and the tab in the app bar already
+         names it. What the bar carried that nothing else did is the disclaimer,
+         so that moves into the overline, where it stays next to the persona the
+         visitor is logged in as. -->
     <nldd-simple-section width="1200px">
       <nldd-title slot="header" size="2">
-        <span slot="overline">Ingelogd als {{ persona?.name ?? profile?.name }}</span>
+        <span slot="overline">Ingelogd als {{ persona?.name ?? profile?.name }} · demo, geen echte overheidsdienst</span>
         <h1>{{ profile?.portal_heading }}</h1>
         <span slot="subtitle">{{ profile?.portal_subtitle }}</span>
         <!-- Tags naast elkaar: gap 8, dezelfde scheiding als de spacer-cells in de lijstrijen. -->


### PR DESCRIPTION
Vijf losse meldingen uit de demo, waarvan twee echte bugs.

## Een onbekende waarde was niet te corrigeren

Wie op het potlood van "Woonlandfactor" klikte, kreeg de letterlijke tekst `[object Object]` in het invoerveld.

Een onbekende waarde is onder RFC-036 een markering (`{__unknown: true, missing: [...]}`) en geen waarde, maar het bewerkpaneel gaf hem ongefilterd door aan `String()`. Nu telt onbekend als afwezig: het veld begint leeg en de burger vult in wat het register niet heeft. Twee tests leggen dat vast, ook dat de markering nooit als record-editor wordt gelezen.

## Twee portalen droegen de naam van een bestaande website

Het burgerportaal heette Burger.nl, het ondernemersportaal Overheid.nl. Dat tweede is een echte overheidssite, en een demo hoort geen bestaande dienst na te bootsen. Het zijn nu "Mijn overheid" en "Mijn onderneming".

## De titelbalk boven het portaal herhaalde zichzelf

Hij toonde de naam van het portaal, direct boven de paginakop die eronder al staat, terwijl het tabblad in de app-balk hem ook al noemt. De balk is weg. Wat hij als enige droeg, de mededeling dat dit geen echte overheidsdienst is, staat nu in de bovenregel bij de persona waarmee je bent ingelogd. Die mededeling laten vallen leek me niet verstandig: het portaal lijkt genoeg op een echte dienst om het te blijven zeggen.

## De knoppen onder een wettegel sprongen per tegel

"Gegevens aanvullen" maakte de drie knoppen samen 374px in een voet van 384px, dus padding en tussenruimte duwden "Wettekst" naar een tweede regel terwijl de buurtegels alles op één regel hielden.

De flexibele spacer die de secundaire knoppen naar rechts duwde is weg, en het label is "Aanvullen": de kop erboven zegt al welke gegevens ontbreken. Gemeten over acht tegels staan alle voetteksten nu op één regel.

## Slides scrolden op een laag scherm

Een slide hoort niet te scrollen. De onderkant van een argument verdwijnt dan achter een gebaar dat niemand maakt tijdens een presentatie, en op een beamer ziet de spreker niet dat er meer is.

De tekst krimpt nu mee met de slide. Dat gaat via een container query (`container-type: size`, `1cqmin`) en niet via `vh`, omdat het dek een smalle rail is naast de app en een volledig scherm op een introslide; een viewport-eenheid zou in een van die twee gevallen fout zijn. Getest op de slide uit de melding: 416px inhoud in 278px ruimte werd 299 in 299.

## Getest

117 frontend-tests groen, en elk punt visueel nagelopen in de draaiende demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EfA9URMnyAnbW62Ha2FK5
