### PR TITLE
feat: veiligheidscontext, celtransport en test-only observatielog in de simulator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `packages/editor-api/` - Rust backend API for the editor frontend
 - `packages/corpus/` - Shared library for working with YAML regulation files
 - `packages/shared/` - Common types/utilities across packages
-- `packages/simulator/` - Chronolexografie testopstelling (RFC-022): cellen met een privé kroniekstore, lexostatus-reducties en een scenario-loader
+- `packages/simulator/` - Chronolexografie testopstelling (RFC-022): cellen met een privé kroniekstore, lexostatus-reducties, een veiligheidscontext plus `CellTransport` als enige weg over een celgrens, het test-only observatielog en een scenario-loader
 - `packages/tui/` - Terminal UI dashboard
 - `packages/grafana/` - Grafana monitoring with provisioned dashboards
 - `frontend/` - Law editor (Vue/Vite + editor-api backend)

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -291,8 +291,17 @@ Het log bewaart het bewijsstuk van de veiligheidscontext ongewijzigd; er komt ge
 kopie-met-andere-namen naast. Wat in het log staat, is exact wat over de grens
 ging.
 
+Daar hangt een prijs aan, en die hoort er expliciet bij te staan: **volledigheid
+is niet afgedwongen.** De veiligheidscontext geeft haar bewijsstuk terug aan wie
+vroeg, en of dat bewijsstuk in het log belandt beslist die aanroeper. Vandaag is
+dat de scenario-runner, die elk bewijsstuk teruggeeft, dus voor een run klopt het
+nu. Zodra een cel zelf kan besluiten, verhuist de vraag naar dat pad en moet het
+vastleggen mee; gebeurt dat niet, dan is het log stil incompleet in plaats van
+rood.
+
 De invarianten-gate die het gedeclareerde vraaggraf met het feitelijke vergelijkt
-(I3) staat er nog niet. Dit is het instrument waar die op gaat rusten.
+(I3) staat er nog niet. Dit is het instrument waar die op gaat rusten, en daar
+hoort die volledigheidseis dan ook thuis.
 
 ## Scenarioformaat
 

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -4,12 +4,17 @@ Testopstelling voor chronolexografie ([RFC-022](../../docs/src/content/rfcs/rfc-
 De crate simuleert een wereld van **cellen** en laat een scenario die wereld
 optuigen en bevragen.
 
-Deze eerste versie is bewust krap: één cel per scenario, geen verkeer tussen
-cellen. Wat er wel al staat, is de grens — en die is met opzet een taalgrens en
-geen afspraak.
+Deze versie is bewust krap, maar de grens staat er wel al — en die is met opzet
+een taalgrens en geen afspraak.
 
 Wetten zijn optioneel. Een cel met `laws: []` is een **bron-cel**: ze legt vast
 en reduceert, zonder engine. Zie [Een bron-cel](#een-bron-cel).
+
+Gaat een vraag over een celgrens, dan loopt hij langs de **veiligheidscontext**
+van de vragende cel naar het **transport**, en dat is de enige weg. Zie
+[Over een celgrens](#over-een-celgrens). Wat daar langs gaat is te meten met het
+**observatielog**, een test-only instrument dat met opzet buiten de band staat:
+[Het observatielog](#het-observatielog-buiten-de-band).
 
 ## De drie chronolexogrammen, en waar ze hier zitten
 
@@ -82,7 +87,7 @@ Precies de drie dingen die er in de praktijk bij gedacht worden (RFC-022 §2):
 - **Geen synthese.** Een reductie raakt uitsluitend de eigen kronieken.
   Combineren over cellen heen doet een consument, nooit een cel.
 
-Twee dingen dwingen dat af in code in plaats van in proza:
+Drie dingen dwingen dat af in code in plaats van in proza:
 
 1. `Cell` houdt haar `ChronicleStore` in een **privéveld** zonder accessor. Er
    is geen `pub fn store()` en die komt er ook niet: dat een andere cel niet bij
@@ -90,6 +95,10 @@ Twee dingen dwingen dat af in code in plaats van in proza:
 2. De reductie mag alleen een regeling gebruiken die de cel zélf laadt. Een
    definitie die naar een vreemde regeling wijst, wordt geweigerd bij het
    optuigen van de cel — niet pas bij de eerste vraag.
+3. `Cell` heeft **geen veld en geen parameter** voor een transport of een
+   veiligheidscontext. `Cell::reduce` kan de grens dus niet bereiken; dat is een
+   compileerfout en geen afspraak. Een test grept `src/cell/` erop, zodat ook een
+   latere toevoeging die de weg zou openen meteen rood wordt.
 
 ## De publieke ingang
 
@@ -194,11 +203,103 @@ met `expect_not_established: true`; dat is een volwaardige verwachting en sluit
 wandklok. Feiten die pas later in de cel zijn vastgelegd, bestaan voor dat
 antwoord niet, en de engine kiest op datzelfde moment de regelingversie.
 
+## Over een celgrens
+
+Een cel bevraagt nooit zelf een andere cel. De vraag gaat langs twee dingen die
+een cel *niet* is (RFC-022 §2):
+
+```rust,ignore
+let transport = InProcessTransport::over(&cells);
+let context = SecurityContext::new(Identity::for_cell("toeslagen"), &transport);
+let signed = context.query("brp", "partnerschap", &params, op_moment)?;
+```
+
+- **`SecurityContext`** — identiteit, ondertekening, transportkeuze. Gebonden aan
+  precies één cel, en de **enige** die het transport aanroept.
+- **`CellTransport`** — de naad: `query(cel, lexostatus, params, op_moment)`.
+  Exact de vorm van de publieke ingang van een cel en met opzet niets meer; een
+  transport dat een reductie of een filter kon meesturen, zou de autonomie van de
+  bevraagde cel omzeilen. In-process nu (`InProcessTransport`), HTTP later, en dat
+  verschil mag `Cell` geen enkele wijziging kosten.
+
+Wat de context teruggeeft is geen antwoord maar een **bewijsstuk**
+(`SignedAnswer`): wie vroeg, ondertekend door welke identiteit, met welke
+parameters, en wat de peer antwoordde. Dat is geen gemak. Een cel die straks een
+waarde van een andere cel *accepteert* in plaats van narekent, moet precies dat in
+haar decretogram vastleggen (RFC-013 `accepted_values`), en het observatielog wil
+hetzelfde weten.
+
+Een vraag aan de eigen cel wordt geweigerd: voor eigen feiten is er een reductie.
+Zonder die weigering zou een cel haar eigen kroniek als cross-cel-contact in het
+log krijgen en daarmee het vraaggraf vervuilen.
+
+### Ondertekening is gesimuleerd
+
+De ondertekening is een **placeholder**, en dat staat in de waarde zelf:
+`GESIMULEERDE-ONDERTEKENING door cel:toeslagen`. Er zit geen sleutel achter en er
+valt niets aan te verifiëren. `Signature::is_simulated()` is daarom waar, en de
+test die dat vastlegt wordt rood op de dag dat er echt ondertekend wordt — wat de
+bedoeling is. Echte sleutels en trust material (Blauwe Knop/FCID, FSC) zijn buiten
+scope. Wat er wél is, is de vorm: een vraag die de grens over gaat draagt de
+identiteit die hem stuurde, en het log laat zien dat en door wie er ondertekend is.
+
+### Twee open vragen in de RFC, en wat wij hier kiezen
+
+Beide keuzes zijn een **standpunt in een open vraag**, geen implementatiedetail.
+Ze komen niet uit de RFC en horen niet als vaststaand gelezen te worden.
+
+- **Open Question 4 — twee transports, of één mechanisme met twee soorten peer?**
+  Wij lezen het als **één mechanisme met twee soorten peer**. Er is één
+  `CellTransport`-trait; wie er aan de andere kant staat (een cel of een
+  burger-client) is een eigenschap van de peer en niet van het mechanisme. Dat
+  standpunt is te falsifiëren: zodra cel↔burger een veld, een methode of een eigen
+  trait blijkt te vragen die cel↔cel niet gebruikt, was de andere lezing de juiste.
+  Vandaag bestaat alleen de cel↔cel-kant, dus het bewijs is nog niet geleverd.
+- **Open Question 2 — waaraan bindt de veiligheidscontext?** Onbeslist in de RFC.
+  Hier: één context per cel, met één identiteit die de cel zélf is
+  (`cel:toeslagen`). Geen medewerker, geen zaak, geen mandaat, geen autorisatie.
+  Dat is de dunste vorm die de vraag openhoudt; komt er een fijnere binding, dan
+  krijgt `Identity` velden en verandert er aan de aanroepers niets.
+
+## Het observatielog (buiten de band)
+
+`ObservationLog` legt per cross-cel-vraag vast: de vrager, de bevraagde cel, de
+lexostatus, de parameters, het moment, de (gesimuleerde) ondertekening en wat er
+terugkwam. Daarmee kan een run het feitelijke vraaggraf *laten zien* in plaats van
+beweren dat het klopt.
+
+Het log staat **niet in de RFC**. Die beweert autonomie, maar zegt nergens hoe je
+die meet; dit is toegevoegd meetgereedschap. En het hoort nooit een
+runtimecomponent te worden, om precies de reden die de opstelling wil bewijzen:
+het log ziet álles, dus wie het houdt kent de unie van wat over de grenzen ging —
+het totaalbeeld waarvan wij zeggen dat het nergens bestaat.
+
+Drie regels, en de eerste twee zijn afgedwongen in plaats van afgesproken:
+
+1. **Geen productiepad verwijst ernaar.** [`src/observation.rs`](src/observation.rs)
+   wordt door geen enkel ander bestand in `src/` geïmporteerd en staat niet in de
+   re-exports van de crate-wortel. Een test in
+   [`tests/observation_log.rs`](tests/observation_log.rs) grept `src/` en wordt
+   rood zodra iemand het toch doet.
+2. **`Cell` komt er niet in voor.** Het log leest wat een vraag opleverde; het kan
+   geen cel bevragen en geen kroniek bereiken. Ook dat is een grep-poort.
+3. **Passief.** `record` geeft niets terug en kan niet falen. Een meetinstrument
+   dat een run kan laten struikelen of een beslissing kan beïnvloeden, meet die
+   run niet meer.
+
+Het log bewaart het bewijsstuk van de veiligheidscontext ongewijzigd; er komt geen
+kopie-met-andere-namen naast. Wat in het log staat, is exact wat over de grens
+ging.
+
+De invarianten-gate die het gedeclareerde vraaggraf met het feitelijke vergelijkt
+(I3) staat er nog niet. Dit is het instrument waar die op gaat rusten.
+
 ## Scenarioformaat
 
-Een scenario is één YAML-bestand met twee blokken: `cells` (de wereld) en
-`queries` (de vragen plus wat ze moeten opleveren). De assertie hoort bij het
-scenario, niet bij Rust: een nieuw testgeval is een nieuw bestand.
+Een scenario is één YAML-bestand met `cells` (de wereld) en twee soorten vraag:
+`queries` (een consument bevraagt een cel) en `query_via_transport` (een cel
+bevraagt een andere cel). Beide dragen hun eigen verwachting; de assertie hoort
+bij het scenario en niet bij Rust, dus een nieuw testgeval is een nieuw bestand.
 
 ```yaml
 name: korte naam van het scenario
@@ -267,7 +368,26 @@ queries:
     op_moment: 2020-01-01
     expect_not_established: true                # verwacht dat er op dit moment
                                                 # niets vastgesteld was
+
+query_via_transport:                            # vragen over een celgrens
+  - description: vrije omschrijving             # optioneel
+    from: toeslagen                             # de vragende cel; haar
+                                                # veiligheidscontext ondertekent
+    cell: brp                                   # de bevraagde cel
+    lexostatus: partnerschap
+    params:
+      bsn: '999993653'
+    op_moment: 2024-01-01
+    expect:                                     # zelfde verwachtingen als bij
+      partnerschap_type: HUWELIJK               # een gewone vraag
 ```
+
+`query_via_transport` is een **test-only stap, en dat is tijdelijk**. In de
+opstelling die we bouwen stelt een cel zo'n vraag uitsluitend vanuit haar
+besluit-pad: ze heeft een input nodig die een andere organisatie vaststelt. Dat
+pad bestaat nog niet — een cel kan nog niets vastleggen en dus niets accepteren —
+en tot die tijd is dit de enige manier om het verkeer te laten zien en erop te
+asserteren. Zodra het besluit-pad er is, verhuist de aanroep daarheen.
 
 Onbekende velden worden geweigerd, zodat een typfout niet stil verdwijnt. Elke
 vraag heeft minstens één verwachting: een vraag zonder `expect` en zonder
@@ -310,8 +430,11 @@ bestand, en de laatste wint. Wie ze wél wil ordenen heeft een fijnere tijdas
 nodig, geen andere schrijfvolgorde.
 
 Feiten die in de echte wereld van een andere organisatie komen, staan hier als
-binnengekomen feit in de eigen kroniek. Zolang er geen transport tussen cellen
-is, is dat het eerlijke model: de cel kan niets ophalen wat ze niet zelf heeft.
+binnengekomen feit in de eigen kroniek. Dat blijft zo, ook nu er een transport is:
+een **reductie** kan geen andere cel bereiken, want de cel houdt geen transport en
+`Cell::reduce` heeft er geen weg naartoe. Over de grens gaat alleen wat langs de
+veiligheidscontext gaat, en die wordt vandaag alleen door een scenario-stap
+aangeroepen (zie [Over een celgrens](#over-een-celgrens)).
 Vraag je een moment op waarop een binnengekomen feit nog niet vastlag, dan faalt
 de reductie: bij een input met een `source` naar een regeling die deze cel niet
 laadt met "Law not found", en anders met "Variable not found". Beide zeggen
@@ -351,8 +474,18 @@ een vastgelegd besluit voor nodig. De eerstvolgende stap is daarom een
 haar eigen kroniek, dus geen consument mag erin schrijven, net zomin als eruit
 lezen.
 
-Verkeer tussen cellen (`CellTransport`), de veiligheidscontext, het
-observatielog, meerdere cellen in één scenario en asynchrone intake met een
-echte tijdlijn volgen apart. De indeling anticipeert erop: de reductielogica
-woont in [`src/cell/`](src/cell/) en niet in de scenario-runner, zodat een
-latere `packages/cell` een verplaatsing is en geen herschrijving.
+Aan de kant van de celgrens ontbreken nog drie dingen. **Accepteren in plaats van
+narekenen** (I5): het bewijsstuk van de veiligheidscontext heeft de vorm die een
+decretogram ervoor nodig heeft, maar er is nog geen decretogram om het in te
+leggen. De **invarianten-gate** die het gedeclareerde vraaggraf uit het scenario
+vergelijkt met het feitelijke uit het observatielog (I3). En **autorisatie**: de
+veiligheidscontext kent identiteit en ondertekening, en beslist nog niets over wat
+mag.
+
+Ook een **HTTP-transport** is er niet; dat is het punt van de trait. Komt het er,
+dan is dat een tweede implementatie naast `InProcessTransport` en geen wijziging in
+`Cell` — en als dat laatste wél nodig blijkt, was de naad op de verkeerde plek
+gelegd. Asynchrone intake met een echte tijdlijn volgt apart. De indeling
+anticipeert erop: de reductielogica woont in [`src/cell/`](src/cell/) en niet in de
+scenario-runner, zodat een latere `packages/cell` een verplaatsing is en geen
+herschrijving.

--- a/packages/simulator/scenarios/transport_toeslagen_brp.yaml
+++ b/packages/simulator/scenarios/transport_toeslagen_brp.yaml
@@ -1,0 +1,72 @@
+---
+name: een cel vraagt een lexostatus op bij een andere cel
+description: >-
+  Twee cellen en één vraag over de grens. De vraag gaat niet van cel naar cel:
+  hij gaat van de veiligheidscontext van `toeslagen` naar het transport, en het
+  transport komt bij de publieke ingang van `brp` uit. Dat is de hele
+  bewijslast van dit scenario — er is precies één weg over een celgrens, en die
+  is waarneembaar.
+
+  Wat er níet gebeurt is even belangrijk. Het antwoord van `brp` verdwijnt niet
+  in een kroniek van `toeslagen`: een kroniek bevat alleen wat de cel zelf
+  overkwam, en een geaccepteerde waarde hoort in het besluit dat haar gebruikt.
+  `toeslagen` legt hier dus niets vast, en bij een volgend besluit gaat de vraag
+  opnieuw naar de bron.
+
+cells:
+  # De bevraagde cel: een bron-cel zonder engine, precies zoals het
+  # bron-celscenario hem laat zien. Ze merkt niet dat de vraag over een
+  # celgrens kwam, en dat is het punt van het transport als naad: in-process
+  # nu, HTTP later, zonder dat hier iets verandert.
+  - id: brp
+    laws: []
+
+    chronicles:
+      - stream: relaties
+        key: bsn
+        events:
+          - op_moment: 2023-03-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: HUWELIJK
+              partner_bsn: '999993756'
+
+    lexostatus_definitions:
+      - name: partnerschap
+        doc: >-
+          De relatievorm van één persoon op één moment, zoals deze cel die
+          vastlegde. Geen berekening: de laatste vastlegging op of vóór het
+          gevraagde moment.
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - partnerschap_type
+          - partner_bsn
+        reduction:
+          chronicle: relaties
+          key: bsn
+          latest: true
+
+  # De vragende cel. Ze publiceert hier zelf niets en legt niets vast: in deze
+  # ronde is ze alleen vrager, want het besluit-pad dat een opgehaalde waarde
+  # zou accepteren bestaat nog niet. Wat ze wél heeft, is een identiteit — en
+  # dat is alles wat er nodig is om een vraag te ondertekenen.
+  - id: toeslagen
+    laws: []
+
+query_via_transport:
+  - description: >-
+      `toeslagen` heeft de relatievorm van deze persoon nodig en stelt die niet
+      zelf vast. Ze vraagt hem dus op bij de cel die hem wél vastlegde, onder de
+      naam die die cel publiceert, met de parameters die daarbij horen, op een
+      moment dat zij kiest.
+    from: toeslagen
+    cell: brp
+    lexostatus: partnerschap
+    params:
+      bsn: '999993653'
+    op_moment: 2024-01-01
+    expect:
+      partnerschap_type: HUWELIJK
+      partner_bsn: '999993756'

--- a/packages/simulator/src/error.rs
+++ b/packages/simulator/src/error.rs
@@ -328,6 +328,35 @@ pub enum SimulatorError {
         cell: String,
     },
 
+    /// Het transport kent de aangewezen peer niet.
+    ///
+    /// Eigen variant naast [`SimulatorError::UnknownCell`]: dit is geen fout in
+    /// een scenariobestand maar een vraag die de grens over wilde naar iets wat
+    /// er niet is. Een transport verzint geen antwoord.
+    #[error("transport kent geen cel '{cell}' (wel: {known})")]
+    UnknownPeer {
+        /// Het onbekende cel-id.
+        cell: String,
+        /// Komma-gescheiden lijst van cellen die het transport wél bereikt.
+        known: String,
+    },
+
+    /// Een cel bevraagt zichzelf via het transport.
+    ///
+    /// Voor de eigen feiten is er een reductie; het transport is er voor peers.
+    /// Zonder deze weigering zou een cel haar eigen kroniek als cross-cel-contact
+    /// in het observatielog krijgen en daarmee het vraaggraf vervuilen.
+    #[error(
+        "cel '{cell}' vraagt '{lexostatus}' via het transport aan zichzelf; \
+         voor eigen feiten is er een reductie"
+    )]
+    TransportToSelf {
+        /// De cel die zichzelf bevroeg.
+        cell: String,
+        /// De gevraagde lexostatus.
+        lexostatus: String,
+    },
+
     /// Het scenariobestand kon niet gelezen worden.
     #[error("kon scenario '{path}' niet lezen: {source}")]
     ScenarioRead {

--- a/packages/simulator/src/lib.rs
+++ b/packages/simulator/src/lib.rs
@@ -8,9 +8,15 @@
 //! vastlegt en reduceert zonder engine, en dat is de toets dat het
 //! lexostatus-contract engine-onafhankelijk is.
 //!
-//! Deze eerste versie kent één cel per scenario en geen verkeer tussen cellen.
-//! De grens ligt er wel al: een cel bezit haar [`ChronicleStore`] privé, en
-//! [`Cell::reduce`] is de enige publieke ingang voor een consument.
+//! De grens tussen cellen is een taalgrens en geen afspraak: een cel bezit haar
+//! [`ChronicleStore`] privé, en [`Cell::reduce`] is de enige publieke ingang voor
+//! een consument. Gaat een vraag over een celgrens, dan loopt hij langs
+//! [`SecurityContext`] (identiteit en ondertekening) naar [`CellTransport`] (de
+//! naad: in-process nu, HTTP later). Een cel houdt zelf geen van beide.
+//!
+//! Het [`observation`]-log is het meetinstrument daarnaast: test-only, passief en
+//! met opzet buiten de band, want een observator die álles ziet kent wél het
+//! totaalbeeld waarvan deze opstelling zegt dat het nergens bestaat.
 //!
 //! ```no_run
 //! use regelrecht_simulator::{regulation_root, Scenario};
@@ -29,7 +35,13 @@
 pub mod cell;
 mod corpus;
 pub mod error;
+// Meetinstrument, geen onderdeel van de opstelling: zie de moduledocs. Met opzet
+// geen re-export hieronder — wie hem gebruikt, noemt hem bij zijn volle naam, en
+// geen ander bestand in `src/` mag dat doen.
+pub mod observation;
 pub mod scenario;
+pub mod security;
+pub mod transport;
 mod values;
 
 pub use cell::{
@@ -38,4 +50,9 @@ pub use cell::{
 };
 pub use corpus::regulation_root;
 pub use error::{Result, SimulatorError};
-pub use scenario::{ExpectationFailure, Query, QueryOutcome, Scenario, ScenarioRun};
+pub use scenario::{
+    ExpectationFailure, Query, QueryOutcome, Scenario, ScenarioRun, TransportOutcome,
+    TransportQuery,
+};
+pub use security::{Identity, SecurityContext, Signature, SignedAnswer};
+pub use transport::{CellTransport, InProcessTransport};

--- a/packages/simulator/src/observation.rs
+++ b/packages/simulator/src/observation.rs
@@ -27,6 +27,21 @@
 //!    beslissing, weigert nooit een aanroep en kan niet falen. [`ObservationLog`]
 //!    heeft daarom geen methode die iets teruggeeft aan de aanroeper van
 //!    [`crate::SecurityContext::query`].
+//!
+//! ## Wat die keuze kost
+//!
+//! Buiten de band staan betekent dat dit log niet uit zichzelf volledig is. De
+//! veiligheidscontext geeft haar bewijsstuk terug aan wie vroeg; of dat
+//! bewijsstuk hier belandt, beslist die aanroeper. Vandaag is dat de
+//! scenario-runner, en die geeft elk bewijsstuk terug, dus voor een run is
+//! volledigheid nu structureel.
+//!
+//! Zodra een cel zelf kan besluiten, verhuist de vraag naar dat pad — en dan moet
+//! het vastleggen mee. Gebeurt dat niet, dan is het log stil incompleet in plaats
+//! van rood, en dat is de gevaarlijke kant op. Volledigheid is daarom een
+//! eigenschap van de invarianten-gate die het gedeclareerde vraaggraf met het
+//! feitelijke vergelijkt (I3), en niet van deze module: die gate hoort te falen
+//! als een cel een peer bevraagt zonder dat het log het weet.
 
 use crate::{LexostatusOutcome, SignedAnswer};
 use std::fmt::Write as _;

--- a/packages/simulator/src/observation.rs
+++ b/packages/simulator/src/observation.rs
@@ -1,0 +1,108 @@
+//! Het observatielog: een meetinstrument, buiten de band.
+//!
+//! Registreert elk contact over een celgrens: wie vroeg, aan wie, welke
+//! lexostatus, met welke parameters, op welk moment, ondertekend door wie, en
+//! wat er terugkwam. Dat is wat een run nodig heeft om te kunnen bewijzen dat
+//! een cel alleen de cellen bevraagt die haar eigen wetten noemen — een
+//! invariant die *niet* in RFC-022 staat en die wij hier zelf toevoegen, omdat
+//! de RFC autonomie wel beweert maar niet meet.
+//!
+//! ## Waarom dit geen runtimecomponent is
+//!
+//! Het log ziet álles. Daarmee kent de houder van het log de unie van wat over
+//! de grenzen ging — precies het totaalbeeld waarvan de hele opstelling zegt
+//! dat het nergens bestaat. Een observator die meedraait in productie zou die
+//! claim ongedaan maken, hoe netjes hij ook geschreven is.
+//!
+//! Daarom drie regels, en de eerste twee zijn afgedwongen in plaats van
+//! afgesproken:
+//!
+//! 1. **Geen productiepad verwijst hiernaar.** Deze module wordt door geen enkel
+//!    ander bestand in `src/` geïmporteerd; een test in `tests/` grept daarop en
+//!    wordt rood zodra iemand het toch doet. De crate-wortel re-exporteert deze
+//!    types met opzet niet.
+//! 2. **`Cell` komt hier niet voor.** Het log leest wat een vraag opleverde, het
+//!    kan geen cel bevragen en geen kroniek bereiken.
+//! 3. **Passief.** Een recorder beïnvloedt niets: hij levert geen waarde aan een
+//!    beslissing, weigert nooit een aanroep en kan niet falen. [`ObservationLog`]
+//!    heeft daarom geen methode die iets teruggeeft aan de aanroeper van
+//!    [`crate::SecurityContext::query`].
+
+use crate::{LexostatusOutcome, SignedAnswer};
+use std::fmt::Write as _;
+
+/// Een passieve recorder van cross-cel-contacten.
+///
+/// Het log bewaart het bewijsstuk dat de veiligheidscontext teruggeeft, en maakt
+/// er geen eigen kopie-met-andere-namen van: wat er in het log staat is exact
+/// wat er over de grens ging.
+#[derive(Debug, Default)]
+pub struct ObservationLog {
+    entries: Vec<SignedAnswer>,
+}
+
+impl ObservationLog {
+    /// Een leeg log.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Leg één cross-cel-contact vast.
+    ///
+    /// Geeft niets terug en kan niet falen: een meetinstrument dat een run kan
+    /// laten struikelen, meet de run niet meer.
+    pub fn record(&mut self, answer: &SignedAnswer) {
+        self.entries.push(answer.clone());
+    }
+
+    /// Alle contacten, in de volgorde waarin ze plaatsvonden.
+    pub fn entries(&self) -> &[SignedAnswer] {
+        &self.entries
+    }
+
+    /// Het aantal vastgelegde contacten.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Is er geen enkel contact vastgelegd?
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Leesbaar verslag: één regel per contact, met alles wat er vastgelegd is.
+    ///
+    /// De ondertekening staat erbij, inclusief dat ze gesimuleerd is. Wie dat
+    /// weglaat, leest later een log waarin een placeholder op bewijs lijkt.
+    pub fn report(&self) -> String {
+        let mut out = String::from("observatielog (meetinstrument, geen productiepad):\n");
+        for entry in &self.entries {
+            let params = entry
+                .params
+                .iter()
+                .map(|(name, value)| format!("{name}={value}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let answer = match &entry.answer.outcome {
+                LexostatusOutcome::Established(values) => values
+                    .iter()
+                    .map(|(name, value)| format!("{name}={value}"))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                LexostatusOutcome::NotEstablished { reason } => {
+                    format!("niets vastgesteld: {reason}")
+                }
+            };
+            let _ = writeln!(
+                out,
+                "  {} vroeg {}.{} op {} ({params}) -> {answer} [{}]",
+                entry.asked_by,
+                entry.answer.cell,
+                entry.answer.name,
+                entry.answer.op_moment,
+                entry.signature,
+            );
+        }
+        out
+    }
+}

--- a/packages/simulator/src/scenario.rs
+++ b/packages/simulator/src/scenario.rs
@@ -80,7 +80,14 @@ pub struct Query {
 /// parameters, een moment, en wat ze moet opleveren — met één veld erbij: wie
 /// vraagt. Dat veld is het hele verschil tussen een consument die een cel
 /// bevraagt en een cel die een andere cel bevraagt.
+///
+/// `deny_unknown_fields` staat hier nog een keer, en dat is geen dubbelop: een
+/// geflatten veld wordt met een losse veldenlijst gevoed, dus de strengheid van
+/// [`Query`] reikt niet tot deze vorm. Zonder deze regel zou `expct:` in een
+/// vraag over de celgrens stil worden weggegooid en de verwachting met zich
+/// meenemen — de vraag zou dan `ok` melden terwijl ze niets meer controleert.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TransportQuery {
     /// De vragende cel. Haar veiligheidscontext zet de vraag over de grens.
     pub from: String,
@@ -522,8 +529,16 @@ query_via_transport:
 
     #[test]
     fn onbekend_veld_in_een_vraag_over_de_celgrens_wordt_geweigerd() {
-        // `from` staat naast de gewone velden van een vraag; dat mag de
-        // strengheid van de loader niet kosten.
+        // `from` staat naast de gewone velden van een vraag, en die combinatie is
+        // precies waar strengheid stil kan wegvallen: bij een geflatten veld
+        // komt de weigering niet van `Query` maar van `TransportQuery` zelf.
+        //
+        // Daarom staat er een geldige `expect` in dit scenario. Zonder die regel
+        // slaagt deze test ook als de typfout ongemerkt doorglipt — dan struikelt
+        // het scenario op "vraag zonder verwachting" en lijkt de poort te werken
+        // terwijl hij niets meer doet. Met de `expect` erbij is het onbekende
+        // veld de enige reden waarom dit nog kan falen, en dat rekenen we ook af
+        // op de melding.
         let yaml = r"
 name: typfout over de grens
 cells: []
@@ -532,12 +547,20 @@ query_via_transport:
     cell: brp
     lexostatus: partnerschap
     op_moment: 2025-01-01
+    expect:
+      partnerschap_type: HUWELIJK
     expct:
       partnerschap_type: HUWELIJK
 ";
+        let err = Scenario::from_yaml(yaml)
+            .expect_err("een onbekend veld hoort te falen, anders verdwijnt een typfout stil");
         assert!(
-            Scenario::from_yaml(yaml).is_err(),
-            "een onbekend veld hoort te falen, anders verdwijnt een typfout stil"
+            matches!(&err, SimulatorError::ScenarioParse(_)),
+            "verwachtte een leesfout op het onbekende veld, kreeg {err}"
+        );
+        assert!(
+            err.to_string().contains("expct"),
+            "de melding hoort het onbekende veld te noemen, kreeg {err}"
         );
     }
 

--- a/packages/simulator/src/scenario.rs
+++ b/packages/simulator/src/scenario.rs
@@ -7,6 +7,8 @@
 
 use crate::cell::{Cell, CellConfig, Lexostatus, LexostatusOutcome};
 use crate::error::{Result, SimulatorError};
+use crate::security::{Identity, SecurityContext, SignedAnswer};
+use crate::transport::{CellTransport, InProcessTransport};
 use crate::values::equivalent;
 use chrono::NaiveDate;
 use regelrecht_engine::Value;
@@ -29,6 +31,17 @@ pub struct Scenario {
     /// De vragen die een consument stelt.
     #[serde(default)]
     pub queries: Vec<Query>,
+    /// De vragen die een cel aan een andere cel stelt, over de celgrens.
+    ///
+    /// **Test-only stap, en dat is tijdelijk.** In de opstelling die we bouwen
+    /// stelt een cel zo'n vraag uitsluitend vanuit haar besluit-pad: ze heeft een
+    /// input nodig die een andere organisatie vaststelt. Dat pad bestaat nog niet
+    /// — een cel kan nog niets vastleggen en dus niets accepteren — en tot die tijd
+    /// is dit de enige manier om het verkeer te laten zien en erop te asserteren.
+    /// Zodra het besluit-pad er is, verhuist de aanroep daarheen en is deze stap
+    /// hoogstens nog een sonde.
+    #[serde(default)]
+    pub query_via_transport: Vec<TransportQuery>,
 }
 
 /// Eén vraag van een consument aan één cel.
@@ -59,6 +72,21 @@ pub struct Query {
     /// scenario moet erop kunnen asserteren. Sluit `expect` uit.
     #[serde(default)]
     pub expect_not_established: bool,
+}
+
+/// Eén vraag van een cel aan een andere cel, over de celgrens.
+///
+/// Dezelfde vraag als een [`Query`] — een gepubliceerde naam, gedocumenteerde
+/// parameters, een moment, en wat ze moet opleveren — met één veld erbij: wie
+/// vraagt. Dat veld is het hele verschil tussen een consument die een cel
+/// bevraagt en een cel die een andere cel bevraagt.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TransportQuery {
+    /// De vragende cel. Haar veiligheidscontext zet de vraag over de grens.
+    pub from: String,
+    /// De vraag zelf, in de vorm die een consument ook gebruikt.
+    #[serde(flatten)]
+    pub query: Query,
 }
 
 /// Eén verwachting die niet uitkwam.
@@ -98,19 +126,43 @@ pub struct QueryOutcome {
     pub failures: Vec<ExpectationFailure>,
 }
 
+/// Het resultaat van één vraag over een celgrens.
+#[derive(Debug, Clone)]
+pub struct TransportOutcome {
+    /// Het bewijsstuk van de veiligheidscontext: wie vroeg, ondertekend, met
+    /// welke parameters, en wat de peer antwoordde.
+    ///
+    /// Dit is wat het observatielog vastlegt, en straks wat een decretogram als
+    /// geaccepteerde waarde draagt.
+    pub signed: SignedAnswer,
+    /// De verwachtingen die niet uitkwamen; leeg is goed.
+    pub failures: Vec<ExpectationFailure>,
+}
+
 /// Het resultaat van een hele run.
 #[derive(Debug, Clone)]
 pub struct ScenarioRun {
     /// De naam van het scenario dat gedraaid heeft.
     pub name: String,
-    /// De uitkomsten, in de volgorde van het scenario.
+    /// De uitkomsten van de vragen van een consument, in scenariovolgorde.
     pub outcomes: Vec<QueryOutcome>,
+    /// De uitkomsten van de vragen over een celgrens, in scenariovolgorde.
+    pub transport_outcomes: Vec<TransportOutcome>,
 }
 
 impl ScenarioRun {
     /// Kwamen alle verwachtingen uit?
     pub fn passed(&self) -> bool {
         self.outcomes.iter().all(|o| o.failures.is_empty())
+            && self
+                .transport_outcomes
+                .iter()
+                .all(|o| o.failures.is_empty())
+    }
+
+    /// Heeft deze run iets vastgelegd? Een run zonder vragen bewijst niets.
+    pub fn proved_something(&self) -> bool {
+        !self.outcomes.is_empty() || !self.transport_outcomes.is_empty()
     }
 
     /// Leesbaar verslag van de run, geschikt voor een terminal of een testfout.
@@ -133,31 +185,65 @@ impl ScenarioRun {
             if let Some(reason) = outcome.lexostatus_value.not_established() {
                 let _ = writeln!(out, "        niets vastgesteld: {reason}");
             }
-            for failure in &outcome.failures {
-                let _ = match failure {
-                    ExpectationFailure::Value {
-                        output,
-                        expected,
-                        actual,
-                    } => {
-                        let actual = match actual {
-                            Some(value) => value.to_string(),
-                            None => "(niet in het antwoord)".to_string(),
-                        };
-                        writeln!(out, "        {output}: verwacht {expected}, kreeg {actual}")
-                    }
-                    ExpectationFailure::NotEstablished { reason } => writeln!(
-                        out,
-                        "        verwachtte waarden, maar de cel stelde niets vast: {reason}"
-                    ),
-                    ExpectationFailure::Established { values } => writeln!(
-                        out,
-                        "        verwachtte 'niets vastgesteld', maar de cel gaf {values:?}"
-                    ),
-                };
-            }
+            write_failures(&mut out, &outcome.failures);
         }
+
+        for outcome in &self.transport_outcomes {
+            let mark = if outcome.failures.is_empty() {
+                "ok"
+            } else {
+                "FOUT"
+            };
+            let answer = &outcome.signed.answer;
+            // De vrager staat erbij, en dat hij ondertekend heeft ook: een
+            // cross-cel-vraag is iets anders dan een consument die vraagt, en het
+            // verslag hoort dat verschil te laten zien.
+            let _ = writeln!(
+                out,
+                "  [{mark}] {} -> {}.{} op {} (over de celgrens, {})",
+                outcome.signed.asked_by,
+                answer.cell,
+                answer.name,
+                answer.op_moment,
+                outcome.signed.signature
+            );
+            if let Some(reason) = answer.not_established() {
+                let _ = writeln!(out, "        niets vastgesteld: {reason}");
+            }
+            write_failures(&mut out, &outcome.failures);
+        }
+
         out
+    }
+}
+
+/// Schrijf de gemiste verwachtingen van één vraag in het verslag.
+///
+/// Eén plek, want een vraag over de celgrens wordt op precies dezelfde manier
+/// afgerekend als een vraag van een consument.
+fn write_failures(out: &mut String, failures: &[ExpectationFailure]) {
+    for failure in failures {
+        let _ = match failure {
+            ExpectationFailure::Value {
+                output,
+                expected,
+                actual,
+            } => {
+                let actual = match actual {
+                    Some(value) => value.to_string(),
+                    None => "(niet in het antwoord)".to_string(),
+                };
+                writeln!(out, "        {output}: verwacht {expected}, kreeg {actual}")
+            }
+            ExpectationFailure::NotEstablished { reason } => writeln!(
+                out,
+                "        verwachtte waarden, maar de cel stelde niets vast: {reason}"
+            ),
+            ExpectationFailure::Established { values } => writeln!(
+                out,
+                "        verwachtte 'niets vastgesteld', maar de cel gaf {values:?}"
+            ),
+        };
     }
 }
 
@@ -181,7 +267,9 @@ impl Scenario {
     /// Een vraag die beide verwachtingen tegelijk stelt, kan nooit slagen; dat
     /// is een schrijffout en wordt hier ook geweigerd.
     fn validate(&self) -> Result<()> {
-        for query in &self.queries {
+        // Dezelfde eis aan beide soorten vraag: wie over de celgrens vraagt zonder
+        // te zeggen wat eruit moet komen, bewijst even weinig.
+        for query in self.all_queries() {
             if query.expect.is_empty() && !query.expect_not_established {
                 return Err(SimulatorError::QueryWithoutExpectation {
                     scenario: self.name.clone(),
@@ -200,6 +288,13 @@ impl Scenario {
         Ok(())
     }
 
+    /// Elke vraag in het scenario, van welke soort ook.
+    fn all_queries(&self) -> impl Iterator<Item = &Query> {
+        self.queries
+            .iter()
+            .chain(self.query_via_transport.iter().map(|via| &via.query))
+    }
+
     /// Lees een scenario van schijf.
     pub fn load(path: &Path) -> Result<Self> {
         let text =
@@ -214,6 +309,10 @@ impl Scenario {
     ///
     /// De runner combineert niets: hij geeft elk antwoord terug zoals de cel het
     /// gaf. Combineren over cellen heen is synthese en hoort bij een consument.
+    ///
+    /// Vragen van een consument gaan rechtstreeks naar de publieke ingang van de
+    /// cel. Vragen uit `query_via_transport` gaan langs de veiligheidscontext van
+    /// de vragende cel naar het transport — de enige weg over een celgrens.
     pub fn run(&self, regulation_root: &Path) -> Result<ScenarioRun> {
         let mut cells: BTreeMap<String, Cell> = BTreeMap::new();
         for config in &self.cells {
@@ -247,10 +346,50 @@ impl Scenario {
             });
         }
 
+        let transport = InProcessTransport::over(&cells);
+        let transport_outcomes = self.run_via_transport(&cells, &transport)?;
+
         Ok(ScenarioRun {
             name: self.name.clone(),
             outcomes,
+            transport_outcomes,
         })
+    }
+
+    /// Stel de cross-cel-vragen, elk vanuit de veiligheidscontext van de vrager.
+    ///
+    /// Het transport is een parameter en geen keuze van deze functie: dat is de
+    /// naad waarlangs later een HTTP-transport aanschuift zonder dat hier of in
+    /// een cel iets verandert.
+    fn run_via_transport(
+        &self,
+        cells: &BTreeMap<String, Cell>,
+        transport: &dyn CellTransport,
+    ) -> Result<Vec<TransportOutcome>> {
+        let mut outcomes = Vec::with_capacity(self.query_via_transport.len());
+        for via in &self.query_via_transport {
+            // De vrager moet een cel in deze wereld zijn. Zonder deze controle zou
+            // een typfout in `from` een identiteit opleveren die nergens bij hoort,
+            // en dan zegt het vraaggraf iets over een cel die niet bestaat.
+            if !cells.contains_key(&via.from) {
+                return Err(SimulatorError::UnknownCell {
+                    cell: via.from.clone(),
+                });
+            }
+
+            let context = SecurityContext::new(Identity::for_cell(&via.from), transport);
+            let query = &via.query;
+            let signed = context.query(
+                &query.cell,
+                &query.lexostatus,
+                &query.params,
+                query.op_moment,
+            )?;
+            let failures = check_expectations(query, &signed.answer.outcome);
+
+            outcomes.push(TransportOutcome { signed, failures });
+        }
+        Ok(outcomes)
     }
 }
 
@@ -359,6 +498,46 @@ queries:
         assert!(
             Scenario::from_yaml(yaml).is_ok(),
             "`expect_not_established` is een volwaardige verwachting"
+        );
+    }
+
+    #[test]
+    fn vraag_over_de_celgrens_zonder_verwachting_wordt_geweigerd() {
+        let yaml = r"
+name: bewijst niets over de grens
+cells: []
+query_via_transport:
+  - from: toeslagen
+    cell: brp
+    lexostatus: partnerschap
+    op_moment: 2025-01-01
+";
+        let err = Scenario::from_yaml(yaml)
+            .expect_err("ook een vraag over de celgrens moet iets vastleggen");
+        assert!(
+            matches!(err, SimulatorError::QueryWithoutExpectation { .. }),
+            "verwachtte QueryWithoutExpectation, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn onbekend_veld_in_een_vraag_over_de_celgrens_wordt_geweigerd() {
+        // `from` staat naast de gewone velden van een vraag; dat mag de
+        // strengheid van de loader niet kosten.
+        let yaml = r"
+name: typfout over de grens
+cells: []
+query_via_transport:
+  - from: toeslagen
+    cell: brp
+    lexostatus: partnerschap
+    op_moment: 2025-01-01
+    expct:
+      partnerschap_type: HUWELIJK
+";
+        assert!(
+            Scenario::from_yaml(yaml).is_err(),
+            "een onbekend veld hoort te falen, anders verdwijnt een typfout stil"
         );
     }
 

--- a/packages/simulator/src/security.rs
+++ b/packages/simulator/src/security.rs
@@ -1,0 +1,296 @@
+//! De veiligheidscontext: identiteit, ondertekening en transportkeuze.
+//!
+//! Een van de drie assen van RFC-022 §2, en met opzet een eigen type: de cel
+//! houdt geen sleutels en kiest geen transport, en het bevoegd gezag is een
+//! juridisch feit van het besluit. Wie die drie op één hoop gooit, krijgt een
+//! cel die alles kan en dus niets afdwingt.
+//!
+//! De context is in deze versie **dun** — een identiteit, een gesimuleerde
+//! ondertekening en een geleend transport — maar hij is de enige die
+//! [`CellTransport`] aanroept. Dat is het punt: alle verkeer over een celgrens
+//! loopt hierlangs, dus er is precies één plek die het kan zien en één plek die
+//! het later mag weigeren.
+
+use crate::cell::Lexostatus;
+use crate::error::{Result, SimulatorError};
+use crate::transport::CellTransport;
+use chrono::NaiveDate;
+use regelrecht_engine::Value;
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// Het voorvoegsel van elke gesimuleerde ondertekening.
+///
+/// Staat letterlijk in de waarde, zodat niemand hem voor echt aanziet en een
+/// grep hem vindt zodra er ooit echt ondertekend moet worden. Echte sleutels en
+/// trust material zijn buiten scope (RFC-022; Blauwe Knop, FCID en FSC volgen
+/// apart).
+pub const SIMULATED_SIGNATURE_PREFIX: &str = "GESIMULEERDE-ONDERTEKENING door ";
+
+/// Wie er vraagt.
+///
+/// De binding van de veiligheidscontext is **Open Question 2** in RFC-022 en
+/// dus onbeslist. Deze versie kiest de eenvoudigste vorm die de vraag openhoudt:
+/// één identiteit per cel, die de cel zelf is. Er is nog geen medewerker, geen
+/// zaak en geen mandaat — komt dat er, dan krijgt dit type velden en hoeft geen
+/// enkele aanroeper te veranderen.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Identity {
+    cell: String,
+}
+
+impl Identity {
+    /// De identiteit van een cel.
+    pub fn for_cell(cell: &str) -> Self {
+        Self {
+            cell: cell.to_string(),
+        }
+    }
+
+    /// De cel waarvoor deze identiteit staat.
+    pub fn cell(&self) -> &str {
+        &self.cell
+    }
+}
+
+impl fmt::Display for Identity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "cel:{}", self.cell)
+    }
+}
+
+/// Een **gesimuleerde** ondertekening.
+///
+/// Niet echt, en dat is zichtbaar in de waarde zelf: er zit geen sleutel achter
+/// en er valt niets aan te verifiëren. Wat er wél is, is de vorm — een vraag die
+/// de celgrens over gaat draagt de identiteit die hem stuurde — zodat een
+/// latere echte ondertekening dezelfde plek inneemt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Signature {
+    value: String,
+    signer: Identity,
+}
+
+impl Signature {
+    /// Onderteken namens deze identiteit.
+    fn simulated(signer: &Identity) -> Self {
+        Self {
+            value: format!("{SIMULATED_SIGNATURE_PREFIX}{signer}"),
+            signer: signer.clone(),
+        }
+    }
+
+    /// De ondertekening zelf, als tekst.
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    /// Wie ondertekende.
+    pub fn signer(&self) -> &Identity {
+        &self.signer
+    }
+
+    /// Is dit een placeholder in plaats van een echte ondertekening? Altijd
+    /// waar, zolang er geen trust material is; een test die dit controleert
+    /// wordt rood op de dag dat dat verandert.
+    pub fn is_simulated(&self) -> bool {
+        self.value.starts_with(SIMULATED_SIGNATURE_PREFIX)
+    }
+}
+
+impl fmt::Display for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.value)
+    }
+}
+
+/// Het bewijsstuk van één vraag over een celgrens: wat er gevraagd is, door
+/// wie, ondertekend, en wat er terugkwam.
+///
+/// De context geeft dit terug in plaats van alleen het antwoord, en dat is geen
+/// gemak. Een cel die straks een waarde van een andere cel *accepteert*, moet in
+/// haar decretogram kunnen vastleggen bij wie ze het ophaalde, onder welke naam,
+/// op welk moment en ondertekend door wie (RFC-013 `accepted_values`). Datzelfde
+/// bewijsstuk is wat het observatielog nodig heeft.
+#[derive(Debug, Clone)]
+pub struct SignedAnswer {
+    /// De identiteit die de vraag stelde en ondertekende.
+    pub asked_by: Identity,
+    /// De gesimuleerde ondertekening van de vraag.
+    pub signature: Signature,
+    /// De parameters waarmee gevraagd is.
+    pub params: BTreeMap<String, Value>,
+    /// Het antwoord van de peer. Draagt zelf de bevraagde cel, de gevraagde
+    /// naam en het moment waarop het geldt.
+    pub answer: Lexostatus,
+}
+
+/// De veiligheidscontext van één cel.
+///
+/// Gebonden aan precies één cel: de identiteit die hij houdt, is die van die
+/// cel. Hij leent een transport en is de enige die het aanroept.
+pub struct SecurityContext<'a> {
+    identity: Identity,
+    transport: &'a dyn CellTransport,
+}
+
+impl<'a> SecurityContext<'a> {
+    /// Bind een context aan een identiteit en een transport.
+    pub fn new(identity: Identity, transport: &'a dyn CellTransport) -> Self {
+        Self {
+            identity,
+            transport,
+        }
+    }
+
+    /// De identiteit waaronder deze context vraagt.
+    pub fn identity(&self) -> &Identity {
+        &self.identity
+    }
+
+    /// De cel waaraan deze context gebonden is.
+    pub fn cell(&self) -> &str {
+        self.identity.cell()
+    }
+
+    /// Vraag een lexostatus op bij een andere cel.
+    ///
+    /// De context ondertekent de vraag (gesimuleerd) en zet hem over de grens.
+    /// Hij combineert niets en onthoudt niets: het bewijsstuk gaat terug naar de
+    /// aanroeper, die het in zijn besluit vastlegt. Synthese hoort bij een
+    /// consument, nooit in een cel (RFC-022 §4.1).
+    ///
+    /// Een vraag aan de eigen cel wordt geweigerd. Daarvoor is er geen transport
+    /// nodig maar een reductie, en het verschil is precies wat deze opstelling
+    /// meet: een cel die zichzelf via de grens bevraagt, zou als cross-cel-
+    /// contact in het log komen en het vraaggraf vervuilen.
+    pub fn query(
+        &self,
+        cell: &str,
+        lexostatus: &str,
+        params: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Result<SignedAnswer> {
+        if cell == self.identity.cell() {
+            return Err(SimulatorError::TransportToSelf {
+                cell: cell.to_string(),
+                lexostatus: lexostatus.to_string(),
+            });
+        }
+
+        let signature = Signature::simulated(&self.identity);
+        let answer = self.transport.query(cell, lexostatus, params, op_moment)?;
+
+        Ok(SignedAnswer {
+            asked_by: self.identity.clone(),
+            signature,
+            params: params.clone(),
+            answer,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cell::LexostatusOutcome;
+    use std::cell::RefCell;
+
+    /// Een transport dat niets doet behalve opschrijven dat het geroepen werd.
+    /// Zo is te zien dat de context wél of juist niet over de grens gaat.
+    struct SpyTransport {
+        calls: RefCell<Vec<String>>,
+    }
+
+    impl SpyTransport {
+        fn new() -> Self {
+            Self {
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl CellTransport for SpyTransport {
+        fn query(
+            &self,
+            cell: &str,
+            lexostatus: &str,
+            _params: &BTreeMap<String, Value>,
+            op_moment: NaiveDate,
+        ) -> Result<Lexostatus> {
+            self.calls.borrow_mut().push(format!("{cell}.{lexostatus}"));
+            Ok(Lexostatus {
+                cell: cell.to_string(),
+                name: lexostatus.to_string(),
+                op_moment,
+                outcome: LexostatusOutcome::Established(BTreeMap::new()),
+            })
+        }
+    }
+
+    fn moment() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2024, 1, 1).expect("geldige datum")
+    }
+
+    #[test]
+    fn de_context_ondertekent_elke_vraag_gesimuleerd() {
+        let transport = SpyTransport::new();
+        let context = SecurityContext::new(Identity::for_cell("toeslagen"), &transport);
+
+        let signed = context
+            .query("brp", "partnerschap", &BTreeMap::new(), moment())
+            .expect("de vraag hoort door te gaan");
+
+        assert_eq!(signed.asked_by, Identity::for_cell("toeslagen"));
+        assert!(
+            signed.signature.is_simulated(),
+            "de ondertekening hoort herkenbaar nep te zijn: {}",
+            signed.signature
+        );
+        assert!(
+            signed.signature.value().contains("cel:toeslagen"),
+            "de ondertekening hoort de identiteit te noemen: {}",
+            signed.signature
+        );
+    }
+
+    #[test]
+    fn een_vraag_aan_de_eigen_cel_gaat_niet_over_de_grens() {
+        let transport = SpyTransport::new();
+        let context = SecurityContext::new(Identity::for_cell("toeslagen"), &transport);
+
+        let err = context
+            .query("toeslagen", "partnerschap", &BTreeMap::new(), moment())
+            .expect_err("de eigen cel is geen peer");
+
+        assert!(
+            matches!(err, SimulatorError::TransportToSelf { .. }),
+            "verwachtte TransportToSelf, kreeg {err}"
+        );
+        assert!(
+            transport.calls.borrow().is_empty(),
+            "er had geen transport aan te pas mogen komen"
+        );
+    }
+
+    #[test]
+    fn het_bewijsstuk_draagt_de_vraag_zoals_die_gesteld_is() {
+        let transport = SpyTransport::new();
+        let context = SecurityContext::new(Identity::for_cell("toeslagen"), &transport);
+        let params = BTreeMap::from([("bsn".to_string(), Value::String("999993653".to_string()))]);
+
+        let signed = context
+            .query("brp", "partnerschap", &params, moment())
+            .expect("de vraag hoort door te gaan");
+
+        assert_eq!(signed.params, params, "de parameters horen erbij te staan");
+        assert_eq!(signed.answer.cell, "brp");
+        assert_eq!(signed.answer.name, "partnerschap");
+        assert_eq!(signed.answer.op_moment, moment());
+        assert_eq!(
+            transport.calls.borrow().as_slice(),
+            ["brp.partnerschap"],
+            "precies één keer over de grens"
+        );
+    }
+}

--- a/packages/simulator/src/transport.rs
+++ b/packages/simulator/src/transport.rs
@@ -1,0 +1,205 @@
+//! Het transport: de enige weg over een celgrens.
+//!
+//! Dit is de **naad**. Vandaag staan alle cellen in hetzelfde proces, morgen
+//! staat er HTTP tussen. Dat verschil mag geen enkele wijziging in
+//! [`crate::Cell`] kosten, en daarom is het transport een trait en geen functie.
+//!
+//! Wie hem aanroept staat vast: uitsluitend de veiligheidscontext van de
+//! vragende cel ([`crate::SecurityContext`]). Een cel houdt geen transport — ze
+//! heeft geen veld, geen parameter en geen bereikbare weg ernaartoe, en dat is
+//! een compileerfout en geen afspraak (RFC-022 §2).
+//!
+//! ## Één mechanisme, twee soorten peer
+//!
+//! RFC-022 Open Question 4 vraagt of cel↔cel en cel↔burger twee transports zijn
+//! of één mechanisme met twee soorten peer. Deze crate kiest het tweede: er is
+//! één trait, en wie er aan de andere kant staat is een eigenschap van de peer
+//! en niet van het mechanisme. Dat is een **standpunt in een open vraag**; zie
+//! de crate-README.
+
+use crate::cell::{Cell, Lexostatus};
+use crate::error::{Result, SimulatorError};
+use chrono::NaiveDate;
+use regelrecht_engine::Value;
+use std::collections::BTreeMap;
+
+/// Eén vraag over een celgrens zetten.
+///
+/// De vorm is die van de publieke ingang van een cel — een gepubliceerde naam,
+/// gedocumenteerde parameters, een moment — en met opzet niets meer. Een
+/// transport dat een reductie of een filter zou kunnen meesturen, zou de
+/// autonomie van de bevraagde cel omzeilen (RFC-022 §4.1).
+///
+/// De implementatie beslist hoe de vraag bij de peer komt. Ze beslist niet wie
+/// er vraagt en of dat mag: dat is de veiligheidscontext.
+pub trait CellTransport {
+    /// Vraag `lexostatus` op bij cel `cell`, geldig op `op_moment`.
+    ///
+    /// Een onbekende peer is een fout. "Op dat moment niets vastgesteld" is dat
+    /// niet: dat is een antwoord van de peer en komt als
+    /// [`crate::LexostatusOutcome::NotEstablished`] terug.
+    fn query(
+        &self,
+        cell: &str,
+        lexostatus: &str,
+        params: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Result<Lexostatus>;
+}
+
+/// Transport binnen één proces: de peers zijn cellen in dezelfde run.
+///
+/// Het houdt de cellen **geleend**, niet in bezit. Daarmee is het geen tweede
+/// eigenaar van de feiten van een cel: het kan precies één ding met een peer,
+/// namelijk hem bevragen langs zijn publieke ingang, net zoals een HTTP-client
+/// dat later zal doen.
+pub struct InProcessTransport<'world> {
+    peers: &'world BTreeMap<String, Cell>,
+}
+
+impl<'world> InProcessTransport<'world> {
+    /// Maak een transport over de cellen van een run.
+    ///
+    /// De sleutel van de map is het cel-id waarmee een vrager de peer aanwijst.
+    pub fn over(peers: &'world BTreeMap<String, Cell>) -> Self {
+        Self { peers }
+    }
+}
+
+impl CellTransport for InProcessTransport<'_> {
+    fn query(
+        &self,
+        cell: &str,
+        lexostatus: &str,
+        params: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Result<Lexostatus> {
+        let peer = self
+            .peers
+            .get(cell)
+            .ok_or_else(|| SimulatorError::UnknownPeer {
+                cell: cell.to_string(),
+                known: self
+                    .peers
+                    .keys()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            })?;
+
+        // De enige ingang die er is. Het transport kent de kronieken van de peer
+        // niet en kan er ook niet bij: `Cell` heeft geen accessor op haar store.
+        peer.reduce(lexostatus, params, op_moment)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cell::CellConfig;
+    use std::path::Path;
+
+    /// Een bron-cel met één kroniekfilter; geen corpus nodig, dus geen engine.
+    fn peer(id: &str) -> Cell {
+        let yaml = format!(
+            r"
+id: {id}
+laws: []
+chronicles:
+  - stream: relaties
+    key: bsn
+    events:
+      - op_moment: 2023-03-01
+        fields:
+          bsn: '999993653'
+          partnerschap_type: HUWELIJK
+lexostatus_definitions:
+  - name: partnerschap
+    inputs:
+      - name: bsn
+        type: string
+    outputs:
+      - partnerschap_type
+    reduction:
+      chronicle: relaties
+      key: bsn
+      latest: true
+"
+        );
+        let config: CellConfig =
+            serde_yaml_ng::from_str(&yaml).expect("de testconfiguratie hoort te lezen");
+        Cell::from_config(&config, Path::new("/bestaat-niet"))
+            .expect("een bron-cel heeft geen corpus nodig")
+    }
+
+    fn world(id: &str) -> BTreeMap<String, Cell> {
+        BTreeMap::from([(id.to_string(), peer(id))])
+    }
+
+    fn bsn() -> BTreeMap<String, Value> {
+        BTreeMap::from([("bsn".to_string(), Value::String("999993653".to_string()))])
+    }
+
+    #[test]
+    fn een_vraag_aan_een_peer_komt_bij_zijn_publieke_ingang_uit() {
+        let cells = world("brp");
+        let transport = InProcessTransport::over(&cells);
+
+        let answer = transport
+            .query(
+                "brp",
+                "partnerschap",
+                &bsn(),
+                NaiveDate::from_ymd_opt(2024, 1, 1).expect("geldige datum"),
+            )
+            .expect("de peer publiceert deze lexostatus");
+
+        assert_eq!(answer.cell, "brp", "het antwoord zegt wie het gaf");
+        assert_eq!(
+            answer.values().and_then(|v| v.get("partnerschap_type")),
+            Some(&Value::String("HUWELIJK".to_string()))
+        );
+    }
+
+    #[test]
+    fn een_onbekende_peer_is_een_fout_en_geen_leeg_antwoord() {
+        let cells = world("brp");
+        let transport = InProcessTransport::over(&cells);
+
+        let err = transport
+            .query(
+                "kadaster",
+                "partnerschap",
+                &bsn(),
+                NaiveDate::from_ymd_opt(2024, 1, 1).expect("geldige datum"),
+            )
+            .expect_err("een peer die niet bestaat hoort te falen");
+
+        assert!(
+            matches!(err, SimulatorError::UnknownPeer { .. }),
+            "verwachtte UnknownPeer, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn het_transport_geeft_een_vraag_ongewijzigd_door() {
+        // Een transport dat een lexostatus niet kent, mag er ook niet over
+        // beslissen: de peer weigert, niet het transport.
+        let cells = world("brp");
+        let transport = InProcessTransport::over(&cells);
+
+        let err = transport
+            .query(
+                "brp",
+                "inkomen",
+                &bsn(),
+                NaiveDate::from_ymd_opt(2024, 1, 1).expect("geldige datum"),
+            )
+            .expect_err("de peer publiceert deze naam niet");
+
+        assert!(
+            matches!(&err, SimulatorError::UnknownLexostatus { cell, .. } if cell == "brp"),
+            "de weigering hoort van de peer te komen, kreeg {err}"
+        );
+    }
+}

--- a/packages/simulator/tests/observation_log.rs
+++ b/packages/simulator/tests/observation_log.rs
@@ -1,0 +1,205 @@
+//! Het observatielog, en de grenzen die het op zijn plek houden.
+//!
+//! Twee soorten assertie staan hier naast elkaar, en dat is geen toeval. De
+//! eerste meet wat er over een celgrens ging; de tweede bewaakt dat het
+//! meetinstrument geen onderdeel van de opstelling wordt. Zonder de tweede is
+//! de eerste op termijn een leugen: een observator die ergens in een
+//! productiepad wordt aangeroepen, kent het totaalbeeld dat nergens hoort te
+//! bestaan.
+
+use regelrecht_engine::Value;
+use regelrecht_simulator::observation::ObservationLog;
+use regelrecht_simulator::security::SIMULATED_SIGNATURE_PREFIX;
+use regelrecht_simulator::{regulation_root, Scenario};
+use std::path::{Path, PathBuf};
+
+/// Het scenario met twee cellen: `toeslagen` vraagt bij `brp`.
+fn scenario_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("scenarios")
+        .join("transport_toeslagen_brp.yaml")
+}
+
+/// Alle Rust-bestanden onder `src/`, met hun pad relatief aan de crate.
+fn source_files() -> Vec<(String, String)> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    walkdir::WalkDir::new(&root)
+        .into_iter()
+        .filter_map(std::result::Result::ok)
+        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "rs"))
+        .map(|entry| {
+            let path = entry.path();
+            let relative = path
+                .strip_prefix(&root)
+                .unwrap_or_else(|e| panic!("{} valt buiten src/: {e}", path.display()))
+                .to_string_lossy()
+                .replace('\\', "/");
+            let text = std::fs::read_to_string(path)
+                .unwrap_or_else(|e| panic!("kan {} niet lezen: {e}", path.display()));
+            (relative, text)
+        })
+        .collect()
+}
+
+/// Regels die niet alleen commentaar zijn: alleen die verwijzen echt.
+fn code_lines(text: &str) -> impl Iterator<Item = (usize, &str)> {
+    text.lines()
+        .enumerate()
+        .map(|(index, line)| (index + 1, line))
+        .filter(|(_, line)| {
+            let trimmed = line.trim_start();
+            !trimmed.starts_with("//") && !trimmed.is_empty()
+        })
+}
+
+/// Komt `needle` in `line` voor als heel woord, en niet als deel van een langere
+/// naam? `CellTransport` is dus geen voorkomen van `Cell`.
+fn mentions_word(line: &str, needle: &str) -> bool {
+    let part_of_identifier = |c: char| c.is_alphanumeric() || c == '_';
+    line.match_indices(needle).any(|(start, _)| {
+        let before = line[..start].chars().next_back();
+        let after = line[start + needle.len()..].chars().next();
+        !before.is_some_and(part_of_identifier) && !after.is_some_and(part_of_identifier)
+    })
+}
+
+#[test]
+fn een_vraag_over_de_celgrens_levert_exact_een_regel_in_het_log() {
+    let path = scenario_path();
+    let scenario = Scenario::load(&path).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    let run = scenario
+        .run(&regulation_root())
+        .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    assert!(run.passed(), "{}", run.report());
+
+    // Het log is een recorder: hij krijgt aangereikt wat er over de grens ging en
+    // beslist niets. Precies daarom staat hij buiten de opstelling.
+    let mut log = ObservationLog::new();
+    for outcome in &run.transport_outcomes {
+        log.record(&outcome.signed);
+    }
+
+    assert_eq!(
+        log.len(),
+        1,
+        "één vraag over de grens hoort één regel te zijn:\n{}",
+        log.report()
+    );
+
+    let entry = &log.entries()[0];
+    assert_eq!(entry.asked_by.cell(), "toeslagen", "de vrager");
+    assert_eq!(entry.answer.cell, "brp", "de bevraagde cel");
+    assert_eq!(entry.answer.name, "partnerschap", "de lexostatus");
+    assert_eq!(
+        entry.params.get("bsn"),
+        Some(&Value::String("999993653".to_string())),
+        "de parameters waarmee gevraagd is"
+    );
+    assert_eq!(
+        entry.answer.op_moment.to_string(),
+        "2024-01-01",
+        "het moment waarop de vraag gold"
+    );
+    assert!(
+        entry.answer.values().is_some(),
+        "en wat er terugkwam: {}",
+        log.report()
+    );
+
+    // De ondertekening staat in het log, én dat ze gesimuleerd is. Wie dat laatste
+    // weglaat, leest later een placeholder als bewijs.
+    assert!(
+        entry.signature.is_simulated(),
+        "de ondertekening hoort herkenbaar nep te zijn: {}",
+        entry.signature
+    );
+    assert_eq!(
+        entry.signature.signer().cell(),
+        "toeslagen",
+        "en ze hoort de identiteit te noemen die ondertekende"
+    );
+    assert!(
+        log.report().contains(SIMULATED_SIGNATURE_PREFIX),
+        "het verslag hoort te laten zien dat er ondertekend is, en hoe:\n{}",
+        log.report()
+    );
+}
+
+#[test]
+fn geen_productiepad_verwijst_naar_het_observatielog() {
+    // De poort die de moduledocs van `observation` belooft. Hij is er niet voor de
+    // sierlijkheid: het log ziet elk cross-cel-contact, dus zodra iets in de
+    // opstelling hem aanroept, bestaat het totaalbeeld wél ergens.
+    let declaration = "pub mod observation;";
+    let mut offenders = Vec::new();
+
+    for (file, text) in source_files() {
+        if file == "observation.rs" {
+            continue;
+        }
+        for (number, line) in code_lines(&text) {
+            if file == "lib.rs" && line.trim() == declaration {
+                continue;
+            }
+            if line.contains("observation") || line.contains("Observation") {
+                offenders.push(format!("src/{file}:{number}: {}", line.trim()));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "het observatielog is een meetinstrument buiten de band; deze regels in \
+         `src/` verwijzen ernaar en horen dat niet te doen:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn het_observatielog_kan_geen_cel_aanraken() {
+    let (_, text) = source_files()
+        .into_iter()
+        .find(|(file, _)| file == "observation.rs")
+        .unwrap_or_else(|| panic!("src/observation.rs hoort te bestaan"));
+
+    let offenders: Vec<String> = code_lines(&text)
+        .filter(|(_, line)| mentions_word(line, "Cell") || mentions_word(line, "ChronicleStore"))
+        .map(|(number, line)| format!("src/observation.rs:{number}: {}", line.trim()))
+        .collect();
+
+    assert!(
+        offenders.is_empty(),
+        "een recorder leest wat een vraag opleverde en mag geen cel of kroniek \
+         kunnen bereiken:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn een_cel_heeft_geen_transport_en_geen_veiligheidscontext() {
+    // Dat een cel niet over haar grens kan reiken, hoort een compileerfout te zijn
+    // en geen afspraak (RFC-022 §2). Deze poort zegt het nog een keer op de plek
+    // waar iemand het per ongeluk zou weghalen: zodra `src/cell/` een transport of
+    // een veiligheidscontext noemt, is de weg terug naar proza ingezet.
+    let mut offenders = Vec::new();
+
+    for (file, text) in source_files() {
+        if !file.starts_with("cell/") {
+            continue;
+        }
+        for (number, line) in code_lines(&text) {
+            for forbidden in ["CellTransport", "SecurityContext", "SignedAnswer"] {
+                if line.contains(forbidden) {
+                    offenders.push(format!("src/{file}:{number}: {}", line.trim()));
+                }
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "een cel houdt geen transport en geen veiligheidscontext; deze regels \
+         zeggen iets anders:\n{}",
+        offenders.join("\n")
+    );
+}

--- a/packages/simulator/tests/observation_log.rs
+++ b/packages/simulator/tests/observation_log.rs
@@ -162,8 +162,20 @@ fn het_observatielog_kan_geen_cel_aanraken() {
         .find(|(file, _)| file == "observation.rs")
         .unwrap_or_else(|| panic!("src/observation.rs hoort te bestaan"));
 
+    // Niet alleen `Cell` en `ChronicleStore`: ook de stromen en de gebeurtenissen
+    // erin zijn de kroniek, en `crate::cell` is de module die ze alle vier
+    // uitdeelt. Wie alleen de twee bekendste namen afvangt, laat `ChronicleStream`
+    // en een volledig uitgeschreven pad ernaartoe gewoon door.
+    let forbidden = [
+        "Cell",
+        "ChronicleStore",
+        "ChronicleStream",
+        "ChronicleEvent",
+    ];
     let offenders: Vec<String> = code_lines(&text)
-        .filter(|(_, line)| mentions_word(line, "Cell") || mentions_word(line, "ChronicleStore"))
+        .filter(|(_, line)| {
+            forbidden.iter().any(|name| mentions_word(line, name)) || line.contains("crate::cell")
+        })
         .map(|(number, line)| format!("src/observation.rs:{number}: {}", line.trim()))
         .collect();
 
@@ -188,7 +200,17 @@ fn een_cel_heeft_geen_transport_en_geen_veiligheidscontext() {
             continue;
         }
         for (number, line) in code_lines(&text) {
-            for forbidden in ["CellTransport", "SecurityContext", "SignedAnswer"] {
+            // De typenamen én de modules waar ze vandaan komen: een `use
+            // crate::transport as wire;` met daarna `wire::…` noemt geen enkel
+            // verboden type, en zou langs een poort glippen die alleen op namen
+            // let.
+            for forbidden in [
+                "CellTransport",
+                "SecurityContext",
+                "SignedAnswer",
+                "crate::transport",
+                "crate::security",
+            ] {
                 if line.contains(forbidden) {
                     offenders.push(format!("src/{file}:{number}: {}", line.trim()));
                 }

--- a/packages/simulator/tests/scenarios.rs
+++ b/packages/simulator/tests/scenarios.rs
@@ -37,7 +37,7 @@ fn alle_scenarios_voldoen_aan_hun_eigen_verwachtingen() {
 
         assert!(run.passed(), "{}:\n{}", path.display(), run.report());
         assert!(
-            !run.outcomes.is_empty(),
+            run.proved_something(),
             "{}: een scenario zonder vragen bewijst niets",
             path.display()
         );


### PR DESCRIPTION
## Wat

Een vraag over een celgrens loopt vanaf nu langs precies één weg: de
**veiligheidscontext** van de vragende cel naar **`CellTransport`**. Die trait is
de naad — in-process nu (`InProcessTransport`), HTTP later — en dat verschil mag
`Cell` geen enkele wijziging kosten.

- **`SecurityContext`** (`src/security.rs`) bindt aan één cel, houdt haar
  identiteit, ondertekent de vraag en is de **enige** die het transport aanroept.
  Hij geeft een `SignedAnswer` terug in plaats van alleen het antwoord: wie vroeg,
  ondertekend door welke identiteit, met welke parameters, en wat de peer
  antwoordde. Dat is geen gemak — een cel die straks een waarde van een andere cel
  *accepteert* in plaats van narekent, moet precies dat in haar besluit vastleggen
  (RFC-013 `accepted_values`), en het observatielog wil hetzelfde weten.
- **Ondertekening is gesimuleerd**, en dat staat in de waarde zelf
  (`GESIMULEERDE-ONDERTEKENING door cel:toeslagen`). Er zit geen sleutel achter en
  er valt niets aan te verifiëren; `Signature::is_simulated()` is daarom waar, en
  de test die dat vastlegt wordt rood op de dag dat er echt ondertekend wordt.
- **Een cel houdt geen van beide.** `Cell` heeft geen veld en geen parameter voor
  een transport of een veiligheidscontext, dus `Cell::reduce` kan de grens niet
  bereiken — een compileerfout, geen afspraak (RFC-022 §2). Een grep-poort in de
  teststuite wordt rood zodra `src/cell/` er een noemt.
- **`ObservationLog`** (`src/observation.rs`) legt per cross-cel-vraag vast:
  vrager, bevraagde cel, lexostatus, parameters, moment, ondertekening en wat er
  terugkwam. Passief (`record` geeft niets terug en kan niet falen), test-only en
  met opzet buiten de band.
- **Een vraag aan de eigen cel wordt geweigerd.** Voor eigen feiten is er een
  reductie; zonder die weigering zou een cel haar eigen kroniek als
  cross-cel-contact in het log krijgen en het vraaggraf vervuilen.
- **Nieuwe scenario-stap `query_via_transport`**, met dezelfde strengheid en
  dezelfde verwachtingen als een gewone vraag. De stap is tijdelijk: zodra een cel
  kan besluiten, verhuist de aanroep naar dat pad. Tot die tijd is dit de enige
  manier om het verkeer te laten zien en erop te asserteren.

## Waarom het log buiten de band staat

Het log ziet álles. Wie het houdt, kent de unie van wat over de grenzen ging —
precies het totaalbeeld waarvan deze opstelling zegt dat het nergens bestaat. Een
observator die meedraait in een productiepad maakt die claim ongedaan, hoe netjes
hij ook geschreven is. Twee grep-poorten dwingen dat af in plaats van het af te
spreken: geen enkel ander bestand in `src/` verwijst naar de module (en de
crate-wortel re-exporteert hem niet), en de module zelf kan geen cel en geen
kroniek bereiken. Beide poorten zijn geverifieerd door ze kapot te maken.

## Een standpunt, geen implementatiedetail

De crate-README documenteert twee keuzes die de RFC openlaat, en benoemt ze als
standpunt in een open vraag:

- **Open Question 4** — twee transports, of één mechanisme met twee soorten peer?
  Wij lezen het als **één mechanisme met twee soorten peer**: er is één trait, en
  wie er aan de andere kant staat is een eigenschap van de peer. Dat is te
  falsifiëren — zodra cel↔burger een veld of een eigen trait blijkt te vragen die
  cel↔cel niet gebruikt, was de andere lezing de juiste.
- **Open Question 2** — waaraan bindt de veiligheidscontext? Onbeslist, dus hier de
  dunste vorm die de vraag openhoudt: één context per cel, met één identiteit die
  de cel zelf is. Geen medewerker, geen zaak, geen mandaat, geen autorisatie.

## Assertie

De kernassertie staat als scenario in `scenarios/transport_toeslagen_brp.yaml`
(twee cellen: `toeslagen` vraagt een lexostatus op bij de bron-cel `brp`), plus
een test die het log naleest: **exact één regel**, met de juiste vrager, cel,
lexostatus, parameters, moment en een ondertekening die zichtbaar gesimuleerd is.
Daarnaast unit-tests op het transport (een onbekende peer faalt; een weigering komt
van de peer en niet van het transport) en op de context (elke vraag wordt
ondertekend; een vraag aan de eigen cel gaat niet over de grens).

## Buiten scope

Accepteren in plaats van narekenen (daar hoort een decretogram bij), de
invarianten-gate die het gedeclareerde met het feitelijke vraaggraf vergelijkt,
autorisatie, HTTP-transport, echte sleutels en trust material.

## Checks

`just format`, `just lint`, `just build-check` en de pre-commit-hooks groen;
`cargo test --workspace --all-features` minus de container-crates groen, inclusief
de 59 tests van deze crate.

Eén stap van `just check` is rood op de basisbranch, los van deze wijziging:
`dockerfile-consistency-test` meldt dat de workspace-member `simulator` in
`frontend-demo/Dockerfile` (wasm-builder) niet ge-COPYd en niet weggeknipt wordt.
Deze PR raakt geen `Cargo.toml` en geen Dockerfile.