### PR TITLE
feat: bron-cel zonder engine en kroniekfilter-reducties

### DIFF
--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -157,17 +157,23 @@ Het **kroniekfilter** levert per sleutelwaarde de laatste vastlegging op of vó�
 - `where` bepaalt **welke** vastleggingen meedoen, en pas van die groep wint de
   laatste. Een voorwaarde op een veld dat over tijd verandert levert dus de
   laatste vastlegging die eraan voldeed, niet de huidige stand — de lexostatus
-  `laatste_huwelijk` in het bron-celscenario staat er om dat te laten zien.
+  `laatste_huwelijk` in het bron-celscenario staat er om dat te laten zien. De
+  waarden in `where` zijn **letterlijk**: `key` is de enige plek waar een
+  kroniekfilter een parameter gebruikt, dus een `$naam` in `where` wordt bij het
+  optuigen geweigerd in plaats van als tekst gezocht.
 
 Het filter doet geen toestandsmerge: één vastlegging gaat er in haar geheel uit,
 niet een record dat uit verschillende momenten is samengeraapt. Wat samen
 vastgelegd is, blijft samen. Een gepubliceerd veld dat déze vastlegging niet
-draagt, blijft uit het antwoord; de cel vult niets aan.
+draagt, blijft uit het antwoord; de cel vult niets aan. Draagt ze er géén van,
+dan is er niets vastgesteld — zie hieronder.
 
 ### "Niets vastgesteld" is een antwoord
 
-Was er op `op_moment` geen feit, dan is dat geen fout en geen lege map die op een
-antwoord lijkt, maar een eigen variant met een reden:
+Dit is het antwoord van een kroniekfilter dat niets aantreft; de wetsvorm levert
+altijd de uitkomst die de engine berekent. Was er op `op_moment` geen feit, dan is
+dat geen fout en geen lege map die op een antwoord lijkt, maar een eigen variant
+met een reden:
 
 ```rust,ignore
 match answer.outcome {
@@ -177,9 +183,12 @@ match answer.outcome {
 ```
 
 De reden zegt welke stroom is nagekeken, met welke sleutelwaarde, op welk moment
-en onder welk filter, zodat een consument kan zien waar hij moet kijken. Een
-scenario legt dit antwoord vast met `expect_not_established: true`; dat is een
-volwaardige verwachting en sluit `expect` uit.
+en onder welk filter, zodat een consument kan zien waar hij moet kijken. Trof het
+filter wél een vastlegging aan maar draagt die geen enkele gepubliceerde uitkomst,
+dan zegt de reden dát, met het moment van die vastlegging erbij: dan moet de lezer
+naar de velden kijken en niet naar de tijdas. Een scenario legt dit antwoord vast
+met `expect_not_established: true`; dat is een volwaardige verwachting en sluit
+`expect` uit.
 
 `op_moment` is het moment waarop gevraagd wordt, altijd expliciet en nooit de
 wandklok. Feiten die pas later in de cel zijn vastgelegd, bestaan voor dat

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -8,6 +8,9 @@ Deze eerste versie is bewust krap: één cel per scenario, geen verkeer tussen
 cellen. Wat er wel al staat, is de grens — en die is met opzet een taalgrens en
 geen afspraak.
 
+Wetten zijn optioneel. Een cel met `laws: []` is een **bron-cel**: ze legt vast
+en reduceert, zonder engine. Zie [Een bron-cel](#een-bron-cel).
+
 ## De drie chronolexogrammen, en waar ze hier zitten
 
 De paper onderscheidt drie soorten chronolexogram (RFC-022 §1.1–§1.2). Deze
@@ -25,10 +28,11 @@ van paper naar code:
 - **Decretogram** — individueel en operationeel: het besluit. Dat wordt hier
   nog nergens vastgelegd; zie [Wat hier nog niet staat](#wat-hier-nog-niet-staat).
 
-En de vierde term, de **reductie**: de huidige vorm (één uitkomst van één eigen
-regeling, per veld wint de laatste vastlegging) is een eerste benadering van wat
-de paper en RFC-022 §4.1 bedoelen, namelijk filteren en aggregeren over
-kronieken.
+En de vierde term, de **reductie**: de huidige vormen (één uitkomst van één
+eigen regeling, of één kroniekfilter dat per sleutelwaarde de laatste
+vastlegging kiest) zijn een eerste benadering van wat de paper en RFC-022 §4.1
+bedoelen, namelijk filteren en aggregeren over kronieken. Het filteren staat er
+nu; aggregeren (som, telling) nog niet.
 
 ## Wat een cel is
 
@@ -38,6 +42,33 @@ Een cel is een *containment- en autonomiedomein*, en verder niets:
 - ze laadt haar eigen **regelingen**;
 - ze **reduceert** over die eigen feiten tot een **lexostatus**: de
   rechtstoestand vanuit een gevraagd perspectief, op de feiten die zij kent.
+
+## Een bron-cel
+
+Een **bron-cel** is een cel met `laws: []`. Ze houdt kronieken en ze reduceert,
+maar er draait geen engine in. Haar lexostatussen zijn filters over haar eigen
+vastleggingen.
+
+Dat is geen uitgeklede cel, het is de gewone vorm van bijna elke organisatie.
+Een register, een vereniging, een betaalsysteem, een legacy-API: die voeren geen
+machineleesbare wet uit en gaan dat morgen ook niet doen. RFC-022 §2 zegt
+daarover precies één ding, en het alternatief "engine = cel" is er expliciet
+afgewezen: **de engine is een component dat in een cel kán draaien, niet de cel
+zelf.** Zolang een cel niet zonder engine kan bestaan, is die scheiding proza.
+Daarom houdt [`Cell`](src/cell/mod.rs) haar engine in een `Option` — een cel
+zonder wetten bouwt er geen, en `Cell::reduce` werkt er gewoon op.
+
+Het is tegelijk de toets op het lexostatus-contract. Als "een gepubliceerde naam
+met gedocumenteerde parameters, bevraagd op een moment" alleen werkt met een
+engine erachter, dan is het contract een engine-interface met een andere naam.
+Een consument kan aan een antwoord niet zien welke van de twee hij bevroeg, en
+dat is het punt: de scenario's [`brp_broncel.yaml`](scenarios/brp_broncel.yaml)
+en [`toeslagen_zorgtoeslag.yaml`](scenarios/toeslagen_zorgtoeslag.yaml) stellen
+hun vragen op dezelfde manier.
+
+Wat een bron-cel (nog) niet kan, is besluiten: daar hoort een regeling bij, een
+bevoegd gezag en een vastgelegd decretogram. Vastleggen en reduceren is genoeg
+om een cel te zijn.
 
 ## Wat een cel níet is
 
@@ -88,6 +119,68 @@ meegeleverde scenario publiceert die uitkomst dus expliciet. Een naam in
 `outputs` die de regeling niet kent, wordt geweigerd bij het optuigen van de
 cel, net als een reductie over een vreemde regeling.
 
+### Twee reductievormen
+
+```yaml
+reduction:                        # wetsvorm: laat een eigen regeling rekenen
+  regulation: wet_op_de_zorgtoeslag
+  output: heeft_recht_op_zorgtoeslag
+  parameters:
+    bsn: $bsn
+
+reduction:                        # kroniekfilter: lees een eigen kroniek
+  chronicle: relaties
+  key: bsn
+  latest: true                    # de enige modus; mag weggelaten worden
+  where:                          # optioneel, gelijkheid op velden
+    partnerschap_type: HUWELIJK
+```
+
+De configuratie kiest door te noemen wat ze bedoelt; er is geen `kind`-veld dat
+herhaalt wat er al staat. Beide vormen in één reductie, of geen van beide, is een
+fout die zegt welke twee vormen er zijn.
+
+Het **kroniekfilter** levert per sleutelwaarde de laatste vastlegging op of vóór
+`op_moment`. Drie dingen om te weten:
+
+- De `key` is de naam van een **gedocumenteerde parameter**: de consument levert
+  de waarde aan. Een sleutel die niet in `inputs` staat, wordt geweigerd — dan
+  zou de vraag over geen enkel onderwerp gaan.
+- `outputs` is hier **verplicht**. Bij de wetsvorm is er altijd één uitkomst die
+  de lexostatus *is*; een filter heeft die niet, dus zonder `outputs` zou de cel
+  haar hele vastlegging naar buiten geven zonder iets beloofd te hebben. Een
+  output die in geen enkele vastlegging van de stroom voorkomt, wordt geweigerd
+  bij het optuigen, net als een onbekende stroomnaam of een `where` op een veld
+  dat de stroom niet kent. Zo'n filter zou anders stil "niets vastgesteld"
+  antwoorden op elke vraag, en dat is niet te onderscheiden van een leeg
+  verleden.
+- `where` bepaalt **welke** vastleggingen meedoen, en pas van die groep wint de
+  laatste. Een voorwaarde op een veld dat over tijd verandert levert dus de
+  laatste vastlegging die eraan voldeed, niet de huidige stand — de lexostatus
+  `laatste_huwelijk` in het bron-celscenario staat er om dat te laten zien.
+
+Het filter doet geen toestandsmerge: één vastlegging gaat er in haar geheel uit,
+niet een record dat uit verschillende momenten is samengeraapt. Wat samen
+vastgelegd is, blijft samen. Een gepubliceerd veld dat déze vastlegging niet
+draagt, blijft uit het antwoord; de cel vult niets aan.
+
+### "Niets vastgesteld" is een antwoord
+
+Was er op `op_moment` geen feit, dan is dat geen fout en geen lege map die op een
+antwoord lijkt, maar een eigen variant met een reden:
+
+```rust,ignore
+match answer.outcome {
+    LexostatusOutcome::Established(values) => /* … */,
+    LexostatusOutcome::NotEstablished { reason } => /* … */,
+}
+```
+
+De reden zegt welke stroom is nagekeken, met welke sleutelwaarde, op welk moment
+en onder welk filter, zodat een consument kan zien waar hij moet kijken. Een
+scenario legt dit antwoord vast met `expect_not_established: true`; dat is een
+volwaardige verwachting en sluit `expect` uit.
+
 `op_moment` is het moment waarop gevraagd wordt, altijd expliciet en nooit de
 wandklok. Feiten die pas later in de cel zijn vastgelegd, bestaan voor dat
 antwoord niet, en de engine kiest op datzelfde moment de regelingversie.
@@ -136,6 +229,17 @@ cells:
             bsn: $bsn                           # $naam verwijst naar een input;
                                                 # alles zonder $ is letterlijk
 
+      - name: partnerschap                      # een cel zonder wetten kan dit
+        inputs:                                 # ook, zie Een bron-cel
+          - name: bsn
+            type: string
+        outputs:                                # verplicht bij een kroniekfilter
+          - partnerschap_type
+        reduction:
+          chronicle: relaties                   # een eigen stroom
+          key: bsn                              # sleutel = naam van een input
+          latest: true                          # de enige modus; mag weg
+
 queries:
   - description: vrije omschrijving             # optioneel
     cell: toeslagen
@@ -146,22 +250,33 @@ queries:
     expect:                                     # wat het antwoord moet bevatten
       heeft_toeslagpartner: false               # uitkomsten die hier niet staan,
                                                 # worden niet gecontroleerd
+
+  - cell: toeslagen
+    lexostatus: partnerschap
+    params:
+      bsn: '999993653'
+    op_moment: 2020-01-01
+    expect_not_established: true                # verwacht dat er op dit moment
+                                                # niets vastgesteld was
 ```
 
 Onbekende velden worden geweigerd, zodat een typfout niet stil verdwijnt. Elke
-vraag heeft minstens één verwachting: een vraag zonder `expect` slaagt altijd en
-zou als `ok` in het verslag komen, wat op bewijs lijkt en het niet is. De loader
-weigert zo'n scenario.
+vraag heeft minstens één verwachting: een vraag zonder `expect` en zonder
+`expect_not_established` slaagt altijd en zou als `ok` in het verslag komen, wat
+op bewijs lijkt en het niet is. De loader weigert zo'n scenario, en ook een vraag
+die beide verwachtingen tegelijk stelt — die kan nooit uitkomen.
 
 ### Kroniekstromen en tijd
 
 Per stroom geldt: alleen vastleggingen met `op_moment <= ` het gevraagde moment
 tellen mee, en van de rest wint per sleutelwaarde en per veld de laatste
-vastlegging. Een vraag over een moment in het verleden levert dus het beeld van
-toen. De stromen worden aan de engine aangeboden als databronnen, waar ze de
-inputs van de eigen regelingen invullen. Twee stromen met dezelfde naam worden
-geweigerd: de stroomnaam is tevens de naam van de databron, dus daar zou de
-tweede de eerste stil schaduwen.
+vastlegging. Dit is de weg naar de engine; een kroniekfilter kiest één hele
+vastlegging en merge't niets (zie
+[Twee reductievormen](#twee-reductievormen)). Een vraag over een moment in het
+verleden levert dus het beeld van toen. De stromen worden aan de engine
+aangeboden als databronnen, waar ze de inputs van de eigen regelingen invullen.
+Twee stromen met dezelfde naam worden geweigerd: de stroomnaam is tevens de naam
+van de databron, dus daar zou de tweede de eerste stil schaduwen.
 
 Dat "per veld wint de laatste vastlegging" is een **bewuste vereenvoudiging**,
 geen eigenschap om trots op te zijn. Het is een toestandsmerge: de velden van
@@ -175,6 +290,10 @@ hoort niet stil samengevoegd te worden. De echte vorm kan pas als een
 vastlegging `recording_actor`, `grondslag`, `intake` en een moment draagt
 (RFC-022 §1.3) en de reductie daarover filtert en aggregeert in plaats van
 alleen te overschrijven.
+
+Het kroniekfilter van een bron-cel doet dat al niet: dat kiest één vastlegging en
+geeft die in haar geheel terug. Die vorm kan hier omdat er geen engine tussen zit
+die records wil.
 
 De dag is de fijnste korrel van de tijdas. Twee vastleggingen op hetzelfde
 `op_moment` vallen daar niet uit elkaar te houden; dan beslist de volgorde in het

--- a/packages/simulator/scenarios/brp_broncel.yaml
+++ b/packages/simulator/scenarios/brp_broncel.yaml
@@ -1,0 +1,123 @@
+---
+name: brp is een cel zonder engine
+description: >-
+  Een bron-cel: `laws: []`, dus geen engine in deze cel. Ze legt vast en ze
+  reduceert, en haar lexostatus is een filter over haar eigen kroniek. Zo is
+  elke organisatie die niet op RegelRecht draait — een register, een partij, een
+  betaalsysteem, een legacy-API — evengoed een cel, en dat is de toets dat het
+  lexostatus-contract niets van een engine nodig heeft.
+
+cells:
+  - id: brp
+    # Geen wetten. Deze cel zou de BRP-wet kunnen laden, maar hoeft dat niet:
+    # wat ze publiceert staat in haar kroniek, niet in een berekening.
+    laws: []
+
+    chronicles:
+      # Twee vastleggingen over dezelfde persoon. De tweede vervangt de eerste
+      # vanaf haar eigen moment; wat daarvóór gevraagd wordt, krijgt het beeld
+      # van toen.
+      - stream: relaties
+        key: bsn
+        events:
+          - op_moment: 2023-03-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: HUWELIJK
+              partner_bsn: '999993756'
+          - op_moment: 2024-07-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: GEEN
+              # Uitdrukkelijk leeg: het register is hier gezaghebbend en zegt
+              # dat er geen partner is. Dat is een waarde, geen ontbrekend feit.
+              partner_bsn: null
+
+    lexostatus_definitions:
+      - name: partnerschap
+        doc: >-
+          De relatievorm van één persoon op één moment, zoals deze cel die
+          vastlegde. Geen berekening: de laatste vastlegging op of vóór het
+          gevraagde moment.
+        inputs:
+          # De sleutel van het filter moet een gedocumenteerde parameter zijn:
+          # de consument levert de waarde aan, en zonder parameter zou de vraag
+          # over geen enkel onderwerp gaan.
+          - name: bsn
+            type: string
+        outputs:
+          # Verplicht bij een kroniekfilter: er is geen wetsuitkomst die het
+          # antwoord bepaalt, dus zonder deze lijst zou de cel haar hele
+          # vastlegging naar buiten geven zonder iets beloofd te hebben.
+          - partnerschap_type
+          - partner_bsn
+        reduction:
+          chronicle: relaties
+          key: bsn
+          latest: true
+
+      - name: laatste_huwelijk
+        doc: >-
+          Dezelfde kroniek, met een gelijkheidsfilter erop. Let op de betekenis:
+          `where` bepaalt welke vastleggingen meedoen, en pas van die groep
+          wint de laatste. Dit is dus niet "is deze persoon gehuwd", maar "wat
+          legde deze cel het laatst vast toen ze HUWELIJK zei".
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - partnerschap_type
+          - partner_bsn
+        reduction:
+          chronicle: relaties
+          key: bsn
+          where:
+            partnerschap_type: HUWELIJK
+
+queries:
+  - description: >-
+      Op 2024-01-01 was de vastlegging van 2023-03-01 de laatste; de hele
+      vastlegging telt, dus ook de partner die erbij hoorde.
+    cell: brp
+    lexostatus: partnerschap
+    params:
+      bsn: '999993653'
+    op_moment: 2024-01-01
+    expect:
+      partnerschap_type: HUWELIJK
+      partner_bsn: '999993756'
+
+  - description: >-
+      Zelfde cel, zelfde persoon, later moment: na de vastlegging van
+      2024-07-01 is de uitkomst een andere.
+    cell: brp
+    lexostatus: partnerschap
+    params:
+      bsn: '999993653'
+    op_moment: 2025-01-01
+    expect:
+      partnerschap_type: GEEN
+      partner_bsn: null
+
+  - description: >-
+      Vóór de eerste vastlegging had deze cel niets vastgesteld. Dat is een
+      gewoon antwoord met een reden, geen fout en geen leeg antwoord dat op een
+      antwoord lijkt.
+    cell: brp
+    lexostatus: partnerschap
+    params:
+      bsn: '999993653'
+    op_moment: 2023-01-01
+    expect_not_established: true
+
+  - description: >-
+      Het gelijkheidsfilter levert de laatste vastlegging die eraan voldeed —
+      hier die van 2023-03-01, ook al is de huidige stand GEEN.
+    cell: brp
+    lexostatus: laatste_huwelijk
+    params:
+      bsn: '999993653'
+    op_moment: 2025-01-01
+    expect:
+      partnerschap_type: HUWELIJK
+      partner_bsn: '999993756'

--- a/packages/simulator/src/cell/chronicle.rs
+++ b/packages/simulator/src/cell/chronicle.rs
@@ -380,4 +380,78 @@ mod tests {
              dan beslist de volgorde in de configuratie"
         );
     }
+
+    #[test]
+    fn het_filter_volgt_bij_gelijk_moment_dezelfde_regel_als_de_tijdreductie() {
+        // `latest_recording` leunt hiervoor op de belofte van `max_by_key` dat
+        // bij gelijke sleutel het laatste element wint. Zonder deze test zou een
+        // andere formulering (`max_by`, eerst sorteren, omgekeerd doorlopen) het
+        // antwoord van een bron-cel stil omdraaien, terwijl de tijdreductie
+        // ernaast wél bewaakt blijft.
+        let store = store(vec![
+            event(
+                "2024-07-01",
+                &[
+                    ("bsn", Value::String("1".to_string())),
+                    ("partnerschap_type", Value::String("HUWELIJK".to_string())),
+                ],
+            ),
+            event(
+                "2024-07-01",
+                &[
+                    ("bsn", Value::String("1".to_string())),
+                    ("partnerschap_type", Value::String("GEEN".to_string())),
+                ],
+            ),
+        ]);
+
+        let found = store
+            .latest_recording(
+                "relatie",
+                "bsn",
+                &Value::String("1".to_string()),
+                &BTreeMap::new(),
+                date("2025-01-01"),
+            )
+            .unwrap_or_else(|| panic!("er staan twee vastleggingen, dus er is er een de laatste"));
+        assert_eq!(
+            found.fields.get("partnerschap_type"),
+            Some(&Value::String("GEEN".to_string())),
+            "het kroniekfilter moet dezelfde vastlegging kiezen als de tijdreductie"
+        );
+    }
+
+    #[test]
+    fn een_voorwaarde_op_een_veld_dat_de_vastlegging_niet_heeft_voldoet_niet() {
+        // "Onbekend" is geen gelijkheid: een vastlegging die het veld niet draagt
+        // doet niet mee, ook niet als ze op de tijdas de laatste zou zijn.
+        let store = store(vec![
+            event(
+                "2023-03-01",
+                &[
+                    ("bsn", Value::String("1".to_string())),
+                    ("partnerschap_type", Value::String("HUWELIJK".to_string())),
+                ],
+            ),
+            event("2024-07-01", &[("bsn", Value::String("1".to_string()))]),
+        ]);
+
+        let found = store
+            .latest_recording(
+                "relatie",
+                "bsn",
+                &Value::String("1".to_string()),
+                &BTreeMap::from([(
+                    "partnerschap_type".to_string(),
+                    Value::String("HUWELIJK".to_string()),
+                )]),
+                date("2025-01-01"),
+            )
+            .unwrap_or_else(|| panic!("de vastlegging van 2023-03-01 voldoet aan het filter"));
+        assert_eq!(
+            found.op_moment,
+            date("2023-03-01"),
+            "de latere vastlegging kent het veld niet en doet dus niet mee"
+        );
+    }
 }

--- a/packages/simulator/src/cell/chronicle.rs
+++ b/packages/simulator/src/cell/chronicle.rs
@@ -9,6 +9,7 @@
 //! [`crate::cell::Cell`].
 
 use crate::error::{Result, SimulatorError};
+use crate::values::equivalent;
 use chrono::NaiveDate;
 use regelrecht_engine::Value;
 use serde::Deserialize;
@@ -90,6 +91,64 @@ impl ChronicleStore {
         Ok(Self { streams })
     }
 
+    /// De veldnamen die deze cel van elke stroom kent.
+    ///
+    /// Het sleutelveld hoort er altijd bij — de stroom declareert het — en
+    /// verder alles wat in een vastlegging voorkomt. Hiermee valt bij het
+    /// optuigen te toetsen of een kroniekfilter praat over velden die bestaan,
+    /// in plaats van stil "niets vastgesteld" te antwoorden op een typfout.
+    pub(crate) fn declared_fields(&self) -> BTreeMap<String, BTreeSet<String>> {
+        self.streams
+            .iter()
+            .map(|stream| {
+                let mut fields: BTreeSet<String> = BTreeSet::from([stream.key.clone()]);
+                for event in &stream.events {
+                    fields.extend(event.fields.keys().cloned());
+                }
+                (stream.stream.clone(), fields)
+            })
+            .collect()
+    }
+
+    /// De laatste vastlegging op of vóór `op_moment` met deze sleutelwaarde.
+    ///
+    /// Dit is de reductie van een cel zonder engine: geen toestandsmerge over
+    /// velden heen, maar precies één vastlegging. Wat samen vastgelegd is,
+    /// blijft samen — de eigenschap die [`Self::reduce_to`] opgeeft omdat de
+    /// engine records als databron wil.
+    ///
+    /// `conditions` bepaalt wélke vastleggingen meedoen, en pas daarna wint de
+    /// laatste. Een voorwaarde op een veld dat over tijd verandert levert dus de
+    /// laatste vastlegging die eraan voldeed, niet de huidige stand.
+    ///
+    /// `None` is een antwoord en geen fout: op dit moment was er niets
+    /// vastgesteld over dit onderwerp.
+    pub(crate) fn latest_recording(
+        &self,
+        stream: &str,
+        key: &str,
+        key_value: &Value,
+        conditions: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Option<&ChronicleEvent> {
+        // `max_by_key` levert bij gelijke sleutel het laatste element, dus twee
+        // vastleggingen op één dag volgen dezelfde regel als in `reduce_to`: de
+        // volgorde in de configuratie beslist.
+        self.streams
+            .iter()
+            .find(|candidate| candidate.stream == stream)?
+            .events
+            .iter()
+            .filter(|event| event.op_moment <= op_moment)
+            .filter(|event| field_equals(&event.fields, key, key_value))
+            .filter(|event| {
+                conditions
+                    .iter()
+                    .all(|(field, expected)| field_equals(&event.fields, field, expected))
+            })
+            .max_by_key(|event| event.op_moment)
+    }
+
     /// De feiten zoals ze op `op_moment` in deze cel bekend waren.
     ///
     /// Dit is de tijdreductie: vastleggingen ná `op_moment` bestaan voor deze
@@ -137,12 +196,29 @@ impl ChronicleStore {
     }
 }
 
-/// De sleutelwaarde van een vastlegging, hoofdletterongevoelig opgezocht.
-fn record_key(fields: &BTreeMap<String, Value>, key: &str) -> Option<String> {
+/// De waarde van een veld, hoofdletterongevoelig opgezocht.
+///
+/// Zelfde souplesse als de engine, die inputnamen ook hoofdletterongevoelig
+/// matcht: een vastlegging die `BSN` schrijft, gaat over hetzelfde veld als een
+/// die `bsn` schrijft.
+pub(crate) fn field<'a>(fields: &'a BTreeMap<String, Value>, name: &str) -> Option<&'a Value> {
     fields
         .iter()
-        .find(|(name, _)| name.eq_ignore_ascii_case(key))
-        .map(|(_, value)| value.to_string())
+        .find(|(field, _)| field.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value)
+}
+
+/// Heeft deze vastlegging dit veld, met deze waarde?
+///
+/// Een veld dat de vastlegging niet heeft, voldoet niet: "onbekend" is geen
+/// gelijkheid.
+fn field_equals(fields: &BTreeMap<String, Value>, name: &str, expected: &Value) -> bool {
+    field(fields, name).is_some_and(|value| equivalent(value, expected))
+}
+
+/// De sleutelwaarde van een vastlegging, hoofdletterongevoelig opgezocht.
+fn record_key(fields: &BTreeMap<String, Value>, key: &str) -> Option<String> {
+    field(fields, key).map(ToString::to_string)
 }
 
 #[cfg(test)]

--- a/packages/simulator/src/cell/config.rs
+++ b/packages/simulator/src/cell/config.rs
@@ -435,6 +435,21 @@ impl LexostatusDefinition {
             }
         }
 
+        // `where` vergelijkt met letterlijke waarden. Wie de `$naam`-vorm van de
+        // wetsvorm hier overneemt, krijgt anders een filter dat de tekst `$naam`
+        // zoekt en dus op elke vraag "niets vastgesteld" antwoordt — niet te
+        // onderscheiden van een leeg verleden, en daarom hier een optuigfout.
+        for (field, expected) in conditions {
+            if let Some(reference) = expected.as_str().and_then(binding_name) {
+                return Err(SimulatorError::FilterValueReference {
+                    cell: cell.to_string(),
+                    lexostatus: self.name.clone(),
+                    field: field.clone(),
+                    reference: reference.to_string(),
+                });
+            }
+        }
+
         if !self.documents(key) {
             return Err(SimulatorError::ChronicleKeyWithoutParameter {
                 cell: cell.to_string(),

--- a/packages/simulator/src/cell/config.rs
+++ b/packages/simulator/src/cell/config.rs
@@ -43,9 +43,13 @@ pub struct LexostatusDefinition {
     /// De gedocumenteerde uitkomsten: wat de cel onder deze naam publiceert.
     ///
     /// Wat hier niet staat, komt niet in het antwoord, ook al berekende de
-    /// engine het onderweg. Leeg of afwezig betekent: alleen
-    /// [`Reduction::output`]. Die uitkomst hoort er altijd bij — ze *is* de
-    /// lexostatus — dus deze lijst breidt uit, ze perkt niet in.
+    /// engine het onderweg. Bij de wetsvorm betekent leeg of afwezig: alleen
+    /// de `output` van de reductie. Die uitkomst hoort er altijd bij — ze *is*
+    /// de lexostatus — dus deze lijst breidt uit, ze perkt niet in.
+    ///
+    /// Bij een kroniekfilter is de lijst **verplicht**: daar is geen
+    /// wetsuitkomst die het antwoord bepaalt, dus zonder deze lijst zou de cel
+    /// haar hele vastlegging naar buiten geven en niets beloofd hebben.
     #[serde(default)]
     pub outputs: Vec<String>,
     /// Hoe de cel over haar eigen feiten reduceert.
@@ -95,39 +99,203 @@ impl ParameterType {
     }
 }
 
-/// De chronolexoreductie: welke uitkomst van welke eigen regeling de cel over
-/// haar eigen feiten berekent, en met welke parameters.
+/// De chronolexoreductie: hoe de cel over haar eigen feiten reduceert.
 ///
-/// In deze eerste versie is de reductie precies één uitkomst van één eigen
-/// regeling. Rijkere vormen (filteren en aggregeren over meerdere kronieken)
-/// passen in dezelfde plek in de configuratie zonder dat de publieke ingang van
-/// de cel verandert.
+/// Twee vormen, en de configuratie kiest door te noemen wat ze bedoelt:
+///
+/// - de **wetsvorm** (`regulation` + `output`) laat een eigen regeling over de
+///   eigen feiten rekenen;
+/// - het **kroniekfilter** (`chronicle` + `key`) leest rechtstreeks uit een
+///   eigen kroniek, zonder engine.
+///
+/// Dat de tweede vorm bestaat is geen gemak maar de toets op het contract: een
+/// organisatie die niet op RegelRecht draait is evengoed een cel, en haar
+/// lexostatussen zijn filters over haar eigen vastleggingen (RFC-022 §2 — de
+/// engine is een component dat in een cel kán draaien, niet de cel zelf).
+///
+/// Aggregeren (som, telling) over kronieken hoort in deze plek thuis en bestaat
+/// nog niet; `latest: true` is het enige filter dat er nu is.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(try_from = "ReductionFields")]
+pub enum Reduction {
+    /// Een uitkomst van een eigen regeling, berekend over de eigen feiten.
+    Law {
+        /// De regeling, bij `$id`. Moet in `laws` van dezelfde cel staan.
+        regulation: String,
+        /// De uitkomst van die regeling die de reductie moet opleveren.
+        ///
+        /// Dit stuurt de evaluatie aan. Wat het antwoord draagt, bepaalt
+        /// [`LexostatusDefinition::outputs`]: de engine levert ook de
+        /// uitkomsten die causaal met deze meekomen, en die zijn daarmee nog
+        /// niet gepubliceerd.
+        output: String,
+        /// De parameters voor de regeling. Een waarde `$naam` verwijst naar een
+        /// gedocumenteerde parameter van de lexostatus; elke andere waarde is
+        /// een letterlijke tekst.
+        parameters: BTreeMap<String, String>,
+    },
+    /// Een filter over één eigen kroniek: per sleutelwaarde de laatste
+    /// vastlegging op of vóór het gevraagde moment.
+    Chronicle {
+        /// De kroniekstroom waarover gefilterd wordt. Moet een stroom van
+        /// dezelfde cel zijn.
+        chronicle: String,
+        /// Het veld waarop de vastlegging gezocht wordt. Tevens de naam van de
+        /// gedocumenteerde parameter die de waarde aanlevert.
+        key: String,
+        /// Extra gelijkheidsvoorwaarden op velden van de vastlegging (`where`).
+        ///
+        /// Ze bepalen wélke vastleggingen het filter in beschouwing neemt;
+        /// daarna wint de laatste. Een voorwaarde op een veld dat over tijd
+        /// verandert levert dus de laatste vastlegging die eraan voldeed, niet
+        /// de huidige stand.
+        conditions: BTreeMap<String, Value>,
+    },
+}
+
+/// Het YAML-oppervlak van een reductie: alle velden van beide vormen, los.
+///
+/// De keuze tussen de vormen valt in [`Reduction::try_from`] en niet in serde.
+/// `#[serde(untagged)]` zou hier "data did not match any variant" opleveren bij
+/// elke typfout, en een verplicht `kind`-veld zou de configuratie laten zeggen
+/// wat ze al toont. Zo staat er in de foutmelding wat er mis is.
+#[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct Reduction {
-    /// De regeling, bij `$id`. Moet in `laws` van dezelfde cel staan.
-    pub regulation: String,
-    /// De uitkomst van die regeling die de reductie moet opleveren.
-    ///
-    /// Dit stuurt de evaluatie aan. Wat het antwoord draagt, bepaalt
-    /// [`LexostatusDefinition::outputs`]: de engine levert ook de uitkomsten
-    /// die causaal met deze meekomen, en die zijn daarmee nog niet
-    /// gepubliceerd.
-    pub output: String,
-    /// De parameters voor de regeling. Een waarde `$naam` verwijst naar een
-    /// gedocumenteerde parameter van de lexostatus; elke andere waarde is een
-    /// letterlijke tekst.
-    #[serde(default)]
-    pub parameters: BTreeMap<String, String>,
+struct ReductionFields {
+    /// Zie [`Reduction::Law::regulation`].
+    regulation: Option<String>,
+    /// Zie [`Reduction::Law::output`].
+    output: Option<String>,
+    /// Zie [`Reduction::Law::parameters`].
+    parameters: Option<BTreeMap<String, String>>,
+    /// Zie [`Reduction::Chronicle::chronicle`].
+    chronicle: Option<String>,
+    /// Zie [`Reduction::Chronicle::key`].
+    key: Option<String>,
+    /// Alleen `true` heeft betekenis; zie [`Reduction`].
+    latest: Option<bool>,
+    /// Zie [`Reduction::Chronicle::conditions`].
+    #[serde(rename = "where")]
+    conditions: Option<BTreeMap<String, Value>>,
+}
+
+impl TryFrom<ReductionFields> for Reduction {
+    type Error = String;
+
+    fn try_from(fields: ReductionFields) -> std::result::Result<Self, Self::Error> {
+        match (fields.regulation, fields.chronicle) {
+            (Some(regulation), Some(chronicle)) => Err(format!(
+                "reductie noemt zowel regeling '{regulation}' als kroniekstroom '{chronicle}'; \
+                 een reductie is óf een wetsvorm (`regulation` + `output`) \
+                 óf een kroniekfilter (`chronicle` + `key`)"
+            )),
+            (Some(regulation), None) => {
+                if fields.key.is_some() || fields.latest.is_some() || fields.conditions.is_some() {
+                    return Err(format!(
+                        "`key`, `latest` en `where` horen bij een kroniekfilter (`chronicle`), \
+                         niet bij de reductie over regeling '{regulation}'"
+                    ));
+                }
+                let output = fields.output.ok_or_else(|| {
+                    format!(
+                        "reductie over regeling '{regulation}' mist `output`: \
+                         zonder uitkomst valt er niets te berekenen"
+                    )
+                })?;
+                Ok(Self::Law {
+                    regulation,
+                    output,
+                    parameters: fields.parameters.unwrap_or_default(),
+                })
+            }
+            (None, Some(chronicle)) => {
+                if fields.output.is_some() || fields.parameters.is_some() {
+                    return Err(format!(
+                        "`output` en `parameters` horen bij een reductie over een regeling, \
+                         niet bij het kroniekfilter op '{chronicle}'; \
+                         wat een kroniekfilter oplevert staat in `outputs`"
+                    ));
+                }
+                if fields.latest == Some(false) {
+                    return Err(format!(
+                        "kroniekfilter op '{chronicle}' kent alleen `latest: true`: \
+                         aggregeren over kronieken (som, telling) bestaat nog niet"
+                    ));
+                }
+                let key = fields.key.ok_or_else(|| {
+                    format!(
+                        "kroniekfilter op '{chronicle}' mist `key`: zonder sleutelveld \
+                         weet het filter niet over welk onderwerp de vraag gaat"
+                    )
+                })?;
+                Ok(Self::Chronicle {
+                    chronicle,
+                    key,
+                    conditions: fields.conditions.unwrap_or_default(),
+                })
+            }
+            (None, None) => Err(
+                "reductie noemt geen `regulation` en geen `chronicle`: een reductie is \
+                 een wetsvorm (`regulation` + `output`) of een kroniekfilter \
+                 (`chronicle` + `key`)"
+                    .to_string(),
+            ),
+        }
+    }
+}
+
+/// Wat een cel te bieden heeft, zoals ze bij het optuigen blijkt te zijn.
+///
+/// Hiermee toetst elke lexostatus-definitie of ze belooft wat de cel kan
+/// waarmaken: haar eigen regelingen met hun uitkomsten, en haar eigen
+/// kroniekstromen met de velden die daarin voorkomen.
+pub(crate) struct CellSurface<'a> {
+    /// De regelingen die de cel zelf laadt, bij `$id`.
+    pub(crate) laws: &'a [String],
+    /// Per regeling de uitkomstnamen, over alle geladen versies heen.
+    pub(crate) outputs: BTreeMap<String, BTreeSet<String>>,
+    /// Per kroniekstroom de veldnamen die de cel van die stroom kent.
+    pub(crate) streams: BTreeMap<String, BTreeSet<String>>,
+}
+
+impl CellSurface<'_> {
+    /// De uitkomsten die een regeling kent; leeg als de cel haar niet laadt.
+    fn outputs_of(&self, regulation: &str) -> BTreeSet<String> {
+        self.outputs.get(regulation).cloned().unwrap_or_default()
+    }
+}
+
+/// Komma-gescheiden opsomming voor een foutmelding.
+fn listing<'a>(names: impl IntoIterator<Item = &'a String>) -> String {
+    names
+        .into_iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Kent deze verzameling de naam, hoofdletterongevoelig?
+///
+/// Zelfde souplesse als de kroniekstore en de engine: veldnamen matchen
+/// hoofdletterongevoelig, dus een definitie afkeuren op een hoofdletter zou
+/// weigeren wat bij het bevragen wél werkt.
+fn contains_name(names: &BTreeSet<String>, name: &str) -> bool {
+    names.iter().any(|known| known.eq_ignore_ascii_case(name))
 }
 
 impl LexostatusDefinition {
     /// De uitkomsten die deze lexostatus publiceert.
     ///
-    /// Altijd [`Reduction::output`], plus wat [`Self::outputs`] noemt. Een
-    /// consument krijgt precies deze namen te zien.
+    /// Bij de wetsvorm altijd de `output` van de reductie, plus wat
+    /// [`Self::outputs`] noemt; bij een kroniekfilter precies
+    /// [`Self::outputs`]. Een consument krijgt precies deze namen te zien.
     pub fn published_outputs(&self) -> BTreeSet<&str> {
-        std::iter::once(self.reduction.output.as_str())
+        let driving = match &self.reduction {
+            Reduction::Law { output, .. } => Some(output.as_str()),
+            Reduction::Chronicle { .. } => None,
+        };
+        driving
+            .into_iter()
             .chain(self.outputs.iter().map(String::as_str))
             .collect()
     }
@@ -148,56 +316,63 @@ impl LexostatusDefinition {
 
     /// Controleer de definitie tegen de cel waarin ze staat.
     ///
-    /// Drie dingen moeten kloppen voordat een consument er ooit bij kan: de
-    /// reductie mag alleen een eigen regeling van de cel raken, elke
-    /// gepubliceerde uitkomst moet een uitkomst zijn die die regeling kent, en
-    /// elke `$`-verwijzing moet een gedocumenteerde parameter zijn.
+    /// Een definitie is een belofte aan een consument, dus alles wat die belofte
+    /// niet waar kan maken blijkt hier — bij het optuigen van de cel, en niet
+    /// pas bij de eerste vraag.
     ///
-    /// `known_outputs` bevat per regeling de uitkomstnamen van álle geladen
+    /// `surface.outputs` bevat per regeling de uitkomstnamen van álle geladen
     /// versies. Een definitie afkeuren om een naam die alleen in de nieuwste
     /// versie ontbreekt, zou een scenario over een ouder moment onterecht
     /// blokkeren.
-    pub(crate) fn validate(
+    pub(crate) fn validate(&self, cell: &str, surface: &CellSurface<'_>) -> Result<()> {
+        match &self.reduction {
+            Reduction::Law {
+                regulation,
+                parameters,
+                ..
+            } => self.validate_law(cell, surface, regulation, parameters),
+            Reduction::Chronicle {
+                chronicle,
+                key,
+                conditions,
+            } => self.validate_chronicle(cell, surface, chronicle, key, conditions),
+        }
+    }
+
+    /// De wetsvorm: eigen regeling, bestaande uitkomsten, bestaande parameters.
+    fn validate_law(
         &self,
         cell: &str,
-        own_laws: &[String],
-        known_outputs: &BTreeMap<String, BTreeSet<String>>,
+        surface: &CellSurface<'_>,
+        regulation: &str,
+        parameters: &BTreeMap<String, String>,
     ) -> Result<()> {
-        if !own_laws.contains(&self.reduction.regulation) {
+        if !surface.laws.iter().any(|law| law == regulation) {
             return Err(SimulatorError::ForeignRegulation {
                 cell: cell.to_string(),
                 lexostatus: self.name.clone(),
-                regulation: self.reduction.regulation.clone(),
+                regulation: regulation.to_string(),
             });
         }
 
-        let known = known_outputs
-            .get(&self.reduction.regulation)
-            .cloned()
-            .unwrap_or_default();
+        let known = surface.outputs_of(regulation);
         for published in self.published_outputs() {
             if !known.contains(published) {
                 return Err(SimulatorError::UnknownOutput {
                     cell: cell.to_string(),
                     lexostatus: self.name.clone(),
-                    regulation: self.reduction.regulation.clone(),
+                    origin: format!("regeling '{regulation}'"),
                     output: published.to_string(),
-                    known: known
-                        .iter()
-                        .map(String::as_str)
-                        .collect::<Vec<_>>()
-                        .join(", "),
+                    known: listing(&known),
                 });
             }
         }
 
-        for reference in self
-            .reduction
-            .parameters
+        for reference in parameters
             .values()
             .filter_map(|binding| binding_name(binding))
         {
-            if !self.inputs.iter().any(|input| input.name == reference) {
+            if !self.documents(reference) {
                 return Err(SimulatorError::UnknownReference {
                     cell: cell.to_string(),
                     lexostatus: self.name.clone(),
@@ -209,16 +384,82 @@ impl LexostatusDefinition {
         Ok(())
     }
 
-    /// Zet de vraag van een consument om in parameters voor de engine.
+    /// Het kroniekfilter: eigen stroom, bestaande velden, en een sleutel die de
+    /// consument kan meegeven.
+    fn validate_chronicle(
+        &self,
+        cell: &str,
+        surface: &CellSurface<'_>,
+        chronicle: &str,
+        key: &str,
+        conditions: &BTreeMap<String, Value>,
+    ) -> Result<()> {
+        let Some(fields) = surface.streams.get(chronicle) else {
+            return Err(SimulatorError::UnknownStream {
+                cell: cell.to_string(),
+                lexostatus: self.name.clone(),
+                stream: chronicle.to_string(),
+                known: listing(surface.streams.keys()),
+            });
+        };
+
+        if self.outputs.is_empty() {
+            return Err(SimulatorError::ChronicleWithoutOutputs {
+                cell: cell.to_string(),
+                lexostatus: self.name.clone(),
+                stream: chronicle.to_string(),
+            });
+        }
+
+        for published in self.published_outputs() {
+            if !contains_name(fields, published) {
+                return Err(SimulatorError::UnknownOutput {
+                    cell: cell.to_string(),
+                    lexostatus: self.name.clone(),
+                    origin: format!("kroniekstroom '{chronicle}'"),
+                    output: published.to_string(),
+                    known: listing(fields),
+                });
+            }
+        }
+
+        for field in std::iter::once(key).chain(conditions.keys().map(String::as_str)) {
+            if !contains_name(fields, field) {
+                return Err(SimulatorError::UnknownFilterField {
+                    cell: cell.to_string(),
+                    lexostatus: self.name.clone(),
+                    stream: chronicle.to_string(),
+                    field: field.to_string(),
+                    known: listing(fields),
+                });
+            }
+        }
+
+        if !self.documents(key) {
+            return Err(SimulatorError::ChronicleKeyWithoutParameter {
+                cell: cell.to_string(),
+                lexostatus: self.name.clone(),
+                key: key.to_string(),
+                documented: self.documented_parameters(),
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Documenteert deze lexostatus een parameter met deze naam?
+    fn documents(&self, name: &str) -> bool {
+        self.inputs.iter().any(|input| input.name == name)
+    }
+
+    /// Controleer de vraag van een consument tegen de gedocumenteerde parameters.
     ///
     /// Weigert een ontbrekende parameter, een niet-gedocumenteerde parameter en
     /// een parameter van het verkeerde type. Dat is wat "gedocumenteerde
     /// parameters" waard maakt: de cel accepteert precies wat ze publiceert.
-    pub(crate) fn bind(
-        &self,
-        cell: &str,
-        params: &BTreeMap<String, Value>,
-    ) -> Result<BTreeMap<String, Value>> {
+    /// Geldt voor beide reductievormen — een bron-cel zonder engine houdt haar
+    /// consument even strikt aan de gepubliceerde vraag.
+    pub(crate) fn check_params(&self, cell: &str, params: &BTreeMap<String, Value>) -> Result<()> {
         for supplied in params.keys() {
             if !self.inputs.iter().any(|input| &input.name == supplied) {
                 return Err(SimulatorError::UndocumentedParameter {
@@ -249,15 +490,7 @@ impl LexostatusDefinition {
             }
         }
 
-        let mut bound = BTreeMap::new();
-        for (name, binding) in &self.reduction.parameters {
-            let value = match binding_name(binding) {
-                Some(reference) => params.get(reference).cloned().unwrap_or(Value::Null),
-                None => Value::String(binding.clone()),
-            };
-            bound.insert(name.clone(), value);
-        }
-        Ok(bound)
+        Ok(())
     }
 
     /// Komma-gescheiden lijst van gedocumenteerde parameters, voor foutmeldingen.
@@ -270,7 +503,160 @@ impl LexostatusDefinition {
     }
 }
 
+/// Zet de gecontroleerde vraag om in parameters voor de engine.
+///
+/// Alleen de wetsvorm heeft dit nodig: een kroniekfilter praat niet met een
+/// engine. Aanroepen ná [`LexostatusDefinition::check_params`] — een `$naam`
+/// die daar niet doorkwam, landt hier als [`Value::Null`].
+pub(crate) fn engine_parameters(
+    bindings: &BTreeMap<String, String>,
+    params: &BTreeMap<String, Value>,
+) -> BTreeMap<String, Value> {
+    bindings
+        .iter()
+        .map(|(name, binding)| {
+            let value = match binding_name(binding) {
+                Some(reference) => params.get(reference).cloned().unwrap_or(Value::Null),
+                None => Value::String(binding.clone()),
+            };
+            (name.clone(), value)
+        })
+        .collect()
+}
+
 /// `"$bsn"` → `Some("bsn")`; alles zonder `$` is een letterlijke waarde.
 fn binding_name(binding: &str) -> Option<&str> {
     binding.strip_prefix('$')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Leest een reductie zoals de loader dat doet, en levert de foutmelding als
+    /// tekst: deze tests gaan juist over wat er in die melding staat.
+    fn reduction(yaml: &str) -> std::result::Result<Reduction, String> {
+        serde_yaml_ng::from_str(yaml).map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn de_wetsvorm_wordt_gelezen() {
+        let parsed = reduction(
+            r"
+regulation: wet_op_de_zorgtoeslag
+output: heeft_recht_op_zorgtoeslag
+parameters:
+  bsn: $bsn
+",
+        )
+        .unwrap_or_else(|e| panic!("de wetsvorm moet gelezen worden: {e}"));
+        let Reduction::Law { output, .. } = parsed else {
+            panic!("verwachtte de wetsvorm, kreeg {parsed:?}");
+        };
+        assert_eq!(output, "heeft_recht_op_zorgtoeslag");
+    }
+
+    #[test]
+    fn het_kroniekfilter_wordt_gelezen() {
+        let parsed = reduction(
+            r"
+chronicle: relaties
+key: bsn
+latest: true
+where:
+  partnerschap_type: HUWELIJK
+",
+        )
+        .unwrap_or_else(|e| panic!("het kroniekfilter moet gelezen worden: {e}"));
+        let Reduction::Chronicle {
+            chronicle,
+            key,
+            conditions,
+        } = parsed
+        else {
+            panic!("verwachtte een kroniekfilter, kreeg {parsed:?}");
+        };
+        assert_eq!(chronicle, "relaties");
+        assert_eq!(key, "bsn");
+        assert_eq!(
+            conditions.get("partnerschap_type"),
+            Some(&Value::String("HUWELIJK".to_string()))
+        );
+    }
+
+    #[test]
+    fn latest_mag_weggelaten_worden() {
+        assert!(
+            reduction("chronicle: relaties\nkey: bsn\n").is_ok(),
+            "`latest: true` is de enige modus, dus de afwezigheid ervan is geen keuze"
+        );
+    }
+
+    #[test]
+    fn twee_vormen_in_een_reductie_noemt_beide() {
+        let err = reduction("regulation: wet_x\noutput: y\nchronicle: relaties\nkey: bsn\n")
+            .expect_err("twee vormen in één reductie hoort te falen");
+        assert!(
+            err.contains("wet_x") && err.contains("relaties"),
+            "de melding moet beide vormen noemen, kreeg: {err}"
+        );
+    }
+
+    #[test]
+    fn geen_van_beide_vormen_noemt_ze_beide() {
+        let err = reduction("parameters:\n  bsn: $bsn\n")
+            .expect_err("een reductie zonder vorm hoort te falen");
+        assert!(
+            err.contains("`regulation`") && err.contains("`chronicle`"),
+            "de melding moet vertellen welke twee vormen er zijn, kreeg: {err}"
+        );
+    }
+
+    #[test]
+    fn de_wetsvorm_zonder_output_wordt_geweigerd() {
+        let err = reduction("regulation: wet_x\n").expect_err("zonder `output` hoort het te falen");
+        assert!(
+            err.contains("`output`"),
+            "de melding moet `output` noemen, kreeg: {err}"
+        );
+    }
+
+    #[test]
+    fn een_kroniekfilter_met_een_wetsveld_wordt_geweigerd() {
+        let err = reduction("chronicle: relaties\nkey: bsn\noutput: heeft_partner\n")
+            .expect_err("`output` bij een kroniekfilter hoort te falen");
+        assert!(
+            err.contains("`outputs`"),
+            "de melding moet naar `outputs` wijzen, kreeg: {err}"
+        );
+    }
+
+    #[test]
+    fn een_wetsvorm_met_een_kroniekveld_wordt_geweigerd() {
+        let err = reduction("regulation: wet_x\noutput: y\nlatest: true\n")
+            .expect_err("`latest` bij de wetsvorm hoort te falen");
+        assert!(
+            err.contains("`latest`"),
+            "de melding moet `latest` noemen, kreeg: {err}"
+        );
+    }
+
+    #[test]
+    fn aggregeren_bestaat_nog_niet_en_zegt_dat() {
+        let err = reduction("chronicle: relaties\nkey: bsn\nlatest: false\n")
+            .expect_err("`latest: false` hoort te falen zolang er niets te aggregeren valt");
+        assert!(
+            err.contains("aggregeren"),
+            "de melding moet zeggen wat er ontbreekt, kreeg: {err}"
+        );
+    }
+
+    #[test]
+    fn een_kroniekfilter_zonder_sleutel_wordt_geweigerd() {
+        let err = reduction("chronicle: relaties\n").expect_err("zonder `key` hoort het te falen");
+        assert!(
+            err.contains("`key`"),
+            "de melding moet `key` noemen, kreeg: {err}"
+        );
+    }
 }

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -16,9 +16,11 @@ pub use config::{CellConfig, LexostatusDefinition, LexostatusInput, ParameterTyp
 use crate::corpus;
 use crate::error::{Result, SimulatorError};
 use chrono::NaiveDate;
+use config::{engine_parameters, CellSurface};
 use regelrecht_engine::{LawExecutionService, Value};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
 use std::path::Path;
 
 /// Het antwoord van een cel: de rechtstoestand vanuit een gevraagd perspectief,
@@ -31,12 +33,48 @@ pub struct Lexostatus {
     pub name: String,
     /// Het moment waarop gevraagd is; het antwoord geldt op dat moment.
     pub op_moment: NaiveDate,
-    /// De waarden die de reductie opleverde.
+    /// Wat de cel op dat moment vond.
+    pub outcome: LexostatusOutcome,
+}
+
+/// De twee antwoorden die een reductie kan opleveren.
+///
+/// "Niets vastgesteld" is er één van. Een cel die op het gevraagde moment geen
+/// feit had, heeft niet gefaald en is niet stuk; ze heeft een antwoord dat een
+/// consument moet kunnen onderscheiden van een antwoord met waarden. Een lege
+/// map zou dat onderscheid verstoppen, want die lijkt op een antwoord.
+#[derive(Debug, Clone)]
+pub enum LexostatusOutcome {
+    /// Er was een feit, en dit is wat de cel erover publiceert.
     ///
     /// Uitsluitend de uitkomsten die de definitie publiceert. De engine levert
     /// bij een gevraagde uitkomst ook wat er causaal mee meekomt; berekend is
     /// niet gepubliceerd, dus dat blijft binnen de cel.
-    pub values: BTreeMap<String, Value>,
+    Established(BTreeMap<String, Value>),
+    /// Er was op het gevraagde moment niets vastgesteld.
+    NotEstablished {
+        /// Waarom er niets was, in de woorden van de cel: welke stroom is
+        /// nagekeken, met welke sleutel en welk filter.
+        reason: String,
+    },
+}
+
+impl Lexostatus {
+    /// De gepubliceerde waarden, of `None` als er niets vastgesteld was.
+    pub fn values(&self) -> Option<&BTreeMap<String, Value>> {
+        match &self.outcome {
+            LexostatusOutcome::Established(values) => Some(values),
+            LexostatusOutcome::NotEstablished { .. } => None,
+        }
+    }
+
+    /// Waarom er niets vastgesteld was, of `None` als er wél een feit was.
+    pub fn not_established(&self) -> Option<&str> {
+        match &self.outcome {
+            LexostatusOutcome::Established(_) => None,
+            LexostatusOutcome::NotEstablished { reason } => Some(reason),
+        }
+    }
 }
 
 /// Eén chronolexocel.
@@ -48,11 +86,17 @@ pub struct Lexostatus {
 pub struct Cell {
     /// Het cel-id, alleen voor foutmeldingen en herkomst in het antwoord.
     id: String,
-    /// Engine met uitsluitend de eigen wetten van deze cel geladen.
+    /// Engine met uitsluitend de eigen wetten van deze cel geladen — of geen
+    /// engine, bij een bron-cel (`laws: []`).
+    ///
+    /// Dat dit een `Option` is, is de vorm van RFC-022 §2: de engine is een
+    /// component dat in een cel kán draaien, niet de cel zelf. Een organisatie
+    /// die niet op RegelRecht draait, legt vast en reduceert, en is daarmee een
+    /// gewone cel.
     ///
     /// In een `RefCell`, omdat elke reductie de zichtbare feiten opnieuw op het
     /// gevraagde moment zet; naar buiten toe blijft bevragen een leesactie.
-    service: RefCell<LawExecutionService>,
+    service: Option<RefCell<LawExecutionService>>,
     /// De eigen feiten. Privé, en dat is het punt.
     chronicles: ChronicleStore,
     /// De gepubliceerde lexostatussen, op naam.
@@ -65,19 +109,36 @@ impl Cell {
     /// Laadt uitsluitend de eigen wetten (alle versies, zodat de engine zelf op
     /// het gevraagde moment de juiste kiest) en controleert de gepubliceerde
     /// lexostatussen voordat er ook maar één vraag gesteld kan worden.
+    ///
+    /// `laws: []` is geldig: dan komt er geen engine, en houdt de cel het bij
+    /// vastleggen en reduceren over haar eigen kronieken.
     pub fn from_config(config: &CellConfig, regulation_root: &Path) -> Result<Self> {
-        let mut service = LawExecutionService::new();
-        for law in &config.laws {
-            for document in corpus::regulation_versions(regulation_root, law)? {
-                service.load_law(&document)?;
-            }
-        }
+        let chronicles = ChronicleStore::from_streams(&config.id, config.chronicles.clone())?;
 
-        let known_outputs = outputs_per_regulation(&service);
+        let service = if config.laws.is_empty() {
+            None
+        } else {
+            let mut service = LawExecutionService::new();
+            for law in &config.laws {
+                for document in corpus::regulation_versions(regulation_root, law)? {
+                    service.load_law(&document)?;
+                }
+            }
+            Some(service)
+        };
+
+        let surface = CellSurface {
+            laws: &config.laws,
+            outputs: service
+                .as_ref()
+                .map(outputs_per_regulation)
+                .unwrap_or_default(),
+            streams: chronicles.declared_fields(),
+        };
 
         let mut published: BTreeMap<String, LexostatusDefinition> = BTreeMap::new();
         for definition in &config.lexostatus_definitions {
-            definition.validate(&config.id, &config.laws, &known_outputs)?;
+            definition.validate(&config.id, &surface)?;
             if published
                 .insert(definition.name.clone(), definition.clone())
                 .is_some()
@@ -91,8 +152,8 @@ impl Cell {
 
         Ok(Self {
             id: config.id.clone(),
-            service: RefCell::new(service),
-            chronicles: ChronicleStore::from_streams(&config.id, config.chronicles.clone())?,
+            service: service.map(RefCell::new),
+            chronicles,
             published,
         })
     }
@@ -109,7 +170,9 @@ impl Cell {
     /// alleen wat de definitie noemt, en het antwoord geeft niet meer dan dat.
     ///
     /// `op_moment` is het moment waarop gevraagd wordt: feiten die pas later in
-    /// deze cel zijn vastgelegd, bestaan voor dit antwoord niet.
+    /// deze cel zijn vastgelegd, bestaan voor dit antwoord niet. Was er op dat
+    /// moment niets vastgesteld, dan is dat een antwoord — zie
+    /// [`LexostatusOutcome`] — en geen fout.
     pub fn reduce(
         &self,
         lexostatus: &str,
@@ -130,28 +193,139 @@ impl Cell {
                         .join(", "),
                 })?;
 
-        let bound = definition.bind(&self.id, params)?;
+        definition.check_params(&self.id, params)?;
 
-        let mut service = self.service.borrow_mut();
+        let outcome = match &definition.reduction {
+            Reduction::Law {
+                regulation,
+                output,
+                parameters,
+            } => self.reduce_with_law(
+                definition, regulation, output, parameters, params, op_moment,
+            )?,
+            Reduction::Chronicle {
+                chronicle,
+                key,
+                conditions,
+            } => {
+                self.filter_chronicle(definition, chronicle, key, conditions, params, op_moment)?
+            }
+        };
+
+        Ok(Lexostatus {
+            cell: self.id.clone(),
+            name: definition.name.clone(),
+            op_moment,
+            outcome,
+        })
+    }
+
+    /// De wetsvorm: laat de eigen engine over de eigen feiten rekenen.
+    fn reduce_with_law(
+        &self,
+        definition: &LexostatusDefinition,
+        regulation: &str,
+        output: &str,
+        parameters: &BTreeMap<String, String>,
+        params: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Result<LexostatusOutcome> {
+        // Onbereikbaar: `validate` weigert bij het optuigen elke wetsvorm over
+        // een regeling die de cel niet zelf laadt, en een cel zonder engine
+        // laadt er geen enkele. De melding is hier dan ook de juiste.
+        let Some(service) = &self.service else {
+            return Err(SimulatorError::ForeignRegulation {
+                cell: self.id.clone(),
+                lexostatus: definition.name.clone(),
+                regulation: regulation.to_string(),
+            });
+        };
+
+        let mut service = service.borrow_mut();
         service.clear_data_sources();
         for stream in self.chronicles.reduce_to(op_moment) {
             service.register_dict_source(&stream.stream, &stream.key, stream.records)?;
         }
 
         let result = service.evaluate_law_output(
-            &definition.reduction.regulation,
-            &definition.reduction.output,
-            bound,
+            regulation,
+            output,
+            engine_parameters(parameters, params),
             &op_moment.format("%Y-%m-%d").to_string(),
         )?;
 
-        Ok(Lexostatus {
-            cell: self.id.clone(),
-            name: definition.name.clone(),
-            op_moment,
-            values: definition.project(result.outputs),
-        })
+        Ok(LexostatusOutcome::Established(
+            definition.project(result.outputs),
+        ))
     }
+
+    /// Het kroniekfilter: lees de laatste vastlegging over dit onderwerp.
+    ///
+    /// Geen engine in zicht. Wat de vastlegging draagt en de definitie
+    /// publiceert, komt in het antwoord; een gepubliceerd veld dat deze
+    /// vastlegging niet heeft, blijft eruit — de cel vult niets aan.
+    fn filter_chronicle(
+        &self,
+        definition: &LexostatusDefinition,
+        chronicle: &str,
+        key: &str,
+        conditions: &BTreeMap<String, Value>,
+        params: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Result<LexostatusOutcome> {
+        // Onbereikbaar: `validate` eist dat de sleutel een gedocumenteerde
+        // parameter is, en `check_params` dat elke gedocumenteerde parameter
+        // meekomt.
+        let key_value = params
+            .get(key)
+            .ok_or_else(|| SimulatorError::MissingParameter {
+                cell: self.id.clone(),
+                lexostatus: definition.name.clone(),
+                parameter: key.to_string(),
+            })?;
+
+        let Some(event) = self
+            .chronicles
+            .latest_recording(chronicle, key, key_value, conditions, op_moment)
+        else {
+            return Ok(LexostatusOutcome::NotEstablished {
+                reason: nothing_established(chronicle, key, key_value, conditions, op_moment),
+            });
+        };
+
+        let values = definition
+            .published_outputs()
+            .into_iter()
+            .filter_map(|output| {
+                chronicle::field(&event.fields, output)
+                    .map(|value| (output.to_string(), value.clone()))
+            })
+            .collect();
+        Ok(LexostatusOutcome::Established(values))
+    }
+}
+
+/// Waarom het kroniekfilter niets vond, zo precies dat het na te lopen is.
+fn nothing_established(
+    chronicle: &str,
+    key: &str,
+    key_value: &Value,
+    conditions: &BTreeMap<String, Value>,
+    op_moment: NaiveDate,
+) -> String {
+    let mut reason = format!(
+        "kroniekstroom '{chronicle}' heeft op of vóór {op_moment} geen vastlegging \
+         met {key} '{key_value}'"
+    );
+    if !conditions.is_empty() {
+        let filter = conditions
+            .iter()
+            .map(|(field, value)| format!("{field} = {value}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let _ = write!(reason, " die voldoet aan {filter}");
+    }
+    reason
 }
 
 /// De uitkomstnamen per regeling, over alle geladen versies heen.
@@ -220,8 +394,25 @@ lexostatus_definitions:
     }
 
     fn moment() -> NaiveDate {
-        NaiveDate::from_ymd_opt(2025, 1, 1)
-            .unwrap_or_else(|| panic!("2025-01-01 moet een geldige datum zijn"))
+        date("2025-01-01")
+    }
+
+    /// Faalt luid op een onleesbare datum: deze tests draaien om de tijdas, dus
+    /// een typfout mag niet stil op een standaarddatum uitkomen.
+    fn date(text: &str) -> NaiveDate {
+        NaiveDate::parse_from_str(text, "%Y-%m-%d")
+            .unwrap_or_else(|e| panic!("testdatum '{text}' moet leesbaar zijn: {e}"))
+    }
+
+    /// De waarden van een antwoord, of een luide fout als er niets vastgesteld
+    /// was: een test die daarop stilvalt, zou niets meer bewijzen.
+    fn values(answer: &Lexostatus) -> &BTreeMap<String, Value> {
+        answer.values().unwrap_or_else(|| {
+            panic!(
+                "verwachtte een vastgesteld feit, kreeg: {}",
+                answer.not_established().unwrap_or("(onbekend)")
+            )
+        })
     }
 
     #[test]
@@ -308,14 +499,14 @@ lexostatus_definitions:
             .unwrap_or_else(|e| panic!("de reductie moet slagen: {e}"));
 
         assert_eq!(
-            answer.values.get("heeft_recht_op_zorgtoeslag"),
+            values(&answer).get("heeft_recht_op_zorgtoeslag"),
             Some(&Value::Bool(true)),
             "de gepubliceerde uitkomst hoort in het antwoord"
         );
         assert!(
-            !answer.values.contains_key("hoogte_zorgtoeslag"),
+            !values(&answer).contains_key("hoogte_zorgtoeslag"),
             "de engine berekent de hoogte mee, maar de cel publiceert haar niet; kreeg {:?}",
-            answer.values
+            values(&answer)
         );
     }
 
@@ -331,9 +522,9 @@ lexostatus_definitions:
             .unwrap_or_else(|e| panic!("de reductie moet slagen: {e}"));
 
         assert!(
-            answer.values.contains_key("hoogte_zorgtoeslag"),
+            values(&answer).contains_key("hoogte_zorgtoeslag"),
             "een uitkomst die in `outputs` staat hoort in het antwoord; kreeg {:?}",
-            answer.values
+            values(&answer)
         );
     }
 
@@ -347,6 +538,250 @@ lexostatus_definitions:
         assert!(
             matches!(err, SimulatorError::UnknownOutput { .. }),
             "verwachtte UnknownOutput, kreeg {err}"
+        );
+    }
+
+    /// Een bron-cel: geen wetten, één kroniek, en een lexostatus die erover
+    /// filtert.
+    ///
+    /// `definition` wordt letterlijk ingeplakt, zodat elke test alleen het blok
+    /// varieert waar ze over gaat. De tweede vastlegging laat `partner_bsn`
+    /// weg: die stond in de eerste, dus de stroom kent het veld, maar deze
+    /// vastlegging draagt het niet.
+    fn brp(definition: &str) -> CellConfig {
+        config(&format!(
+            r"
+id: brp
+laws: []
+chronicles:
+  - stream: relaties
+    key: bsn
+    events:
+      - op_moment: 2023-03-01
+        fields:
+          bsn: '999993653'
+          partnerschap_type: HUWELIJK
+          partner_bsn: '999993756'
+      - op_moment: 2024-07-01
+        fields:
+          bsn: '999993653'
+          partnerschap_type: GEEN
+lexostatus_definitions:
+  - name: partnerschap
+    inputs:
+      - name: bsn
+        type: string
+{definition}
+"
+        ))
+    }
+
+    /// Het kroniekfilter zoals de meeste tests hieronder het bedoelen.
+    const PARTNERSCHAP: &str = "    outputs:
+      - partnerschap_type
+      - partner_bsn
+    reduction:
+      chronicle: relaties
+      key: bsn
+      latest: true";
+
+    fn source_cell(definition: &str) -> Cell {
+        Cell::from_config(&brp(definition), &regulation_root())
+            .unwrap_or_else(|e| panic!("een bron-cel moet op te tuigen zijn: {e}"))
+    }
+
+    #[test]
+    fn een_cel_zonder_wetten_reduceert_over_haar_eigen_kroniek() {
+        let cell = source_cell(PARTNERSCHAP);
+
+        let eerder = cell
+            .reduce("partnerschap", &bsn(), date("2024-01-01"))
+            .unwrap_or_else(|e| panic!("de reductie moet slagen: {e}"));
+        assert_eq!(
+            values(&eerder).get("partnerschap_type"),
+            Some(&Value::String("HUWELIJK".to_string())),
+            "op 2024-01-01 gold de vastlegging van 2023-03-01"
+        );
+        assert_eq!(
+            values(&eerder).get("partner_bsn"),
+            Some(&Value::String("999993756".to_string())),
+            "de hele vastlegging telt, niet alleen het sleutelveld"
+        );
+
+        let later = cell
+            .reduce("partnerschap", &bsn(), moment())
+            .unwrap_or_else(|e| panic!("de reductie moet slagen: {e}"));
+        assert_eq!(
+            values(&later).get("partnerschap_type"),
+            Some(&Value::String("GEEN".to_string())),
+            "na 2024-07-01 is de latere vastlegging de laatste"
+        );
+        assert!(
+            !values(&later).contains_key("partner_bsn"),
+            "deze vastlegging draagt het veld niet, en de cel vult niets aan; kreeg {:?}",
+            values(&later)
+        );
+    }
+
+    #[test]
+    fn niets_vastgesteld_is_een_gewoon_antwoord() {
+        let answer = source_cell(PARTNERSCHAP)
+            .reduce("partnerschap", &bsn(), date("2023-01-01"))
+            .unwrap_or_else(|e| panic!("een moment vóór het eerste feit is geen fout: {e}"));
+
+        let reason = answer
+            .not_established()
+            .unwrap_or_else(|| panic!("verwachtte 'niets vastgesteld', kreeg {answer:?}"));
+        assert!(
+            reason.contains("relaties") && reason.contains("2023-01-01"),
+            "de reden moet zeggen waar en wanneer er niets stond, kreeg: {reason}"
+        );
+    }
+
+    #[test]
+    fn where_filtert_over_de_vastleggingen_en_pas_daarna_wint_de_laatste() {
+        let answer = source_cell(
+            "    outputs:
+      - partnerschap_type
+      - partner_bsn
+    reduction:
+      chronicle: relaties
+      key: bsn
+      where:
+        partnerschap_type: HUWELIJK",
+        )
+        .reduce("partnerschap", &bsn(), moment())
+        .unwrap_or_else(|e| panic!("de reductie moet slagen: {e}"));
+
+        assert_eq!(
+            values(&answer).get("partner_bsn"),
+            Some(&Value::String("999993756".to_string())),
+            "het filter bepaalt welke vastleggingen meedoen; van die groep wint de laatste"
+        );
+    }
+
+    #[test]
+    fn where_dat_niets_aantreft_stelt_niets_vast() {
+        let answer = source_cell(
+            "    outputs:
+      - partnerschap_type
+    reduction:
+      chronicle: relaties
+      key: bsn
+      where:
+        partnerschap_type: GEREGISTREERD_PARTNERSCHAP",
+        )
+        .reduce("partnerschap", &bsn(), moment())
+        .unwrap_or_else(|e| panic!("een filter zonder treffer is geen fout: {e}"));
+
+        let reason = answer
+            .not_established()
+            .unwrap_or_else(|| panic!("verwachtte 'niets vastgesteld', kreeg {answer:?}"));
+        assert!(
+            reason.contains("GEREGISTREERD_PARTNERSCHAP"),
+            "de reden moet het filter noemen waaraan niets voldeed, kreeg: {reason}"
+        );
+    }
+
+    #[test]
+    fn een_onbekende_stroomnaam_wordt_geweigerd() {
+        let err = Cell::from_config(
+            &brp("    outputs:
+      - partnerschap_type
+    reduction:
+      chronicle: relatis
+      key: bsn"),
+            &regulation_root(),
+        )
+        .expect_err("een typfout in de stroomnaam hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownStream { .. }),
+            "verwachtte UnknownStream, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn een_kroniekfilter_zonder_outputs_wordt_geweigerd() {
+        let err = Cell::from_config(
+            &brp("    reduction:
+      chronicle: relaties
+      key: bsn"),
+            &regulation_root(),
+        )
+        .expect_err("een kroniekfilter zonder `outputs` hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::ChronicleWithoutOutputs { .. }),
+            "verwachtte ChronicleWithoutOutputs, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn een_output_die_de_stroom_niet_kent_wordt_geweigerd() {
+        let err = Cell::from_config(
+            &brp("    outputs:
+      - partnerschap_duur
+    reduction:
+      chronicle: relaties
+      key: bsn"),
+            &regulation_root(),
+        )
+        .expect_err("een uitkomst die geen vastlegging draagt hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownOutput { .. }),
+            "verwachtte UnknownOutput, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn een_filter_op_een_onbekend_veld_wordt_geweigerd() {
+        let err = Cell::from_config(
+            &brp("    outputs:
+      - partnerschap_type
+    reduction:
+      chronicle: relaties
+      key: bsn
+      where:
+        partnerschaptype: HUWELIJK"),
+            &regulation_root(),
+        )
+        .expect_err("een `where` op een onbekend veld hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownFilterField { .. }),
+            "verwachtte UnknownFilterField, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn een_sleutel_zonder_gedocumenteerde_parameter_wordt_geweigerd() {
+        let err = Cell::from_config(
+            &brp("    outputs:
+      - partnerschap_type
+    reduction:
+      chronicle: relaties
+      key: partner_bsn"),
+            &regulation_root(),
+        )
+        .expect_err("een sleutel die de consument niet kan meegeven hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::ChronicleKeyWithoutParameter { .. }),
+            "verwachtte ChronicleKeyWithoutParameter, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn een_wetsvorm_in_een_cel_zonder_wetten_wordt_geweigerd() {
+        let err = Cell::from_config(
+            &brp("    reduction:
+      regulation: wet_basisregistratie_personen
+      output: heeft_partner
+      parameters:
+        bsn: $bsn"),
+            &regulation_root(),
+        )
+        .expect_err("zonder geladen regeling hoort een wetsvorm te falen");
+        assert!(
+            matches!(err, SimulatorError::ForeignRegulation { .. }),
+            "verwachtte ForeignRegulation, kreeg {err}"
         );
     }
 

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -263,7 +263,9 @@ impl Cell {
     ///
     /// Geen engine in zicht. Wat de vastlegging draagt en de definitie
     /// publiceert, komt in het antwoord; een gepubliceerd veld dat deze
-    /// vastlegging niet heeft, blijft eruit — de cel vult niets aan.
+    /// vastlegging niet heeft, blijft eruit — de cel vult niets aan. Draagt de
+    /// vastlegging er geen enkele, dan is er niets vastgesteld: een lege map zou
+    /// op een antwoord lijken zonder er een te zijn.
     fn filter_chronicle(
         &self,
         definition: &LexostatusDefinition,
@@ -293,7 +295,7 @@ impl Cell {
             });
         };
 
-        let values = definition
+        let values: BTreeMap<String, Value> = definition
             .published_outputs()
             .into_iter()
             .filter_map(|output| {
@@ -301,6 +303,20 @@ impl Cell {
                     .map(|value| (output.to_string(), value.clone()))
             })
             .collect();
+
+        // Draagt de vastlegging geen enkele gepubliceerde uitkomst, dan blijft er
+        // een lege map over — en dat is precies het antwoord dat op een antwoord
+        // lijkt zonder er een te zijn. Een stroom mag heterogeen zijn (het
+        // optuigen eist alleen dat elke uitkomst in één of andere vastlegging
+        // voorkomt), dus dit is bereikbaar met een geldige configuratie. De cel
+        // zegt dan wat er aan de hand is: er was wél een vastlegging, maar niet
+        // over datgene wat gevraagd werd.
+        if values.is_empty() {
+            return Ok(LexostatusOutcome::NotEstablished {
+                reason: nothing_published(definition, chronicle, key, key_value, event.op_moment),
+            });
+        }
+
         Ok(LexostatusOutcome::Established(values))
     }
 }
@@ -326,6 +342,31 @@ fn nothing_established(
         let _ = write!(reason, " die voldoet aan {filter}");
     }
     reason
+}
+
+/// Waarom een gevonden vastlegging toch niets oplevert.
+///
+/// Dit is een ander verhaal dan [`nothing_established`]: er ís vastgelegd, maar
+/// niet over wat deze lexostatus publiceert. De reden noemt beide, zodat de lezer
+/// weet dat hij naar de velden van die vastlegging moet kijken en niet naar de
+/// tijdas.
+fn nothing_published(
+    definition: &LexostatusDefinition,
+    chronicle: &str,
+    key: &str,
+    key_value: &Value,
+    recorded: NaiveDate,
+) -> String {
+    let published = definition
+        .published_outputs()
+        .into_iter()
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "kroniekstroom '{chronicle}' heeft voor {key} '{key_value}' wel een vastlegging \
+         (van {recorded}), maar die draagt geen van de gepubliceerde uitkomsten \
+         ({published})"
+    )
 }
 
 /// De uitkomstnamen per regeling, over alle geladen versies heen.
@@ -684,6 +725,58 @@ lexostatus_definitions:
     }
 
     #[test]
+    fn een_vastlegging_zonder_gepubliceerd_veld_levert_geen_lege_map_op() {
+        // Een stroom mag heterogeen zijn: het optuigen eist alleen dat elke
+        // gepubliceerde uitkomst in één of andere vastlegging voorkomt. De
+        // laatste vastlegging hier draagt alleen de sleutel, dus er valt niets
+        // te publiceren — en een leeg antwoord dat op een antwoord lijkt, is
+        // precies wat `LexostatusOutcome` moet voorkomen.
+        let cell = Cell::from_config(
+            &config(
+                r"
+id: brp
+laws: []
+chronicles:
+  - stream: relaties
+    key: bsn
+    events:
+      - op_moment: 2023-03-01
+        fields:
+          bsn: '999993653'
+          partnerschap_type: HUWELIJK
+      - op_moment: 2024-07-01
+        fields:
+          bsn: '999993653'
+lexostatus_definitions:
+  - name: partnerschap
+    inputs:
+      - name: bsn
+        type: string
+    outputs:
+      - partnerschap_type
+    reduction:
+      chronicle: relaties
+      key: bsn
+",
+            ),
+            &regulation_root(),
+        )
+        .unwrap_or_else(|e| panic!("een bron-cel moet op te tuigen zijn: {e}"));
+
+        let answer = cell
+            .reduce("partnerschap", &bsn(), moment())
+            .unwrap_or_else(|e| panic!("de reductie moet slagen: {e}"));
+
+        let reason = answer.not_established().unwrap_or_else(|| {
+            panic!("verwachtte 'niets vastgesteld', kreeg {:?}", answer.outcome)
+        });
+        assert!(
+            reason.contains("2024-07-01") && reason.contains("partnerschap_type"),
+            "de reden moet de vastlegging noemen die niets publiceert, kreeg: {reason}"
+        );
+    }
+
+    #[test]
     fn een_onbekende_stroomnaam_wordt_geweigerd() {
         let err = Cell::from_config(
             &brp("    outputs:
@@ -748,6 +841,25 @@ lexostatus_definitions:
         assert!(
             matches!(err, SimulatorError::UnknownFilterField { .. }),
             "verwachtte UnknownFilterField, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn een_where_die_naar_een_parameter_verwijst_wordt_geweigerd() {
+        let err = Cell::from_config(
+            &brp("    outputs:
+      - partnerschap_type
+    reduction:
+      chronicle: relaties
+      key: bsn
+      where:
+        partner_bsn: $bsn"),
+            &regulation_root(),
+        )
+        .expect_err("`where` kent geen `$`-verwijzingen, dus dit hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::FilterValueReference { .. }),
+            "verwachtte FilterValueReference, kreeg {err}"
         );
     }
 

--- a/packages/simulator/src/error.rs
+++ b/packages/simulator/src/error.rs
@@ -107,27 +107,110 @@ pub enum SimulatorError {
         regulation: String,
     },
 
-    /// Een lexostatus publiceert een uitkomst die haar regeling niet kent.
+    /// Een lexostatus publiceert een uitkomst die haar bron niet kent.
     ///
     /// Wat een cel publiceert is een belofte aan de consument; een naam die
-    /// geen enkele geladen versie van de regeling oplevert, kan die belofte
-    /// niet waarmaken. Dat blijkt bij het optuigen, net als bij
+    /// geen enkele geladen versie van de regeling oplevert — of die in geen
+    /// enkele vastlegging van de kroniekstroom voorkomt — kan die belofte niet
+    /// waarmaken. Dat blijkt bij het optuigen, net als bij
     /// [`SimulatorError::ForeignRegulation`], en niet pas bij de eerste vraag.
     #[error(
         "cel '{cell}': lexostatus '{lexostatus}' publiceert uitkomst '{output}', \
-         maar regeling '{regulation}' kent die niet (wel: {known})"
+         maar {origin} kent die niet (wel: {known})"
     )]
     UnknownOutput {
         /// Cel waarin de definitie staat.
         cell: String,
         /// De lexostatus met de onbekende uitkomst.
         lexostatus: String,
-        /// De regeling waarover gereduceerd wordt.
-        regulation: String,
+        /// Waar de uitkomst uit had moeten komen: `regeling '…'` of
+        /// `kroniekstroom '…'`. Niet `source`: dat veld zou thiserror als de
+        /// onderliggende fout lezen.
+        origin: String,
         /// De uitkomstnaam die niet bestaat.
         output: String,
-        /// Komma-gescheiden lijst van uitkomsten die de regeling wél kent.
+        /// Komma-gescheiden lijst van namen die de bron wél kent.
         known: String,
+    },
+
+    /// Een kroniekfilter verwijst naar een stroom die de cel niet houdt.
+    ///
+    /// Een reductie raakt uitsluitend de eigen feiten van de cel. Een onbekende
+    /// stroomnaam is de kroniek-tegenhanger van
+    /// [`SimulatorError::ForeignRegulation`] en blijkt op hetzelfde moment.
+    #[error(
+        "cel '{cell}': kroniekfilter van '{lexostatus}' verwijst naar kroniekstroom \
+         '{stream}', die deze cel niet houdt (wel: {known})"
+    )]
+    UnknownStream {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// De lexostatus met de onbekende stroom.
+        lexostatus: String,
+        /// De stroomnaam die niet bestaat.
+        stream: String,
+        /// Komma-gescheiden lijst van stromen die de cel wél houdt.
+        known: String,
+    },
+
+    /// Een kroniekfilter zegt niet wat het publiceert.
+    ///
+    /// Bij de wetsvorm is er altijd één uitkomst die de lexostatus *is*; een
+    /// kroniekfilter heeft die niet. Zonder `outputs` zou de cel dus haar hele
+    /// vastlegging naar buiten geven zonder iets beloofd te hebben.
+    #[error(
+        "cel '{cell}': kroniekfilter van '{lexostatus}' op '{stream}' moet in `outputs` \
+         noemen wat het publiceert; een kroniekfilter heeft geen wetsuitkomst \
+         die dat bepaalt"
+    )]
+    ChronicleWithoutOutputs {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// De lexostatus zonder `outputs`.
+        lexostatus: String,
+        /// De stroom waarover gefilterd wordt.
+        stream: String,
+    },
+
+    /// Een kroniekfilter sleutelt of filtert op een veld dat de stroom niet kent.
+    ///
+    /// Zo'n filter zou stil "niets vastgesteld" antwoorden op elke vraag, en dat
+    /// is niet te onderscheiden van een leeg verleden.
+    #[error(
+        "cel '{cell}': kroniekfilter van '{lexostatus}' gebruikt veld '{field}', \
+         maar kroniekstroom '{stream}' kent dat niet (wel: {known})"
+    )]
+    UnknownFilterField {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// De lexostatus met het onbekende veld.
+        lexostatus: String,
+        /// De stroom waarover gefilterd wordt.
+        stream: String,
+        /// Het veld dat de stroom niet kent.
+        field: String,
+        /// Komma-gescheiden lijst van velden die de stroom wél kent.
+        known: String,
+    },
+
+    /// De sleutel van een kroniekfilter is geen gedocumenteerde parameter.
+    ///
+    /// De consument levert de sleutelwaarde aan; staat de sleutel niet in
+    /// `inputs`, dan is er niets dat hem aanlevert en gaat de vraag over geen
+    /// enkel onderwerp.
+    #[error(
+        "cel '{cell}': kroniekfilter van '{lexostatus}' sleutelt op '{key}', maar dat \
+         is geen gedocumenteerde parameter (gedocumenteerd: {documented})"
+    )]
+    ChronicleKeyWithoutParameter {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// De lexostatus met de onbereikbare sleutel.
+        lexostatus: String,
+        /// Het sleutelveld van het filter.
+        key: String,
+        /// Komma-gescheiden lijst van gedocumenteerde parameters.
+        documented: String,
     },
 
     /// Geen regelingmap met deze naam in het corpus.
@@ -187,9 +270,27 @@ pub enum SimulatorError {
     /// altijd en bewijst niets; dat mag geen groen opleveren.
     #[error(
         "scenario '{scenario}': vraag naar '{cell}.{lexostatus}' heeft geen `expect` \
-         en bewijst dus niets"
+         en geen `expect_not_established`, en bewijst dus niets"
     )]
     QueryWithoutExpectation {
+        /// Het scenario waarin de vraag staat.
+        scenario: String,
+        /// De bevraagde cel.
+        cell: String,
+        /// De gevraagde lexostatus.
+        lexostatus: String,
+    },
+
+    /// Een vraag verwacht waarden én dat er niets vastgesteld is.
+    ///
+    /// Die twee sluiten elkaar uit, dus zo'n vraag kan nooit slagen. Dat is een
+    /// schrijffout in het scenario en geen falende assertie: hij blijkt bij het
+    /// lezen, niet pas na een run.
+    #[error(
+        "scenario '{scenario}': vraag naar '{cell}.{lexostatus}' verwacht zowel waarden \
+         als `expect_not_established`; dat kan niet samen uitkomen"
+    )]
+    ContradictoryExpectation {
         /// Het scenario waarin de vraag staat.
         scenario: String,
         /// De bevraagde cel.

--- a/packages/simulator/src/error.rs
+++ b/packages/simulator/src/error.rs
@@ -193,6 +193,28 @@ pub enum SimulatorError {
         known: String,
     },
 
+    /// Een `where`-voorwaarde vergelijkt met een `$`-verwijzing.
+    ///
+    /// `where` kent alleen letterlijke waarden; de `$naam`-vorm van de wetsvorm
+    /// betekent hier niets. Zonder deze controle zou zo'n filter de tekst
+    /// `$naam` zoeken en op elke vraag "niets vastgesteld" antwoorden, wat niet
+    /// te onderscheiden is van een leeg verleden.
+    #[error(
+        "cel '{cell}': `where` van '{lexostatus}' vergelijkt veld '{field}' met \
+         '${reference}', maar `where` vergelijkt met letterlijke waarden; de enige \
+         plek waar een kroniekfilter een parameter gebruikt, is `key`"
+    )]
+    FilterValueReference {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// De lexostatus met de kapotte voorwaarde.
+        lexostatus: String,
+        /// Het veld waarop de voorwaarde staat.
+        field: String,
+        /// De naam waarnaar verwezen werd.
+        reference: String,
+    },
+
     /// De sleutel van een kroniekfilter is geen gedocumenteerde parameter.
     ///
     /// De consument levert de sleutelwaarde aan; staat de sleutel niet in

--- a/packages/simulator/src/lib.rs
+++ b/packages/simulator/src/lib.rs
@@ -4,6 +4,9 @@
 //! eigen kronieken, laadt haar eigen wetten en reduceert daarover tot een
 //! *lexostatus*. Wat een cel niet is: ze houdt geen sleutels, ze heeft geen
 //! bevoegd gezag en ze combineert niets over cellen heen (RFC-022 §2, §4.1).
+//! Wetten zijn optioneel: een cel met `laws: []` is een **bron-cel** die
+//! vastlegt en reduceert zonder engine, en dat is de toets dat het
+//! lexostatus-contract engine-onafhankelijk is.
 //!
 //! Deze eerste versie kent één cel per scenario en geen verkeer tussen cellen.
 //! De grens ligt er wel al: een cel bezit haar [`ChronicleStore`] privé, en
@@ -27,10 +30,11 @@ pub mod cell;
 mod corpus;
 pub mod error;
 pub mod scenario;
+mod values;
 
 pub use cell::{
     Cell, CellConfig, ChronicleEvent, ChronicleStore, ChronicleStream, Lexostatus,
-    LexostatusDefinition, LexostatusInput, ParameterType, Reduction,
+    LexostatusDefinition, LexostatusInput, LexostatusOutcome, ParameterType, Reduction,
 };
 pub use corpus::regulation_root;
 pub use error::{Result, SimulatorError};

--- a/packages/simulator/src/scenario.rs
+++ b/packages/simulator/src/scenario.rs
@@ -5,8 +5,9 @@
 //! staat in het scenariobestand, niet in Rust. Zo blijft een testgeval een
 //! bestand dat iemand kan lezen en wijzigen zonder de crate te kennen.
 
-use crate::cell::{Cell, CellConfig, Lexostatus};
+use crate::cell::{Cell, CellConfig, Lexostatus, LexostatusOutcome};
 use crate::error::{Result, SimulatorError};
+use crate::values::equivalent;
 use chrono::NaiveDate;
 use regelrecht_engine::Value;
 use serde::Deserialize;
@@ -51,17 +52,37 @@ pub struct Query {
     /// anders bewijst de vraag niets.
     #[serde(default)]
     pub expect: BTreeMap<String, Value>,
+    /// Verwacht dat de cel op dit moment niets vastgesteld had.
+    ///
+    /// Een volwaardige verwachting, en de enige manier om dat antwoord vast te
+    /// leggen: "niets vastgesteld" is geen fout en geen leeg antwoord, dus een
+    /// scenario moet erop kunnen asserteren. Sluit `expect` uit.
+    #[serde(default)]
+    pub expect_not_established: bool,
 }
 
 /// Eén verwachting die niet uitkwam.
 #[derive(Debug, Clone)]
-pub struct ExpectationFailure {
-    /// De uitkomst waarover de verwachting ging.
-    pub output: String,
-    /// Wat het scenario verwachtte.
-    pub expected: Value,
-    /// Wat de reductie opleverde; `None` als de uitkomst ontbrak.
-    pub actual: Option<Value>,
+pub enum ExpectationFailure {
+    /// Een uitkomst had een andere waarde dan verwacht, of ontbrak.
+    Value {
+        /// De uitkomst waarover de verwachting ging.
+        output: String,
+        /// Wat het scenario verwachtte.
+        expected: Value,
+        /// Wat de reductie opleverde; `None` als de uitkomst ontbrak.
+        actual: Option<Value>,
+    },
+    /// Het scenario verwachtte waarden, maar de cel stelde niets vast.
+    NotEstablished {
+        /// Wat de cel als reden gaf.
+        reason: String,
+    },
+    /// Het scenario verwachtte "niets vastgesteld", maar de cel gaf een feit.
+    Established {
+        /// De waarden die de cel toch opleverde.
+        values: BTreeMap<String, Value>,
+    },
 }
 
 /// Het resultaat van één vraag.
@@ -106,16 +127,34 @@ impl ScenarioRun {
                 "  [{mark}] {}.{} op {}",
                 outcome.cell, outcome.lexostatus, outcome.lexostatus_value.op_moment
             );
+            // "Niets vastgesteld" is een antwoord, dus het verslag zegt het ook
+            // als het klopte: anders staat er `ok` bij een regel waarvan de
+            // lezer niet kan zien wat de cel antwoordde.
+            if let Some(reason) = outcome.lexostatus_value.not_established() {
+                let _ = writeln!(out, "        niets vastgesteld: {reason}");
+            }
             for failure in &outcome.failures {
-                let actual = match &failure.actual {
-                    Some(value) => value.to_string(),
-                    None => "(niet in het antwoord)".to_string(),
+                let _ = match failure {
+                    ExpectationFailure::Value {
+                        output,
+                        expected,
+                        actual,
+                    } => {
+                        let actual = match actual {
+                            Some(value) => value.to_string(),
+                            None => "(niet in het antwoord)".to_string(),
+                        };
+                        writeln!(out, "        {output}: verwacht {expected}, kreeg {actual}")
+                    }
+                    ExpectationFailure::NotEstablished { reason } => writeln!(
+                        out,
+                        "        verwachtte waarden, maar de cel stelde niets vast: {reason}"
+                    ),
+                    ExpectationFailure::Established { values } => writeln!(
+                        out,
+                        "        verwachtte 'niets vastgesteld', maar de cel gaf {values:?}"
+                    ),
                 };
-                let _ = writeln!(
-                    out,
-                    "        {}: verwacht {}, kreeg {actual}",
-                    failure.output, failure.expected
-                );
             }
         }
         out
@@ -138,10 +177,20 @@ impl Scenario {
     /// zonder assertie geen groen kan opleveren. Zonder deze controle draait een
     /// scenariobestand dat niets verwacht mee in de suite en meldt het `ok` —
     /// het duurste soort groen, want het lijkt op bewijs.
+    ///
+    /// Een vraag die beide verwachtingen tegelijk stelt, kan nooit slagen; dat
+    /// is een schrijffout en wordt hier ook geweigerd.
     fn validate(&self) -> Result<()> {
         for query in &self.queries {
-            if query.expect.is_empty() {
+            if query.expect.is_empty() && !query.expect_not_established {
                 return Err(SimulatorError::QueryWithoutExpectation {
+                    scenario: self.name.clone(),
+                    cell: query.cell.clone(),
+                    lexostatus: query.lexostatus.clone(),
+                });
+            }
+            if !query.expect.is_empty() && query.expect_not_established {
+                return Err(SimulatorError::ContradictoryExpectation {
                     scenario: self.name.clone(),
                     cell: query.cell.clone(),
                     lexostatus: query.lexostatus.clone(),
@@ -188,7 +237,7 @@ impl Scenario {
                 })?;
 
             let answer = cell.reduce(&query.lexostatus, &query.params, query.op_moment)?;
-            let failures = check_expectations(&query.expect, &answer.values);
+            let failures = check_expectations(query, &answer.outcome);
 
             outcomes.push(QueryOutcome {
                 cell: query.cell.clone(),
@@ -205,33 +254,39 @@ impl Scenario {
     }
 }
 
-/// Vergelijk de verwachtingen met wat de reductie opleverde.
-fn check_expectations(
-    expect: &BTreeMap<String, Value>,
-    actual: &BTreeMap<String, Value>,
-) -> Vec<ExpectationFailure> {
-    expect
-        .iter()
-        .filter_map(|(output, expected)| {
-            let found = actual.get(output);
-            match found {
-                Some(value) if equivalent(expected, value) => None,
-                _ => Some(ExpectationFailure {
-                    output: output.clone(),
-                    expected: expected.clone(),
-                    actual: found.cloned(),
-                }),
-            }
-        })
-        .collect()
-}
-
-/// Gelijkheid met één versoepeling: getallen vergelijken op waarde, niet op
-/// variant. YAML kent geen verschil tussen `1` en `1.0`, de engine wel.
-fn equivalent(expected: &Value, actual: &Value) -> bool {
-    match (expected.as_decimal(), actual.as_decimal()) {
-        (Some(left), Some(right)) => left == right,
-        _ => expected == actual,
+/// Vergelijk de verwachtingen van een vraag met wat de reductie opleverde.
+///
+/// De twee soorten antwoord worden apart afgerekend: wie waarden verwacht en
+/// "niets vastgesteld" krijgt, heeft geen ontbrekende uitkomst maar een ander
+/// antwoord, en het verslag zegt dat ook zo.
+fn check_expectations(query: &Query, outcome: &LexostatusOutcome) -> Vec<ExpectationFailure> {
+    match (outcome, query.expect_not_established) {
+        (LexostatusOutcome::NotEstablished { .. }, true) => Vec::new(),
+        (LexostatusOutcome::NotEstablished { reason }, false) => {
+            vec![ExpectationFailure::NotEstablished {
+                reason: reason.clone(),
+            }]
+        }
+        (LexostatusOutcome::Established(values), true) => {
+            vec![ExpectationFailure::Established {
+                values: values.clone(),
+            }]
+        }
+        (LexostatusOutcome::Established(values), false) => query
+            .expect
+            .iter()
+            .filter_map(|(output, expected)| {
+                let found = values.get(output);
+                match found {
+                    Some(value) if equivalent(expected, value) => None,
+                    _ => Some(ExpectationFailure::Value {
+                        output: output.clone(),
+                        expected: expected.clone(),
+                        actual: found.cloned(),
+                    }),
+                }
+            })
+            .collect(),
     }
 }
 
@@ -270,17 +325,101 @@ queries:
     }
 
     #[test]
-    fn getallen_vergelijken_op_waarde() {
-        assert!(equivalent(&Value::Int(1), &Value::Int(1)));
-        assert!(!equivalent(&Value::Int(1), &Value::Int(2)));
-        assert!(!equivalent(&Value::Int(1), &Value::String("1".to_string())));
+    fn vraag_die_waarden_en_niets_vastgesteld_verwacht_wordt_geweigerd() {
+        let yaml = r"
+name: kan niet uitkomen
+cells: []
+queries:
+  - cell: brp
+    lexostatus: partnerschap
+    op_moment: 2025-01-01
+    expect_not_established: true
+    expect:
+      partnerschap_type: GEEN
+";
+        let err = Scenario::from_yaml(yaml)
+            .expect_err("twee verwachtingen die elkaar uitsluiten horen te falen");
+        assert!(
+            matches!(err, SimulatorError::ContradictoryExpectation { .. }),
+            "verwachtte ContradictoryExpectation, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn niets_vastgesteld_mag_de_enige_verwachting_zijn() {
+        let yaml = r"
+name: bewijst dat er niets was
+cells: []
+queries:
+  - cell: brp
+    lexostatus: partnerschap
+    op_moment: 2025-01-01
+    expect_not_established: true
+";
+        assert!(
+            Scenario::from_yaml(yaml).is_ok(),
+            "`expect_not_established` is een volwaardige verwachting"
+        );
+    }
+
+    /// Een vraag met precies één verwachting, voor de assertietests hieronder.
+    fn query(expect_not_established: bool, expect: BTreeMap<String, Value>) -> Query {
+        Query {
+            description: None,
+            cell: "brp".to_string(),
+            lexostatus: "partnerschap".to_string(),
+            params: BTreeMap::new(),
+            op_moment: NaiveDate::default(),
+            expect,
+            expect_not_established,
+        }
     }
 
     #[test]
     fn ontbrekende_uitkomst_is_een_gemiste_verwachting() {
         let expect = BTreeMap::from([("hoogte".to_string(), Value::Int(1))]);
-        let failures = check_expectations(&expect, &BTreeMap::new());
-        assert_eq!(failures.len(), 1);
-        assert!(failures[0].actual.is_none());
+        let failures = check_expectations(
+            &query(false, expect),
+            &LexostatusOutcome::Established(BTreeMap::new()),
+        );
+        assert!(
+            matches!(
+                failures.as_slice(),
+                [ExpectationFailure::Value { actual: None, .. }]
+            ),
+            "verwachtte één gemiste uitkomst, kreeg {failures:?}"
+        );
+    }
+
+    #[test]
+    fn niets_vastgesteld_is_geen_gemiste_uitkomst_maar_een_ander_antwoord() {
+        let expect = BTreeMap::from([("partnerschap_type".to_string(), Value::Null)]);
+        let outcome = LexostatusOutcome::NotEstablished {
+            reason: "geen vastlegging".to_string(),
+        };
+        let failures = check_expectations(&query(false, expect), &outcome);
+        assert!(
+            matches!(
+                failures.as_slice(),
+                [ExpectationFailure::NotEstablished { .. }]
+            ),
+            "verwachtte NotEstablished, kreeg {failures:?}"
+        );
+    }
+
+    #[test]
+    fn een_feit_waar_niets_verwacht_werd_is_een_gemiste_verwachting() {
+        let outcome = LexostatusOutcome::Established(BTreeMap::from([(
+            "partnerschap_type".to_string(),
+            Value::String("GEEN".to_string()),
+        )]));
+        let failures = check_expectations(&query(true, BTreeMap::new()), &outcome);
+        assert!(
+            matches!(
+                failures.as_slice(),
+                [ExpectationFailure::Established { .. }]
+            ),
+            "verwachtte Established, kreeg {failures:?}"
+        );
     }
 }

--- a/packages/simulator/src/values.rs
+++ b/packages/simulator/src/values.rs
@@ -1,0 +1,35 @@
+//! Waarden vergelijken zoals een leesbaar bestand ze bedoelt.
+//!
+//! Eén plek, want er zijn twee plekken die dezelfde vraag stellen: het
+//! kroniekfilter (voldoet dit veld aan deze voorwaarde?) en de scenario-runner
+//! (kwam deze verwachting uit?). Wie ze uit elkaar laat lopen, krijgt een
+//! scenario dat iets anders vergelijkt dan de cel.
+
+use regelrecht_engine::Value;
+
+/// Gelijkheid met één versoepeling: getallen vergelijken op waarde, niet op
+/// variant. YAML kent geen verschil tussen `1` en `1.0`, de engine wel.
+pub(crate) fn equivalent(left: &Value, right: &Value) -> bool {
+    match (left.as_decimal(), right.as_decimal()) {
+        (Some(a), Some(b)) => a == b,
+        _ => left == right,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn getallen_vergelijken_op_waarde() {
+        assert!(equivalent(&Value::Int(1), &Value::Int(1)));
+        assert!(!equivalent(&Value::Int(1), &Value::Int(2)));
+        assert!(!equivalent(&Value::Int(1), &Value::String("1".to_string())));
+    }
+
+    #[test]
+    fn afwezigheid_is_gelijk_aan_afwezigheid() {
+        assert!(equivalent(&Value::Null, &Value::Null));
+        assert!(!equivalent(&Value::Null, &Value::Bool(false)));
+    }
+}


### PR DESCRIPTION
## Waarom

De simulator kon tot nu toe alleen cellen die een machineleesbare wet uitvoeren. Daarmee was "de engine is een component dat in een cel kán draaien, niet de cel zelf" (RFC-022 §2) proza: zolang een cel niet zonder engine kan bestaan, valt die scheiding niet te controleren. En bijna elke organisatie in een decentrale keten voert geen wet uit — een register, een vereniging, een betaalsysteem, een legacy-API.

Een cel met `laws: []` is nu geldig. Ze legt vast en ze reduceert; `Cell` houdt haar engine in een `Option` en bouwt er geen als er geen wetten zijn. Dat is tegelijk de toets dat het lexostatus-contract engine-onafhankelijk is: een consument kan aan het antwoord niet zien welke van de twee soorten cel hij bevroeg.

## Wat er verandert

- **`Reduction` is een enum met twee vormen.** De bestaande wetsvorm (`regulation` + `output` + `parameters`) en een **kroniekfilter** (`chronicle` + `key`, met een optionele `where`-map met gelijkheden op velden). De configuratie kiest door te noemen wat ze bedoelt — geen `kind`-veld dat herhaalt wat er al staat, en geen `#[serde(untagged)]`, want dat zou elke typfout als "data did not match any variant" melden. Twee vormen in één reductie, of geen van beide, levert een melding die zegt welke twee vormen er zijn.
- **Het filter levert per sleutelwaarde de laatste vastlegging op of vóór `op_moment`** — één hele vastlegging, geen toestandsmerge van velden uit verschillende momenten. `where` bepaalt *welke* vastleggingen meedoen; pas van die groep wint de laatste. Dat betekent dat een voorwaarde op een veld dat over tijd verandert de laatste vastlegging oplevert die eraan voldeed en niet de huidige stand; het scenario en de README benoemen dat expliciet, want het is een val.
- **`outputs` is verplicht bij een kroniekfilter.** Bij de wetsvorm is er altijd één uitkomst die de lexostatus *is*; een filter heeft die niet, dus zonder `outputs` zou de cel haar hele vastlegging naar buiten geven zonder iets beloofd te hebben. Bij het optuigen worden vier dingen geweigerd: een onbekende stroomnaam, een output die in geen enkele vastlegging van de stroom voorkomt, een sleutel- of `where`-veld dat de stroom niet kent, en een sleutel die geen gedocumenteerde parameter is (dan kan de consument de waarde niet aanleveren en gaat de vraag over geen enkel onderwerp).
- **"Niets vastgesteld" is een gewoon antwoord.** `Lexostatus` draagt een `LexostatusOutcome`: `Established(values)` of `NotEstablished { reason }`. Geen fout, en geen lege map die op een antwoord lijkt. De reden noemt de stroom, de sleutelwaarde, het moment en het filter, zodat een consument weet waar hij moet kijken. Een scenario legt dit vast met `expect_not_established: true`; dat sluit `expect` uit, en een vraag die beide stelt wordt bij het lezen geweigerd in plaats van na een run te falen.
- **Nieuw scenario** `scenarios/brp_broncel.yaml`: een bron-cel met kroniek `relaties` en lexostatus `partnerschap(bsn)`, bevraagd op twee momenten met verschillende uitkomst, op een moment vóór het eerste feit (niets vastgesteld) en met een `where`-variant.
- **README**: wat een bron-cel is en waarom een organisatie zonder engine gewoon een cel is, plus de twee reductievormen en het antwoord "niets vastgesteld".

De outputs-projectie voor de wetsvorm stond al op de basisbranch en is hergebruikt; de vergelijking van waarden (`1` versus `1.0`) stond dubbel te ontstaan en woont nu op één plek in `src/values.rs`, gebruikt door het filter én de scenario-runner.

## Checks

`just format`, `just lint`, `just build-check`, `just validate` en `just test-no-docker` groen; alle pre-commit-hooks groen. `cargo test -p regelrecht-simulator`: 43 unittests plus beide scenariobestanden. De container-gedekte crates (`regelrecht-admin`) vallen lokaal op `PoolTimedOut` — ook zonder deze wijziging, dus omgeving en niet deze diff.

Eén punt dat op de basisbranch al rood staat en hier niet bij hoort: `just check` valt over `dockerfile-consistency-test` omdat de workspace-member `simulator` in `frontend-demo/Dockerfile` (wasm-builder) niet ge-COPYd en niet weggeknipt is. Dat kwam met de crate mee en raakt deze diff niet.