### PR TITLE
fix(demo): knip de simulator-crate weg in de wasm-bouwtrap

### DIFF
--- a/frontend-demo/Dockerfile
+++ b/frontend-demo/Dockerfile
@@ -43,7 +43,7 @@ RUN set -eu; \
 # Trim workspace members to engine + law-model + shared. When adding a new
 # workspace member that this image does NOT build, add it here as well.
 RUN grep -qE '^members = \[$' Cargo.toml && \
-    sed -i '/"admin"/d; /"arch-extract"/d; /"auth"/d; /"corpus"/d; /"editor-api"/d; /"github"/d; /"harvester"/d; /"pipeline"/d; /"tui"/d' Cargo.toml
+    sed -i '/"admin"/d; /"arch-extract"/d; /"auth"/d; /"corpus"/d; /"editor-api"/d; /"github"/d; /"harvester"/d; /"pipeline"/d; /"simulator"/d; /"tui"/d' Cargo.toml
 COPY packages/engine/ engine/
 COPY packages/law-model/ law-model/
 COPY packages/shared/ shared/


### PR DESCRIPTION
De demo-image bouwt de engine naar WASM met cargo-chef en verwijdert daarvoor elke workspace-member die hij niet meebouwt uit `Cargo.toml`. De member `simulator` ontbrak in die lijst; `just dockerfile-consistency-test` wees dat aan op de integratiebranch. Eén regel in `frontend-demo/Dockerfile`, test weer groen.