### PR TITLE
feat: logische klok per wereld, advance en executogram-vorm in de simulator

### DIFF
--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -361,6 +361,12 @@ Wie een scenario draait, hoeft `advance` niet zelf aan te roepen: de runner loop
 de vragen af in de volgorde van het bestand en zet de klok vooruit tot het moment
 van de volgende vraag. Een vraag over een eerder moment kan altijd.
 
+De vragen bepalen daarmee hoe ver de tijd loopt, dus een fixture met een datum
+voorbij de laatste vraag gaat in die run niet af. Dat mag — "dit feit landt in
+2030 en doet nu dus niet mee" is een geldige bewering — maar het verslag sluit af
+met hoeveel vastleggingen bleven wachten, zodat een fixture die niemand ooit
+bereikt geen stille regel in het bestand is.
+
 ## Het wereldbestand
 
 Een wereld is één YAML-bestand: `clock` (de tijdlijn), `cells` (wie er zijn),

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -26,10 +26,9 @@ van paper naar code:
   versiebestand onder `laws`. De map met `valid_from`-versies van een regeling
   *is* de lexogram-kroniek; de engine kiest daarin op `op_moment`. Niemand
   noemde dat hier eerder zo, maar het is precies wat RFC-022 §1.1 beschrijft.
-- **Executogram** — de vastgelegde vaststelling van een feit. Dat is wat een
-  `ChronicleEvent` wil worden: een veldwaarde op een moment. Wat er nog aan
-  ontbreekt is de procesrelatieve kant (wie stelde het vast, op welke
-  grondslag, in welke intake).
+- **Executogram** — de vastgelegde vaststelling van een feit. Dat is een
+  `ChronicleEvent`, en sinds de tijdlijn erin zit heeft die de vorm die
+  RFC-022 §1.3 vraagt: zie [De executogram-vorm](#de-executogram-vorm).
 - **Decretogram** — individueel en operationeel: het besluit. Dat wordt hier
   nog nergens vastgelegd; zie [Wat hier nog niet staat](#wat-hier-nog-niet-staat).
 
@@ -47,6 +46,22 @@ Een cel is een *containment- en autonomiedomein*, en verder niets:
 - ze laadt haar eigen **regelingen**;
 - ze **reduceert** over die eigen feiten tot een **lexostatus**: de
   rechtstoestand vanuit een gevraagd perspectief, op de feiten die zij kent.
+
+En één regel die bepaalt wat er in zo'n kroniek terecht mag komen:
+
+> **Een kroniek bevat alleen wat de cel zelf overkwam.**
+
+Een aanvraag die binnenkwam, een levering die ze ontving, een betaling die ze
+deed, een besluit dat ze zelf nam. Wat een cel elders *opvroeg* hoort er niet
+in: dat zou een schaduwboekhouding zijn van andermans feiten, en dan ligt het
+totaalbeeld dat volgens RFC-022 nergens bestaat alsnog in één cel. Een
+opgehaalde waarde die meedeed in een besluit hoort in het decretogram van dat
+besluit, met bron en moment erbij — niet als los feit in een kroniek.
+
+Daarom draagt elke vastlegging de naam van de cel zelf als `recording_actor`, en
+weigert de loader een vastlegging op naam van een ander. Niet omdat een cel
+nooit iets van buiten te weten krijgt, maar omdat ze dan vastlegt wat *haar*
+overkwam: `intake: levering` zegt dat het geleverd werd.
 
 ## Een bron-cel
 
@@ -201,7 +216,8 @@ met `expect_not_established: true`; dat is een volwaardige verwachting en sluit
 
 `op_moment` is het moment waarop gevraagd wordt, altijd expliciet en nooit de
 wandklok. Feiten die pas later in de cel zijn vastgelegd, bestaan voor dat
-antwoord niet, en de engine kiest op datzelfde moment de regelingversie.
+antwoord niet, en de engine kiest op datzelfde moment de regelingversie. Een
+moment ná de klok van de wereld is een fout; zie [De tijdlijn](#de-tijdlijn).
 
 ## Over een celgrens
 
@@ -303,16 +319,62 @@ De invarianten-gate die het gedeclareerde vraaggraf met het feitelijke vergelijk
 (I3) staat er nog niet. Dit is het instrument waar die op gaat rusten, en daar
 hoort die volledigheidseis dan ook thuis.
 
-## Scenarioformaat
+## De tijdlijn
 
-Een scenario is één YAML-bestand met `cells` (de wereld) en twee soorten vraag:
-`queries` (een consument bevraagt een cel) en `query_via_transport` (een cel
-bevraagt een andere cel). Beide dragen hun eigen verwachting; de assertie hoort
-bij het scenario en niet bij Rust, dus een nieuw testgeval is een nieuw bestand.
+Tijd is een eigenschap van de **wereld**, niet van een vraag. Eén logische klok
+per wereld — een datum, nooit de wandklok — en `World::advance(tot)` zet haar
+vooruit:
+
+```rust,ignore
+let mut world = scenario.world(&regulation_root())?;   // klok op clock.start
+world.advance(NaiveDate::from_ymd_opt(2024, 8, 1)...)?; // triggers gaan onderweg af
+world.reduce("toeslagen", "toeslagpartnerschap", &params, moment)?;
+```
+
+Vier eigenschappen, en ze hangen samen:
+
+- **De klok woont in de wereld, niet in een cel.** Een cel kent alleen de
+  momenten die haar aangereikt worden. Zij houdt geen klok, net zoals ze geen
+  sleutels en geen bevoegdheid houdt (RFC-022 §2).
+- **`advance` loopt de triggers af in datumvolgorde**, en tijdens een trigger
+  staat de klok op het moment van die trigger. Een vastlegging krijgt dus haar
+  eigen datum als `op_moment`, niet de eindstand van de sprong. De lus is
+  generiek — een gesorteerde lijst van `(datum, trigger)` — zodat vervallende
+  verplichtingen en gemiste termijnen er later naast passen. Vandaag bestaat er
+  één soort: een `fixture` die bij het passeren wordt vastgelegd.
+- **Een trigger voegt toe en wijzigt nooit een bestaand gram.** Daarom verandert
+  het beeld van een eerder moment niet doordat de wereld verder loopt. Dat is de
+  kernassertie, en ze staat als scenario in
+  [`scenarios/toeslagen_tijdlijn.yaml`](scenarios/toeslagen_tijdlijn.yaml): een
+  feit dat op T2 landt verandert de reductie op T2, terwijl dezelfde vraag over
+  T1 exact hetzelfde antwoord blijft geven. Dezelfde vraag staat er twee keer in,
+  vóór en ná de vastlegging — zonder dat paar is het geen assertie.
+- **Vooruitkijken kan niet, terugkijken wel.** Een reductie op een moment ná de
+  klok is een fout: wat na de klok gebeurt heeft nog niets vastgelegd, dus een
+  antwoord zou een voorspelling zijn die zich voordoet als een reductie. Een
+  moment ervóór levert het beeld van toen. De klok loopt zelf nooit terug.
+
+De dag blijft de fijnste korrel. Twee vastleggingen op dezelfde dag ordent de
+tijdas niet; dan beslist de volgorde van vastlegging, en de laatste wint.
+
+Wie een scenario draait, hoeft `advance` niet zelf aan te roepen: de runner loopt
+de vragen af in de volgorde van het bestand en zet de klok vooruit tot het moment
+van de volgende vraag. Een vraag over een eerder moment kan altijd.
+
+## Het wereldbestand
+
+Een wereld is één YAML-bestand: `clock` (de tijdlijn), `cells` (wie er zijn),
+`fixtures` (de startstand) en twee soorten vraag: `queries` (een consument
+bevraagt een cel) en `query_via_transport` (een cel bevraagt een andere cel).
+Beide dragen hun eigen verwachting. De assertie hoort bij het bestand, niet bij
+Rust: een nieuw testgeval is een nieuw bestand.
 
 ```yaml
 name: korte naam van het scenario
 description: waarom dit scenario bestaat        # optioneel
+
+clock:
+  start: 2024-01-01                             # waar de klok begint; verplicht
 
 cells:
   - id: toeslagen                               # het cel-id
@@ -323,15 +385,15 @@ cells:
     chronicles:                                 # de eigen feiten van de cel
       - stream: relaties                        # naam van de kroniekstroom
         key: bsn                                # veld waarop gegroepeerd wordt
-        events:
-          - op_moment: 2023-01-01               # wanneer dit feit feit werd
+        events:                                 # mag leeg: zie `fixtures`
+          - name: relatie_gewijzigd             # wat er gebeurde
+            intake: levering                    # waarlangs het binnenkwam
+            recording_actor: toeslagen          # wie vastlegde: de cel zelf
+            grondslag: melding uit de brp       # op welke grondslag; mag leeg
+            op_moment: 2023-01-01               # wanneer dit feit feit werd
             fields:                             # veldnamen = input-namen in de wet
               bsn: '999993653'
               partnerschap_type: HUWELIJK
-          - op_moment: 2024-07-01               # latere vastlegging wint
-            fields:
-              bsn: '999993653'
-              partnerschap_type: GEEN
 
     lexostatus_definitions:                     # wat de cel publiceert
       - name: toeslagpartnerschap
@@ -358,6 +420,18 @@ cells:
           chronicle: relaties                   # een eigen stroom
           key: bsn                              # sleutel = naam van een input
           latest: true                          # de enige modus; mag weg
+
+fixtures:                                       # de startstand van de wereld
+  - at: 2024-07-01                              # het moment van de vastlegging
+    record:
+      cell: toeslagen                           # bij wie het gram landt, en
+      chronicle: relaties                       # in welke stroom
+      name: relatie_gewijzigd
+      intake: levering
+      grondslag: melding uit de brp
+      fields:
+        bsn: '999993653'
+        partnerschap_type: GEEN
 
 queries:
   - description: vrije omschrijving             # optioneel
@@ -402,7 +476,57 @@ Onbekende velden worden geweigerd, zodat een typfout niet stil verdwijnt. Elke
 vraag heeft minstens één verwachting: een vraag zonder `expect` en zonder
 `expect_not_established` slaagt altijd en zou als `ok` in het verslag komen, wat
 op bewijs lijkt en het niet is. De loader weigert zo'n scenario, en ook een vraag
-die beide verwachtingen tegelijk stelt — die kan nooit uitkomen.
+die beide verwachtingen tegelijk stelt — die kan nooit uitkomen. `clock.start` is
+verplicht: een wereld zonder startmoment zou op de wandklok moeten terugvallen,
+en dan is dezelfde run morgen een andere run.
+
+### De executogram-vorm
+
+Een vastlegging is een executogram, en die draagt de vorm van RFC-022 §1.3. Vier
+vragen moeten per gram beantwoord zijn, plus één:
+
+| veld | vraag |
+|---|---|
+| `name` + `fields` | **wat** is er vastgelegd |
+| `recording_actor` | **door wie** — het cel-id; de celbeheerder, niet de `competent_authority`, want een executogram is een feit en geen besluit |
+| `grondslag` | op **welke grondslag** — vrije tekst, mag leeg |
+| `op_moment` | op **welk moment** |
+| `intake` | **waarlangs** het de cel bereikte: `aanvraag`, `levering`, `betaling` of `eigen_besluit` |
+
+Een vastlegging die alleen een veldwaarde en een datum draagt, laat de helft van
+die vragen onbeantwoord — en zonder `intake` en `grondslag` valt van een feit in
+een kroniek niet meer te zeggen hoe het daar kwam.
+
+`intake` is hier een enum en geen vrije tekst, terwijl RFC-022 het vocabulaire
+open houdt. Dat is een bewuste afwijking: een typfout in een kanaalnaam mag niet
+stil doorgaan. Een kanaal erbij is één regel Rust — het is platformvocabulaire,
+geen casusdata.
+
+`recording_actor` moet de cel zijn die de stroom houdt; een vastlegging op naam
+van een ander wordt geweigerd bij het optuigen. Zie [Wat een cel
+is](#wat-een-cel-is): een kroniek is het eigen journaal van de cel.
+
+In een `fixture` staat `recording_actor` niet, want dat is `record.cell`, en `at`
+geeft het moment. Die twee kunnen niet uiteenlopen en hoeven dus niet twee keer
+opgeschreven.
+
+### Startstand: `fixtures`
+
+Een startstand is data, geen opbouwcode. Een fixture is een vastlegging met een
+moment:
+
+- **op of vóór `clock.start`** — staat bij het optuigen al in de kroniek; de klok
+  staat op `start`, dus wat toen al gebeurd was, is gebeurd;
+- **erna** — is een trigger, en landt zodra `advance` die datum passeert.
+
+Een fixture die naar een onbekende cel of een onbekende stroom wijst, faalt bij
+het optuigen, ook als haar datum nog jaren weg is: een typfout in een startstand
+hoort niet halverwege een tijdlijn op te duiken.
+
+Eenzelfde feit kan dus twee kanten op geschreven worden — als `events` in de
+celconfiguratie of als `fixture` met een `at` — en dat is geen dubbelop. Het
+eerste is wat de cel al bijhield toen de wereld begon, het tweede is wat er
+tijdens de run gebeurt.
 
 ### Kroniekstromen en tijd
 
@@ -424,10 +548,11 @@ de engine records als databron wil. De paper legt de nadruk op het omgekeerde �
 niet de resulterende toestand opslaan, maar de procesrelatieve vaststelling ("op
 moment T heeft actor X vastgesteld dat …") en bij hergebruik expliciet
 herinterpreteren. Wat samen ontstond hoort samen te blijven; wat apart ontstond
-hoort niet stil samengevoegd te worden. De echte vorm kan pas als een
-vastlegging `recording_actor`, `grondslag`, `intake` en een moment draagt
-(RFC-022 §1.3) en de reductie daarover filtert en aggregeert in plaats van
-alleen te overschrijven.
+hoort niet stil samengevoegd te worden. De vastlegging draagt inmiddels wél
+`recording_actor`, `grondslag`, `intake`, een naam en een moment (zie [De
+executogram-vorm](#de-executogram-vorm)); wat nog mist is een reductie die
+daarover filtert en aggregeert in plaats van alleen te overschrijven. De
+gegevens zijn er dus al voordat de reductie ze gebruikt.
 
 Het kroniekfilter van een bron-cel doet dat al niet: dat kiest één vastlegging en
 geeft die in haar geheel terug. Die vorm kan hier omdat er geen engine tussen zit
@@ -467,10 +592,11 @@ Het corpus wordt standaard naast de crate gezocht (`corpus/regulation`);
 
 ## Wat hier nog niet staat
 
-**De cel legt nooit zelf iets vast.** Haar kroniekstore wordt bij het optuigen
-gevuld en daarna alleen gelezen; alles hierboven is de leeshelft. In
-chronolexografie is vastleggen juist de *productieve* activiteit, en de lus is
-informeren → concluderen → **vastleggen**. Een reductie die
+**De cel besluit nog niets.** Er wordt inmiddels vastgelegd — een trigger op de
+klok legt een executogram in een kroniek — maar alleen wat de startstand
+voorschrijft. De cel zelf concludeert nog niks. In chronolexografie is
+vastleggen juist de *productieve* activiteit, en de lus is informeren →
+concluderen → **vastleggen**. Een reductie die
 `heeft_recht_op_zorgtoeslag: true` oplevert is een besluit, en dat hoort als
 decretogram (BESCHIKKING, met moment en `zaakkenmerk`) in de eigen kroniek te
 landen (RFC-022 §1.2), zodat een latere vraag *op dat moment* het besluit
@@ -478,10 +604,9 @@ terugvindt in plaats van het opnieuw uit te rekenen onder een mogelijk andere
 wetsversie. Precies dat verschil — decretogram tegenover lexogram — is wat deze
 opstelling wil laten zien, en zonder vastleggen valt het niet te demonstreren;
 "een besluit van een andere bevoegde organisatie accepteren" heeft er evengoed
-een vastgelegd besluit voor nodig. De eerstvolgende stap is daarom een
-**vastleg-pad naast `reduce`**, alleen aanroepbaar door de cel zelf: het is
-haar eigen kroniek, dus geen consument mag erin schrijven, net zomin als eruit
-lezen.
+een vastgelegd besluit voor nodig. Het vastleg-pad dat daarvoor nodig is, staat
+er nu: `Cell::record` is `pub(crate)`, dus geen consument kan erin schrijven,
+net zomin als eruit lezen. Wat mist is de trigger die een besluit *neemt*.
 
 Aan de kant van de celgrens ontbreken nog drie dingen. **Accepteren in plaats van
 narekenen** (I5): het bewijsstuk van de veiligheidscontext heeft de vorm die een

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -500,7 +500,9 @@ een kroniek niet meer te zeggen hoe het daar kwam.
 `intake` is hier een enum en geen vrije tekst, terwijl RFC-022 het vocabulaire
 open houdt. Dat is een bewuste afwijking: een typfout in een kanaalnaam mag niet
 stil doorgaan. Een kanaal erbij is één regel Rust — het is platformvocabulaire,
-geen casusdata.
+geen casusdata. De vier namen zijn ook niet die van het voorbeeld in de RFC
+(`external_intake`): dit zijn de kanalen waarlangs een cel iets *overkomt*.
+Aansluiten op een breder vocabulaire is later een hernoeming, geen herontwerp.
 
 `recording_actor` moet de cel zijn die de stroom houdt; een vastlegging op naam
 van een ander wordt geweigerd bij het optuigen. Zie [Wat een cel
@@ -519,9 +521,11 @@ moment:
   staat op `start`, dus wat toen al gebeurd was, is gebeurd;
 - **erna** — is een trigger, en landt zodra `advance` die datum passeert.
 
-Een fixture die naar een onbekende cel of een onbekende stroom wijst, faalt bij
-het optuigen, ook als haar datum nog jaren weg is: een typfout in een startstand
-hoort niet halverwege een tijdlijn op te duiken.
+Een fixture wordt bij het optuigen getoetst zoals ze bij het vastleggen getoetst
+wordt: een onbekende cel, een onbekende stroom of een ontbrekend sleutelveld
+faalt daar, ook als haar datum nog jaren weg is. Een typfout in een startstand
+hoort niet halverwege een tijdlijn op te duiken, en of dat gebeurt mag niet
+afhangen van hoe ver die datum weg ligt.
 
 Eenzelfde feit kan dus twee kanten op geschreven worden — als `events` in de
 celconfiguratie of als `fixture` met een `at` — en dat is geen dubbelop. Het

--- a/packages/simulator/scenarios/brp_broncel.yaml
+++ b/packages/simulator/scenarios/brp_broncel.yaml
@@ -7,6 +7,12 @@ description: >-
   betaalsysteem, een legacy-API — evengoed een cel, en dat is de toets dat het
   lexostatus-contract niets van een engine nodig heeft.
 
+clock:
+  # Beide vastleggingen staan als `events` in de celconfiguratie, dus ze staan
+  # er al bij het optuigen; de klok begint ervoor en er is geen fixture die
+  # nog moet landen.
+  start: 2023-01-01
+
 cells:
   - id: brp
     # Geen wetten. Deze cel zou de BRP-wet kunnen laden, maar hoeft dat niet:
@@ -20,12 +26,20 @@ cells:
       - stream: relaties
         key: bsn
         events:
-          - op_moment: 2023-03-01
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: brp
+            grondslag: eigen registratie
+            op_moment: 2023-03-01
             fields:
               bsn: '999993653'
               partnerschap_type: HUWELIJK
               partner_bsn: '999993756'
-          - op_moment: 2024-07-01
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: brp
+            grondslag: eigen registratie
+            op_moment: 2024-07-01
             fields:
               bsn: '999993653'
               partnerschap_type: GEEN

--- a/packages/simulator/scenarios/toeslagen_tijdlijn.yaml
+++ b/packages/simulator/scenarios/toeslagen_tijdlijn.yaml
@@ -1,0 +1,101 @@
+---
+name: de tijdlijn verandert het heden en laat het verleden staan
+description: >-
+  De kernassertie over tijd. De wereld heeft één logische klok; een feit landt
+  op zijn eigen moment en verandert daarmee het beeld vanaf dat moment. Wat
+  eerder gevraagd werd, blijft exact hetzelfde antwoord geven: een kroniek
+  groeit, ze wordt niet herschreven. Dezelfde vraag staat daarom twee keer in
+  dit bestand, vóór en ná de vastlegging die ertussen landt — zonder dat paar is
+  het geen assertie maar een bewering.
+
+clock:
+  # De wereld begint hier. De vastlegging van 2023-01-01 ligt ervóór en staat
+  # bij het optuigen al in de kroniek; die van 2024-07-01 ligt erna en landt
+  # pas wanneer de klok hem passeert.
+  start: 2024-01-01
+
+cells:
+  - id: toeslagen
+    laws:
+      - algemene_wet_inkomensafhankelijke_regelingen
+
+    # De stroom wordt hier leeg opgetuigd: de inhoud is startstand, en die
+    # staat onder `fixtures` met een moment erbij. Een cel declareert welke
+    # kronieken ze houdt; wat erin komt, brengt de tijd.
+    chronicles:
+      - stream: relaties
+        key: bsn
+
+    lexostatus_definitions:
+      - name: toeslagpartnerschap
+        doc: >-
+          Of deze persoon op het gevraagde moment een toeslagpartner had (AWIR
+          art. 3), op de relatiefeiten die deze cel kent.
+        inputs:
+          - name: bsn
+            type: string
+        reduction:
+          regulation: algemene_wet_inkomensafhankelijke_regelingen
+          output: heeft_toeslagpartner
+          parameters:
+            bsn: $bsn
+
+fixtures:
+  # Wat de cel overkwam: er werd haar een relatiewijziging geleverd, en zij
+  # legde die vast. `recording_actor` staat er niet bij — dat is `cell`.
+  - at: 2023-01-01
+    record:
+      cell: toeslagen
+      chronicle: relaties
+      name: relatie_gewijzigd
+      intake: levering
+      grondslag: melding uit de basisregistratie personen
+      fields:
+        bsn: '999993653'
+        partnerschap_type: HUWELIJK
+
+  - at: 2024-07-01
+    record:
+      cell: toeslagen
+      chronicle: relaties
+      name: relatie_gewijzigd
+      intake: levering
+      grondslag: melding uit de basisregistratie personen
+      fields:
+        bsn: '999993653'
+        partnerschap_type: GEEN
+
+queries:
+  # T1, vóór de tweede vastlegging. De klok staat op 2024-06-01 als deze vraag
+  # gesteld wordt; het feit van 2024-07-01 bestaat nog niet.
+  - description: op T1 gold de vastlegging van 2023-01-01
+    cell: toeslagen
+    lexostatus: toeslagpartnerschap
+    params:
+      bsn: '999993653'
+    op_moment: 2024-06-01
+    expect:
+      heeft_toeslagpartner: true
+
+  # T2. De klok loopt hierheen, dus de vastlegging van 2024-07-01 gaat onderweg
+  # af en verandert het antwoord.
+  - description: op T2 is de vastlegging van 2024-07-01 geland
+    cell: toeslagen
+    lexostatus: toeslagpartnerschap
+    params:
+      bsn: '999993653'
+    op_moment: 2024-08-01
+    expect:
+      heeft_toeslagpartner: false
+
+  # T1 opnieuw, met de klok inmiddels op T2. Exact dezelfde vraag als de eerste,
+  # en daarom exact hetzelfde antwoord: een gram dat later landde, verandert het
+  # beeld van toen niet.
+  - description: T1 blijft na de vastlegging precies hetzelfde antwoord geven
+    cell: toeslagen
+    lexostatus: toeslagpartnerschap
+    params:
+      bsn: '999993653'
+    op_moment: 2024-06-01
+    expect:
+      heeft_toeslagpartner: true

--- a/packages/simulator/scenarios/toeslagen_zorgtoeslag.yaml
+++ b/packages/simulator/scenarios/toeslagen_zorgtoeslag.yaml
@@ -4,8 +4,14 @@ description: >-
   Eén cel, geen verkeer tussen cellen. De cel `toeslagen` laadt haar eigen drie
   regelingen en houdt de feiten die ze nodig heeft in haar eigen kronieken —
   ook de feiten die in de echte wereld van een andere organisatie komen. Die
-  zijn hier vastgelegd als binnengekomen feit, niet als vraag aan een buurcel:
-  zolang er geen transport is, is dat het eerlijke model.
+  zijn hier vastgelegd als wat de cel overkwam (een levering die binnenkwam),
+  niet als vraag aan een buurcel: zolang er geen transport is, is dat het
+  eerlijke model.
+
+clock:
+  # De wereld begint hier. Alle vastleggingen hieronder liggen vóór dit moment,
+  # dus ze staan bij het optuigen al in de kroniek.
+  start: 2024-12-01
 
 cells:
   - id: toeslagen
@@ -21,28 +27,42 @@ cells:
       - stream: relaties
         key: bsn
         events:
-          - op_moment: 2023-01-01
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: toeslagen
+            grondslag: melding uit de basisregistratie personen
+            op_moment: 2023-01-01
             fields:
               bsn: '999993653'
               partnerschap_type: HUWELIJK
-          - op_moment: 2024-07-01
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: toeslagen
+            grondslag: melding uit de basisregistratie personen
+            op_moment: 2024-07-01
             fields:
               bsn: '999993653'
               partnerschap_type: GEEN
 
-      # Feiten die van buiten binnenkwamen en die de cel als eigen feit heeft
-      # vastgelegd: verzekeringsstatus, inkomen en vermogen.
+      # Wat de cel overkwam: er werd inkomen aan haar geleverd, en dat legde ze
+      # vast. Niet "wij haalden op" — de kroniek is haar eigen journaal, en de
+      # verzekeringsstatus, het inkomen en het vermogen kwamen langs dit ene
+      # kanaal binnen.
       #
       # `wet_op_de_zorgtoeslag` noemt deze drie als input met een
       # `source.regulation` naar een andere regeling. Deze stroom overschaduwt
       # die verwijzingen bewust: een kroniekstroom is een databron en wint op
       # tier 1 van de resolutievolgorde (RFC-022 §4.2), dus de cross-law-vraag
-      # komt niet aan bod. Dat is hier de bedoeling — het zijn binnengekomen
-      # feiten — maar het gebeurt stil.
-      - stream: intake
+      # komt niet aan bod. Dat is hier de bedoeling — het is een levering die
+      # binnenkwam — maar het gebeurt stil.
+      - stream: inkomensleveringen
         key: bsn
         events:
-          - op_moment: 2024-11-15
+          - name: inkomenslevering
+            intake: levering
+            recording_actor: toeslagen
+            grondslag: jaarlijkse inkomenslevering
+            op_moment: 2024-11-15
             fields:
               bsn: '999993653'
               is_verzekerde: true

--- a/packages/simulator/scenarios/transport_toeslagen_brp.yaml
+++ b/packages/simulator/scenarios/transport_toeslagen_brp.yaml
@@ -13,6 +13,12 @@ description: >-
   `toeslagen` legt hier dus niets vast, en bij een volgend besluit gaat de vraag
   opnieuw naar de bron.
 
+clock:
+  # De vastlegging staat als `events` in de celconfiguratie, dus ze staat er al
+  # bij het optuigen; de klok begint ervoor en er is geen fixture die nog moet
+  # landen.
+  start: 2023-01-01
+
 cells:
   # De bevraagde cel: een bron-cel zonder engine, precies zoals het
   # bron-celscenario hem laat zien. Ze merkt niet dat de vraag over een
@@ -25,7 +31,11 @@ cells:
       - stream: relaties
         key: bsn
         events:
-          - op_moment: 2023-03-01
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: brp
+            grondslag: eigen registratie
+            op_moment: 2023-03-01
             fields:
               bsn: '999993653'
               partnerschap_type: HUWELIJK

--- a/packages/simulator/src/cell/chronicle.rs
+++ b/packages/simulator/src/cell/chronicle.rs
@@ -41,18 +41,6 @@ pub enum Intake {
     EigenBesluit,
 }
 
-impl Intake {
-    /// De naam zoals die in de configuratie en in foutmeldingen staat.
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::Aanvraag => "aanvraag",
-            Self::Levering => "levering",
-            Self::Betaling => "betaling",
-            Self::EigenBesluit => "eigen_besluit",
-        }
-    }
-}
-
 /// Eén vastlegging in een kroniekstroom: één executogram.
 ///
 /// De vorm komt uit RFC-022 §1.3, die vraagt dat per vastlegging vier dingen
@@ -197,16 +185,33 @@ impl ChronicleStore {
             .max_by_key(|event| event.op_moment)
     }
 
-    /// Houdt deze store een stroom met deze naam?
+    /// Zou deze vastlegging in deze stroom mogen?
     ///
     /// Zodat een wereld een vastlegging kan afkeuren bij het optuigen in plaats
-    /// van halverwege de tijdlijn. Geeft alleen prijs *of* de stroom bestaat —
-    /// haar naam staat toch al in de celconfiguratie — en nooit wat erin staat.
-    pub(crate) fn check_stream(&self, cell: &str, stream: &str) -> Result<()> {
-        match self.index_of(stream) {
-            Some(_) => Ok(()),
-            None => Err(self.unknown_stream(cell, stream)),
-        }
+    /// van halverwege de tijdlijn. Dezelfde toets als bij het vastleggen zelf,
+    /// zodat er geen fixture is die het optuigen haalt en later alsnog omvalt.
+    /// Geeft niets prijs over wat er al in de stroom staat.
+    pub(crate) fn check_recording(
+        &self,
+        cell: &str,
+        stream: &str,
+        event: &ChronicleEvent,
+    ) -> Result<()> {
+        self.checked_index(cell, stream, event).map(|_| ())
+    }
+
+    /// De plaats van de stroom waarin deze vastlegging mag, of de fout die haar
+    /// tegenhoudt.
+    ///
+    /// Eén plek voor de toets, zodat het optuigen en het vastleggen niet uit
+    /// elkaar kunnen lopen.
+    fn checked_index(&self, cell: &str, stream: &str, event: &ChronicleEvent) -> Result<usize> {
+        let Some(index) = self.index_of(stream) else {
+            return Err(self.unknown_stream(cell, stream));
+        };
+        let target = &self.streams[index];
+        check_event(cell, &target.stream, &target.key, event)?;
+        Ok(index)
     }
 
     /// De plaats van een stroom in de store, op naam.
@@ -237,12 +242,8 @@ impl ChronicleStore {
     /// Achteraan, en niet op datumpositie: bij een gelijk moment beslist de
     /// volgorde van vastlegging, en [`Self::reduce_to`] sorteert stabiel.
     pub(crate) fn record(&mut self, cell: &str, stream: &str, event: ChronicleEvent) -> Result<()> {
-        let Some(index) = self.index_of(stream) else {
-            return Err(self.unknown_stream(cell, stream));
-        };
-        let target = &mut self.streams[index];
-        check_event(cell, &target.stream, &target.key, &event)?;
-        target.events.push(event);
+        let index = self.checked_index(cell, stream, &event)?;
+        self.streams[index].events.push(event);
         Ok(())
     }
 

--- a/packages/simulator/src/cell/chronicle.rs
+++ b/packages/simulator/src/cell/chronicle.rs
@@ -221,7 +221,7 @@ impl ChronicleStore {
 
     /// De fout voor een stroom die deze cel niet houdt, met wat ze wél houdt.
     fn unknown_stream(&self, cell: &str, stream: &str) -> SimulatorError {
-        SimulatorError::UnknownStream {
+        SimulatorError::UnknownChronicleStream {
             cell: cell.to_string(),
             stream: stream.to_string(),
             known: self
@@ -548,8 +548,8 @@ mod tests {
                 event("2024-01-01", &[("bsn", Value::String("1".to_string()))]),
             )
             .expect_err("een stroom die de cel niet houdt hoort te falen");
-        let SimulatorError::UnknownStream { known, .. } = &err else {
-            panic!("verwachtte UnknownStream, kreeg {err}");
+        let SimulatorError::UnknownChronicleStream { known, .. } = &err else {
+            panic!("verwachtte UnknownChronicleStream, kreeg {err}");
         };
         assert_eq!(known, "relatie");
     }

--- a/packages/simulator/src/cell/chronicle.rs
+++ b/packages/simulator/src/cell/chronicle.rs
@@ -5,6 +5,12 @@
 //! vastlegging draagt het moment waarop het feit feit werd — de as waarop een
 //! reductie ordent (RFC-022 §4.1).
 //!
+//! Een kroniek bevat **alleen wat de cel zelf overkwam**: een aanvraag die
+//! binnenkwam, een levering die ze ontving, een betaling die ze deed, een
+//! besluit dat ze zelf nam. Geen schaduwboekhouding van waarden die ze elders
+//! ophaalde — dat zou het totaalbeeld dat volgens RFC-022 nergens bestaat
+//! alsnog in één cel leggen.
+//!
 //! De store is bewust *niet* publiek bereikbaar vanaf een cel: zie
 //! [`crate::cell::Cell`].
 
@@ -15,10 +21,62 @@ use regelrecht_engine::Value;
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet};
 
-/// Eén vastlegging in een kroniekstroom.
+/// Het kanaal waarlangs een feit de cel binnenkwam of in de cel ontstond.
+///
+/// RFC-022 §1.3 noemt dit `intake` en houdt het vocabulaire open. Hier is het
+/// een enum, want een typfout in een kanaalnaam mag niet stil doorgaan: dan
+/// staat er een vastlegging in de kroniek waarvan niemand meer kan zeggen
+/// waarlangs ze binnenkwam. Een kanaal erbij is één regel — het is
+/// platformvocabulaire, geen casusdata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Intake {
+    /// Iemand vroeg iets aan bij deze cel.
+    Aanvraag,
+    /// Een andere partij leverde een feit aan deze cel.
+    Levering,
+    /// Er werd door of aan deze cel betaald.
+    Betaling,
+    /// De cel nam zelf een besluit en legde dat vast.
+    EigenBesluit,
+}
+
+impl Intake {
+    /// De naam zoals die in de configuratie en in foutmeldingen staat.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Aanvraag => "aanvraag",
+            Self::Levering => "levering",
+            Self::Betaling => "betaling",
+            Self::EigenBesluit => "eigen_besluit",
+        }
+    }
+}
+
+/// Eén vastlegging in een kroniekstroom: één executogram.
+///
+/// De vorm komt uit RFC-022 §1.3, die vraagt dat per vastlegging vier dingen
+/// vaststaan: *wat* ([`Self::name`] en [`Self::fields`]), *door wie*
+/// ([`Self::recording_actor`]), op *welke grondslag* ([`Self::grondslag`]) en
+/// op *welk moment* ([`Self::op_moment`]). [`Self::intake`] vult dat aan met
+/// *waarlangs*. Een vastlegging die alleen een veldwaarde en een datum draagt,
+/// laat de helft van die vragen onbeantwoord.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ChronicleEvent {
+    /// Wat er gebeurde, in de woorden van de cel: `inkomenslevering`,
+    /// `aanvraag_ontvangen`, `relatie_gewijzigd`.
+    pub name: String,
+    /// Het kanaal waarlangs dit feit de cel bereikte.
+    pub intake: Intake,
+    /// Wie vastlegde: het id van de cel zelf (RFC-022 §1.3 — de celbeheerder,
+    /// niet de `competent_authority`, want een executogram is een feit en geen
+    /// besluit). Een cel kan dus niet beweren dat een ander haar kroniek
+    /// bijhield.
+    pub recording_actor: String,
+    /// Op welke grondslag dit feit vastgelegd wordt; vrije tekst, mag leeg.
+    #[serde(default)]
+    pub grondslag: String,
     /// Het moment waarop dit feit in deze cel feit werd.
     pub op_moment: NaiveDate,
     /// De vastgelegde velden. Veldnamen komen overeen met de `input`-namen van
@@ -75,17 +133,7 @@ impl ChronicleStore {
                 });
             }
             for event in &stream.events {
-                if !event
-                    .fields
-                    .keys()
-                    .any(|f| f.eq_ignore_ascii_case(&stream.key))
-                {
-                    return Err(SimulatorError::ChronicleEventWithoutKey {
-                        stream: stream.stream.clone(),
-                        key: stream.key.clone(),
-                        op_moment: event.op_moment.to_string(),
-                    });
-                }
+                check_event(cell, &stream.stream, &stream.key, event)?;
             }
         }
         Ok(Self { streams })
@@ -149,6 +197,55 @@ impl ChronicleStore {
             .max_by_key(|event| event.op_moment)
     }
 
+    /// Houdt deze store een stroom met deze naam?
+    ///
+    /// Zodat een wereld een vastlegging kan afkeuren bij het optuigen in plaats
+    /// van halverwege de tijdlijn. Geeft alleen prijs *of* de stroom bestaat —
+    /// haar naam staat toch al in de celconfiguratie — en nooit wat erin staat.
+    pub(crate) fn check_stream(&self, cell: &str, stream: &str) -> Result<()> {
+        match self.index_of(stream) {
+            Some(_) => Ok(()),
+            None => Err(self.unknown_stream(cell, stream)),
+        }
+    }
+
+    /// De plaats van een stroom in de store, op naam.
+    fn index_of(&self, stream: &str) -> Option<usize> {
+        self.streams.iter().position(|s| s.stream == stream)
+    }
+
+    /// De fout voor een stroom die deze cel niet houdt, met wat ze wél houdt.
+    fn unknown_stream(&self, cell: &str, stream: &str) -> SimulatorError {
+        SimulatorError::UnknownStream {
+            cell: cell.to_string(),
+            stream: stream.to_string(),
+            known: self
+                .streams
+                .iter()
+                .map(|s| s.stream.as_str())
+                .collect::<Vec<_>>()
+                .join(", "),
+        }
+    }
+
+    /// Voeg één vastlegging achteraan een stroom toe.
+    ///
+    /// Toevoegen is het enige dat kan: een bestaande vastlegging wordt nooit
+    /// gewijzigd of verwijderd. Een kroniek groeit, en een reductie over een
+    /// eerder moment blijft daardoor exact hetzelfde antwoord geven.
+    ///
+    /// Achteraan, en niet op datumpositie: bij een gelijk moment beslist de
+    /// volgorde van vastlegging, en [`Self::reduce_to`] sorteert stabiel.
+    pub(crate) fn record(&mut self, cell: &str, stream: &str, event: ChronicleEvent) -> Result<()> {
+        let Some(index) = self.index_of(stream) else {
+            return Err(self.unknown_stream(cell, stream));
+        };
+        let target = &mut self.streams[index];
+        check_event(cell, &target.stream, &target.key, &event)?;
+        target.events.push(event);
+        Ok(())
+    }
+
     /// De feiten zoals ze op `op_moment` in deze cel bekend waren.
     ///
     /// Dit is de tijdreductie: vastleggingen ná `op_moment` bestaan voor deze
@@ -208,6 +305,33 @@ pub(crate) fn field<'a>(fields: &'a BTreeMap<String, Value>, name: &str) -> Opti
         .map(|(_, value)| value)
 }
 
+/// Mag deze vastlegging in deze stroom van deze cel?
+///
+/// Twee dingen moeten kloppen, en bij het vastleggen net zo goed als bij het
+/// optuigen: de vastlegging moet het sleutelveld van haar stroom dragen (anders
+/// valt niet vast te stellen over welk onderwerp het feit gaat), en ze moet op
+/// naam van de cel zelf staan. Dat laatste is de kern van RFC-022 §1.3: een
+/// kroniek is het eigen journaal van de celbeheerder, dus een vastlegging op
+/// naam van een ander is geen feit maar een aanname over een ander.
+fn check_event(cell: &str, stream: &str, key: &str, event: &ChronicleEvent) -> Result<()> {
+    if !event.fields.keys().any(|f| f.eq_ignore_ascii_case(key)) {
+        return Err(SimulatorError::ChronicleEventWithoutKey {
+            stream: stream.to_string(),
+            key: key.to_string(),
+            op_moment: event.op_moment.to_string(),
+        });
+    }
+    if event.recording_actor != cell {
+        return Err(SimulatorError::ForeignRecordingActor {
+            cell: cell.to_string(),
+            stream: stream.to_string(),
+            recording_actor: event.recording_actor.clone(),
+            op_moment: event.op_moment.to_string(),
+        });
+    }
+    Ok(())
+}
+
 /// Heeft deze vastlegging dit veld, met deze waarde?
 ///
 /// Een veld dat de vastlegging niet heeft, voldoet niet: "onbekend" is geen
@@ -235,6 +359,10 @@ mod tests {
 
     fn event(op_moment: &str, fields: &[(&str, Value)]) -> ChronicleEvent {
         ChronicleEvent {
+            name: "relatie_gewijzigd".to_string(),
+            intake: Intake::Levering,
+            recording_actor: "toeslagen".to_string(),
+            grondslag: String::new(),
             op_moment: date(op_moment),
             fields: fields
                 .iter()
@@ -351,6 +479,78 @@ mod tests {
             matches!(err, SimulatorError::DuplicateStream { .. }),
             "verwachtte DuplicateStream, kreeg {err}"
         );
+    }
+
+    #[test]
+    fn vastlegging_op_naam_van_een_ander_wordt_geweigerd() {
+        let mut foreign = event("2024-01-01", &[("bsn", Value::String("1".to_string()))]);
+        foreign.recording_actor = "belastingdienst".to_string();
+        let err = ChronicleStore::from_streams(
+            "toeslagen",
+            vec![ChronicleStream {
+                stream: "relatie".to_string(),
+                key: "bsn".to_string(),
+                events: vec![foreign],
+            }],
+        )
+        .expect_err("een vastlegging op naam van een andere cel hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::ForeignRecordingActor { .. }),
+            "verwachtte ForeignRecordingActor, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn vastleggen_voegt_toe_en_wijzigt_niets() {
+        let mut store = store(vec![event(
+            "2024-01-01",
+            &[
+                ("bsn", Value::String("1".to_string())),
+                ("partnerschap_type", Value::String("GEEN".to_string())),
+            ],
+        )]);
+
+        store
+            .record(
+                "toeslagen",
+                "relatie",
+                event(
+                    "2024-06-01",
+                    &[
+                        ("bsn", Value::String("1".to_string())),
+                        ("partnerschap_type", Value::String("HUWELIJK".to_string())),
+                    ],
+                ),
+            )
+            .unwrap_or_else(|e| panic!("vastleggen in een eigen stroom moet lukken: {e}"));
+
+        let before = store.reduce_to(date("2024-03-01"));
+        assert_eq!(
+            before[0].records[0].get("partnerschap_type"),
+            Some(&Value::String("GEEN".to_string())),
+            "een latere vastlegging mag het beeld van een eerder moment niet raken"
+        );
+        let after = store.reduce_to(date("2024-07-01"));
+        assert_eq!(
+            after[0].records[0].get("partnerschap_type"),
+            Some(&Value::String("HUWELIJK".to_string()))
+        );
+    }
+
+    #[test]
+    fn vastleggen_in_een_onbekende_stroom_wordt_geweigerd() {
+        let mut store = store(vec![]);
+        let err = store
+            .record(
+                "toeslagen",
+                "betalingen",
+                event("2024-01-01", &[("bsn", Value::String("1".to_string()))]),
+            )
+            .expect_err("een stroom die de cel niet houdt hoort te falen");
+        let SimulatorError::UnknownStream { known, .. } = &err else {
+            panic!("verwachtte UnknownStream, kreeg {err}");
+        };
+        assert_eq!(known, "relatie");
     }
 
     #[test]

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -171,12 +171,14 @@ impl Cell {
         self.chronicles.record(&self.id, stream, event)
     }
 
-    /// Houdt deze cel een kroniekstroom met deze naam?
+    /// Zou deze vastlegging in deze stroom van deze cel mogen?
     ///
     /// Alleen zodat een wereld een vastlegging bij het optuigen kan afkeuren in
-    /// plaats van halverwege de tijdlijn. Geeft niets prijs over de inhoud.
-    pub(crate) fn check_chronicle(&self, stream: &str) -> Result<()> {
-        self.chronicles.check_stream(&self.id, stream)
+    /// plaats van halverwege de tijdlijn: dezelfde toets als
+    /// [`Self::record`] doet, zonder iets vast te leggen. Geeft niets prijs over
+    /// de inhoud van de kroniek.
+    pub(crate) fn check_recording(&self, stream: &str, event: &ChronicleEvent) -> Result<()> {
+        self.chronicles.check_recording(&self.id, stream, event)
     }
 
     /// Reduceer over de eigen feiten en lever de gevraagde lexostatus.

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -10,7 +10,7 @@
 mod chronicle;
 mod config;
 
-pub use chronicle::{ChronicleEvent, ChronicleStore, ChronicleStream};
+pub use chronicle::{ChronicleEvent, ChronicleStore, ChronicleStream, Intake};
 pub use config::{CellConfig, LexostatusDefinition, LexostatusInput, ParameterType, Reduction};
 
 use crate::corpus;
@@ -156,6 +156,27 @@ impl Cell {
             chronicles,
             published,
         })
+    }
+
+    /// Leg één executogram vast in een eigen kroniekstroom.
+    ///
+    /// `pub(crate)` en niet `pub`: het is de eigen kroniek van de cel, dus net
+    /// zomin als een consument eruit kan lezen mag hij erin schrijven. In deze
+    /// crate legt alleen [`crate::World`] vast, op een moment dat de klok
+    /// passeert.
+    ///
+    /// Vastleggen voegt toe. Een bestaand gram wordt nooit gewijzigd, dus een
+    /// reductie over een eerder moment blijft na dit vastleggen exact hetzelfde.
+    pub(crate) fn record(&mut self, stream: &str, event: ChronicleEvent) -> Result<()> {
+        self.chronicles.record(&self.id, stream, event)
+    }
+
+    /// Houdt deze cel een kroniekstroom met deze naam?
+    ///
+    /// Alleen zodat een wereld een vastlegging bij het optuigen kan afkeuren in
+    /// plaats van halverwege de tijdlijn. Geeft niets prijs over de inhoud.
+    pub(crate) fn check_chronicle(&self, stream: &str) -> Result<()> {
+        self.chronicles.check_stream(&self.id, stream)
     }
 
     /// Reduceer over de eigen feiten en lever de gevraagde lexostatus.
@@ -410,7 +431,10 @@ chronicles:
   - stream: relaties
     key: bsn
     events:
-      - op_moment: 2024-01-01
+      - name: relatie_gewijzigd
+        intake: levering
+        recording_actor: toeslagen
+        op_moment: 2024-01-01
         fields:
           bsn: '999993653'
           partnerschap_type: GEEN
@@ -505,10 +529,14 @@ laws:
   - algemene_wet_inkomensafhankelijke_regelingen
   - regeling_standaardpremie
 chronicles:
-  - stream: intake
+  - stream: inkomensleveringen
     key: bsn
     events:
-      - op_moment: 2024-11-15
+      - name: inkomenslevering
+        intake: levering
+        recording_actor: toeslagen
+        grondslag: jaarlijkse inkomenslevering
+        op_moment: 2024-11-15
         fields:
           bsn: '999993653'
           partnerschap_type: GEEN

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -112,7 +112,18 @@ impl Cell {
     ///
     /// `laws: []` is geldig: dan komt er geen engine, en houdt de cel het bij
     /// vastleggen en reduceren over haar eigen kronieken.
-    pub fn from_config(config: &CellConfig, regulation_root: &Path) -> Result<Self> {
+    ///
+    /// `fixture_fields` telt de veldnamen mee die de wereld via een `fixture`
+    /// aan een stroom van deze cel toevoegt. Een stroom mag leeg opgetuigd
+    /// worden en haar inhoud pas via `fixtures` krijgen — zie
+    /// `scenarios/toeslagen_tijdlijn.yaml` — en dan zou `declared_fields()`
+    /// alleen het sleutelveld kennen. Een kroniekfilter dat over zo'n veld
+    /// praat, zou dan onterecht als typfout afgekeurd worden.
+    pub fn from_config(
+        config: &CellConfig,
+        regulation_root: &Path,
+        fixture_fields: &BTreeMap<String, BTreeSet<String>>,
+    ) -> Result<Self> {
         let chronicles = ChronicleStore::from_streams(&config.id, config.chronicles.clone())?;
 
         let service = if config.laws.is_empty() {
@@ -127,13 +138,21 @@ impl Cell {
             Some(service)
         };
 
+        let mut streams = chronicles.declared_fields();
+        for (stream, fields) in fixture_fields {
+            streams
+                .entry(stream.clone())
+                .or_default()
+                .extend(fields.iter().cloned());
+        }
+
         let surface = CellSurface {
             laws: &config.laws,
             outputs: service
                 .as_ref()
                 .map(outputs_per_regulation)
                 .unwrap_or_default(),
-            streams: chronicles.declared_fields(),
+            streams,
         };
 
         let mut published: BTreeMap<String, LexostatusDefinition> = BTreeMap::new();
@@ -423,6 +442,12 @@ mod tests {
         serde_yaml_ng::from_str(yaml).unwrap_or_else(|e| panic!("testconfig moet parsen: {e}"))
     }
 
+    /// Geen fixtures: deze tests tuigen een cel rechtstreeks op, buiten een
+    /// wereld om, dus er is niets dat een stroom extra velden aanreikt.
+    fn no_fixtures() -> BTreeMap<String, BTreeSet<String>> {
+        BTreeMap::new()
+    }
+
     fn toeslagen() -> Cell {
         let config = config(
             r"
@@ -452,7 +477,7 @@ lexostatus_definitions:
         bsn: $bsn
 ",
         );
-        Cell::from_config(&config, &regulation_root())
+        Cell::from_config(&config, &regulation_root(), &no_fixtures())
             .unwrap_or_else(|e| panic!("cel moet op te tuigen zijn: {e}"))
     }
 
@@ -563,7 +588,7 @@ lexostatus_definitions:
 
     #[test]
     fn een_niet_gepubliceerde_uitkomst_blijft_binnen_de_cel() {
-        let cell = Cell::from_config(&zorgtoeslag(""), &regulation_root())
+        let cell = Cell::from_config(&zorgtoeslag(""), &regulation_root(), &no_fixtures())
             .unwrap_or_else(|e| panic!("cel moet op te tuigen zijn: {e}"));
         let answer = cell
             .reduce("zorgtoeslag_rechtstoestand", &bsn(), moment())
@@ -586,6 +611,7 @@ lexostatus_definitions:
         let cell = Cell::from_config(
             &zorgtoeslag("    outputs:\n      - hoogte_zorgtoeslag"),
             &regulation_root(),
+            &no_fixtures(),
         )
         .unwrap_or_else(|e| panic!("cel moet op te tuigen zijn: {e}"));
         let answer = cell
@@ -604,6 +630,7 @@ lexostatus_definitions:
         let err = Cell::from_config(
             &zorgtoeslag("    outputs:\n      - hoogte_huurtoeslag"),
             &regulation_root(),
+            &no_fixtures(),
         )
         .expect_err("een uitkomst die de regeling niet kent hoort te falen");
         assert!(
@@ -628,12 +655,18 @@ chronicles:
   - stream: relaties
     key: bsn
     events:
-      - op_moment: 2023-03-01
+      - name: relatie_gewijzigd
+        intake: levering
+        recording_actor: brp
+        op_moment: 2023-03-01
         fields:
           bsn: '999993653'
           partnerschap_type: HUWELIJK
           partner_bsn: '999993756'
-      - op_moment: 2024-07-01
+      - name: relatie_gewijzigd
+        intake: levering
+        recording_actor: brp
+        op_moment: 2024-07-01
         fields:
           bsn: '999993653'
           partnerschap_type: GEEN
@@ -657,7 +690,7 @@ lexostatus_definitions:
       latest: true";
 
     fn source_cell(definition: &str) -> Cell {
-        Cell::from_config(&brp(definition), &regulation_root())
+        Cell::from_config(&brp(definition), &regulation_root(), &no_fixtures())
             .unwrap_or_else(|e| panic!("een bron-cel moet op te tuigen zijn: {e}"))
     }
 
@@ -770,11 +803,17 @@ chronicles:
   - stream: relaties
     key: bsn
     events:
-      - op_moment: 2023-03-01
+      - name: relatie_gewijzigd
+        intake: levering
+        recording_actor: brp
+        op_moment: 2023-03-01
         fields:
           bsn: '999993653'
           partnerschap_type: HUWELIJK
-      - op_moment: 2024-07-01
+      - name: relatie_gewijzigd
+        intake: levering
+        recording_actor: brp
+        op_moment: 2024-07-01
         fields:
           bsn: '999993653'
 lexostatus_definitions:
@@ -790,6 +829,7 @@ lexostatus_definitions:
 ",
             ),
             &regulation_root(),
+            &no_fixtures(),
         )
         .unwrap_or_else(|e| panic!("een bron-cel moet op te tuigen zijn: {e}"));
 
@@ -815,6 +855,7 @@ lexostatus_definitions:
       chronicle: relatis
       key: bsn"),
             &regulation_root(),
+            &no_fixtures(),
         )
         .expect_err("een typfout in de stroomnaam hoort te falen");
         assert!(
@@ -830,6 +871,7 @@ lexostatus_definitions:
       chronicle: relaties
       key: bsn"),
             &regulation_root(),
+            &no_fixtures(),
         )
         .expect_err("een kroniekfilter zonder `outputs` hoort te falen");
         assert!(
@@ -847,6 +889,7 @@ lexostatus_definitions:
       chronicle: relaties
       key: bsn"),
             &regulation_root(),
+            &no_fixtures(),
         )
         .expect_err("een uitkomst die geen vastlegging draagt hoort te falen");
         assert!(
@@ -866,6 +909,7 @@ lexostatus_definitions:
       where:
         partnerschaptype: HUWELIJK"),
             &regulation_root(),
+            &no_fixtures(),
         )
         .expect_err("een `where` op een onbekend veld hoort te falen");
         assert!(
@@ -885,6 +929,7 @@ lexostatus_definitions:
       where:
         partner_bsn: $bsn"),
             &regulation_root(),
+            &no_fixtures(),
         )
         .expect_err("`where` kent geen `$`-verwijzingen, dus dit hoort te falen");
         assert!(
@@ -902,6 +947,7 @@ lexostatus_definitions:
       chronicle: relaties
       key: partner_bsn"),
             &regulation_root(),
+            &no_fixtures(),
         )
         .expect_err("een sleutel die de consument niet kan meegeven hoort te falen");
         assert!(
@@ -919,6 +965,7 @@ lexostatus_definitions:
       parameters:
         bsn: $bsn"),
             &regulation_root(),
+            &no_fixtures(),
         )
         .expect_err("zonder geladen regeling hoort een wetsvorm te falen");
         assert!(
@@ -942,7 +989,7 @@ lexostatus_definitions:
       output: rendementsgrondslag
 ",
         );
-        let err = Cell::from_config(&config, &regulation_root())
+        let err = Cell::from_config(&config, &regulation_root(), &no_fixtures())
             .expect_err("een reductie over een vreemde regeling hoort te falen");
         assert!(
             matches!(err, SimulatorError::ForeignRegulation { .. }),

--- a/packages/simulator/src/error.rs
+++ b/packages/simulator/src/error.rs
@@ -266,6 +266,69 @@ pub enum SimulatorError {
         op_moment: String,
     },
 
+    /// Een vastlegging staat op naam van een andere cel dan die haar houdt.
+    ///
+    /// Een kroniek is het eigen journaal van de celbeheerder (RFC-022 §1.3):
+    /// wat de cel zelf overkwam, door haar vastgelegd. Een vastlegging op naam
+    /// van een ander is geen feit maar een aanname over een ander.
+    #[error(
+        "cel '{cell}': vastlegging van {op_moment} in stroom '{stream}' staat op naam van \
+         '{recording_actor}', maar een kroniek houdt alleen de eigen vastleggingen van de cel"
+    )]
+    ForeignRecordingActor {
+        /// De cel die de stroom houdt.
+        cell: String,
+        /// De stroom waarin de vastlegging staat.
+        stream: String,
+        /// De actor die de vastlegging opgeeft.
+        recording_actor: String,
+        /// Het moment van de vastlegging.
+        op_moment: String,
+    },
+
+    /// Er wordt vastgelegd in een stroom die de cel niet houdt.
+    #[error("cel '{cell}' houdt geen kroniekstroom '{stream}' (wel: {known})")]
+    UnknownStream {
+        /// De cel waarin vastgelegd werd.
+        cell: String,
+        /// De gevraagde stroomnaam.
+        stream: String,
+        /// Komma-gescheiden lijst van stromen die de cel wél houdt.
+        known: String,
+    },
+
+    /// De klok van de wereld zou achteruit moeten lopen.
+    ///
+    /// Een logische klok gaat één kant op. Wie het beeld van een eerder moment
+    /// wil, vraagt dat op met `op_moment`; daarvoor hoeft de wereld niet terug.
+    #[error("de klok van de wereld staat op {clock} en loopt niet terug naar {to}")]
+    ClockRunsBackwards {
+        /// Waar de klok nu staat.
+        clock: String,
+        /// Het moment waarnaar gevraagd werd.
+        to: String,
+    },
+
+    /// Er wordt gereduceerd over een moment dat nog niet gebeurd is.
+    ///
+    /// De wereld weet niet wat er na haar klok gebeurt: triggers die nog moeten
+    /// afgaan hebben niets vastgelegd. Een antwoord "op" zo'n moment zou een
+    /// voorspelling zijn die zich voordoet als een reductie.
+    #[error(
+        "cel '{cell}': reductie van '{lexostatus}' op {op_moment} vraagt een moment ná de klok \
+         van de wereld ({clock})"
+    )]
+    MomentAfterClock {
+        /// De bevraagde cel.
+        cell: String,
+        /// De gevraagde lexostatus.
+        lexostatus: String,
+        /// Het gevraagde moment.
+        op_moment: String,
+        /// Waar de klok staat.
+        clock: String,
+    },
+
     /// Twee kroniekstromen met dezelfde naam in één cel.
     ///
     /// De stroomnaam is tevens de naam van de databron in de engine. Twee

--- a/packages/simulator/src/error.rs
+++ b/packages/simulator/src/error.rs
@@ -288,7 +288,7 @@ pub enum SimulatorError {
 
     /// Er wordt vastgelegd in een stroom die de cel niet houdt.
     #[error("cel '{cell}' houdt geen kroniekstroom '{stream}' (wel: {known})")]
-    UnknownStream {
+    UnknownChronicleStream {
         /// De cel waarin vastgelegd werd.
         cell: String,
         /// De gevraagde stroomnaam.

--- a/packages/simulator/src/lib.rs
+++ b/packages/simulator/src/lib.rs
@@ -18,6 +18,10 @@
 //! met opzet buiten de band, want een observator die álles ziet kent wél het
 //! totaalbeeld waarvan deze opstelling zegt dat het nergens bestaat.
 //!
+//! Tijd hoort bij de [`World`] en niet bij een vraag: één logische klok per
+//! wereld, nooit de wandklok, en [`World::advance`] laat de tijd lopen zodat
+//! triggers op hun eigen moment vastleggen.
+//!
 //! ```no_run
 //! use regelrecht_simulator::{regulation_root, Scenario};
 //! use std::path::Path;
@@ -43,9 +47,10 @@ pub mod scenario;
 pub mod security;
 pub mod transport;
 mod values;
+pub mod world;
 
 pub use cell::{
-    Cell, CellConfig, ChronicleEvent, ChronicleStore, ChronicleStream, Lexostatus,
+    Cell, CellConfig, ChronicleEvent, ChronicleStore, ChronicleStream, Intake, Lexostatus,
     LexostatusDefinition, LexostatusInput, LexostatusOutcome, ParameterType, Reduction,
 };
 pub use corpus::regulation_root;
@@ -56,3 +61,4 @@ pub use scenario::{
 };
 pub use security::{Identity, SecurityContext, Signature, SignedAnswer};
 pub use transport::{CellTransport, InProcessTransport};
+pub use world::{Clock, Fixture, Recording, World};

--- a/packages/simulator/src/scenario.rs
+++ b/packages/simulator/src/scenario.rs
@@ -8,7 +8,7 @@
 use crate::cell::{CellConfig, Lexostatus, LexostatusOutcome};
 use crate::error::{Result, SimulatorError};
 use crate::security::{Identity, SecurityContext, SignedAnswer};
-use crate::transport::{CellTransport, InProcessTransport};
+use crate::transport::InProcessTransport;
 use crate::values::equivalent;
 use crate::world::{Clock, Fixture, World};
 use chrono::NaiveDate;
@@ -572,6 +572,7 @@ queries:
     fn vraag_over_de_celgrens_zonder_verwachting_wordt_geweigerd() {
         let yaml = r"
 name: bewijst niets over de grens
+clock: { start: 2025-01-01 }
 cells: []
 query_via_transport:
   - from: toeslagen
@@ -657,6 +658,7 @@ query_via_transport:
             clock: moment(),
             pending_triggers,
             outcomes: Vec::new(),
+            transport_outcomes: Vec::new(),
         };
 
         assert!(
@@ -691,6 +693,7 @@ query_via_transport:
             clock: moment,
             pending_triggers: 0,
             outcomes: vec![outcome("vóór de vastlegging"), outcome("erna, ongewijzigd")],
+            transport_outcomes: Vec::new(),
         };
 
         let report = run.report();

--- a/packages/simulator/src/scenario.rs
+++ b/packages/simulator/src/scenario.rs
@@ -1,15 +1,16 @@
-//! Het scenario: de cellen van een run, de vragen die gesteld worden en wat
-//! die vragen moeten opleveren.
+//! Het wereldbestand: de klok, de cellen, de startstand, de vragen die gesteld
+//! worden en wat die vragen moeten opleveren.
 //!
-//! Een scenario is data. De assertie hoort erbij: wat een run moet opleveren
-//! staat in het scenariobestand, niet in Rust. Zo blijft een testgeval een
-//! bestand dat iemand kan lezen en wijzigen zonder de crate te kennen.
+//! Een wereld is data. De assertie hoort erbij: wat een run moet opleveren
+//! staat in het bestand, niet in Rust. Zo blijft een testgeval een bestand dat
+//! iemand kan lezen en wijzigen zonder de crate te kennen.
 
-use crate::cell::{Cell, CellConfig, Lexostatus, LexostatusOutcome};
+use crate::cell::{CellConfig, Lexostatus, LexostatusOutcome};
 use crate::error::{Result, SimulatorError};
 use crate::security::{Identity, SecurityContext, SignedAnswer};
 use crate::transport::{CellTransport, InProcessTransport};
 use crate::values::equivalent;
+use crate::world::{Clock, Fixture, World};
 use chrono::NaiveDate;
 use regelrecht_engine::Value;
 use serde::Deserialize;
@@ -17,7 +18,7 @@ use std::collections::BTreeMap;
 use std::fmt::Write as _;
 use std::path::Path;
 
-/// Een volledig scenario.
+/// Een volledig wereldbestand.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Scenario {
@@ -26,8 +27,16 @@ pub struct Scenario {
     /// Waarom dit scenario bestaat; vrije tekst.
     #[serde(default)]
     pub description: Option<String>,
+    /// De logische klok van deze wereld. Verplicht en expliciet: een run mag
+    /// niet van de wandklok afhangen.
+    pub clock: Clock,
     /// De cellen in deze run.
     pub cells: Vec<CellConfig>,
+    /// De startstand: vastleggingen met een moment. Wat vóór het startmoment
+    /// van de klok valt staat er bij het optuigen al; de rest landt zodra de
+    /// klok die datum passeert.
+    #[serde(default)]
+    pub fixtures: Vec<Fixture>,
     /// De vragen die een consument stelt.
     #[serde(default)]
     pub queries: Vec<Query>,
@@ -151,6 +160,8 @@ pub struct TransportOutcome {
 pub struct ScenarioRun {
     /// De naam van het scenario dat gedraaid heeft.
     pub name: String,
+    /// Waar de logische klok na de run staat.
+    pub clock: NaiveDate,
     /// De uitkomsten van de vragen van een consument, in scenariovolgorde.
     pub outcomes: Vec<QueryOutcome>,
     /// De uitkomsten van de vragen over een celgrens, in scenariovolgorde.
@@ -220,6 +231,7 @@ impl ScenarioRun {
             write_failures(&mut out, &outcome.failures);
         }
 
+        let _ = writeln!(out, "  klok staat op {}", self.clock);
         out
     }
 }
@@ -312,7 +324,18 @@ impl Scenario {
         Self::from_yaml(&text)
     }
 
-    /// Tuig de cellen op en stel alle vragen.
+    /// Tuig de wereld op: de cellen, de klok op haar startmoment en de
+    /// startstand die op dat moment al gebeurd was.
+    pub fn world(&self, regulation_root: &Path) -> Result<World> {
+        World::new(&self.cells, self.clock, &self.fixtures, regulation_root)
+    }
+
+    /// Tuig de wereld op, laat de tijd lopen en stel alle vragen.
+    ///
+    /// De vragen lopen de tijdlijn af in de volgorde van het bestand: staat de
+    /// klok nog vóór het moment van een vraag, dan gaat de wereld eerst vooruit
+    /// en gaan onderweg de triggers af. Een vraag over een eerder moment kan
+    /// altijd; die levert het beeld van toen. Vooruitkijken kan niet.
     ///
     /// De runner combineert niets: hij geeft elk antwoord terug zoals de cel het
     /// gaf. Combineren over cellen heen is synthese en hoort bij een consument.
@@ -321,28 +344,20 @@ impl Scenario {
     /// cel. Vragen uit `query_via_transport` gaan langs de veiligheidscontext van
     /// de vragende cel naar het transport — de enige weg over een celgrens.
     pub fn run(&self, regulation_root: &Path) -> Result<ScenarioRun> {
-        let mut cells: BTreeMap<String, Cell> = BTreeMap::new();
-        for config in &self.cells {
-            if cells.contains_key(&config.id) {
-                return Err(SimulatorError::DuplicateCell {
-                    cell: config.id.clone(),
-                });
-            }
-            cells.insert(
-                config.id.clone(),
-                Cell::from_config(config, regulation_root)?,
-            );
-        }
+        let mut world = self.world(regulation_root)?;
 
         let mut outcomes = Vec::with_capacity(self.queries.len());
         for query in &self.queries {
-            let cell = cells
-                .get(&query.cell)
-                .ok_or_else(|| SimulatorError::UnknownCell {
-                    cell: query.cell.clone(),
-                })?;
+            if query.op_moment > world.now() {
+                world.advance(query.op_moment)?;
+            }
 
-            let answer = cell.reduce(&query.lexostatus, &query.params, query.op_moment)?;
+            let answer = world.reduce(
+                &query.cell,
+                &query.lexostatus,
+                &query.params,
+                query.op_moment,
+            )?;
             let failures = check_expectations(query, &answer.outcome);
 
             outcomes.push(QueryOutcome {
@@ -353,11 +368,11 @@ impl Scenario {
             });
         }
 
-        let transport = InProcessTransport::over(&cells);
-        let transport_outcomes = self.run_via_transport(&cells, &transport)?;
+        let transport_outcomes = self.run_via_transport(&mut world)?;
 
         Ok(ScenarioRun {
             name: self.name.clone(),
+            clock: world.now(),
             outcomes,
             transport_outcomes,
         })
@@ -365,27 +380,31 @@ impl Scenario {
 
     /// Stel de cross-cel-vragen, elk vanuit de veiligheidscontext van de vrager.
     ///
-    /// Het transport is een parameter en geen keuze van deze functie: dat is de
-    /// naad waarlangs later een HTTP-transport aanschuift zonder dat hier of in
-    /// een cel iets verandert.
-    fn run_via_transport(
-        &self,
-        cells: &BTreeMap<String, Cell>,
-        transport: &dyn CellTransport,
-    ) -> Result<Vec<TransportOutcome>> {
+    /// Net als bij een vraag van een consument gaat de klok eerst vooruit tot het
+    /// gevraagde moment, zodat een fixture die ertussen valt onderweg vastlegt.
+    /// Het transport zelf wordt per vraag opnieuw opgebouwd over `world.cells()`
+    /// — dat is de naad waarlangs later een HTTP-transport aanschuift zonder dat
+    /// hier of in een cel iets verandert — en dat kan niet één keer vooraf: de
+    /// lening zou anders `world.advance` in de weg staan.
+    fn run_via_transport(&self, world: &mut World) -> Result<Vec<TransportOutcome>> {
         let mut outcomes = Vec::with_capacity(self.query_via_transport.len());
         for via in &self.query_via_transport {
             // De vrager moet een cel in deze wereld zijn. Zonder deze controle zou
             // een typfout in `from` een identiteit opleveren die nergens bij hoort,
             // en dan zegt het vraaggraf iets over een cel die niet bestaat.
-            if !cells.contains_key(&via.from) {
+            if !world.cells().contains_key(&via.from) {
                 return Err(SimulatorError::UnknownCell {
                     cell: via.from.clone(),
                 });
             }
 
-            let context = SecurityContext::new(Identity::for_cell(&via.from), transport);
             let query = &via.query;
+            if query.op_moment > world.now() {
+                world.advance(query.op_moment)?;
+            }
+
+            let transport = InProcessTransport::over(world.cells());
+            let context = SecurityContext::new(Identity::for_cell(&via.from), &transport);
             let signed = context.query(
                 &query.cell,
                 &query.lexostatus,
@@ -444,6 +463,7 @@ mod tests {
     fn onbekend_veld_in_scenario_wordt_geweigerd() {
         let yaml = r"
 name: typfout
+clock: { start: 2025-01-01 }
 cells: []
 queeries: []
 ";
@@ -457,6 +477,7 @@ queeries: []
     fn vraag_zonder_verwachting_wordt_geweigerd() {
         let yaml = r"
 name: bewijst niets
+clock: { start: 2025-01-01 }
 cells: []
 queries:
   - cell: toeslagen
@@ -474,6 +495,7 @@ queries:
     fn vraag_die_waarden_en_niets_vastgesteld_verwacht_wordt_geweigerd() {
         let yaml = r"
 name: kan niet uitkomen
+clock: { start: 2025-01-01 }
 cells: []
 queries:
   - cell: brp
@@ -492,9 +514,23 @@ queries:
     }
 
     #[test]
+    fn een_wereld_zonder_klok_wordt_geweigerd() {
+        let yaml = r"
+name: zonder klok
+cells: []
+";
+        assert!(
+            Scenario::from_yaml(yaml).is_err(),
+            "zonder startmoment zou de wereld op de wandklok moeten terugvallen, \
+             en dan is een run morgen een andere run"
+        );
+    }
+
+    #[test]
     fn niets_vastgesteld_mag_de_enige_verwachting_zijn() {
         let yaml = r"
 name: bewijst dat er niets was
+clock: { start: 2025-01-01 }
 cells: []
 queries:
   - cell: brp

--- a/packages/simulator/src/scenario.rs
+++ b/packages/simulator/src/scenario.rs
@@ -164,6 +164,10 @@ pub struct ScenarioRun {
     pub name: String,
     /// Waar de logische klok na de run staat.
     pub clock: NaiveDate,
+    /// Hoeveel vastleggingen niet afgegaan zijn omdat hun moment ná de klok
+    /// ligt. De runner loopt de tijd af tot de laatste vraag, dus een fixture
+    /// verder in de toekomst gebeurt in deze run niet.
+    pub pending_triggers: usize,
     /// De uitkomsten van de vragen van een consument, in scenariovolgorde.
     pub outcomes: Vec<QueryOutcome>,
     /// De uitkomsten van de vragen over een celgrens, in scenariovolgorde.
@@ -240,6 +244,16 @@ impl ScenarioRun {
         }
 
         let _ = writeln!(out, "  klok staat op {}", self.clock);
+        // Een fixture waar de klok nooit aan toe komt, is een regel in het
+        // bestand die niets doet. Dat mag, maar het hoort niet stil te zijn:
+        // wie hem als startstand bedoelde, ziet hier dat hij niet meedeed.
+        if self.pending_triggers > 0 {
+            let _ = writeln!(
+                out,
+                "  {} vastlegging(en) gingen niet af: hun moment ligt ná de klok",
+                self.pending_triggers
+            );
+        }
         out
     }
 }
@@ -382,6 +396,7 @@ impl Scenario {
         Ok(ScenarioRun {
             name: self.name.clone(),
             clock: world.now(),
+            pending_triggers: world.pending_triggers(),
             outcomes,
             transport_outcomes,
         })
@@ -626,10 +641,39 @@ query_via_transport:
     /// elkaar te vallen. In de kernassertie over tijd staat dezelfde vraag twee
     /// keer, vóór en ná een vastlegging; zonder de omschrijving zijn dat twee
     /// identieke regels en zegt het verslag niet welke welke is.
+    fn moment() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2024, 6, 1)
+            .unwrap_or_else(|| panic!("2024-06-01 moet een geldige datum zijn"))
+    }
+
+    /// Een vastlegging waar de klok niet aan toe kwam, hoort in het verslag te
+    /// staan. Zij is geldig bevonden bij het optuigen en doet daarna niets; dat
+    /// stil laten betekent dat een regel in het wereldbestand niets bewijst
+    /// zonder dat iemand het merkt.
+    #[test]
+    fn het_verslag_meldt_vastleggingen_die_niet_afgingen() {
+        let run = |pending_triggers| ScenarioRun {
+            name: "tijd".to_string(),
+            clock: moment(),
+            pending_triggers,
+            outcomes: Vec::new(),
+        };
+
+        assert!(
+            run(2).report().contains("2 vastlegging(en) gingen niet af"),
+            "het verslag hoort te melden dat er nog iets wachtte; kreeg:\n{}",
+            run(2).report()
+        );
+        assert!(
+            !run(0).report().contains("gingen niet af"),
+            "zonder wachtende vastleggingen hoort die regel weg te blijven; kreeg:\n{}",
+            run(0).report()
+        );
+    }
+
     #[test]
     fn het_verslag_onderscheidt_twee_gelijke_vragen_aan_hun_omschrijving() {
-        let moment = NaiveDate::from_ymd_opt(2024, 6, 1)
-            .unwrap_or_else(|| panic!("2024-06-01 moet een geldige datum zijn"));
+        let moment = moment();
         let outcome = |description: &str| QueryOutcome {
             description: Some(description.to_string()),
             cell: "toeslagen".to_string(),
@@ -645,6 +689,7 @@ query_via_transport:
         let run = ScenarioRun {
             name: "tijd".to_string(),
             clock: moment,
+            pending_triggers: 0,
             outcomes: vec![outcome("vóór de vastlegging"), outcome("erna, ongewijzigd")],
         };
 

--- a/packages/simulator/src/scenario.rs
+++ b/packages/simulator/src/scenario.rs
@@ -132,6 +132,8 @@ pub enum ExpectationFailure {
 /// Het resultaat van één vraag.
 #[derive(Debug, Clone)]
 pub struct QueryOutcome {
+    /// De omschrijving uit het scenario, als die er stond.
+    pub description: Option<String>,
     /// De cel waaraan gevraagd is.
     pub cell: String,
     /// De gevraagde lexostatus.
@@ -197,6 +199,12 @@ impl ScenarioRun {
                 "  [{mark}] {}.{} op {}",
                 outcome.cell, outcome.lexostatus, outcome.lexostatus_value.op_moment
             );
+            // De omschrijving erbij, want twee vragen kunnen dezelfde cel, naam
+            // en moment hebben — in de kernassertie over tijd is dat juist het
+            // punt — en dan is de regel hierboven twee keer dezelfde.
+            if let Some(description) = &outcome.description {
+                let _ = writeln!(out, "        {description}");
+            }
             // "Niets vastgesteld" is een antwoord, dus het verslag zegt het ook
             // als het klopte: anders staat er `ok` bij een regel waarvan de
             // lezer niet kan zien wat de cel antwoordde.
@@ -361,6 +369,7 @@ impl Scenario {
             let failures = check_expectations(query, &answer.outcome);
 
             outcomes.push(QueryOutcome {
+                description: query.description.clone(),
                 cell: query.cell.clone(),
                 lexostatus: query.lexostatus.clone(),
                 lexostatus_value: answer,
@@ -611,6 +620,39 @@ query_via_transport:
             expect,
             expect_not_established,
         }
+    }
+
+    /// Twee vragen met dezelfde cel, naam en moment horen in het verslag uit
+    /// elkaar te vallen. In de kernassertie over tijd staat dezelfde vraag twee
+    /// keer, vóór en ná een vastlegging; zonder de omschrijving zijn dat twee
+    /// identieke regels en zegt het verslag niet welke welke is.
+    #[test]
+    fn het_verslag_onderscheidt_twee_gelijke_vragen_aan_hun_omschrijving() {
+        let moment = NaiveDate::from_ymd_opt(2024, 6, 1)
+            .unwrap_or_else(|| panic!("2024-06-01 moet een geldige datum zijn"));
+        let outcome = |description: &str| QueryOutcome {
+            description: Some(description.to_string()),
+            cell: "toeslagen".to_string(),
+            lexostatus: "toeslagpartnerschap".to_string(),
+            lexostatus_value: Lexostatus {
+                cell: "toeslagen".to_string(),
+                name: "toeslagpartnerschap".to_string(),
+                op_moment: moment,
+                outcome: LexostatusOutcome::Established(BTreeMap::new()),
+            },
+            failures: Vec::new(),
+        };
+        let run = ScenarioRun {
+            name: "tijd".to_string(),
+            clock: moment,
+            outcomes: vec![outcome("vóór de vastlegging"), outcome("erna, ongewijzigd")],
+        };
+
+        let report = run.report();
+        assert!(
+            report.contains("vóór de vastlegging") && report.contains("erna, ongewijzigd"),
+            "het verslag hoort elke omschrijving te noemen; kreeg:\n{report}"
+        );
     }
 
     #[test]

--- a/packages/simulator/src/transport.rs
+++ b/packages/simulator/src/transport.rs
@@ -109,7 +109,10 @@ chronicles:
   - stream: relaties
     key: bsn
     events:
-      - op_moment: 2023-03-01
+      - name: relatie_gewijzigd
+        intake: levering
+        recording_actor: {id}
+        op_moment: 2023-03-01
         fields:
           bsn: '999993653'
           partnerschap_type: HUWELIJK
@@ -128,7 +131,7 @@ lexostatus_definitions:
         );
         let config: CellConfig =
             serde_yaml_ng::from_str(&yaml).expect("de testconfiguratie hoort te lezen");
-        Cell::from_config(&config, Path::new("/bestaat-niet"))
+        Cell::from_config(&config, Path::new("/bestaat-niet"), &BTreeMap::new())
             .expect("een bron-cel heeft geen corpus nodig")
     }
 

--- a/packages/simulator/src/world.rs
+++ b/packages/simulator/src/world.rs
@@ -21,7 +21,7 @@ use crate::error::{Result, SimulatorError};
 use chrono::NaiveDate;
 use regelrecht_engine::Value;
 use serde::Deserialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::path::Path;
 
 /// De logische klok van een wereld, zoals het wereldbestand haar opgeeft.
@@ -112,7 +112,12 @@ pub struct World {
     /// Wat er nog moet gebeuren, oplopend op datum. Bij een gelijke datum
     /// beslist de volgorde waarin de triggers zijn opgegeven; de sortering is
     /// stabiel, dus dat is een vastgelegde eigenschap en geen toeval.
-    pending: Vec<(NaiveDate, Trigger)>,
+    ///
+    /// Oplopend is een **invariant**, niet een toestand: [`World::fire_due`]
+    /// leest alleen de kop. Wie hier later iets bij zet — een trigger die een
+    /// volgende trigger inplant — moet dat op datumpositie doen en niet
+    /// achteraan, anders gaat wat erbij komt te laat af of helemaal niet.
+    pending: VecDeque<(NaiveDate, Trigger)>,
 }
 
 impl World {
@@ -166,7 +171,7 @@ impl World {
         let mut world = Self {
             cells,
             clock: clock.start,
-            pending,
+            pending: pending.into(),
         };
         world.fire_due(clock.start)?;
         Ok(world)
@@ -244,11 +249,16 @@ impl World {
     /// Laat alles afgaan wat op of vóór `tot` valt, in datumvolgorde.
     ///
     /// De klok schuift mee naar het moment van de trigger die afgaat, zodat een
-    /// trigger die zelf iets vastlegt of straks iets nieuws inplant, dat op zijn
-    /// eigen moment doet.
+    /// trigger die zelf iets vastlegt dat op zijn eigen moment doet.
+    ///
+    /// Eén voor één van de kop af, en niet een hele kop in één keer weggehaald:
+    /// valt een trigger om, dan blijven de triggers ná hem gewoon staan in
+    /// plaats van met de fout te verdwijnen. Vandaag kan een trigger niet
+    /// omvallen — [`World::new`] toetst elke fixture met dezelfde toets die het
+    /// vastleggen gebruikt — maar dat is een eigenschap van de enige
+    /// trigger-soort die er nu is, geen eigenschap van de lus.
     fn fire_due(&mut self, tot: NaiveDate) -> Result<()> {
-        let due = self.pending.partition_point(|(at, _)| *at <= tot);
-        for (at, trigger) in self.pending.drain(..due).collect::<Vec<_>>() {
+        while let Some((at, trigger)) = self.next_due(tot) {
             self.clock = self.clock.max(at);
             match trigger {
                 Trigger::Record(recording) => {
@@ -263,6 +273,27 @@ impl World {
             }
         }
         Ok(())
+    }
+
+    /// De volgende trigger die op of vóór `tot` valt, van de kop van de lijst.
+    ///
+    /// De kop is genoeg omdat [`Self::pending`] oplopend is; is de eerste nog
+    /// niet vervallen, dan is geen van de volgende dat.
+    fn next_due(&mut self, tot: NaiveDate) -> Option<(NaiveDate, Trigger)> {
+        let at = self.pending.front().map(|(at, _)| *at)?;
+        if at > tot {
+            return None;
+        }
+        self.pending.pop_front()
+    }
+
+    /// Hoeveel triggers nog niet afgegaan zijn.
+    ///
+    /// Voor het verslag van een run: een vastlegging die op geen enkel moment
+    /// gevraagd wordt, gebeurt nooit, en dat hoort te zien te zijn in plaats van
+    /// stil te blijven.
+    pub fn pending_triggers(&self) -> usize {
+        self.pending.len()
     }
 }
 
@@ -383,6 +414,40 @@ lexostatus_definitions:
             Value::Bool(true),
             "de vastlegging kreeg 2024-07-01 als moment, dus het beeld van \
              2024-01-01 blijft gelijk"
+        );
+    }
+
+    /// Een trigger die nog moet afgaan mag de klok niet meenemen.
+    ///
+    /// Dit is de test die de lus vastpint in plaats van de tijdreductie. Elke
+    /// andere assertie over de tijdlijn loopt via een reductie, en die filtert
+    /// zelf al op `op_moment`, dus ze blijft ook groen als *elke* fixture
+    /// meteen bij het optuigen wordt vastgelegd — de klok volledig negerend.
+    /// Waar dat verschil wél zichtbaar wordt, is de stand van de klok: die
+    /// bepaalt tot waar er gereduceerd mag worden, en een wereld die haar
+    /// toekomst al heeft vastgelegd zou een antwoord geven op een moment
+    /// waarover nog niets vaststaat.
+    #[test]
+    fn een_trigger_die_nog_moet_afgaan_zet_de_klok_niet_vooruit() {
+        let world = world("2024-01-01", &[fixture("2024-07-01", "relaties", "GEEN")]);
+        assert_eq!(
+            world.now(),
+            date("2024-01-01"),
+            "de klok hoort op haar startmoment te staan, niet op dat van een \
+             trigger die nog moet afgaan"
+        );
+
+        let err = world
+            .reduce(
+                "toeslagen",
+                "toeslagpartnerschap",
+                &bsn(),
+                date("2024-07-01"),
+            )
+            .expect_err("het moment van een trigger die nog niet afging ligt ná de klok");
+        assert!(
+            matches!(err, SimulatorError::MomentAfterClock { .. }),
+            "verwachtte MomentAfterClock, kreeg {err}"
         );
     }
 

--- a/packages/simulator/src/world.rs
+++ b/packages/simulator/src/world.rs
@@ -440,6 +440,42 @@ lexostatus_definitions:
         );
     }
 
+    /// De executogram-vorm weigert wat ze niet kent, en dat geldt voor een
+    /// veldnaam net zo goed als voor een kanaalnaam. Zonder die twee weigeringen
+    /// staat er straks een vastlegging in een kroniek die iets anders zegt dan
+    /// de auteur bedoelde: een grondslag die stil wegviel, of een kanaal
+    /// waarvan niemand meer kan zeggen waarlangs het feit binnenkwam. Dat
+    /// laatste is de hele reden dat `intake` een enum is en geen vrije tekst.
+    #[test]
+    fn een_onbekend_veld_of_kanaal_in_een_fixture_wordt_geweigerd() {
+        let yaml = |grondslag: &str, intake: &str| {
+            format!(
+                r"
+at: 2024-01-01
+record:
+  cell: toeslagen
+  chronicle: relaties
+  name: relatie_gewijzigd
+  intake: {intake}
+  {grondslag}: AWIR art. 3
+  fields:
+    bsn: '999993653'
+"
+            )
+        };
+
+        serde_yaml_ng::from_str::<Fixture>(&yaml("grondslag", "levering"))
+            .unwrap_or_else(|e| panic!("een correcte fixture moet parsen: {e}"));
+        assert!(
+            serde_yaml_ng::from_str::<Fixture>(&yaml("grondlsag", "levering")).is_err(),
+            "een typfout in een veldnaam hoort te falen; anders verdwijnt de grondslag stil"
+        );
+        assert!(
+            serde_yaml_ng::from_str::<Fixture>(&yaml("grondslag", "leverng")).is_err(),
+            "een typfout in een kanaalnaam hoort te falen"
+        );
+    }
+
     /// Twee triggers op dezelfde dag vallen op de tijdas niet uit elkaar; dan
     /// beslist de volgorde in het bestand, en de laatste wint. De sortering van
     /// de trigger-lijst is stabiel, dus dat is een vastgelegde eigenschap en

--- a/packages/simulator/src/world.rs
+++ b/packages/simulator/src/world.rs
@@ -1,0 +1,456 @@
+//! De wereld: de cellen, de logische klok en de triggers die onderweg afgaan.
+//!
+//! Tijd is een eigenschap van de wereld en niet van een vraag. Eén logische
+//! klok ([`NaiveDate`], nooit de wandklok) staat op een moment; [`World::advance`]
+//! zet haar vooruit en loopt daarbij de triggers af die tussen het oude en het
+//! nieuwe moment vallen, in datumvolgorde. Een trigger **voegt toe** en wijzigt
+//! nooit een bestaand gram, dus het beeld van een eerder moment verandert niet
+//! doordat de wereld verder loopt.
+//!
+//! Waarom in de wereld en niet in de cel: een cel kent alleen de momenten die
+//! haar aangereikt worden. Zij houdt geen klok, precies zoals ze geen sleutels
+//! en geen bevoegdheid houdt (RFC-022 §2).
+//!
+//! In deze versie bestaat één trigger-soort: een [`Fixture`] met een `at`-datum
+//! die bij het passeren wordt vastgelegd. De lus is generiek — een gesorteerde
+//! lijst van `(datum, trigger)` — zodat vervallende verplichtingen en gemiste
+//! termijnen er later naast passen zonder dat de klok verandert.
+
+use crate::cell::{Cell, CellConfig, ChronicleEvent, Intake, Lexostatus};
+use crate::error::{Result, SimulatorError};
+use chrono::NaiveDate;
+use regelrecht_engine::Value;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// De logische klok van een wereld, zoals het wereldbestand haar opgeeft.
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Clock {
+    /// Het moment waarop de wereld begint. Verplicht: een wereld zonder
+    /// startmoment zou op de wandklok moeten terugvallen, en dan is een run
+    /// morgen een andere run.
+    pub start: NaiveDate,
+}
+
+/// Eén startstand-gebeurtenis: wat er op welk moment wordt vastgelegd.
+///
+/// Een startstand is data. Fixtures vóór het startmoment van de klok staan bij
+/// het optuigen al in de kroniek; latere fixtures zijn triggers die afgaan
+/// wanneer [`World::advance`] hun datum passeert.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Fixture {
+    /// Het moment waarop deze vastlegging gebeurt.
+    pub at: NaiveDate,
+    /// Wat er vastgelegd wordt, en bij wie.
+    pub record: Recording,
+}
+
+/// Een vastlegging in de kroniek van één cel: de executogram-vorm van
+/// RFC-022 §1.3, plus bij wie het gram landt.
+///
+/// `recording_actor` staat er niet bij: dat is [`Self::cell`]. Een kroniek
+/// houdt alleen de eigen vastleggingen van de cel, dus die twee kunnen niet
+/// uiteenlopen en hoeven niet twee keer opgeschreven.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Recording {
+    /// De cel die vastlegt, en in wiens kroniek het gram landt.
+    pub cell: String,
+    /// De kroniekstroom binnen die cel.
+    pub chronicle: String,
+    /// Wat er gebeurde.
+    pub name: String,
+    /// Het kanaal waarlangs het feit de cel bereikte.
+    pub intake: Intake,
+    /// Op welke grondslag dit feit vastgelegd wordt; mag leeg.
+    #[serde(default)]
+    pub grondslag: String,
+    /// De vastgelegde velden.
+    pub fields: BTreeMap<String, Value>,
+}
+
+impl Recording {
+    /// Het executogram zoals het in de kroniek belandt, op het moment dat de
+    /// klok passeert.
+    fn event(&self, op_moment: NaiveDate) -> ChronicleEvent {
+        ChronicleEvent {
+            name: self.name.clone(),
+            intake: self.intake,
+            recording_actor: self.cell.clone(),
+            grondslag: self.grondslag.clone(),
+            op_moment,
+            fields: self.fields.clone(),
+        }
+    }
+}
+
+/// Wat er gebeurt als de klok een moment passeert.
+///
+/// Eén soort in deze versie. De lus die ze afloopt is generiek, dus een soort
+/// erbij is een variant erbij en geen andere klok.
+#[derive(Debug, Clone)]
+enum Trigger {
+    /// Er wordt een executogram vastgelegd.
+    Record(Recording),
+}
+
+/// Eén gesimuleerde wereld: cellen, een klok, en wat er nog moet gebeuren.
+///
+/// De wereld bezit de cellen en is de enige die hun vastleg-pad kan aanroepen.
+/// Naar buiten is [`World::reduce`] de weg naar een cel, met de klok als grens:
+/// een moment ná de klok is een fout en geen voorspelling.
+#[derive(Debug)]
+pub struct World {
+    /// De cellen, op id.
+    cells: BTreeMap<String, Cell>,
+    /// Waar de logische klok staat.
+    clock: NaiveDate,
+    /// Wat er nog moet gebeuren, oplopend op datum. Bij een gelijke datum
+    /// beslist de volgorde waarin de triggers zijn opgegeven; de sortering is
+    /// stabiel, dus dat is een vastgelegde eigenschap en geen toeval.
+    pending: Vec<(NaiveDate, Trigger)>,
+}
+
+impl World {
+    /// Tuig een wereld op: bouw de cellen, zet de klok op haar startmoment en
+    /// leg vast wat vóór dat moment al gebeurd was.
+    ///
+    /// Fixtures met een datum tot en met het startmoment landen hier meteen in
+    /// de kroniek: de klok staat op `start`, dus wat toen al gebeurd was, is
+    /// gebeurd. De rest blijft staan tot [`World::advance`] eraan komt.
+    ///
+    /// Een fixture die naar een onbekende cel of een onbekende stroom wijst,
+    /// faalt hier — ook als haar datum nog jaren weg is. Een typfout in een
+    /// startstand hoort niet halverwege een tijdlijn op te duiken.
+    pub fn new(
+        configs: &[CellConfig],
+        clock: Clock,
+        fixtures: &[Fixture],
+        regulation_root: &Path,
+    ) -> Result<Self> {
+        let mut cells: BTreeMap<String, Cell> = BTreeMap::new();
+        for config in configs {
+            if cells.contains_key(&config.id) {
+                return Err(SimulatorError::DuplicateCell {
+                    cell: config.id.clone(),
+                });
+            }
+            cells.insert(
+                config.id.clone(),
+                Cell::from_config(config, regulation_root)?,
+            );
+        }
+
+        for fixture in fixtures {
+            let target = &fixture.record;
+            let cell = cells
+                .get(&target.cell)
+                .ok_or_else(|| SimulatorError::UnknownCell {
+                    cell: target.cell.clone(),
+                })?;
+            cell.check_chronicle(&target.chronicle)?;
+        }
+
+        let mut pending: Vec<(NaiveDate, Trigger)> = fixtures
+            .iter()
+            .map(|fixture| (fixture.at, Trigger::Record(fixture.record.clone())))
+            .collect();
+        pending.sort_by_key(|(at, _)| *at);
+
+        let mut world = Self {
+            cells,
+            clock: clock.start,
+            pending,
+        };
+        world.fire_due(clock.start)?;
+        Ok(world)
+    }
+
+    /// Waar de logische klok staat.
+    pub fn now(&self) -> NaiveDate {
+        self.clock
+    }
+
+    /// De cellen van deze wereld, geleend en niet in bezit.
+    ///
+    /// `pub(crate)`, niet publiek: dit is geen tweede weg voor een consument om
+    /// bij een cel te komen (dat blijft [`World::reduce`]), maar de ingang die
+    /// `InProcessTransport` nodig heeft om een vraag over een celgrens te
+    /// zetten. Het transport houdt de cellen zelf ook geleend — zie
+    /// `transport.rs` — dus dit voegt geen tweede eigenaar toe.
+    pub(crate) fn cells(&self) -> &BTreeMap<String, Cell> {
+        &self.cells
+    }
+
+    /// Zet de klok vooruit naar `tot` en laat onderweg elke trigger afgaan.
+    ///
+    /// De triggers gaan af in datumvolgorde, en tijdens een trigger staat de
+    /// klok op het moment van die trigger — een vastlegging krijgt dus haar
+    /// eigen datum als `op_moment`, niet de eindstand. Achteruit loopt de klok
+    /// niet: wie het beeld van een eerder moment wil, vraagt dat op met
+    /// `op_moment` in [`World::reduce`].
+    pub fn advance(&mut self, tot: NaiveDate) -> Result<()> {
+        if tot < self.clock {
+            return Err(SimulatorError::ClockRunsBackwards {
+                clock: self.clock.to_string(),
+                to: tot.to_string(),
+            });
+        }
+        self.fire_due(tot)?;
+        self.clock = tot;
+        Ok(())
+    }
+
+    /// Vraag een gepubliceerde lexostatus aan één cel, op één moment.
+    ///
+    /// `op_moment` mag niet ná de klok liggen. Wat na de klok gebeurt heeft nog
+    /// niets vastgelegd, dus een antwoord "op" zo'n moment zou een voorspelling
+    /// zijn die zich voordoet als een reductie. Ervóór mag wel, en levert het
+    /// beeld van toen: de cel laat feiten die pas later vastlagen buiten
+    /// beschouwing.
+    ///
+    /// De wereld combineert niets. Ze zoekt de cel op en geeft het antwoord
+    /// door zoals de cel het gaf; synthese over cellen heen hoort bij een
+    /// consument (RFC-022 §4.1).
+    pub fn reduce(
+        &self,
+        cell: &str,
+        lexostatus: &str,
+        params: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Result<Lexostatus> {
+        if op_moment > self.clock {
+            return Err(SimulatorError::MomentAfterClock {
+                cell: cell.to_string(),
+                lexostatus: lexostatus.to_string(),
+                op_moment: op_moment.to_string(),
+                clock: self.clock.to_string(),
+            });
+        }
+        self.cells
+            .get(cell)
+            .ok_or_else(|| SimulatorError::UnknownCell {
+                cell: cell.to_string(),
+            })?
+            .reduce(lexostatus, params, op_moment)
+    }
+
+    /// Laat alles afgaan wat op of vóór `tot` valt, in datumvolgorde.
+    ///
+    /// De klok schuift mee naar het moment van de trigger die afgaat, zodat een
+    /// trigger die zelf iets vastlegt of straks iets nieuws inplant, dat op zijn
+    /// eigen moment doet.
+    fn fire_due(&mut self, tot: NaiveDate) -> Result<()> {
+        let due = self.pending.partition_point(|(at, _)| *at <= tot);
+        for (at, trigger) in self.pending.drain(..due).collect::<Vec<_>>() {
+            self.clock = self.clock.max(at);
+            match trigger {
+                Trigger::Record(recording) => {
+                    let event = recording.event(at);
+                    let cell = self.cells.get_mut(&recording.cell).ok_or_else(|| {
+                        SimulatorError::UnknownCell {
+                            cell: recording.cell.clone(),
+                        }
+                    })?;
+                    cell.record(&recording.chronicle, event)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::corpus::regulation_root;
+
+    fn date(text: &str) -> NaiveDate {
+        NaiveDate::parse_from_str(text, "%Y-%m-%d")
+            .unwrap_or_else(|e| panic!("testdatum '{text}' moet leesbaar zijn: {e}"))
+    }
+
+    fn toeslagen() -> Vec<CellConfig> {
+        let config = serde_yaml_ng::from_str(
+            r"
+id: toeslagen
+laws:
+  - algemene_wet_inkomensafhankelijke_regelingen
+chronicles:
+  - stream: relaties
+    key: bsn
+lexostatus_definitions:
+  - name: toeslagpartnerschap
+    inputs:
+      - name: bsn
+        type: string
+    reduction:
+      regulation: algemene_wet_inkomensafhankelijke_regelingen
+      output: heeft_toeslagpartner
+      parameters:
+        bsn: $bsn
+",
+        )
+        .unwrap_or_else(|e| panic!("testconfig moet parsen: {e}"));
+        vec![config]
+    }
+
+    fn fixture(at: &str, chronicle: &str, partnerschap: &str) -> Fixture {
+        Fixture {
+            at: date(at),
+            record: Recording {
+                cell: "toeslagen".to_string(),
+                chronicle: chronicle.to_string(),
+                name: "relatie_gewijzigd".to_string(),
+                intake: Intake::Levering,
+                grondslag: "AWIR art. 3".to_string(),
+                fields: BTreeMap::from([
+                    ("bsn".to_string(), Value::String("999993653".to_string())),
+                    (
+                        "partnerschap_type".to_string(),
+                        Value::String(partnerschap.to_string()),
+                    ),
+                ]),
+            },
+        }
+    }
+
+    fn world(clock_start: &str, fixtures: &[Fixture]) -> World {
+        World::new(
+            &toeslagen(),
+            Clock {
+                start: date(clock_start),
+            },
+            fixtures,
+            &regulation_root(),
+        )
+        .unwrap_or_else(|e| panic!("wereld moet op te tuigen zijn: {e}"))
+    }
+
+    fn bsn() -> BTreeMap<String, Value> {
+        BTreeMap::from([("bsn".to_string(), Value::String("999993653".to_string()))])
+    }
+
+    fn partner(world: &World, op_moment: &str) -> Value {
+        world
+            .reduce("toeslagen", "toeslagpartnerschap", &bsn(), date(op_moment))
+            .unwrap_or_else(|e| panic!("de reductie op {op_moment} moet slagen: {e}"))
+            .values()
+            .unwrap_or_else(|| panic!("de reductie op {op_moment} hoort een antwoord te geven"))
+            .get("heeft_toeslagpartner")
+            .cloned()
+            .unwrap_or_else(|| panic!("de reductie op {op_moment} hoort een antwoord te geven"))
+    }
+
+    #[test]
+    fn fixture_van_voor_het_startmoment_staat_er_bij_het_optuigen_al() {
+        let world = world(
+            "2024-01-01",
+            &[fixture("2023-01-01", "relaties", "HUWELIJK")],
+        );
+        assert_eq!(world.now(), date("2024-01-01"));
+        assert_eq!(partner(&world, "2024-01-01"), Value::Bool(true));
+    }
+
+    #[test]
+    fn een_latere_fixture_landt_pas_bij_advance_en_raakt_het_verleden_niet() {
+        let mut world = world(
+            "2024-01-01",
+            &[
+                fixture("2023-01-01", "relaties", "HUWELIJK"),
+                fixture("2024-07-01", "relaties", "GEEN"),
+            ],
+        );
+        assert_eq!(
+            partner(&world, "2024-01-01"),
+            Value::Bool(true),
+            "een feit dat nog niet geland is, bestaat voor de cel niet"
+        );
+
+        world
+            .advance(date("2025-01-01"))
+            .unwrap_or_else(|e| panic!("de klok moet vooruit kunnen: {e}"));
+
+        assert_eq!(partner(&world, "2025-01-01"), Value::Bool(false));
+        assert_eq!(
+            partner(&world, "2024-01-01"),
+            Value::Bool(true),
+            "de vastlegging kreeg 2024-07-01 als moment, dus het beeld van \
+             2024-01-01 blijft gelijk"
+        );
+    }
+
+    #[test]
+    fn triggers_gaan_af_in_datumvolgorde_ongeacht_de_volgorde_in_het_bestand() {
+        let mut world = world(
+            "2024-01-01",
+            &[
+                fixture("2024-09-01", "relaties", "GEEN"),
+                fixture("2024-03-01", "relaties", "HUWELIJK"),
+            ],
+        );
+        world
+            .advance(date("2025-01-01"))
+            .unwrap_or_else(|e| panic!("de klok moet vooruit kunnen: {e}"));
+
+        assert_eq!(
+            partner(&world, "2024-06-01"),
+            Value::Bool(true),
+            "tussen maart en september gold de vastlegging van maart"
+        );
+        assert_eq!(
+            partner(&world, "2025-01-01"),
+            Value::Bool(false),
+            "na september geldt de vastlegging van september"
+        );
+    }
+
+    #[test]
+    fn een_moment_na_de_klok_wordt_geweigerd() {
+        let world = world("2024-01-01", &[]);
+        let err = world
+            .reduce(
+                "toeslagen",
+                "toeslagpartnerschap",
+                &bsn(),
+                date("2024-06-01"),
+            )
+            .expect_err("een moment ná de klok hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::MomentAfterClock { .. }),
+            "verwachtte MomentAfterClock, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn de_klok_loopt_niet_terug() {
+        let mut world = world("2024-06-01", &[]);
+        let err = world
+            .advance(date("2024-01-01"))
+            .expect_err("achteruit lopen hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::ClockRunsBackwards { .. }),
+            "verwachtte ClockRunsBackwards, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn een_fixture_naar_een_onbekende_stroom_faalt_bij_het_optuigen() {
+        let err = World::new(
+            &toeslagen(),
+            Clock {
+                start: date("2024-01-01"),
+            },
+            &[fixture("2030-01-01", "betalingen", "GEEN")],
+            &regulation_root(),
+        )
+        .expect_err("een stroom die de cel niet houdt hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownStream { .. }),
+            "verwachtte UnknownStream, kreeg {err}"
+        );
+    }
+}

--- a/packages/simulator/src/world.rs
+++ b/packages/simulator/src/world.rs
@@ -36,9 +36,10 @@ pub struct Clock {
 
 /// Eén startstand-gebeurtenis: wat er op welk moment wordt vastgelegd.
 ///
-/// Een startstand is data. Fixtures vóór het startmoment van de klok staan bij
-/// het optuigen al in de kroniek; latere fixtures zijn triggers die afgaan
-/// wanneer [`World::advance`] hun datum passeert.
+/// Een startstand is data. Fixtures op of vóór het startmoment van de klok staan
+/// bij het optuigen al in de kroniek — de grens is inclusief, want een reductie
+/// op het startmoment ziet wat op dat moment gebeurde. Latere fixtures zijn
+/// triggers die afgaan wanneer [`World::advance`] hun datum passeert.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Fixture {
@@ -122,9 +123,11 @@ impl World {
     /// de kroniek: de klok staat op `start`, dus wat toen al gebeurd was, is
     /// gebeurd. De rest blijft staan tot [`World::advance`] eraan komt.
     ///
-    /// Een fixture die naar een onbekende cel of een onbekende stroom wijst,
-    /// faalt hier — ook als haar datum nog jaren weg is. Een typfout in een
-    /// startstand hoort niet halverwege een tijdlijn op te duiken.
+    /// Elke fixture wordt hier getoetst zoals ze bij het vastleggen getoetst zou
+    /// worden — onbekende cel, onbekende stroom, ontbrekend sleutelveld — ook als
+    /// haar datum nog jaren weg is. Een typfout in een startstand hoort niet
+    /// halverwege een tijdlijn op te duiken, en of dat gebeurt mag niet afhangen
+    /// van hoe ver die datum weg ligt.
     pub fn new(
         configs: &[CellConfig],
         clock: Clock,
@@ -151,7 +154,7 @@ impl World {
                 .ok_or_else(|| SimulatorError::UnknownCell {
                     cell: target.cell.clone(),
                 })?;
-            cell.check_chronicle(&target.chronicle)?;
+            cell.check_recording(&target.chronicle, &target.event(fixture.at))?;
         }
 
         let mut pending: Vec<(NaiveDate, Trigger)> = fixtures
@@ -437,6 +440,45 @@ lexostatus_definitions:
         );
     }
 
+    /// Twee triggers op dezelfde dag vallen op de tijdas niet uit elkaar; dan
+    /// beslist de volgorde in het bestand, en de laatste wint. De sortering van
+    /// de trigger-lijst is stabiel, dus dat is een vastgelegde eigenschap en
+    /// geen toeval — zonder deze test zou een sortering die dat omgooit
+    /// ongemerkt door kunnen.
+    #[test]
+    fn bij_een_gelijke_datum_beslist_de_volgorde_in_het_bestand() {
+        let mut world = world(
+            "2024-01-01",
+            &[
+                fixture("2024-06-01", "relaties", "HUWELIJK"),
+                fixture("2024-06-01", "relaties", "GEEN"),
+            ],
+        );
+        world
+            .advance(date("2024-07-01"))
+            .unwrap_or_else(|e| panic!("de klok moet vooruit kunnen: {e}"));
+
+        assert_eq!(
+            partner(&world, "2024-07-01"),
+            Value::Bool(false),
+            "de laatste van twee triggers op dezelfde dag hoort te winnen"
+        );
+    }
+
+    #[test]
+    fn een_fixture_op_het_startmoment_staat_er_bij_het_optuigen_al() {
+        let world = world(
+            "2024-01-01",
+            &[fixture("2024-01-01", "relaties", "HUWELIJK")],
+        );
+        assert_eq!(
+            partner(&world, "2024-01-01"),
+            Value::Bool(true),
+            "de grens is inclusief: wat op het startmoment gebeurde, is gebeurd, \
+             en een reductie op dat moment hoort het te zien"
+        );
+    }
+
     #[test]
     fn een_fixture_naar_een_onbekende_stroom_faalt_bij_het_optuigen() {
         let err = World::new(
@@ -452,5 +494,50 @@ lexostatus_definitions:
             matches!(err, SimulatorError::UnknownStream { .. }),
             "verwachtte UnknownStream, kreeg {err}"
         );
+    }
+
+    #[test]
+    fn een_fixture_naar_een_onbekende_cel_faalt_bij_het_optuigen() {
+        let mut elders = fixture("2030-01-01", "relaties", "GEEN");
+        elders.record.cell = "belastingdienst".to_string();
+        let err = World::new(
+            &toeslagen(),
+            Clock {
+                start: date("2024-01-01"),
+            },
+            &[elders],
+            &regulation_root(),
+        )
+        .expect_err("een cel die de wereld niet kent hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownCell { .. }),
+            "verwachtte UnknownCell, kreeg {err}"
+        );
+    }
+
+    /// Een fixture die het sleutelveld van haar stroom mist, hoort bij het
+    /// optuigen te falen en niet halverwege de tijdlijn — en dat mag niet
+    /// afhangen van de datum. Stond die datum vóór het startmoment, dan viel de
+    /// fout op omdat de vastlegging bij het optuigen afging; lag hij erna, dan
+    /// kwam dezelfde typfout pas bij `advance` boven water.
+    #[test]
+    fn een_fixture_zonder_sleutelveld_faalt_bij_het_optuigen_ook_als_haar_datum_ver_weg_ligt() {
+        for at in ["2023-01-01", "2030-01-01"] {
+            let mut zonder_sleutel = fixture(at, "relaties", "GEEN");
+            zonder_sleutel.record.fields.remove("bsn");
+            let err = World::new(
+                &toeslagen(),
+                Clock {
+                    start: date("2024-01-01"),
+                },
+                &[zonder_sleutel],
+                &regulation_root(),
+            )
+            .expect_err("een vastlegging zonder sleutelveld hoort te falen");
+            assert!(
+                matches!(err, SimulatorError::ChronicleEventWithoutKey { .. }),
+                "fixture van {at}: verwachtte ChronicleEventWithoutKey, kreeg {err}"
+            );
+        }
     }
 }

--- a/packages/simulator/src/world.rs
+++ b/packages/simulator/src/world.rs
@@ -21,7 +21,7 @@ use crate::error::{Result, SimulatorError};
 use chrono::NaiveDate;
 use regelrecht_engine::Value;
 use serde::Deserialize;
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::path::Path;
 
 /// De logische klok van een wereld, zoals het wereldbestand haar opgeeft.
@@ -139,6 +139,23 @@ impl World {
         fixtures: &[Fixture],
         regulation_root: &Path,
     ) -> Result<Self> {
+        // Per cel, per stroom: de veldnamen die een `fixture` erin zet. Een
+        // stroom mag leeg opgetuigd worden en haar inhoud pas via `fixtures`
+        // krijgen (zie `scenarios/toeslagen_tijdlijn.yaml`); zonder dit zou
+        // `Cell::from_config` zo'n stroom als veldloos zien en een
+        // kroniekfilter daarop onterecht als typfout afkeuren.
+        let mut fixture_fields: BTreeMap<String, BTreeMap<String, BTreeSet<String>>> =
+            BTreeMap::new();
+        for fixture in fixtures {
+            let target = &fixture.record;
+            fixture_fields
+                .entry(target.cell.clone())
+                .or_default()
+                .entry(target.chronicle.clone())
+                .or_default()
+                .extend(target.fields.keys().cloned());
+        }
+
         let mut cells: BTreeMap<String, Cell> = BTreeMap::new();
         for config in configs {
             if cells.contains_key(&config.id) {
@@ -146,9 +163,10 @@ impl World {
                     cell: config.id.clone(),
                 });
             }
+            let fields = fixture_fields.get(&config.id).cloned().unwrap_or_default();
             cells.insert(
                 config.id.clone(),
-                Cell::from_config(config, regulation_root)?,
+                Cell::from_config(config, regulation_root, &fields)?,
             );
         }
 
@@ -592,8 +610,8 @@ record:
         )
         .expect_err("een stroom die de cel niet houdt hoort te falen");
         assert!(
-            matches!(err, SimulatorError::UnknownStream { .. }),
-            "verwachtte UnknownStream, kreeg {err}"
+            matches!(err, SimulatorError::UnknownChronicleStream { .. }),
+            "verwachtte UnknownChronicleStream, kreeg {err}"
         );
     }
 
@@ -640,5 +658,60 @@ record:
                 "fixture van {at}: verwachtte ChronicleEventWithoutKey, kreeg {err}"
             );
         }
+    }
+
+    /// Een kroniekfilter op een veld dat alleen via `fixtures` in een leeg
+    /// opgetuigde stroom komt, hoort niet als typfout afgekeurd te worden.
+    ///
+    /// `declared_fields()` kent alleen wat in `chronicles[].events` van de
+    /// celconfiguratie staat; een stroom die daar leeg blijft en haar inhoud
+    /// pas via `fixtures` krijgt (zoals `scenarios/toeslagen_tijdlijn.yaml`)
+    /// zou zonder deze toets een kroniekfilter op `partnerschap_type` ten
+    /// onrechte als `UnknownFilterField` weigeren.
+    #[test]
+    fn een_kroniekfilter_op_een_veld_dat_alleen_via_fixtures_komt_wordt_niet_afgekeurd() {
+        let config: CellConfig = serde_yaml_ng::from_str(
+            r"
+id: toeslagen
+laws: []
+chronicles:
+  - stream: relaties
+    key: bsn
+lexostatus_definitions:
+  - name: partnerschap
+    inputs:
+      - name: bsn
+        type: string
+    outputs:
+      - partnerschap_type
+    reduction:
+      chronicle: relaties
+      key: bsn
+      latest: true
+",
+        )
+        .unwrap_or_else(|e| panic!("testconfig moet parsen: {e}"));
+
+        let world = World::new(
+            &[config],
+            Clock {
+                start: date("2024-01-01"),
+            },
+            &[fixture("2023-01-01", "relaties", "HUWELIJK")],
+            &regulation_root(),
+        )
+        .unwrap_or_else(|e| panic!("een wereld met dit kroniekfilter moet op te tuigen zijn: {e}"));
+
+        let answer = world
+            .reduce("toeslagen", "partnerschap", &bsn(), date("2024-01-01"))
+            .unwrap_or_else(|e| panic!("de reductie moet slagen: {e}"));
+        assert_eq!(
+            answer
+                .values()
+                .unwrap_or_else(|| panic!("verwachtte een vastgesteld feit"))
+                .get("partnerschap_type"),
+            Some(&Value::String("HUWELIJK".to_string())),
+            "de fixture-waarde hoort in het antwoord van het kroniekfilter"
+        );
     }
 }

--- a/packages/simulator/tests/scenarios.rs
+++ b/packages/simulator/tests/scenarios.rs
@@ -43,3 +43,35 @@ fn alle_scenarios_voldoen_aan_hun_eigen_verwachtingen() {
         );
     }
 }
+
+/// Twee runs van hetzelfde bestand geven hetzelfde verslag.
+///
+/// De klok van een wereld is logisch en de tijdlijn staat in het bestand, dus
+/// een run mag nergens van de wandklok of van een willekeurige volgorde
+/// afhangen. Dat is niet per scenario te beweren — het is een eigenschap van de
+/// opstelling — dus staat het hier en niet in een YAML-verwachting.
+#[test]
+fn twee_runs_geven_hetzelfde_verslag() {
+    for path in scenario_files() {
+        let scenario = Scenario::load(&path).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+        let first = scenario
+            .run(&regulation_root())
+            .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+        let second = scenario
+            .run(&regulation_root())
+            .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+
+        assert_eq!(
+            first.report(),
+            second.report(),
+            "{}: twee runs horen identiek te zijn",
+            path.display()
+        );
+        assert_eq!(
+            first.clock,
+            second.clock,
+            "{}: de klok hoort na elke run op hetzelfde moment te staan",
+            path.display()
+        );
+    }
+}

--- a/packages/simulator/tests/scenarios.rs
+++ b/packages/simulator/tests/scenarios.rs
@@ -58,7 +58,7 @@ fn answers(run: &ScenarioRun) -> Vec<String> {
                 outcome.cell,
                 outcome.lexostatus,
                 outcome.lexostatus_value.op_moment,
-                outcome.lexostatus_value.values
+                outcome.lexostatus_value.outcome
             )
         })
         .collect()

--- a/packages/simulator/tests/scenarios.rs
+++ b/packages/simulator/tests/scenarios.rs
@@ -4,7 +4,7 @@
 //! dat elk bestand draait en dat geen enkele verwachting mist. Een nieuw
 //! testgeval is dus een nieuw YAML-bestand, geen nieuwe Rust.
 
-use regelrecht_simulator::{regulation_root, Scenario};
+use regelrecht_simulator::{regulation_root, Scenario, ScenarioRun};
 use std::path::{Path, PathBuf};
 
 fn scenario_files() -> Vec<PathBuf> {
@@ -44,7 +44,27 @@ fn alle_scenarios_voldoen_aan_hun_eigen_verwachtingen() {
     }
 }
 
-/// Twee runs van hetzelfde bestand geven hetzelfde verslag.
+/// Elk antwoord van een run, ook de uitkomsten waarover geen `expect` gaat.
+///
+/// Het verslag noemt bij een geslaagde vraag alleen `ok`, dus twee runs die
+/// dezelfde verwachtingen halen met verschillende waarden eronder zouden op het
+/// verslag alleen identiek lijken. Determinisme gaat over de waarden zelf.
+fn answers(run: &ScenarioRun) -> Vec<String> {
+    run.outcomes
+        .iter()
+        .map(|outcome| {
+            format!(
+                "{}.{} op {}: {:?}",
+                outcome.cell,
+                outcome.lexostatus,
+                outcome.lexostatus_value.op_moment,
+                outcome.lexostatus_value.values
+            )
+        })
+        .collect()
+}
+
+/// Twee runs van hetzelfde bestand geven hetzelfde verslag én dezelfde waarden.
 ///
 /// De klok van een wereld is logisch en de tijdlijn staat in het bestand, dus
 /// een run mag nergens van de wandklok of van een willekeurige volgorde
@@ -65,6 +85,12 @@ fn twee_runs_geven_hetzelfde_verslag() {
             first.report(),
             second.report(),
             "{}: twee runs horen identiek te zijn",
+            path.display()
+        );
+        assert_eq!(
+            answers(&first),
+            answers(&second),
+            "{}: twee runs horen dezelfde waarden op te leveren",
             path.display()
         );
         assert_eq!(


### PR DESCRIPTION
## Wat

Tijd wordt in de simulator een eigenschap van de **wereld** en niet van een
vraag, en een vastlegging krijgt de vorm die RFC-022 §1.3 vraagt.

- **Nieuwe `World`** (`src/world.rs`): de cellen plus één logische klok — een
  datum, nooit de wandklok. `World::advance(tot)` zet de klok vooruit en laat
  onderweg de triggers afgaan in datumvolgorde; tijdens een trigger staat de
  klok op het moment van die trigger, dus een vastlegging krijgt haar eigen
  datum. De lus is generiek (een gesorteerde lijst van `(datum, trigger)`),
  zodat vervallende verplichtingen en gemiste termijnen er later naast passen.
  Vandaag bestaat er één soort trigger.
- **Triggers voegen toe, ze wijzigen nooit een bestaand gram.** Daarom blijft
  het beeld van een eerder moment exact hetzelfde terwijl de wereld verder
  loopt. Vastleggen loopt via een `pub(crate)`-pad op de cel: geen consument kan
  in een kroniek schrijven, net zomin als eruit lezen.
- **Vooruitkijken kan niet.** Een reductie op een moment ná de klok is een fout;
  wat na de klok gebeurt heeft nog niets vastgelegd, dus een antwoord zou een
  voorspelling zijn die zich voordoet als een reductie. Een moment ervóór levert
  het beeld van toen. De klok loopt zelf nooit terug.
- **De executogram-vorm.** `ChronicleEvent` draagt nu `name`, `intake` (kanaal),
  `recording_actor`, `grondslag`, `op_moment` en `fields` — de vier vragen die
  RFC-022 §1.3 per vastlegging beantwoord wil zien, plus "waarlangs". Onbekende
  velden worden geweigerd. `intake` is een enum en geen vrije tekst: een typfout
  in een kanaalnaam mag niet stil doorgaan (bewuste afwijking van het open
  vocabulaire in de RFC, toegelicht in de README).
- **Een kroniek bevat alleen wat de cel zelf overkwam.** `recording_actor` moet
  de cel zijn die de stroom houdt; een vastlegging op naam van een ander wordt
  geweigerd bij het optuigen. De inkomensstroom in het meegeleverde
  wereldbestand is daarom een levering geworden (`intake: levering`): de kroniek
  zegt wat er gebeurde, niet "wij haalden op".
- **Het wereldbestand** krijgt `clock: { start: <datum> }` — verplicht, want een
  wereld zonder startmoment zou op de wandklok terugvallen en dan is dezelfde
  run morgen een andere run — en `fixtures`: vastleggingen met een moment. Wat
  vóór het startmoment valt staat bij het optuigen al in de kroniek, de rest
  landt zodra `advance` die datum passeert. Een fixture naar een onbekende cel
  of stroom faalt bij het optuigen, niet halverwege de tijdlijn.

## Waarom

"Vaststelling op moment T" is het hele punt van procesrelatieve feiten, dus de
tijdas moet expliciet en reproduceerbaar zijn in plaats van impliciet en van de
wandklok afhankelijk. En een vastlegging die alleen een veldwaarde en een datum
draagt, laat onbeantwoord wie haar deed, waarlangs ze binnenkwam en op welke
grondslag — precies wat een kroniek van een toestandstabel onderscheidt.

De klok zit in de wereld en niet in een cel: een cel kent alleen de momenten die
haar aangereikt worden, net zoals ze geen sleutels en geen bevoegdheid houdt.

## Assertie

De kernassertie staat als scenario in `scenarios/toeslagen_tijdlijn.yaml`, niet
in Rust: een feit dat op T2 landt verandert de reductie op T2, terwijl dezelfde
vraag over T1 exact hetzelfde antwoord blijft geven. Dezelfde vraag staat er twee
keer in, vóór en ná de vastlegging die ertussen landt — zonder dat paar is het
geen assertie maar een bewering. Een datum in die fixture verzetten maakt het
scenario rood, dus hij heeft tanden.

Daarnaast draait de suite elk wereldbestand twee keer en vergelijkt de
verslagen: determinisme is een eigenschap van de opstelling en niet van één
scenario.

## Checks

`just format`, `just lint`, `just build-check` en `just test-no-docker` groen;
`cargo test -p regelrecht-simulator` groen (32 tests).

Eén stap van `just check` is rood op de basisbranch, los van deze wijziging:
`dockerfile-consistency-test` meldt dat de workspace-member `simulator` in
`frontend-demo/Dockerfile` (wasm-builder) niet ge-COPYd en niet weggeknipt wordt.
Die member kwam met de crate zelf mee; deze PR raakt geen `Cargo.toml` en geen
Dockerfile. De docker-gebaseerde testsuites (pipeline/admin) vielen lokaal om op
`PoolTimedOut` en hebben geen relatie met deze crate.
