### PR TITLE
feat: besluit-pad met decretogrammen en twee engine-configuraties in de simulator

### DIFF
--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -244,12 +244,18 @@ gebeurt, in deze volgorde:
    die toen gold;
 4. de uitkomst gaat als één gram de stroom `beschikkingen` in.
 
-Die stroom is **voorbehouden**: ze wordt automatisch aangemaakt zodra een cel
-besluit-definities heeft, een configuratie die haar zelf declareert wordt
-geweigerd, en een `fixture` kan er niets in zetten. Alleen besluiten legt er iets
-in. Zou een wereldbestand er een gram in mogen schrijven, dan lag er een
-"besluit" zonder receipt en zonder herkomst tussen de echte, en kon een reductie
-de twee niet onderscheiden — dan bewijst het kernscenario hieronder niets meer.
+Die stroom is **voorbehouden**, aan drie kanten:
+
+- een configuratie die haar zelf declareert wordt geweigerd; ze wordt automatisch
+  aangemaakt zodra een cel besluit-definities heeft;
+- een `fixture` kan er niets in zetten. Zou een wereldbestand er een gram in
+  mogen schrijven, dan lag er een "besluit" zonder receipt en zonder herkomst
+  tussen de echte, en kon een reductie de twee niet onderscheiden — dan bewijst
+  het kernscenario hieronder niets meer;
+- een besluit kan er geen input uit halen (`from_chronicle: beschikkingen`).
+  Daar liggen besluiten en geen feiten: een besluit leest geen besluit.
+
+Alleen besluiten legt er iets in, en alleen een reductie haalt er iets uit.
 
 ### Twee paden, twee engines
 

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -10,6 +10,10 @@ een taalgrens en geen afspraak.
 Wetten zijn optioneel. Een cel met `laws: []` is een **bron-cel**: ze legt vast
 en reduceert, zonder engine. Zie [Een bron-cel](#een-bron-cel).
 
+Een cel met eigen wetten kan ook **besluiten**: ze voert een regeling uit en legt
+de uitkomst vast als decretogram in haar eigen kroniek. Zie
+[Het besluit-pad](#het-besluit-pad).
+
 Gaat een vraag over een celgrens, dan loopt hij langs de **veiligheidscontext**
 van de vragende cel naar het **transport**, en dat is de enige weg. Zie
 [Over een celgrens](#over-een-celgrens). Wat daar langs gaat is te meten met het
@@ -19,8 +23,8 @@ van de vragende cel naar het **transport**, en dat is de enige weg. Zie
 ## De drie chronolexogrammen, en waar ze hier zitten
 
 De paper onderscheidt drie soorten chronolexogram (RFC-022 §1.1–§1.2). Deze
-crate kent ze alle drie bij naam, maar legt er nog maar één zelf vast — de kaart
-van paper naar code:
+crate kent ze alle drie bij naam; twee ervan ontstaan hier tijdens een run — de
+kaart van paper naar code:
 
 - **Lexogram** — generiek en compile-time: het recht zelf. Hier is dat elk
   versiebestand onder `laws`. De map met `valid_from`-versies van een regeling
@@ -29,8 +33,8 @@ van paper naar code:
 - **Executogram** — de vastgelegde vaststelling van een feit. Dat is een
   `ChronicleEvent`, en sinds de tijdlijn erin zit heeft die de vorm die
   RFC-022 §1.3 vraagt: zie [De executogram-vorm](#de-executogram-vorm).
-- **Decretogram** — individueel en operationeel: het besluit. Dat wordt hier
-  nog nergens vastgelegd; zie [Wat hier nog niet staat](#wat-hier-nog-niet-staat).
+- **Decretogram** — individueel en operationeel: het besluit. Dat legt een cel
+  nu zelf vast, in haar eigen kroniek: zie [Het besluit-pad](#het-besluit-pad).
 
 En de vierde term, de **reductie**: de huidige vormen (één uitkomst van één
 eigen regeling, of één kroniekfilter dat per sleutelwaarde de laatste
@@ -86,9 +90,9 @@ dat is het punt: de scenario's [`brp_broncel.yaml`](scenarios/brp_broncel.yaml)
 en [`toeslagen_zorgtoeslag.yaml`](scenarios/toeslagen_zorgtoeslag.yaml) stellen
 hun vragen op dezelfde manier.
 
-Wat een bron-cel (nog) niet kan, is besluiten: daar hoort een regeling bij, een
-bevoegd gezag en een vastgelegd decretogram. Vastleggen en reduceren is genoeg
-om een cel te zijn.
+Wat een bron-cel niet kan, is besluiten: daar hoort een eigen regeling bij, en
+die heeft ze niet. Vastleggen en reduceren is genoeg om een cel te zijn — zie
+[Het besluit-pad](#het-besluit-pad) voor wat een cel mét wetten er nog bij kan.
 
 ## Wat een cel níet is
 
@@ -218,6 +222,111 @@ met `expect_not_established: true`; dat is een volwaardige verwachting en sluit
 wandklok. Feiten die pas later in de cel zijn vastgelegd, bestaan voor dat
 antwoord niet, en de engine kiest op datzelfde moment de regelingversie. Een
 moment ná de klok van de wereld is een fout; zie [De tijdlijn](#de-tijdlijn).
+
+## Het besluit-pad
+
+De lus van chronolexografie is informeren → concluderen → **vastleggen**, en dit
+is het derde deel. Een cel voert een eigen regeling uit en legt de uitkomst vast
+als **decretogram** in haar eigen kroniek:
+
+```rust,ignore
+world.decide("toeslagen", "zorgtoeslag_vaststelling", &params, op_moment)?;
+```
+
+`Cell::decide` is `pub(crate)`, net als `Cell::record`: een consument kan een cel
+niet laten besluiten, net zomin als hij in haar kroniek kan schrijven. Wat er
+gebeurt, in deze volgorde:
+
+1. de gedocumenteerde parameters worden gecontroleerd, precies zoals bij een vraag;
+2. de inputs worden verzameld — uit de eigen kronieken zoals ze op `op_moment`
+   waren, en uit de parameters van het besluit;
+3. de **besluit-engine** voert de regeling uit op dat moment, dus op de wetsversie
+   die toen gold;
+4. de uitkomst gaat als één gram de stroom `beschikkingen` in.
+
+### Twee paden, twee engines
+
+Een cel met besluit-definities houdt **twee engine-instanties over precies dezelfde
+wetten**. Dat is geen verdubbeling maar de plek waar het verschil tussen de twee
+paden afdwingbaar wordt (RFC-022 §4.2):
+
+| pad | engine | mag de celgrens over |
+|---|---|---|
+| `Cell::reduce` (publiek) | reduce-engine, **nooit** een `CellResolver` | nee — tier 1 en 2 |
+| `Cell::decide` (intern) | besluit-engine, de enige die er ooit een krijgt | ja, straks — tier 3 |
+
+Een cross-cel-pull vanuit een reductie is daarmee een *ontbrekende capability* en
+geen afspraak: de engine van het reduce-pad heeft geen resolver, dus ze kan een
+`source.regulation` die een andere cel aanwijst niet beantwoorden en levert geen
+antwoord in plaats van een geraden antwoord. Vandaag heeft géén van beide engines
+een resolver — het accepteren van een waarde van een andere cel volgt apart — dus
+het verschil is nu een belofte over wie wat mag, met de haak op zijn plek en een
+test eromheen.
+
+### Wat een decretogram draagt
+
+Het decretogram **is** het RFC-013 Execution Receipt, plus wat dat receipt niet
+kan weten. Geen parallel formaat ernaast: een handgeschreven selectie zou bij elke
+uitbreiding van RFC-013 stil achterlopen.
+
+| veld | wat |
+|---|---|
+| `zaakkenmerk` | waaronder deze zaak terug te vinden is, uit het sjabloon van de definitie |
+| `op_moment` | wanneer besloten is (het gram is een gewoon executogram) |
+| `regulation` + `regulation_valid_from` | welke regeling, en **welke versie daarvan gold** |
+| `competent_authority` | het bevoegd gezag dat de regeling noemt (RFC-002) |
+| `legal_character` | wat de wet ervan maakt: `BESCHIKKING`, `TOETS`, … |
+| de uitkomsten | de uitkomst die het besluit *is*, plus wat `outputs` erbij noemt |
+| `inputs` | elke waarde waarop besloten is, **met haar herkomst** |
+| `receipt` | het volledige Execution Receipt |
+
+De herkomst per input is geen versiering. Zonder haar staat er wel een waarde in
+het gram, maar niet van wanneer ze was of wie haar leverde — en dan is
+"accepteren in plaats van narekenen" niet van gokken te onderscheiden. Wat het
+besluit ophaalde, gaat daarom ín het gram en **niet** als los feit in een
+kroniek: een volgend besluit haalt het opnieuw op. Een kroniek bevat alleen wat de
+cel zelf overkwam (zie [Wat een cel is](#wat-een-cel-is)).
+
+Eén besluit is één gram. Wat tegelijk ontstaat, wordt samen vastgelegd (RFC-022
+§1.2 — elk chronolexogram is *elementair*): het recht en het bedrag staan in
+hetzelfde gram, niet in twee.
+
+### Terugzien is een reductie, nooit een herberekening
+
+Het gram is een gewoon `ChronicleEvent` met `intake: eigen_besluit`, dus de
+tijdreductie werkt er zonder speciale gevallen overheen. Een lexostatus die over
+`beschikkingen` filtert levert het besluit terug zoals het toen vastgelegd is;
+ligt er op het gevraagde moment nog geen gram, dan is het antwoord "niets
+vastgesteld" — en geen som van vandaag.
+
+Dat verschil is de hele reden dat een decretogram naast een lexogram bestaat, en
+het staat als scenario in
+[`scenarios/toeslagen_besluit.yaml`](scenarios/toeslagen_besluit.yaml): een
+besluit op T1 onder wetsversie V1, een vraag op T2 waar V2 geldt en een
+herberekening een ander bedrag zou geven, en een antwoord dat nog steeds het gram
+van T1 is — met `regulation_valid_from: 2024-01-01` erin, zodat te zien is onder
+welk recht besloten is. Het tegenscenario staat er direct naast: een nieuw besluit
+op T2 levert wél V2.
+
+De stroom `beschikkingen` gaat met opzet **niet** als databron naar de engine. Een
+besluit is geen feit om op te rekenen; zou ze meedoen, dan kon een volgende
+uitvoering stil op de uitkomst van een eerder besluit leunen, en dan is niet meer
+te zeggen of er gerekend of overgeschreven is.
+
+### Wat van RFC-022 §1.2 hier wel en niet in zit
+
+**Wel**: dat een decretogram een engine-uitkomst met een `legal_character` is en
+het RFC-013 receipt haar lichaam; dat elk gram elementair is en co-ontstane
+uitkomsten samen draagt; het `zaakkenmerk` als de sleutel waaronder de grammen van
+één zaak een kroniek vormen; het moment.
+
+**Niet**: de RFC-008-stages (BESLUIT, BEKENDMAKING, BEZWAAR — er is één soort gram
+en geen stage-decretogrammen, dus "de huidige stap" bestaat hier niet); `modality`
+(`is_intrekking_van`, `is_wijziging_van`); de afgeleide rechtsbeschermingsroute
+(§3.3); `decision_type` als open vocabulaire; `extensions`; en de handtekening —
+het gram wordt niet ondertekend, want er is geen sleutelmateriaal (zie
+[Ondertekening is gesimuleerd](#ondertekening-is-gesimuleerd)). Verplichtingen
+die uit een besluit volgen horen ook bij §1.2 en staan er nog niet.
 
 ## Over een celgrens
 
@@ -370,10 +479,11 @@ bereikt geen stille regel in het bestand is.
 ## Het wereldbestand
 
 Een wereld is één YAML-bestand: `clock` (de tijdlijn), `cells` (wie er zijn),
-`fixtures` (de startstand) en twee soorten vraag: `queries` (een consument
-bevraagt een cel) en `query_via_transport` (een cel bevraagt een andere cel).
-Beide dragen hun eigen verwachting. De assertie hoort bij het bestand, niet bij
-Rust: een nieuw testgeval is een nieuw bestand.
+`fixtures` (de startstand), `decide` (welke cel wanneer waarover besluit) en twee
+soorten vraag: `queries` (een consument bevraagt een cel) en
+`query_via_transport` (een cel bevraagt een andere cel). Elk draagt zijn eigen
+verwachting. De assertie hoort bij het bestand, niet bij Rust: een nieuw
+testgeval is een nieuw bestand.
 
 ```yaml
 name: korte naam van het scenario
@@ -427,6 +537,25 @@ cells:
           key: bsn                              # sleutel = naam van een input
           latest: true                          # de enige modus; mag weg
 
+    besluit_definitions:                        # wat de cel kan besluiten
+      - name: zorgtoeslag_vaststelling
+        doc: vrije toelichting                  # optioneel
+        regulation: wet_op_de_zorgtoeslag       # een eigen regeling
+        output: heeft_recht_op_zorgtoeslag      # de uitkomst die het besluit ís
+        outputs:                                # wat er in hetzelfde gram mee gaat
+          - hoogte_zorgtoeslag
+        zaakkenmerk: 'zorgtoeslag/{bsn}'        # {naam} = een gedocumenteerde
+                                                # parameter; minstens één
+        params:                                 # de gedocumenteerde parameters
+          - name: bsn
+            type: string
+        inputs:                                 # wat de cel de engine aanlevert
+          bsn:
+            param: bsn                          # uit de parameters van het besluit
+          is_verzekerde:
+            from_chronicle: inkomensleveringen  # uit een eigen stroom: de laatste
+            field: is_verzekerde                # vastlegging op of vóór het moment
+
 fixtures:                                       # de startstand van de wereld
   - at: 2024-07-01                              # het moment van de vastlegging
     record:
@@ -438,6 +567,17 @@ fixtures:                                       # de startstand van de wereld
       fields:
         bsn: '999993653'
         partnerschap_type: GEEN
+
+decide:                                         # besluiten, elk op een moment
+  - description: vrije omschrijving             # optioneel
+    cell: toeslagen                             # de cel die besluit
+    besluit: zorgtoeslag_vaststelling           # de definitie hierboven
+    params:
+      bsn: '999993653'
+    op_moment: 2024-06-01                       # bepaalt welke feiten de cel
+                                                # kent én welke wetsversie geldt
+    expect:                                     # optioneel: wat het gram draagt
+      heeft_recht_op_zorgtoeslag: true
 
 queries:
   - description: vrije omschrijving             # optioneel
@@ -474,9 +614,22 @@ query_via_transport:                            # vragen over een celgrens
 `query_via_transport` is een **test-only stap, en dat is tijdelijk**. In de
 opstelling die we bouwen stelt een cel zo'n vraag uitsluitend vanuit haar
 besluit-pad: ze heeft een input nodig die een andere organisatie vaststelt. Dat
-pad bestaat nog niet — een cel kan nog niets vastleggen en dus niets accepteren —
-en tot die tijd is dit de enige manier om het verkeer te laten zien en erop te
-asserteren. Zodra het besluit-pad er is, verhuist de aanroep daarheen.
+pad bestaat inmiddels, maar het *accepteren* van zo'n waarde nog niet — een
+besluit haalt zijn inputs uit de eigen kronieken en uit zijn parameters — en tot
+die tijd is dit de enige manier om het verkeer te laten zien en erop te
+asserteren. Zodra accepteren er is, verhuist de aanroep naar het besluit-pad.
+
+De stappen lopen in deze volgorde: eerst de besluiten, dan de vragen van een
+consument, dan die over een celgrens. Dat past bij wat ze zijn — een besluit is
+een gebeurtenis op de tijdlijn, een vraag kijkt erop terug — en het maakt niets
+onmogelijk: een vraag over een moment *vóór* een besluit levert nog steeds het
+beeld van toen, want de reductie filtert zelf op `op_moment`. De klok gaat vóór
+elke stap vooruit tot haar moment, zodat een levering die ertussen valt eerst
+landt.
+
+Een `decide` mag zonder `expect`, anders dan een vraag: hij legt iets vast, en
+bewijst daarmee ook zonder verwachting iets — namelijk dat de vragen erna iets te
+vinden hebben.
 
 Onbekende velden worden geweigerd, zodat een typfout niet stil verdwijnt. Elke
 vraag heeft minstens één verwachting: een vraag zonder `expect` en zonder
@@ -602,29 +755,27 @@ Het corpus wordt standaard naast de crate gezocht (`corpus/regulation`);
 
 ## Wat hier nog niet staat
 
-**De cel besluit nog niets.** Er wordt inmiddels vastgelegd — een trigger op de
-klok legt een executogram in een kroniek — maar alleen wat de startstand
-voorschrijft. De cel zelf concludeert nog niks. In chronolexografie is
-vastleggen juist de *productieve* activiteit, en de lus is informeren →
-concluderen → **vastleggen**. Een reductie die
-`heeft_recht_op_zorgtoeslag: true` oplevert is een besluit, en dat hoort als
-decretogram (BESCHIKKING, met moment en `zaakkenmerk`) in de eigen kroniek te
-landen (RFC-022 §1.2), zodat een latere vraag *op dat moment* het besluit
-terugvindt in plaats van het opnieuw uit te rekenen onder een mogelijk andere
-wetsversie. Precies dat verschil — decretogram tegenover lexogram — is wat deze
-opstelling wil laten zien, en zonder vastleggen valt het niet te demonstreren;
-"een besluit van een andere bevoegde organisatie accepteren" heeft er evengoed
-een vastgelegd besluit voor nodig. Het vastleg-pad dat daarvoor nodig is, staat
-er nu: `Cell::record` is `pub(crate)`, dus geen consument kan erin schrijven,
-net zomin als eruit lezen. Wat mist is de trigger die een besluit *neemt*.
+**Een besluit trekt nog geen verplichtingen na zich aan.** Een beschikking die
+een bedrag toekent, brengt in de echte wereld betalingen voort met een
+vervaldatum; die horen bij het decretogram (RFC-022 §1.2) en worden bij het
+verstrijken van de tijd executogrammen. De trigger-lus in de wereld is er al op
+gebouwd, maar er is nog geen soort trigger voor.
 
-Aan de kant van de celgrens ontbreken nog drie dingen. **Accepteren in plaats van
-narekenen** (I5): het bewijsstuk van de veiligheidscontext heeft de vorm die een
-decretogram ervoor nodig heeft, maar er is nog geen decretogram om het in te
-leggen. De **invarianten-gate** die het gedeclareerde vraaggraf uit het scenario
-vergelijkt met het feitelijke uit het observatielog (I3). En **autorisatie**: de
-veiligheidscontext kent identiteit en ondertekening, en beslist nog niets over wat
-mag.
+**Een besluit wordt nog niet door een actie uitgelokt.** Het scenario zegt in
+`decide` wie wanneer waarover besluit; er is nog geen `World::act` waarmee een
+actor (een aanvraag indienen, een opgave doen) een cel aan het werk zet. Dat is
+de reden dat `decide` een stap in het bestand is en geen gevolg van iets anders.
+
+**Een besluit accepteert nog niets van een andere cel** (I5). De inputs komen uit
+de eigen kronieken en uit de parameters; de haak voor tier 3 zit op de
+besluit-engine en het bewijsstuk van de veiligheidscontext heeft al de vorm die
+`accepted_values` vraagt, maar de twee zijn nog niet verbonden. Het besluit-pad is
+wel de plek waar dat gaat gebeuren, en de enige.
+
+Aan de kant van de celgrens ontbreken verder de **invarianten-gate** die het
+gedeclareerde vraaggraf uit het scenario vergelijkt met het feitelijke uit het
+observatielog (I3), en **autorisatie**: de veiligheidscontext kent identiteit en
+ondertekening, en beslist nog niets over wat mag.
 
 Ook een **HTTP-transport** is er niet; dat is het punt van de trait. Komt het er,
 dan is dat een tweede implementatie naast `InProcessTransport` en geen wijziging in

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -244,6 +244,13 @@ gebeurt, in deze volgorde:
    die toen gold;
 4. de uitkomst gaat als één gram de stroom `beschikkingen` in.
 
+Die stroom is **voorbehouden**: ze wordt automatisch aangemaakt zodra een cel
+besluit-definities heeft, een configuratie die haar zelf declareert wordt
+geweigerd, en een `fixture` kan er niets in zetten. Alleen besluiten legt er iets
+in. Zou een wereldbestand er een gram in mogen schrijven, dan lag er een
+"besluit" zonder receipt en zonder herkomst tussen de echte, en kon een reductie
+de twee niet onderscheiden — dan bewijst het kernscenario hieronder niets meer.
+
 ### Twee paden, twee engines
 
 Een cel met besluit-definities houdt **twee engine-instanties over precies dezelfde
@@ -291,6 +298,35 @@ Eén besluit is één gram. Wat tegelijk ontstaat, wordt samen vastgelegd (RFC-0
 §1.2 — elk chronolexogram is *elementair*): het recht en het bedrag staan in
 hetzelfde gram, niet in twee.
 
+### Het zaakkenmerk moet bij precies één zaak horen
+
+Het `zaakkenmerk` is waaronder een zaak terug te vinden is, dus twee zaken mogen
+er nooit één worden. Twee regels bewaken dat:
+
+- **Bij het optuigen**: twee verwijzingen die aan elkaar plakken worden
+  geweigerd. `{jaar}{bsn}` geeft voor `2024` + `999993653` precies hetzelfde
+  kenmerk als voor `20249` + `99993653`, en geen enkele waarde repareert dat.
+- **Bij het besluit**: een parameterwaarde waarin een scheidingsteken van het
+  sjabloon voorkomt wordt geweigerd. Bij `{jaar}/{bsn}` is `jaar = '2024/9'`
+  met `bsn = '99993653'` niet te onderscheiden van `jaar = '2024'` met
+  `bsn = '999993653'`.
+
+Een sjabloon met één verwijzing heeft geen scheidingstekens en weigert dus niets:
+wat ervóór en erachter staat ligt vast, dus `zorgtoeslag/{bsn}` blijft eenduidig
+ook als de waarde zelf een `/` bevat.
+
+Grammen van verschillende besluiten kunnen wél bewust één kenmerk delen — dat is
+juist wat "de kroniek van een zaak" betekent. Ze houden elkaar uit elkaar met het
+veld `besluit`, waar een kroniekfilter met `where:` op kan filteren.
+
+### Twee besluiten op één moment
+
+De dag is hier de fijnste korrel van de tijdas. Twee besluiten op dezelfde dag
+over dezelfde zaak zijn daarop niet uit elkaar te houden; dan beslist de volgorde
+van vastleggen, en een reductie levert het **laatstgenomen** besluit. Beide
+grammen blijven staan — een kroniek groeit en vervangt niets — dus het eerste is
+niet verdwenen, alleen niet meer het laatste woord van die dag.
+
 ### Terugzien is een reductie, nooit een herberekening
 
 Het gram is een gewoon `ChronicleEvent` met `intake: eigen_besluit`, dus de
@@ -312,6 +348,21 @@ De stroom `beschikkingen` gaat met opzet **niet** als databron naar de engine. E
 besluit is geen feit om op te rekenen; zou ze meedoen, dan kon een volgende
 uitvoering stil op de uitkomst van een eerder besluit leunen, en dan is niet meer
 te zeggen of er gerekend of overgeschreven is.
+
+Welk van de twee een vraag oplevert, staat in het `reduction`-blok van de
+lexostatus, en dat verschil is het lezen waard:
+
+| `reduction` | wat de vraag oplevert |
+|---|---|
+| `chronicle: beschikkingen` | het **vastgelegde besluit** van toen, met de `regulation_valid_from` van toen; geen engine in zicht |
+| `regulation: …` + `output: …` | de **rechtstoestand nu**, opnieuw berekend op de wetsversie die op `op_moment` gold |
+
+Allebei zijn ze geldig en allebei zijn ze nodig: de tweede vorm is het lexogram
+(*wat zegt het recht over deze feiten*), de eerste het decretogram (*wat is er
+besloten*). Ze geven alleen niet hetzelfde antwoord zodra de wet of een feit
+verandert, en dat is precies waarom ze naast elkaar bestaan. Een lexostatus die
+naar het besluit heet te vragen maar de wetsvorm gebruikt, rekent dus nog steeds
+— vandaar dat de naam en de vorm in een wereldbestand bij elkaar horen te passen.
 
 ### Wat van RFC-022 §1.2 hier wel en niet in zit
 

--- a/packages/simulator/scenarios/toeslagen_besluit.yaml
+++ b/packages/simulator/scenarios/toeslagen_besluit.yaml
@@ -1,0 +1,189 @@
+---
+name: een besluit wordt vastgelegd en niet opnieuw uitgerekend
+description: >-
+  De lus sluit: informeren → concluderen → **vastleggen**. De cel `toeslagen`
+  voert op T1 haar eigen wet uit, en het resultaat landt als decretogram in haar
+  eigen kroniek. Op T2 geldt een andere wetsversie met een andere uitkomst, maar
+  een vraag op T2 levert nog steeds het besluit van T1 — met de `valid_from` van
+  toen erbij, zodat te zien is onder welk recht besloten is. Pas een nieuw
+  besluit op T2 levert de nieuwe uitkomst.
+
+  Dat verschil is de hele reden dat een decretogram bestaat naast een lexogram.
+  Zonder vastleggen zou elke vraag een herberekening zijn, en dan zou het
+  antwoord op "wat is er destijds beslist" veranderen zodra de wet verandert.
+
+clock:
+  # De feiten van deze persoon staan als `events` in de celconfiguratie en
+  # liggen allemaal vóór dit moment; de besluiten hieronder liggen erna en
+  # nemen de klok mee.
+  start: 2024-01-01
+
+cells:
+  - id: toeslagen
+    laws:
+      - wet_op_de_zorgtoeslag
+      - algemene_wet_inkomensafhankelijke_regelingen
+      - regeling_standaardpremie
+
+    chronicles:
+      # Wat de cel over deze persoon vastlegde. Er staat géén stroom
+      # `beschikkingen` bij: die hoort bij het besluit-pad en wordt automatisch
+      # aangemaakt zodra een cel besluit-definities heeft.
+      - stream: relaties
+        key: bsn
+        events:
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: toeslagen
+            grondslag: melding uit de basisregistratie personen
+            op_moment: 2023-01-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: GEEN
+
+      - stream: inkomensleveringen
+        key: bsn
+        events:
+          - name: inkomenslevering
+            intake: levering
+            recording_actor: toeslagen
+            grondslag: jaarlijkse inkomenslevering
+            op_moment: 2023-11-15
+            fields:
+              bsn: '999993653'
+              is_verzekerde: true
+              verzamelinkomen: 79547
+              buitenlands_inkomen: 0
+              vermogen: 0
+
+    besluit_definitions:
+      - name: zorgtoeslag_vaststelling
+        doc: >-
+          De cel voert artikel 2 van de Wet op de zorgtoeslag uit en legt de
+          uitkomst vast. Het artikel zegt zelf dat het een BESCHIKKING
+          voortbrengt; de cel neemt dat over in het gram, samen met het bevoegd
+          gezag dat de wet noemt.
+        regulation: wet_op_de_zorgtoeslag
+        # De uitkomst die het besluit *is*. Wat er causaal mee meekomt, blijft
+        # binnen de cel tenzij het hieronder in `outputs` staat.
+        output: heeft_recht_op_zorgtoeslag
+        outputs:
+          # Wat samen ontstaat, wordt samen vastgelegd: één besluit is één gram
+          # met het recht én het bedrag erin, niet twee grammen.
+          - hoogte_zorgtoeslag
+        # Waaronder deze zaak terug te vinden is. Elke verwijzing moet een
+        # gedocumenteerde parameter zijn, anders zou het kenmerk voor elke zaak
+        # hetzelfde zijn.
+        zaakkenmerk: zorgtoeslag/{bsn}
+        params:
+          - name: bsn
+            type: string
+        inputs:
+          # Wat de cel aan de engine aanlevert, met de herkomst erbij. Die
+          # herkomst gaat mee ín het decretogram: van welk moment het feit was,
+          # en uit welke stroom het kwam.
+          bsn:
+            param: bsn
+          is_verzekerde:
+            from_chronicle: inkomensleveringen
+            field: is_verzekerde
+
+    lexostatus_definitions:
+      - name: zorgtoeslagbeschikking
+        doc: >-
+          Wat deze cel over deze zaak besloten heeft, op het gevraagde moment.
+          Een gewoon kroniekfilter — geen engine, geen herberekening — over de
+          stroom waarin het besluit-pad zijn decretogrammen legt.
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - heeft_recht_op_zorgtoeslag
+          - hoogte_zorgtoeslag
+          # De versie van de regeling waaronder besloten is. Dít maakt zichtbaar
+          # dat het antwoord een besluit is en geen som van vandaag.
+          - regulation_valid_from
+          - legal_character
+          - competent_authority
+        reduction:
+          chronicle: beschikkingen
+          key: zaakkenmerk
+          latest: true
+
+decide:
+  # T1. De wet van 2024 geldt, en de standaardpremie van 2024 (€ 1.987).
+  - description: op T1 besluit de cel onder de wetsversie die dan geldt
+    cell: toeslagen
+    besluit: zorgtoeslag_vaststelling
+    params:
+      bsn: '999993653'
+    op_moment: 2024-06-01
+    expect:
+      heeft_recht_op_zorgtoeslag: true
+      hoogte_zorgtoeslag: 197205.31187
+
+  # T2. Inmiddels geldt de wet van 2025, met een hogere standaardpremie en
+  # andere drempels. Hetzelfde besluit over dezelfde persoon valt daarom anders
+  # uit — en dat is precies wat het tegenscenario hieronder nodig heeft.
+  - description: op T2 levert hetzelfde besluit een andere uitkomst
+    cell: toeslagen
+    besluit: zorgtoeslag_vaststelling
+    params:
+      bsn: '999993653'
+    op_moment: 2025-02-01
+    expect:
+      heeft_recht_op_zorgtoeslag: true
+      hoogte_zorgtoeslag: 209692
+
+queries:
+  - description: >-
+      Vóór het eerste besluit had deze cel over deze zaak niets vastgesteld. Dat
+      is een gewoon antwoord met een reden, en nadrukkelijk geen berekening ter
+      plekke.
+    cell: toeslagen
+    lexostatus: zorgtoeslagbeschikking
+    params:
+      zaakkenmerk: zorgtoeslag/999993653
+    op_moment: 2024-01-01
+    expect_not_established: true
+
+  - description: >-
+      De kernassertie. Op 2025-01-01 is de wetsversie van 2025 in werking en zou
+      een herberekening een ander bedrag geven. Het antwoord is het besluit van
+      T1, met de `valid_from` van de versie waaronder het genomen is.
+    cell: toeslagen
+    lexostatus: zorgtoeslagbeschikking
+    params:
+      zaakkenmerk: zorgtoeslag/999993653
+    op_moment: 2025-01-01
+    expect:
+      heeft_recht_op_zorgtoeslag: true
+      hoogte_zorgtoeslag: 197205.31187
+      regulation_valid_from: '2024-01-01'
+      legal_character: BESCHIKKING
+      competent_authority: Dienst Toeslagen
+
+  - description: >-
+      Het tegenscenario: ná het tweede besluit levert dezelfde vraag het nieuwe
+      gram, onder de nieuwe versie. Een besluit vervangt het vorige niet — de
+      kroniek groeit — maar op dit moment is dit de laatste vaststelling.
+    cell: toeslagen
+    lexostatus: zorgtoeslagbeschikking
+    params:
+      zaakkenmerk: zorgtoeslag/999993653
+    op_moment: 2025-02-01
+    expect:
+      hoogte_zorgtoeslag: 209692
+      regulation_valid_from: '2025-01-01'
+
+  - description: >-
+      En het beeld van T1 blijft daarna exact hetzelfde: een gram dat later
+      landde, raakt een eerder moment niet.
+    cell: toeslagen
+    lexostatus: zorgtoeslagbeschikking
+    params:
+      zaakkenmerk: zorgtoeslag/999993653
+    op_moment: 2024-06-01
+    expect:
+      hoogte_zorgtoeslag: 197205.31187
+      regulation_valid_from: '2024-01-01'

--- a/packages/simulator/src/cell/besluit.rs
+++ b/packages/simulator/src/cell/besluit.rs
@@ -497,22 +497,39 @@ impl BesluitDefinition {
                         .join(", "),
                 });
             }
-            self.validate_input(cell, surface, origin)?;
+            self.validate_input(cell, surface, input, origin)?;
         }
 
         self.validate_zaakkenmerk(cell)
     }
 
-    /// Eén input: bestaat de stroom, kent ze het veld, en is haar sleutel
-    /// aan te leveren? Of, bij een parameter: is die gedocumenteerd?
+    /// Eén input: is de stroom er een om feiten uit te lezen, bestaat ze, kent
+    /// ze het veld, en is haar sleutel aan te leveren? Of, bij een parameter: is
+    /// die gedocumenteerd?
     fn validate_input(
         &self,
         cell: &str,
         surface: &CellSurface<'_>,
+        input: &str,
         origin: &BesluitInput,
     ) -> Result<()> {
         match origin {
             BesluitInput::FromChronicle { chronicle, field } => {
+                // Een besluit leest geen besluit. De stroom met decretogrammen is
+                // een gewone stroom zodra een cel besluit-definities heeft, dus
+                // zonder deze weigering kan een besluit een veld van een eerder
+                // decretogram als "eigen feit" binnenhalen — dezelfde
+                // schaduwboekhouding die `register_own_facts` aan de kant van de
+                // engine al buiten de deur houdt, langs de andere weg.
+                if chronicle == BESCHIKKINGEN {
+                    return Err(SimulatorError::DecretogramAsBesluitInput {
+                        cell: cell.to_string(),
+                        besluit: self.name.clone(),
+                        input: input.to_string(),
+                        stream: chronicle.clone(),
+                        field: field.clone(),
+                    });
+                }
                 surface.check_stream_field(cell, Subject::Besluit, &self.name, chronicle, field)?;
                 // Onbereikbaar leeg: `check_stream_field` heeft de stroom
                 // hierboven al gevonden, en elke stroom declareert een sleutel.

--- a/packages/simulator/src/cell/besluit.rs
+++ b/packages/simulator/src/cell/besluit.rs
@@ -1,0 +1,750 @@
+//! Het besluit-pad: een cel voert een wet uit en legt de uitkomst vast.
+//!
+//! De lus van chronolexografie is informeren → concluderen → **vastleggen**, en
+//! dit is het derde deel. Een besluit-definitie is data, net als een
+//! lexostatus-definitie: ze noemt een eigen regeling, de uitkomst die het
+//! besluit *is*, waar de inputs vandaan komen en hoe het zaakkenmerk gevormd
+//! wordt. Wat eruit komt is een [`Decretogram`]: het RFC-013 Execution Receipt
+//! plus het moment en het zaakkenmerk, vastgelegd als gewoon executogram in de
+//! eigen kroniek van de cel.
+//!
+//! Twee dingen die dit pad met opzet *niet* doet:
+//!
+//! - **Het bewaart niets naast het decretogram.** Een waarde die het besluit
+//!   ophaalde, gaat mee ín het decretogram (met haar herkomst) en niet als los
+//!   feit in een kroniek. Anders zou een volgend besluit of een volgende
+//!   reductie op andermans feiten leunen zonder opnieuw te kijken — de
+//!   schaduwboekhouding die RFC-022 uitsluit.
+//! - **Het rekent niet in een reductie.** [`crate::Cell::reduce`] leest het
+//!   decretogram terug als kroniekfeit; ligt er geen, dan is het antwoord
+//!   "niets vastgesteld". Nooit een herberekening onder een inmiddels andere
+//!   wetsversie.
+
+use crate::cell::config::{
+    check_documented_params, documents, parameter_listing, published_outputs, CellSurface,
+    DocumentedParameter,
+};
+use crate::cell::{ChronicleEvent, Intake};
+use crate::error::{Result, SimulatorError, Subject};
+use chrono::NaiveDate;
+use regelrecht_engine::{ExecutionReceipt, Value};
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// De kroniekstroom waarin een cel haar eigen decretogrammen legt.
+///
+/// Eén vaste naam per cel, automatisch aanwezig zodra de cel besluit-definities
+/// heeft, en voorbehouden: een configuratie die zelf een stroom met deze naam
+/// declareert wordt geweigerd. Dat de naam vastligt, is wat een reductie erover
+/// mogelijk maakt zonder dat elke casus hem opnieuw verzint.
+pub const BESCHIKKINGEN: &str = "beschikkingen";
+
+/// De veldnamen die elk decretogram draagt, naast de uitkomsten van het besluit.
+///
+/// Ze staan hier bij elkaar omdat twee plekken ze allebei moeten kennen: het
+/// vastleggen (welke velden krijgt het gram) en het optuigen (waarover mag een
+/// lexostatus over deze stroom iets beloven). Zouden die uit elkaar lopen, dan
+/// zou een reductie over een bestaand veld als typfout geweigerd worden.
+pub const ZAAKKENMERK: &str = "zaakkenmerk";
+/// Veld met de naam van de besluit-definitie die het gram voortbracht.
+pub const BESLUIT: &str = "besluit";
+/// Veld met de `$id` van de uitgevoerde regeling.
+pub const REGULATION: &str = "regulation";
+/// Veld met de `valid_from` van de regelingversie die gold op `op_moment`.
+pub const REGULATION_VALID_FROM: &str = "regulation_valid_from";
+/// Veld met het bevoegd gezag dat de regeling noemt (RFC-002).
+pub const COMPETENT_AUTHORITY: &str = "competent_authority";
+/// Veld met het rechtskarakter dat de regeling aan deze uitkomst geeft.
+pub const LEGAL_CHARACTER: &str = "legal_character";
+/// Veld met de inputs van het besluit, elk met hun herkomst.
+pub const INPUTS: &str = "inputs";
+/// Veld met het volledige RFC-013 Execution Receipt.
+pub const RECEIPT: &str = "receipt";
+
+/// De vaste velden van een decretogram, in de volgorde waarin ze hierboven staan.
+const FIXED_FIELDS: [&str; 8] = [
+    ZAAKKENMERK,
+    BESLUIT,
+    REGULATION,
+    REGULATION_VALID_FROM,
+    COMPETENT_AUTHORITY,
+    LEGAL_CHARACTER,
+    INPUTS,
+    RECEIPT,
+];
+
+/// Eén besluit dat een cel kan nemen.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BesluitDefinition {
+    /// De naam waarmee dit besluit aangeroepen wordt.
+    pub name: String,
+    /// Vrije toelichting; verschijnt niet in het decretogram, wel in de config.
+    #[serde(default)]
+    pub doc: Option<String>,
+    /// De regeling die uitgevoerd wordt, bij `$id`. Moet in `laws` van dezelfde
+    /// cel staan: een cel besluit op haar eigen recht.
+    pub regulation: String,
+    /// De uitkomst die dit besluit *is* en die de uitvoering aanstuurt.
+    pub output: String,
+    /// Uitkomsten die naast [`Self::output`] in het decretogram meegaan.
+    ///
+    /// Wat samen ontstaat, wordt samen vastgelegd (RFC-022 §1.2): één besluit is
+    /// één elementair gram met al zijn uitkomsten erin, niet één gram per
+    /// uitkomst.
+    #[serde(default)]
+    pub outputs: Vec<String>,
+    /// Het zaakkenmerk, als sjabloon met `{parameter}`-verwijzingen.
+    ///
+    /// Dit is waaronder de zaak terug te vinden is: de kroniek van
+    /// decretogrammen over één zaak deelt één zaakkenmerk (RFC-022 §1.2).
+    pub zaakkenmerk: String,
+    /// De gedocumenteerde parameters van dit besluit.
+    #[serde(default)]
+    pub params: Vec<DocumentedParameter>,
+    /// Wat het besluit aan de engine aanlevert, op inputnaam.
+    ///
+    /// De naam is die van een parameter of input van de regeling; de waarde
+    /// zegt waar hij vandaan komt. In deze versie zijn dat de eigen kronieken
+    /// van de cel en de parameters van het besluit; een waarde van een andere
+    /// cel accepteren volgt apart.
+    #[serde(default)]
+    pub inputs: BTreeMap<String, BesluitInput>,
+}
+
+/// Waar één input van een besluit vandaan komt.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(try_from = "BesluitInputFields")]
+pub enum BesluitInput {
+    /// Uit een eigen kroniek van de besluitende cel (tier 1 van RFC-022 §4.2).
+    ///
+    /// De laatste vastlegging op of vóór het moment van het besluit, gezocht op
+    /// het sleutelveld van die stroom — en de waarde van dat sleutelveld komt
+    /// uit de gedocumenteerde parameter met dezelfde naam.
+    FromChronicle {
+        /// De eigen kroniekstroom waaruit gelezen wordt.
+        chronicle: String,
+        /// Het veld van die vastlegging dat de waarde draagt.
+        field: String,
+    },
+    /// Meegegeven bij het besluit zelf.
+    Param {
+        /// De gedocumenteerde parameter die de waarde levert.
+        param: String,
+    },
+}
+
+/// Het YAML-oppervlak van een input: alle velden van beide vormen, los.
+///
+/// Zelfde keuze als bij [`crate::Reduction`]: de vorm valt hieronder en niet in
+/// serde, zodat er in de foutmelding staat wat er mis is in plaats van "data did
+/// not match any variant".
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BesluitInputFields {
+    from_chronicle: Option<String>,
+    field: Option<String>,
+    param: Option<String>,
+}
+
+impl TryFrom<BesluitInputFields> for BesluitInput {
+    type Error = String;
+
+    fn try_from(fields: BesluitInputFields) -> std::result::Result<Self, Self::Error> {
+        match (fields.from_chronicle, fields.param) {
+            (Some(chronicle), Some(param)) => Err(format!(
+                "input noemt zowel kroniekstroom '{chronicle}' als parameter '{param}'; \
+                 een input komt óf uit een eigen kroniek (`from_chronicle` + `field`) \
+                 óf uit een parameter (`param`)"
+            )),
+            (Some(chronicle), None) => {
+                let field = fields.field.ok_or_else(|| {
+                    format!(
+                        "input uit kroniekstroom '{chronicle}' mist `field`: zonder veld \
+                         weet de cel niet welke waarde van de vastlegging ze bedoelt"
+                    )
+                })?;
+                Ok(Self::FromChronicle { chronicle, field })
+            }
+            (None, Some(param)) => {
+                if fields.field.is_some() {
+                    return Err(format!(
+                        "`field` hoort bij een input uit een kroniekstroom \
+                         (`from_chronicle`), niet bij parameter '{param}'"
+                    ));
+                }
+                Ok(Self::Param { param })
+            }
+            (None, None) => Err(
+                "input noemt geen `from_chronicle` en geen `param`: een input komt uit \
+                 een eigen kroniek (`from_chronicle` + `field`) of uit een parameter \
+                 (`param`)"
+                    .to_string(),
+            ),
+        }
+    }
+}
+
+/// Waar één waarde in een decretogram vandaan kwam.
+///
+/// Dit is wat het decretogram zelf draagt: niet alleen de waarde waarop besloten
+/// is, maar ook wie haar aanleverde en van wanneer ze was. Zonder die herkomst
+/// is een besluit niet terug te lezen, en is "accepteren in plaats van
+/// narekenen" niet van "gokken" te onderscheiden.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InputOrigin {
+    /// Uit een eigen kroniek van de besluitende cel.
+    OwnChronicle {
+        /// De stroom waaruit gelezen is.
+        chronicle: String,
+        /// Het veld dat de waarde droeg.
+        field: String,
+        /// Het moment van de vastlegging waaruit de waarde komt — niet het
+        /// moment van het besluit. Dat verschil is het hele punt van een
+        /// kroniek.
+        recorded_op_moment: NaiveDate,
+    },
+    /// Meegegeven bij het besluit.
+    Parameter {
+        /// De parameter die de waarde leverde.
+        parameter: String,
+    },
+}
+
+impl InputOrigin {
+    /// De herkomst als vastlegbare waarde, voor in het decretogram.
+    fn as_value(&self) -> Value {
+        match self {
+            Self::OwnChronicle {
+                chronicle,
+                field,
+                recorded_op_moment,
+            } => Value::Object(BTreeMap::from([
+                (
+                    "herkomst".to_string(),
+                    Value::String("eigen_kroniek".to_string()),
+                ),
+                ("chronicle".to_string(), Value::String(chronicle.clone())),
+                ("field".to_string(), Value::String(field.clone())),
+                (
+                    "op_moment".to_string(),
+                    Value::String(recorded_op_moment.to_string()),
+                ),
+            ])),
+            Self::Parameter { parameter } => Value::Object(BTreeMap::from([
+                (
+                    "herkomst".to_string(),
+                    Value::String("parameter".to_string()),
+                ),
+                ("parameter".to_string(), Value::String(parameter.clone())),
+            ])),
+        }
+    }
+
+    /// Leesbare herkomst voor een verslag.
+    pub fn describe(&self) -> String {
+        match self {
+            Self::OwnChronicle {
+                chronicle,
+                field,
+                recorded_op_moment,
+            } => format!("eigen kroniek '{chronicle}.{field}', vastgelegd {recorded_op_moment}"),
+            Self::Parameter { parameter } => format!("parameter '{parameter}'"),
+        }
+    }
+}
+
+/// Eén input van een besluit: de waarde waarop besloten is, met haar herkomst.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DecretogramInput {
+    /// De waarde zoals ze meedeed in het besluit.
+    pub value: Value,
+    /// Waar ze vandaan kwam.
+    pub origin: InputOrigin,
+}
+
+/// Het vastgelegde besluit: het RFC-013 Execution Receipt plus moment en
+/// zaakkenmerk.
+///
+/// Geen parallel formaat naast het receipt (RFC-022 §1.2 — een decretogram *is*
+/// een engine-uitkomst met een rechtskarakter, en het receipt is haar lichaam).
+/// Wat erbij komt, is wat het receipt niet kan weten: op welk moment in de
+/// logische tijd dit besluit genomen is, onder welk zaakkenmerk het terug te
+/// vinden is, en waar elke input vandaan kwam.
+#[derive(Debug, Clone)]
+pub struct Decretogram {
+    /// De cel die besloot.
+    pub cell: String,
+    /// De besluit-definitie die uitgevoerd is.
+    pub besluit: String,
+    /// Waaronder deze zaak terug te vinden is.
+    pub zaakkenmerk: String,
+    /// Het moment waarop besloten is.
+    pub op_moment: NaiveDate,
+    /// De uitgevoerde regeling, bij `$id`.
+    pub regulation: String,
+    /// De `valid_from` van de regelingversie die op `op_moment` gold.
+    ///
+    /// Dit is wat een besluit van een lexogram onderscheidt: het gram houdt vast
+    /// welk recht gold toen, ook als er later een andere versie in werking treedt.
+    pub regulation_valid_from: Option<String>,
+    /// Het bevoegd gezag dat de regeling noemt (RFC-002). Een juridisch feit van
+    /// het besluit, geen eigenschap van de cel (RFC-022 §2).
+    pub competent_authority: Option<String>,
+    /// Het rechtskarakter dat de regeling aan deze uitkomst geeft
+    /// (`produces.legal_character`), bijvoorbeeld `BESCHIKKING`.
+    pub legal_character: Option<String>,
+    /// De uitkomsten van het besluit: de aansturende uitkomst plus wat de
+    /// definitie erbij noemt. Alle samen in één gram.
+    pub outputs: BTreeMap<String, Value>,
+    /// De inputs waarop besloten is, met hun herkomst.
+    pub inputs: BTreeMap<String, DecretogramInput>,
+    /// Het volledige receipt van de uitvoering.
+    pub receipt: ExecutionReceipt,
+}
+
+impl Decretogram {
+    /// Het decretogram als kroniekgebeurtenis.
+    ///
+    /// Een gewoon executogram met `intake: eigen_besluit`, zodat de tijdreductie
+    /// er zonder speciale gevallen overheen werkt: wie op een moment vóór dit
+    /// besluit vraagt, ziet het niet, en wie erna vraagt krijgt het terug zoals
+    /// het toen vastgelegd is.
+    pub(crate) fn event(&self) -> Result<ChronicleEvent> {
+        let mut fields: BTreeMap<String, Value> = BTreeMap::from([
+            (
+                ZAAKKENMERK.to_string(),
+                Value::String(self.zaakkenmerk.clone()),
+            ),
+            (BESLUIT.to_string(), Value::String(self.besluit.clone())),
+            (
+                REGULATION.to_string(),
+                Value::String(self.regulation.clone()),
+            ),
+            (
+                REGULATION_VALID_FROM.to_string(),
+                optional_text(self.regulation_valid_from.as_deref()),
+            ),
+            (
+                COMPETENT_AUTHORITY.to_string(),
+                optional_text(self.competent_authority.as_deref()),
+            ),
+            (
+                LEGAL_CHARACTER.to_string(),
+                optional_text(self.legal_character.as_deref()),
+            ),
+            (
+                INPUTS.to_string(),
+                Value::Object(
+                    self.inputs
+                        .iter()
+                        .map(|(name, input)| {
+                            (
+                                name.clone(),
+                                Value::Object(BTreeMap::from([
+                                    ("value".to_string(), input.value.clone()),
+                                    ("origin".to_string(), input.origin.as_value()),
+                                ])),
+                            )
+                        })
+                        .collect(),
+                ),
+            ),
+            (RECEIPT.to_string(), self.receipt_value()?),
+        ]);
+        fields.extend(
+            self.outputs
+                .iter()
+                .map(|(name, value)| (name.clone(), value.clone())),
+        );
+
+        Ok(ChronicleEvent {
+            name: self.besluit.clone(),
+            intake: Intake::EigenBesluit,
+            recording_actor: self.cell.clone(),
+            grondslag: self.grondslag(),
+            op_moment: self.op_moment,
+            fields,
+        })
+    }
+
+    /// Het receipt als vastlegbare waarde.
+    ///
+    /// Via serde en niet met de hand overgeschreven: een handmatige kopie zou
+    /// bij elke uitbreiding van RFC-013 stil achterlopen, en dan zou het
+    /// decretogram niet meer het receipt zijn maar een selectie eruit.
+    fn receipt_value(&self) -> Result<Value> {
+        let encoded = serde_yaml_ng::to_string(&self.receipt).map_err(|source| {
+            SimulatorError::ReceiptEncoding {
+                cell: self.cell.clone(),
+                besluit: self.besluit.clone(),
+                source,
+            }
+        })?;
+        serde_yaml_ng::from_str(&encoded).map_err(|source| SimulatorError::ReceiptEncoding {
+            cell: self.cell.clone(),
+            besluit: self.besluit.clone(),
+            source,
+        })
+    }
+
+    /// De grondslag van deze vastlegging: de regeling die uitgevoerd is, met de
+    /// versie die toen gold.
+    fn grondslag(&self) -> String {
+        match &self.regulation_valid_from {
+            Some(valid_from) => format!("{} (versie {valid_from})", self.regulation),
+            None => self.regulation.clone(),
+        }
+    }
+}
+
+/// Een tekst die er kan zijn, als vastlegbare waarde.
+///
+/// `null` en niet "de lege tekst": dat de regeling geen bevoegd gezag noemt is
+/// iets anders dan een bevoegd gezag zonder naam.
+fn optional_text(text: Option<&str>) -> Value {
+    text.map_or(Value::Null, |value| Value::String(value.to_string()))
+}
+
+impl BesluitDefinition {
+    /// De uitkomsten die dit besluit vastlegt.
+    pub fn recorded_outputs(&self) -> BTreeSet<&str> {
+        published_outputs(Some(self.output.as_str()), &self.outputs)
+    }
+
+    /// Controleer de meegegeven parameters tegen de gedocumenteerde.
+    pub(crate) fn check_params(&self, cell: &str, params: &BTreeMap<String, Value>) -> Result<()> {
+        check_documented_params(cell, Subject::Besluit, &self.name, &self.params, params)
+    }
+
+    /// Het zaakkenmerk voor deze parameters.
+    ///
+    /// Aanroepen ná [`Self::check_params`]: elke verwijzing is bij het optuigen
+    /// aan een gedocumenteerde parameter gebonden, en die is dan aanwezig.
+    pub(crate) fn zaakkenmerk(&self, params: &BTreeMap<String, Value>) -> String {
+        let mut out = String::with_capacity(self.zaakkenmerk.len());
+        let mut rest = self.zaakkenmerk.as_str();
+        while let Some((before, after)) = rest.split_once('{') {
+            out.push_str(before);
+            let Some((reference, remainder)) = after.split_once('}') else {
+                out.push('{');
+                out.push_str(after);
+                return out;
+            };
+            if let Some(value) = params.get(reference) {
+                out.push_str(&value.to_string());
+            }
+            rest = remainder;
+        }
+        out.push_str(rest);
+        out
+    }
+
+    /// Controleer de definitie tegen de cel waarin ze staat.
+    ///
+    /// Een besluit belooft dat het uit te voeren is: op een eigen regeling, met
+    /// uitkomsten die die regeling kent, met inputs die ze declareert, uit
+    /// stromen die de cel houdt. Dat blijkt hier — bij het optuigen — en niet
+    /// pas op het moment dat er besloten moet worden.
+    pub(crate) fn validate(&self, cell: &str, surface: &CellSurface<'_>) -> Result<()> {
+        surface.check_own_regulation(cell, Subject::Besluit, &self.name, &self.regulation)?;
+        surface.check_regulation_outputs(
+            cell,
+            Subject::Besluit,
+            &self.name,
+            &self.regulation,
+            self.recorded_outputs(),
+        )?;
+
+        // De uitkomsten komen in hetzelfde gram als de vaste velden. Een
+        // uitkomst die zo heet, zou er een overschrijven — het gram zou dan
+        // bijvoorbeeld zijn receipt kwijt zijn zonder dat iemand het merkt.
+        for output in self.recorded_outputs() {
+            if FIXED_FIELDS.contains(&output) {
+                return Err(SimulatorError::ReservedDecretogramField {
+                    cell: cell.to_string(),
+                    besluit: self.name.clone(),
+                    output: output.to_string(),
+                    fixed: FIXED_FIELDS.join(", "),
+                });
+            }
+        }
+
+        let known_inputs = surface
+            .regulation_inputs
+            .get(&self.regulation)
+            .cloned()
+            .unwrap_or_default();
+        for (input, origin) in &self.inputs {
+            if !known_inputs
+                .iter()
+                .any(|known| known.eq_ignore_ascii_case(input))
+            {
+                return Err(SimulatorError::UnknownRegulationInput {
+                    cell: cell.to_string(),
+                    besluit: self.name.clone(),
+                    input: input.clone(),
+                    regulation: self.regulation.clone(),
+                    known: known_inputs
+                        .iter()
+                        .map(String::as_str)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                });
+            }
+            self.validate_input(cell, surface, origin)?;
+        }
+
+        self.validate_zaakkenmerk(cell)
+    }
+
+    /// Eén input: bestaat de stroom, kent ze het veld, en is haar sleutel
+    /// aan te leveren? Of, bij een parameter: is die gedocumenteerd?
+    fn validate_input(
+        &self,
+        cell: &str,
+        surface: &CellSurface<'_>,
+        origin: &BesluitInput,
+    ) -> Result<()> {
+        match origin {
+            BesluitInput::FromChronicle { chronicle, field } => {
+                surface.check_stream_field(cell, Subject::Besluit, &self.name, chronicle, field)?;
+                // Onbereikbaar leeg: `check_stream_field` heeft de stroom
+                // hierboven al gevonden, en elke stroom declareert een sleutel.
+                let key = surface
+                    .stream_key(chronicle)
+                    .unwrap_or_default()
+                    .to_string();
+                if !documents(&self.params, &key) {
+                    return Err(SimulatorError::BesluitStreamKeyWithoutParameter {
+                        cell: cell.to_string(),
+                        besluit: self.name.clone(),
+                        stream: chronicle.clone(),
+                        key,
+                        documented: parameter_listing(&self.params),
+                    });
+                }
+                Ok(())
+            }
+            BesluitInput::Param { param } => {
+                if documents(&self.params, param) {
+                    return Ok(());
+                }
+                Err(SimulatorError::UnknownReference {
+                    cell: cell.to_string(),
+                    subject: Subject::Besluit,
+                    name: self.name.clone(),
+                    reference: param.clone(),
+                })
+            }
+        }
+    }
+
+    /// Het zaakkenmerk-sjabloon: sluitende accolades, minstens één verwijzing,
+    /// en elke verwijzing een gedocumenteerde parameter.
+    fn validate_zaakkenmerk(&self, cell: &str) -> Result<()> {
+        let mut rest = self.zaakkenmerk.as_str();
+        let mut references = 0usize;
+        while let Some((_, after)) = rest.split_once('{') {
+            let Some((reference, remainder)) = after.split_once('}') else {
+                return Err(SimulatorError::MalformedZaakkenmerk {
+                    cell: cell.to_string(),
+                    besluit: self.name.clone(),
+                    template: self.zaakkenmerk.clone(),
+                });
+            };
+            if !documents(&self.params, reference) {
+                return Err(SimulatorError::UnknownReference {
+                    cell: cell.to_string(),
+                    subject: Subject::Besluit,
+                    name: self.name.clone(),
+                    reference: reference.to_string(),
+                });
+            }
+            references += 1;
+            rest = remainder;
+        }
+
+        if references == 0 {
+            return Err(SimulatorError::ZaakkenmerkWithoutReference {
+                cell: cell.to_string(),
+                besluit: self.name.clone(),
+                template: self.zaakkenmerk.clone(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// De veldnamen die de stroom met decretogrammen van deze cel gaat dragen.
+///
+/// Bekend vóór het eerste besluit, en dat moet ook: een lexostatus die over deze
+/// stroom reduceert wordt bij het optuigen getoetst, en dan is de stroom nog
+/// leeg. Zonder deze lijst zou elke reductie over een decretogram als typfout
+/// geweigerd worden.
+pub(crate) fn declared_fields(definitions: &[BesluitDefinition]) -> BTreeSet<String> {
+    let mut fields: BTreeSet<String> = FIXED_FIELDS.iter().map(|f| (*f).to_string()).collect();
+    for definition in definitions {
+        fields.extend(
+            definition
+                .recorded_outputs()
+                .into_iter()
+                .map(str::to_string),
+        );
+    }
+    fields
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(yaml: &str) -> std::result::Result<BesluitInput, String> {
+        serde_yaml_ng::from_str(yaml).map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn een_input_uit_een_kroniek_wordt_gelezen() {
+        let parsed = input("from_chronicle: inkomensleveringen\nfield: verzamelinkomen\n")
+            .unwrap_or_else(|e| panic!("de kroniekvorm moet gelezen worden: {e}"));
+        assert_eq!(
+            parsed,
+            BesluitInput::FromChronicle {
+                chronicle: "inkomensleveringen".to_string(),
+                field: "verzamelinkomen".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn een_input_uit_een_parameter_wordt_gelezen() {
+        let parsed =
+            input("param: bsn\n").unwrap_or_else(|e| panic!("de parametervorm moet lezen: {e}"));
+        assert_eq!(
+            parsed,
+            BesluitInput::Param {
+                param: "bsn".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn een_input_met_twee_vormen_noemt_ze_beide() {
+        let err = input("from_chronicle: relaties\nfield: x\nparam: bsn\n")
+            .expect_err("twee vormen in één input hoort te falen");
+        assert!(
+            err.contains("relaties") && err.contains("bsn"),
+            "de melding moet beide vormen noemen, kreeg: {err}"
+        );
+    }
+
+    #[test]
+    fn een_input_uit_een_kroniek_zonder_veld_wordt_geweigerd() {
+        let err =
+            input("from_chronicle: relaties\n").expect_err("zonder `field` hoort het te falen");
+        assert!(
+            err.contains("`field`"),
+            "de melding moet `field` noemen, kreeg: {err}"
+        );
+    }
+
+    #[test]
+    fn een_input_zonder_vorm_noemt_de_twee_vormen() {
+        let err = input("{}\n").expect_err("een input zonder vorm hoort te falen");
+        assert!(
+            err.contains("`from_chronicle`") && err.contains("`param`"),
+            "de melding moet vertellen welke twee vormen er zijn, kreeg: {err}"
+        );
+    }
+
+    fn definition(zaakkenmerk: &str) -> BesluitDefinition {
+        serde_yaml_ng::from_str(&format!(
+            r"
+name: toekenning
+regulation: wet_op_de_zorgtoeslag
+output: heeft_recht_op_zorgtoeslag
+zaakkenmerk: '{zaakkenmerk}'
+params:
+  - name: bsn
+    type: string
+"
+        ))
+        .unwrap_or_else(|e| panic!("testdefinitie moet parsen: {e}"))
+    }
+
+    #[test]
+    fn het_zaakkenmerk_vult_de_parameters_in() {
+        let params = BTreeMap::from([("bsn".to_string(), Value::String("999993653".to_string()))]);
+        assert_eq!(
+            definition("zorgtoeslag/{bsn}").zaakkenmerk(&params),
+            "zorgtoeslag/999993653"
+        );
+    }
+
+    #[test]
+    fn een_zaakkenmerk_zonder_verwijzing_wordt_geweigerd() {
+        let err = definition("zorgtoeslag")
+            .validate_zaakkenmerk("toeslagen")
+            .expect_err("een zaakkenmerk dat elke zaak gelijk maakt hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::ZaakkenmerkWithoutReference { .. }),
+            "verwachtte ZaakkenmerkWithoutReference, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn een_zaakkenmerk_met_een_open_accolade_wordt_geweigerd() {
+        let err = definition("zorgtoeslag/{bsn")
+            .validate_zaakkenmerk("toeslagen")
+            .expect_err("een accolade die niet sluit hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::MalformedZaakkenmerk { .. }),
+            "verwachtte MalformedZaakkenmerk, kreeg {err}"
+        );
+    }
+
+    /// Een oppervlak dat alles kent wat de definitie hieronder noemt.
+    ///
+    /// Rechtstreeks in elkaar gezet en niet uit een corpus gelezen: de botsing
+    /// die deze test afdekt vraagt een regeling met een uitkomst die `receipt`
+    /// heet, en die bestaat in het corpus niet. Dat ze er niet is, is geen reden
+    /// om de weigering ongetest te laten — ze is er morgen misschien wel.
+    fn surface_met_uitkomst<'a>(laws: &'a [String], output: &str) -> CellSurface<'a> {
+        CellSurface {
+            laws,
+            outputs: BTreeMap::from([(
+                "wet_op_de_zorgtoeslag".to_string(),
+                BTreeSet::from([output.to_string()]),
+            )]),
+            regulation_inputs: BTreeMap::new(),
+            streams: BTreeMap::new(),
+            stream_keys: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn een_uitkomst_die_een_vast_veld_zou_overschrijven_wordt_geweigerd() {
+        let laws = vec!["wet_op_de_zorgtoeslag".to_string()];
+        let mut definition = definition("zorgtoeslag/{bsn}");
+        definition.output = RECEIPT.to_string();
+
+        let err = definition
+            .validate("toeslagen", &surface_met_uitkomst(&laws, RECEIPT))
+            .expect_err("een uitkomst die een vast veld overschrijft hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::ReservedDecretogramField { .. }),
+            "verwachtte ReservedDecretogramField, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn een_zaakkenmerk_dat_naar_een_onbekende_parameter_verwijst_wordt_geweigerd() {
+        let err = definition("zorgtoeslag/{burgerservicenummer}")
+            .validate_zaakkenmerk("toeslagen")
+            .expect_err("een verwijzing zonder gedocumenteerde parameter hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownReference { .. }),
+            "verwachtte UnknownReference, kreeg {err}"
+        );
+    }
+}

--- a/packages/simulator/src/cell/besluit.rs
+++ b/packages/simulator/src/cell/besluit.rs
@@ -421,23 +421,28 @@ impl BesluitDefinition {
     ///
     /// Aanroepen ná [`Self::check_params`]: elke verwijzing is bij het optuigen
     /// aan een gedocumenteerde parameter gebonden, en die is dan aanwezig.
-    pub(crate) fn zaakkenmerk(&self, params: &BTreeMap<String, Value>) -> String {
+    ///
+    /// Weigert een waarde waarin een scheidingsteken van het sjabloon zelf
+    /// voorkomt. Zie [`Template::check_separators_absent`]: zonder die weigering
+    /// zouden twee verschillende zaken hetzelfde kenmerk kunnen krijgen, en dan
+    /// levert een reductie op dat kenmerk het besluit van een ander.
+    pub(crate) fn zaakkenmerk(
+        &self,
+        cell: &str,
+        params: &BTreeMap<String, Value>,
+    ) -> Result<String> {
+        let template = Template::parse(&self.zaakkenmerk);
+        template.check_separators_absent(cell, &self.name, &self.zaakkenmerk, params)?;
+
         let mut out = String::with_capacity(self.zaakkenmerk.len());
-        let mut rest = self.zaakkenmerk.as_str();
-        while let Some((before, after)) = rest.split_once('{') {
-            out.push_str(before);
-            let Some((reference, remainder)) = after.split_once('}') else {
-                out.push('{');
-                out.push_str(after);
-                return out;
-            };
-            if let Some(value) = params.get(reference) {
+        out.push_str(template.leading);
+        for part in &template.parts {
+            if let Some(value) = params.get(part.reference) {
                 out.push_str(&value.to_string());
             }
-            rest = remainder;
+            out.push_str(part.literal);
         }
-        out.push_str(rest);
-        out
+        Ok(out)
     }
 
     /// Controleer de definitie tegen de cel waarin ze staat.
@@ -541,39 +546,177 @@ impl BesluitDefinition {
     }
 
     /// Het zaakkenmerk-sjabloon: sluitende accolades, minstens één verwijzing,
-    /// en elke verwijzing een gedocumenteerde parameter.
+    /// elke verwijzing een gedocumenteerde parameter, en tussen twee
+    /// verwijzingen iets dat ze uit elkaar houdt.
     fn validate_zaakkenmerk(&self, cell: &str) -> Result<()> {
-        let mut rest = self.zaakkenmerk.as_str();
-        let mut references = 0usize;
-        while let Some((_, after)) = rest.split_once('{') {
-            let Some((reference, remainder)) = after.split_once('}') else {
-                return Err(SimulatorError::MalformedZaakkenmerk {
-                    cell: cell.to_string(),
-                    besluit: self.name.clone(),
-                    template: self.zaakkenmerk.clone(),
-                });
-            };
-            if !documents(&self.params, reference) {
+        if !closing_braces_match(&self.zaakkenmerk) {
+            return Err(SimulatorError::MalformedZaakkenmerk {
+                cell: cell.to_string(),
+                besluit: self.name.clone(),
+                template: self.zaakkenmerk.clone(),
+            });
+        }
+
+        let template = Template::parse(&self.zaakkenmerk);
+        for part in &template.parts {
+            if !documents(&self.params, part.reference) {
                 return Err(SimulatorError::UnknownReference {
                     cell: cell.to_string(),
                     subject: Subject::Besluit,
                     name: self.name.clone(),
-                    reference: reference.to_string(),
+                    reference: part.reference.to_string(),
                 });
             }
-            references += 1;
-            rest = remainder;
         }
 
-        if references == 0 {
+        if template.parts.is_empty() {
             return Err(SimulatorError::ZaakkenmerkWithoutReference {
                 cell: cell.to_string(),
                 besluit: self.name.clone(),
                 template: self.zaakkenmerk.clone(),
             });
         }
+
+        // Twee verwijzingen die aan elkaar plakken zijn nooit uit elkaar te
+        // houden: `{jaar}{bsn}` met 2024 + 999993653 levert hetzelfde kenmerk
+        // als 20249 + 99993653. Geen waarde kan dat repareren, dus dit is een
+        // optuigfout en geen weigering bij het besluit.
+        for pair in template.parts.windows(2) {
+            if pair[0].literal.is_empty() {
+                return Err(SimulatorError::AdjacentZaakkenmerkReferences {
+                    cell: cell.to_string(),
+                    besluit: self.name.clone(),
+                    template: self.zaakkenmerk.clone(),
+                    first: pair[0].reference.to_string(),
+                    second: pair[1].reference.to_string(),
+                });
+            }
+        }
+
         Ok(())
     }
+}
+
+/// Eén verwijzing uit een zaakkenmerk-sjabloon, met de letterlijke tekst erachter.
+struct TemplatePart<'a> {
+    /// De parameternaam tussen de accolades.
+    reference: &'a str,
+    /// Wat er letterlijk achter deze verwijzing staat, tot de volgende
+    /// verwijzing of tot het eind.
+    literal: &'a str,
+}
+
+/// Een zaakkenmerk-sjabloon, uit elkaar gehaald.
+///
+/// Eén parser voor het optuigen én het invullen: zouden die uit elkaar lopen,
+/// dan zou een sjabloon dat bij het optuigen goedgekeurd is bij het besluit
+/// iets anders opleveren dan de toets veronderstelde.
+struct Template<'a> {
+    /// De letterlijke tekst vóór de eerste verwijzing.
+    leading: &'a str,
+    /// De verwijzingen, in volgorde.
+    parts: Vec<TemplatePart<'a>>,
+}
+
+impl<'a> Template<'a> {
+    /// Haal een sjabloon uit elkaar.
+    ///
+    /// Een accolade die niet sluit levert geen verwijzing op; dat geval wordt bij
+    /// het optuigen apart geweigerd ([`closing_braces_match`]), zodat het hier
+    /// niet stil als letterlijke tekst hoeft te eindigen.
+    fn parse(template: &'a str) -> Self {
+        let (leading, mut rest) = match template.split_once('{') {
+            Some((leading, rest)) => (leading, rest),
+            None => {
+                return Self {
+                    leading: template,
+                    parts: Vec::new(),
+                }
+            }
+        };
+
+        let mut parts = Vec::new();
+        while let Some((reference, after)) = rest.split_once('}') {
+            // Geen volgende `{` betekent dat de rest letterlijke tekst is; `rest`
+            // wordt dan leeg en de lus stopt vanzelf op de volgende ronde.
+            let (literal, remainder) = after.split_once('{').unwrap_or((after, ""));
+            parts.push(TemplatePart { reference, literal });
+            rest = remainder;
+        }
+        Self { leading, parts }
+    }
+
+    /// De letterlijke stukken die twee verwijzingen uit elkaar houden.
+    ///
+    /// De tekst vóór de eerste en die ná de laatste verwijzing tellen niet mee:
+    /// die staan vast en kunnen geen twee invullingen laten samenvallen.
+    fn separators(&self) -> impl Iterator<Item = &'a str> + '_ {
+        let last = self.parts.len().saturating_sub(1);
+        self.parts[..last].iter().map(|part| part.literal)
+    }
+
+    /// Weiger een parameterwaarde waarin een scheidingsteken van dit sjabloon
+    /// voorkomt.
+    ///
+    /// Het zaakkenmerk is waaronder een zaak terug te vinden is, dus twee zaken
+    /// mogen er nooit één worden. Bij `{jaar}/{bsn}` zou `jaar = "2024/9"` met
+    /// `bsn = "99993653"` hetzelfde kenmerk geven als `jaar = "2024"` met
+    /// `bsn = "999993653"`, en dan levert een reductie op dat kenmerk het besluit
+    /// over iemand anders. Zolang geen waarde een scheidingsteken bevat, is de
+    /// invulling omkeerbaar en kan dat niet gebeuren.
+    ///
+    /// Een sjabloon met één verwijzing heeft geen scheidingstekens en weigert dus
+    /// niets: daar is elke waarde ondubbelzinnig.
+    fn check_separators_absent(
+        &self,
+        cell: &str,
+        besluit: &str,
+        template: &str,
+        params: &BTreeMap<String, Value>,
+    ) -> Result<()> {
+        let separators: Vec<&str> = self
+            .separators()
+            .filter(|separator| !separator.is_empty())
+            .collect();
+        if separators.is_empty() {
+            return Ok(());
+        }
+
+        for part in &self.parts {
+            let Some(value) = params.get(part.reference) else {
+                continue;
+            };
+            let text = value.to_string();
+            for separator in &separators {
+                if text.contains(separator) {
+                    return Err(SimulatorError::ZaakkenmerkSeparatorInValue {
+                        cell: cell.to_string(),
+                        besluit: besluit.to_string(),
+                        template: template.to_string(),
+                        parameter: part.reference.to_string(),
+                        separator: (*separator).to_string(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Sluit elke `{` in dit sjabloon weer?
+///
+/// Apart van [`Template::parse`], omdat de parser een niet-sluitende accolade
+/// overslaat: die twee moeten het eens zijn over wat een verwijzing is, en de
+/// weigering hoort bij het optuigen te vallen.
+fn closing_braces_match(template: &str) -> bool {
+    let mut rest = template;
+    while let Some((_, after)) = rest.split_once('{') {
+        let Some((_, remainder)) = after.split_once('}') else {
+            return false;
+        };
+        rest = remainder;
+    }
+    true
 }
 
 /// De veldnamen die de stroom met decretogrammen van deze cel gaat dragen.
@@ -667,18 +810,83 @@ zaakkenmerk: '{zaakkenmerk}'
 params:
   - name: bsn
     type: string
+  - name: jaar
+    type: string
 "
         ))
         .unwrap_or_else(|e| panic!("testdefinitie moet parsen: {e}"))
     }
 
+    /// Vul een sjabloon in, of leg luid uit waarom dat niet mocht.
+    fn zaakkenmerk(template: &str, params: &[(&str, &str)]) -> Result<String> {
+        let params: BTreeMap<String, Value> = params
+            .iter()
+            .map(|(name, value)| ((*name).to_string(), Value::String((*value).to_string())))
+            .collect();
+        definition(template).zaakkenmerk("toeslagen", &params)
+    }
+
     #[test]
     fn het_zaakkenmerk_vult_de_parameters_in() {
-        let params = BTreeMap::from([("bsn".to_string(), Value::String("999993653".to_string()))]);
         assert_eq!(
-            definition("zorgtoeslag/{bsn}").zaakkenmerk(&params),
+            zaakkenmerk("zorgtoeslag/{bsn}", &[("bsn", "999993653")])
+                .unwrap_or_else(|e| panic!("het sjabloon moet in te vullen zijn: {e}")),
             "zorgtoeslag/999993653"
         );
+    }
+
+    /// Eén verwijzing kent geen scheidingsteken, dus elke waarde is eenduidig.
+    ///
+    /// Wat er vóór en achter staat ligt vast, dus `zorgtoeslag/` gevolgd door een
+    /// waarde met een `/` erin blijft terug te lezen. Weigeren zou hier een regel
+    /// opleggen die niets beschermt.
+    #[test]
+    fn een_enkele_verwijzing_neemt_elke_waarde_zoals_ze_is() {
+        assert_eq!(
+            zaakkenmerk("zorgtoeslag/{bsn}", &[("bsn", "9999/93653")])
+                .unwrap_or_else(|e| panic!("één verwijzing hoort niets te weigeren: {e}")),
+            "zorgtoeslag/9999/93653"
+        );
+    }
+
+    /// Twee zaken mogen nooit één kenmerk krijgen.
+    ///
+    /// `{jaar}/{bsn}` met `2024/9` + `99993653` levert letterlijk hetzelfde
+    /// kenmerk als `2024` + `999993653`. Dan wijst het kenmerk naar twee zaken en
+    /// levert een reductie erop het besluit over iemand anders.
+    #[test]
+    fn een_waarde_met_het_scheidingsteken_erin_wordt_geweigerd() {
+        let eerlijk = zaakkenmerk("{jaar}/{bsn}", &[("jaar", "2024"), ("bsn", "999993653")])
+            .unwrap_or_else(|e| panic!("een gewone invulling moet slagen: {e}"));
+
+        let err = zaakkenmerk("{jaar}/{bsn}", &[("jaar", "2024/9"), ("bsn", "99993653")])
+            .expect_err("een waarde die het scheidingsteken bevat hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::ZaakkenmerkSeparatorInValue { .. }),
+            "verwachtte ZaakkenmerkSeparatorInValue, kreeg {err}"
+        );
+        assert_eq!(
+            eerlijk, "2024/999993653",
+            "de botsing die geweigerd wordt, is precies dit kenmerk"
+        );
+    }
+
+    #[test]
+    fn twee_verwijzingen_zonder_scheiding_worden_bij_het_optuigen_geweigerd() {
+        let err = definition("{jaar}{bsn}")
+            .validate_zaakkenmerk("toeslagen")
+            .expect_err("twee verwijzingen tegen elkaar aan hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::AdjacentZaakkenmerkReferences { .. }),
+            "verwachtte AdjacentZaakkenmerkReferences, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn twee_verwijzingen_met_scheiding_mogen_wel() {
+        definition("{jaar}/{bsn}")
+            .validate_zaakkenmerk("toeslagen")
+            .unwrap_or_else(|e| panic!("een gescheiden sjabloon hoort te mogen: {e}"));
     }
 
     #[test]

--- a/packages/simulator/src/cell/chronicle.rs
+++ b/packages/simulator/src/cell/chronicle.rs
@@ -146,6 +146,35 @@ impl ChronicleStore {
             .collect()
     }
 
+    /// Het sleutelveld dat elke stroom declareert, op stroomnaam.
+    pub(crate) fn declared_keys(&self) -> BTreeMap<String, String> {
+        self.streams
+            .iter()
+            .map(|stream| (stream.stream.clone(), stream.key.clone()))
+            .collect()
+    }
+
+    /// Het sleutelveld van één stroom; `None` als de cel haar niet houdt.
+    pub(crate) fn key_of(&self, stream: &str) -> Option<&str> {
+        self.streams
+            .iter()
+            .find(|candidate| candidate.stream == stream)
+            .map(|candidate| candidate.key.as_str())
+    }
+
+    /// Het aantal vastleggingen in een stroom; `None` als de cel haar niet houdt.
+    ///
+    /// Alleen voor tests: dat een besluit precies één gram vastlegt (RFC-022
+    /// §1.2 — elk chronolexogram is elementair) is niet van buiten de cel te
+    /// zien, en het hoort ook niet van buiten de cel te zien te zijn.
+    #[cfg(test)]
+    pub(crate) fn len_of(&self, stream: &str) -> Option<usize> {
+        self.streams
+            .iter()
+            .find(|candidate| candidate.stream == stream)
+            .map(|candidate| candidate.events.len())
+    }
+
     /// De laatste vastlegging op of vóór `op_moment` met deze sleutelwaarde.
     ///
     /// Dit is de reductie van een cel zonder engine: geen toestandsmerge over

--- a/packages/simulator/src/cell/chronicle.rs
+++ b/packages/simulator/src/cell/chronicle.rs
@@ -162,6 +162,19 @@ impl ChronicleStore {
             .map(|candidate| candidate.key.as_str())
     }
 
+    /// De laatst vastgelegde gebeurtenis van een stroom; `None` als er geen is.
+    ///
+    /// Alleen voor tests: wat een reductie op één dag oplevert hangt af van de
+    /// volgorde van vastleggen, en dat is van buiten de cel niet te zien.
+    #[cfg(test)]
+    pub(crate) fn last_recording(&self, stream: &str) -> Option<&ChronicleEvent> {
+        self.streams
+            .iter()
+            .find(|candidate| candidate.stream == stream)?
+            .events
+            .last()
+    }
+
     /// Het aantal vastleggingen in een stroom; `None` als de cel haar niet houdt.
     ///
     /// Alleen voor tests: dat een besluit precies één gram vastlegt (RFC-022
@@ -198,7 +211,11 @@ impl ChronicleStore {
     ) -> Option<&ChronicleEvent> {
         // `max_by_key` levert bij gelijke sleutel het laatste element, dus twee
         // vastleggingen op één dag volgen dezelfde regel als in `reduce_to`: de
-        // volgorde in de configuratie beslist.
+        // volgorde in de stroom beslist, en de laatste wint. Voor een stroom uit
+        // de configuratie is dat de volgorde in het bestand; voor een stroom
+        // waarin de cel zelf vastlegt (zie [`Self::record`]) de volgorde waarin
+        // dat gebeurde. Twee besluiten op één dag over dezelfde zaak leveren dus
+        // het laatstgenomen besluit — de dag is hier de fijnste korrel.
         self.streams
             .iter()
             .find(|candidate| candidate.stream == stream)?

--- a/packages/simulator/src/cell/config.rs
+++ b/packages/simulator/src/cell/config.rs
@@ -1,13 +1,21 @@
-//! De celconfiguratie: welke wetten een cel laadt, welke feiten ze houdt en
-//! welke lexostatussen ze publiceert.
+//! De celconfiguratie: welke wetten een cel laadt, welke feiten ze houdt, welke
+//! lexostatussen ze publiceert en welke besluiten ze kan nemen.
 //!
-//! Lexostatus-definities zijn **data**, geen Rust. Ze staan in de configuratie
-//! van de cel, worden gelezen door de loader en zijn verder onveranderlijk. Een
-//! consument kan dus geen eigen reductie injecteren; hij kan alleen een
-//! gepubliceerde naam opvragen met gedocumenteerde parameters (RFC-022 §4.1).
+//! Lexostatus- en besluit-definities zijn **data**, geen Rust. Ze staan in de
+//! configuratie van de cel, worden gelezen door de loader en zijn verder
+//! onveranderlijk. Een consument kan dus geen eigen reductie injecteren; hij kan
+//! alleen een gepubliceerde naam opvragen met gedocumenteerde parameters
+//! (RFC-022 §4.1).
+//!
+//! Wat de twee soorten definitie delen, staat hier ook: de gedocumenteerde
+//! parameter, de controle van een vraag daartegen, en de toetsen die een
+//! definitie aan de cel houden waarin ze staat ([`CellSurface`]). Ze beloven
+//! allebei hetzelfde soort ding, dus ze horen op dezelfde manier afgekeurd te
+//! worden.
 
+use crate::cell::besluit::BesluitDefinition;
 use crate::cell::chronicle::ChronicleStream;
-use crate::error::{Result, SimulatorError};
+use crate::error::{Result, SimulatorError, Subject};
 use regelrecht_engine::Value;
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet};
@@ -26,6 +34,14 @@ pub struct CellConfig {
     /// De lexostatussen die de cel naar buiten publiceert.
     #[serde(default)]
     pub lexostatus_definitions: Vec<LexostatusDefinition>,
+    /// De besluiten die de cel kan nemen.
+    ///
+    /// Niet gepubliceerd: een besluit wordt niet door een consument opgevraagd
+    /// maar door de cel zelf uitgevoerd (zie [`crate::World::decide`]). Wat er
+    /// naar buiten van te zien is, is het decretogram dat eruit komt — en dat
+    /// via een reductie over de eigen kroniek.
+    #[serde(default)]
+    pub besluit_definitions: Vec<BesluitDefinition>,
 }
 
 /// Eén gepubliceerde lexostatus met haar gedocumenteerde parameters en reductie.
@@ -39,7 +55,7 @@ pub struct LexostatusDefinition {
     pub doc: Option<String>,
     /// De gedocumenteerde parameters. Een vraag die hiervan afwijkt, faalt.
     #[serde(default)]
-    pub inputs: Vec<LexostatusInput>,
+    pub inputs: Vec<DocumentedParameter>,
     /// De gedocumenteerde uitkomsten: wat de cel onder deze naam publiceert.
     ///
     /// Wat hier niet staat, komt niet in het antwoord, ook al berekende de
@@ -56,11 +72,16 @@ pub struct LexostatusDefinition {
     pub reduction: Reduction,
 }
 
-/// Eén gedocumenteerde parameter van een lexostatus.
+/// Eén gedocumenteerde parameter van een lexostatus of van een besluit.
+///
+/// Dezelfde vorm voor beide, want het is dezelfde belofte: dit zijn de namen en
+/// typen die de aanroeper mag — en moet — meegeven, en alles daarbuiten wordt
+/// geweigerd.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct LexostatusInput {
-    /// Parameternaam, waarnaar de reductie met `$naam` verwijst.
+pub struct DocumentedParameter {
+    /// Parameternaam, waarnaar een reductie met `$naam` en een zaakkenmerk met
+    /// `{naam}` verwijst.
     pub name: String,
     /// Het verwachte type van de meegegeven waarde.
     #[serde(rename = "type")]
@@ -254,8 +275,13 @@ pub(crate) struct CellSurface<'a> {
     pub(crate) laws: &'a [String],
     /// Per regeling de uitkomstnamen, over alle geladen versies heen.
     pub(crate) outputs: BTreeMap<String, BTreeSet<String>>,
+    /// Per regeling de namen die ze als parameter of input declareert, over alle
+    /// geladen versies heen. Dit is wat een besluit aan de engine mag aanleveren.
+    pub(crate) regulation_inputs: BTreeMap<String, BTreeSet<String>>,
     /// Per kroniekstroom de veldnamen die de cel van die stroom kent.
     pub(crate) streams: BTreeMap<String, BTreeSet<String>>,
+    /// Per kroniekstroom het sleutelveld waarop ze groepeert.
+    pub(crate) stream_keys: BTreeMap<String, String>,
 }
 
 impl CellSurface<'_> {
@@ -263,6 +289,184 @@ impl CellSurface<'_> {
     fn outputs_of(&self, regulation: &str) -> BTreeSet<String> {
         self.outputs.get(regulation).cloned().unwrap_or_default()
     }
+
+    /// Laadt de cel deze regeling zelf?
+    ///
+    /// Eén plek voor de weigering, want de reden is voor een reductie en voor
+    /// een besluit dezelfde: een cel rekent op haar eigen recht.
+    pub(crate) fn check_own_regulation(
+        &self,
+        cell: &str,
+        subject: Subject,
+        name: &str,
+        regulation: &str,
+    ) -> Result<()> {
+        if self.laws.iter().any(|law| law == regulation) {
+            return Ok(());
+        }
+        Err(SimulatorError::ForeignRegulation {
+            cell: cell.to_string(),
+            subject,
+            name: name.to_string(),
+            regulation: regulation.to_string(),
+        })
+    }
+
+    /// Kent deze regeling elk van deze uitkomsten?
+    ///
+    /// `self.outputs` bevat de uitkomstnamen van álle geladen versies. Een
+    /// definitie afkeuren om een naam die alleen in de nieuwste versie ontbreekt,
+    /// zou een vraag of een besluit over een ouder moment onterecht blokkeren.
+    pub(crate) fn check_regulation_outputs<'a>(
+        &self,
+        cell: &str,
+        subject: Subject,
+        name: &str,
+        regulation: &str,
+        outputs: impl IntoIterator<Item = &'a str>,
+    ) -> Result<()> {
+        let known = self.outputs_of(regulation);
+        for output in outputs {
+            if !known.contains(output) {
+                return Err(SimulatorError::UnknownOutput {
+                    cell: cell.to_string(),
+                    subject,
+                    name: name.to_string(),
+                    origin: format!("regeling '{regulation}'"),
+                    output: output.to_string(),
+                    known: listing(&known),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// De velden die de cel van deze stroom kent, of de fout die zegt dat ze de
+    /// stroom niet houdt.
+    pub(crate) fn fields_of_stream(
+        &self,
+        cell: &str,
+        subject: Subject,
+        name: &str,
+        stream: &str,
+    ) -> Result<&BTreeSet<String>> {
+        self.streams
+            .get(stream)
+            .ok_or_else(|| SimulatorError::UnknownStream {
+                cell: cell.to_string(),
+                subject,
+                name: name.to_string(),
+                stream: stream.to_string(),
+                known: listing(self.streams.keys()),
+            })
+    }
+
+    /// Het sleutelveld van een stroom; `None` als de cel haar niet houdt.
+    pub(crate) fn stream_key(&self, stream: &str) -> Option<&str> {
+        self.stream_keys.get(stream).map(String::as_str)
+    }
+
+    /// Kent deze stroom dit veld?
+    pub(crate) fn check_stream_field(
+        &self,
+        cell: &str,
+        subject: Subject,
+        name: &str,
+        stream: &str,
+        field: &str,
+    ) -> Result<()> {
+        let fields = self.fields_of_stream(cell, subject, name, stream)?;
+        if contains_name(fields, field) {
+            return Ok(());
+        }
+        Err(SimulatorError::UnknownFilterField {
+            cell: cell.to_string(),
+            subject,
+            name: name.to_string(),
+            stream: stream.to_string(),
+            field: field.to_string(),
+            known: listing(fields),
+        })
+    }
+}
+
+/// De uitkomsten die een definitie publiceert: de uitkomst die de uitvoering
+/// aanstuurt, plus wat `outputs` erbij noemt.
+///
+/// Eén plek voor de regel, want ze geldt voor een lexostatus en voor een
+/// besluit: de aansturende uitkomst hoort er altijd bij — ze *is* het antwoord
+/// of het besluit — dus `outputs` breidt uit en perkt niet in.
+pub(crate) fn published_outputs<'a>(
+    driving: Option<&'a str>,
+    extra: &'a [String],
+) -> BTreeSet<&'a str> {
+    driving
+        .into_iter()
+        .chain(extra.iter().map(String::as_str))
+        .collect()
+}
+
+/// Controleer de meegegeven parameters tegen de gedocumenteerde.
+///
+/// Weigert een ontbrekende parameter, een niet-gedocumenteerde parameter en een
+/// parameter van het verkeerde type. Dat is wat "gedocumenteerde parameters"
+/// waard maakt: de cel accepteert precies wat ze publiceert. Eén plek, want een
+/// besluit is even strikt als een reductie.
+pub(crate) fn check_documented_params(
+    cell: &str,
+    subject: Subject,
+    name: &str,
+    documented: &[DocumentedParameter],
+    params: &BTreeMap<String, Value>,
+) -> Result<()> {
+    for supplied in params.keys() {
+        if !documented.iter().any(|input| &input.name == supplied) {
+            return Err(SimulatorError::UndocumentedParameter {
+                cell: cell.to_string(),
+                subject,
+                name: name.to_string(),
+                parameter: supplied.clone(),
+                documented: parameter_listing(documented),
+            });
+        }
+    }
+
+    for input in documented {
+        let Some(value) = params.get(&input.name) else {
+            return Err(SimulatorError::MissingParameter {
+                cell: cell.to_string(),
+                subject,
+                name: name.to_string(),
+                parameter: input.name.clone(),
+            });
+        };
+        if !input.value_type.accepts(value) {
+            return Err(SimulatorError::ParameterType {
+                cell: cell.to_string(),
+                subject,
+                name: name.to_string(),
+                parameter: input.name.clone(),
+                expected: input.value_type.label(),
+                actual: value.type_name(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Komma-gescheiden lijst van gedocumenteerde parameters, voor foutmeldingen.
+pub(crate) fn parameter_listing(documented: &[DocumentedParameter]) -> String {
+    documented
+        .iter()
+        .map(|input| input.name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Documenteert deze lijst een parameter met deze naam?
+pub(crate) fn documents(documented: &[DocumentedParameter], name: &str) -> bool {
+    documented.iter().any(|input| input.name == name)
 }
 
 /// Komma-gescheiden opsomming voor een foutmelding.
@@ -294,10 +498,7 @@ impl LexostatusDefinition {
             Reduction::Law { output, .. } => Some(output.as_str()),
             Reduction::Chronicle { .. } => None,
         };
-        driving
-            .into_iter()
-            .chain(self.outputs.iter().map(String::as_str))
-            .collect()
+        published_outputs(driving, &self.outputs)
     }
 
     /// Laat van het antwoord van de engine alleen de gepubliceerde uitkomsten
@@ -347,26 +548,14 @@ impl LexostatusDefinition {
         regulation: &str,
         parameters: &BTreeMap<String, String>,
     ) -> Result<()> {
-        if !surface.laws.iter().any(|law| law == regulation) {
-            return Err(SimulatorError::ForeignRegulation {
-                cell: cell.to_string(),
-                lexostatus: self.name.clone(),
-                regulation: regulation.to_string(),
-            });
-        }
-
-        let known = surface.outputs_of(regulation);
-        for published in self.published_outputs() {
-            if !known.contains(published) {
-                return Err(SimulatorError::UnknownOutput {
-                    cell: cell.to_string(),
-                    lexostatus: self.name.clone(),
-                    origin: format!("regeling '{regulation}'"),
-                    output: published.to_string(),
-                    known: listing(&known),
-                });
-            }
-        }
+        surface.check_own_regulation(cell, Subject::Lexostatus, &self.name, regulation)?;
+        surface.check_regulation_outputs(
+            cell,
+            Subject::Lexostatus,
+            &self.name,
+            regulation,
+            self.published_outputs(),
+        )?;
 
         for reference in parameters
             .values()
@@ -375,7 +564,8 @@ impl LexostatusDefinition {
             if !self.documents(reference) {
                 return Err(SimulatorError::UnknownReference {
                     cell: cell.to_string(),
-                    lexostatus: self.name.clone(),
+                    subject: Subject::Lexostatus,
+                    name: self.name.clone(),
                     reference: reference.to_string(),
                 });
             }
@@ -394,14 +584,7 @@ impl LexostatusDefinition {
         key: &str,
         conditions: &BTreeMap<String, Value>,
     ) -> Result<()> {
-        let Some(fields) = surface.streams.get(chronicle) else {
-            return Err(SimulatorError::UnknownStream {
-                cell: cell.to_string(),
-                lexostatus: self.name.clone(),
-                stream: chronicle.to_string(),
-                known: listing(surface.streams.keys()),
-            });
-        };
+        let fields = surface.fields_of_stream(cell, Subject::Lexostatus, &self.name, chronicle)?;
 
         if self.outputs.is_empty() {
             return Err(SimulatorError::ChronicleWithoutOutputs {
@@ -415,7 +598,8 @@ impl LexostatusDefinition {
             if !contains_name(fields, published) {
                 return Err(SimulatorError::UnknownOutput {
                     cell: cell.to_string(),
-                    lexostatus: self.name.clone(),
+                    subject: Subject::Lexostatus,
+                    name: self.name.clone(),
                     origin: format!("kroniekstroom '{chronicle}'"),
                     output: published.to_string(),
                     known: listing(fields),
@@ -424,15 +608,7 @@ impl LexostatusDefinition {
         }
 
         for field in std::iter::once(key).chain(conditions.keys().map(String::as_str)) {
-            if !contains_name(fields, field) {
-                return Err(SimulatorError::UnknownFilterField {
-                    cell: cell.to_string(),
-                    lexostatus: self.name.clone(),
-                    stream: chronicle.to_string(),
-                    field: field.to_string(),
-                    known: listing(fields),
-                });
-            }
+            surface.check_stream_field(cell, Subject::Lexostatus, &self.name, chronicle, field)?;
         }
 
         // `where` vergelijkt met letterlijke waarden. Wie de `$naam`-vorm van de
@@ -464,57 +640,20 @@ impl LexostatusDefinition {
 
     /// Documenteert deze lexostatus een parameter met deze naam?
     fn documents(&self, name: &str) -> bool {
-        self.inputs.iter().any(|input| input.name == name)
+        documents(&self.inputs, name)
     }
 
     /// Controleer de vraag van een consument tegen de gedocumenteerde parameters.
     ///
-    /// Weigert een ontbrekende parameter, een niet-gedocumenteerde parameter en
-    /// een parameter van het verkeerde type. Dat is wat "gedocumenteerde
-    /// parameters" waard maakt: de cel accepteert precies wat ze publiceert.
     /// Geldt voor beide reductievormen — een bron-cel zonder engine houdt haar
     /// consument even strikt aan de gepubliceerde vraag.
     pub(crate) fn check_params(&self, cell: &str, params: &BTreeMap<String, Value>) -> Result<()> {
-        for supplied in params.keys() {
-            if !self.inputs.iter().any(|input| &input.name == supplied) {
-                return Err(SimulatorError::UndocumentedParameter {
-                    cell: cell.to_string(),
-                    lexostatus: self.name.clone(),
-                    parameter: supplied.clone(),
-                    documented: self.documented_parameters(),
-                });
-            }
-        }
-
-        for input in &self.inputs {
-            let Some(value) = params.get(&input.name) else {
-                return Err(SimulatorError::MissingParameter {
-                    cell: cell.to_string(),
-                    lexostatus: self.name.clone(),
-                    parameter: input.name.clone(),
-                });
-            };
-            if !input.value_type.accepts(value) {
-                return Err(SimulatorError::ParameterType {
-                    cell: cell.to_string(),
-                    lexostatus: self.name.clone(),
-                    parameter: input.name.clone(),
-                    expected: input.value_type.label(),
-                    actual: value.type_name(),
-                });
-            }
-        }
-
-        Ok(())
+        check_documented_params(cell, Subject::Lexostatus, &self.name, &self.inputs, params)
     }
 
     /// Komma-gescheiden lijst van gedocumenteerde parameters, voor foutmeldingen.
     fn documented_parameters(&self) -> String {
-        self.inputs
-            .iter()
-            .map(|input| input.name.as_str())
-            .collect::<Vec<_>>()
-            .join(", ")
+        parameter_listing(&self.inputs)
     }
 }
 

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -598,6 +598,9 @@ impl Cell {
 
     /// Eén input uit een eigen kroniek: de laatste vastlegging op of vóór het
     /// moment van het besluit, over het onderwerp dat de parameters aanwijzen.
+    ///
+    /// Nooit uit [`BESCHIKKINGEN`]: `validate` weigert die stroom als bron bij
+    /// het optuigen, want daar liggen besluiten en geen feiten.
     fn read_own_chronicle(
         &self,
         definition: &BesluitDefinition,
@@ -1700,6 +1703,38 @@ besluit_definitions:
         assert!(
             matches!(err, SimulatorError::UnknownRegulationInput { .. }),
             "verwachtte UnknownRegulationInput, kreeg {err}"
+        );
+    }
+
+    /// Een besluit leest geen besluit.
+    ///
+    /// Zodra een cel besluit-definities heeft, is `beschikkingen` een gewone
+    /// stroom met gewone velden, en zou een tweede besluit een veld van een
+    /// eerder decretogram als "eigen feit" kunnen binnenhalen. Dat is dezelfde
+    /// schaduwboekhouding die `register_own_facts` aan de kant van de engine al
+    /// buiten de deur houdt, langs de andere weg.
+    #[test]
+    fn een_besluit_kan_geen_eerder_besluit_als_input_lezen() {
+        let err = Cell::from_config(
+            &besluitende_cel(
+                "    regulation: wet_op_de_zorgtoeslag
+    output: heeft_recht_op_zorgtoeslag
+    zaakkenmerk: 'zorgtoeslag/{bsn}'
+    params:
+      - name: bsn
+        type: string
+    inputs:
+      is_verzekerde:
+        from_chronicle: beschikkingen
+        field: heeft_recht_op_zorgtoeslag",
+            ),
+            &regulation_root(),
+            &no_fixtures(),
+        )
+        .expect_err("een besluit dat uit de beschikkingen leest hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::DecretogramAsBesluitInput { .. }),
+            "verwachtte DecretogramAsBesluitInput, kreeg {err}"
         );
     }
 

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -264,7 +264,19 @@ impl Cell {
     ///
     /// Vastleggen voegt toe. Een bestaand gram wordt nooit gewijzigd, dus een
     /// reductie over een eerder moment blijft na dit vastleggen exact hetzelfde.
+    ///
+    /// De stroom [`BESCHIKKINGEN`] kan hier niet in: daar ontstaat een gram door
+    /// te *besluiten*. Zie [`Self::check_not_a_decretogram`].
     pub(crate) fn record(&mut self, stream: &str, event: ChronicleEvent) -> Result<()> {
+        self.check_not_a_decretogram(stream, &event)?;
+        self.record_own(stream, event)
+    }
+
+    /// Vastleggen zonder de poort op [`BESCHIKKINGEN`].
+    ///
+    /// Privé, en alleen voor [`Self::decide`]: dat is het enige pad dat een
+    /// decretogram mág maken.
+    fn record_own(&mut self, stream: &str, event: ChronicleEvent) -> Result<()> {
         self.chronicles.record(&self.id, stream, event)
     }
 
@@ -275,7 +287,29 @@ impl Cell {
     /// [`Self::record`] doet, zonder iets vast te leggen. Geeft niets prijs over
     /// de inhoud van de kroniek.
     pub(crate) fn check_recording(&self, stream: &str, event: &ChronicleEvent) -> Result<()> {
+        self.check_not_a_decretogram(stream, event)?;
         self.chronicles.check_recording(&self.id, stream, event)
+    }
+
+    /// Weiger een vastlegging van buiten het besluit-pad in de stroom met
+    /// decretogrammen.
+    ///
+    /// Dat de configuratie die stroom niet zelf mag declareren, is niet genoeg:
+    /// zodra een cel besluit-definities heeft, bestaat de stroom en zou een
+    /// `fixture` er een gram in kunnen zetten dat nooit langs een engine kwam —
+    /// zonder receipt, zonder herkomst, en met een `intake` naar keuze. Een
+    /// reductie erover zou dat niet van een besluit kunnen onderscheiden, en
+    /// precies dat onderscheid is wat deze stroom waard maakt.
+    fn check_not_a_decretogram(&self, stream: &str, event: &ChronicleEvent) -> Result<()> {
+        if stream != BESCHIKKINGEN {
+            return Ok(());
+        }
+        Err(SimulatorError::ReservedStreamRecording {
+            cell: self.id.clone(),
+            stream: stream.to_string(),
+            name: event.name.clone(),
+            op_moment: event.op_moment.to_string(),
+        })
     }
 
     /// Reduceer over de eigen feiten en lever de gevraagde lexostatus.
@@ -505,12 +539,16 @@ impl Cell {
             .clone();
 
         definition.check_params(&self.id, params)?;
+        // Vóór het ophalen en het rekenen: een zaak waarvan het kenmerk niet
+        // eenduidig is, hoort er helemaal niet te komen — en dan hoeft de engine
+        // er ook niet voor te draaien.
+        let zaakkenmerk = definition.zaakkenmerk(&self.id, params)?;
 
         let inputs = self.collect_inputs(&definition, params, op_moment)?;
-        let decretogram = self.execute(&definition, params, inputs, op_moment)?;
+        let decretogram = self.execute(&definition, zaakkenmerk, inputs, op_moment)?;
 
         let event = decretogram.event()?;
-        self.record(BESCHIKKINGEN, event)?;
+        self.record_own(BESCHIKKINGEN, event)?;
 
         Ok(decretogram)
     }
@@ -627,7 +665,7 @@ impl Cell {
     fn execute(
         &self,
         definition: &BesluitDefinition,
-        params: &BTreeMap<String, Value>,
+        zaakkenmerk: String,
         inputs: BTreeMap<String, DecretogramInput>,
         op_moment: NaiveDate,
     ) -> Result<Decretogram> {
@@ -681,7 +719,7 @@ impl Cell {
         Ok(Decretogram {
             cell: self.id.clone(),
             besluit: definition.name.clone(),
-            zaakkenmerk: definition.zaakkenmerk(params),
+            zaakkenmerk,
             op_moment,
             regulation: definition.regulation.clone(),
             regulation_valid_from: result.regulation_valid_from.clone(),
@@ -1585,6 +1623,47 @@ besluit_definitions:
             cell.chronicles.len_of(BESCHIKKINGEN),
             Some(0),
             "een besluit dat niet doorging, hoort geen gram achter te laten"
+        );
+    }
+
+    /// Twee besluiten op één dag over dezelfde zaak: beide grammen blijven, en
+    /// het laatstgenomen besluit is wat een reductie oplevert.
+    ///
+    /// De dag is de fijnste korrel van deze tijdas, dus op de tijdas zelf zijn ze
+    /// niet uit elkaar te houden; de volgorde van vastleggen beslist dan. Dat een
+    /// kroniek groeit en niets vervangt, blijft daarbij overeind: het eerste gram
+    /// staat er nog.
+    #[test]
+    fn twee_besluiten_op_een_dag_leveren_het_laatstgenomen_besluit() {
+        let mut cell = besluitende_toeslagen(VASTSTELLING);
+        for _ in 0..2 {
+            cell.decide("zorgtoeslag_vaststelling", &bsn(), moment())
+                .unwrap_or_else(|e| panic!("het besluit moet genomen kunnen worden: {e}"));
+        }
+
+        assert_eq!(
+            cell.chronicles.len_of(BESCHIKKINGEN),
+            Some(2),
+            "een tweede besluit vervangt het eerste niet; de kroniek groeit"
+        );
+
+        let laatste = cell
+            .chronicles
+            .latest_recording(
+                BESCHIKKINGEN,
+                besluit::ZAAKKENMERK,
+                &Value::String("zorgtoeslag/999993653".to_string()),
+                &BTreeMap::new(),
+                moment(),
+            )
+            .unwrap_or_else(|| panic!("er liggen twee grammen over deze zaak"));
+        let laatst_vastgelegd = cell
+            .chronicles
+            .last_recording(BESCHIKKINGEN)
+            .unwrap_or_else(|| panic!("de stroom heeft vastleggingen"));
+        assert!(
+            std::ptr::eq(laatste, laatst_vastgelegd),
+            "op één dag beslist de volgorde van vastleggen, en de laatste wint"
         );
     }
 

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -6,18 +6,35 @@
 //!
 //! De reductielogica woont hier, niet in de scenario-runner. De runner leest
 //! configuratie en stelt vragen; wat een reductie inhoudt, weet alleen de cel.
+//!
+//! Twee paden, en ze zijn met opzet ongelijk:
+//!
+//! - **reduceren** ([`Cell::reduce`]) is publiek en zuiver: een filter of een
+//!   berekening over de eigen kronieken met de eigen wetten, zonder enige weg
+//!   naar een andere cel;
+//! - **besluiten** (`Cell::decide`) is intern: de cel voert een eigen regeling
+//!   uit en legt de uitkomst vast als decretogram. Dit is het pad waar straks
+//!   een waarde van een andere cel binnenkomt, en het enige.
+//!
+//! Zie [`Decretogram`] voor wat een besluit vastlegt, en waarom dat het
+//! RFC-013 Execution Receipt is en geen eigen formaat ernaast.
 
+mod besluit;
 mod chronicle;
 mod config;
 
+pub use besluit::{
+    BesluitDefinition, BesluitInput, Decretogram, DecretogramInput, InputOrigin, BESCHIKKINGEN,
+};
 pub use chronicle::{ChronicleEvent, ChronicleStore, ChronicleStream, Intake};
-pub use config::{CellConfig, LexostatusDefinition, LexostatusInput, ParameterType, Reduction};
+pub use config::{CellConfig, DocumentedParameter, LexostatusDefinition, ParameterType, Reduction};
 
 use crate::corpus;
-use crate::error::{Result, SimulatorError};
+use crate::error::{Result, SimulatorError, Subject};
 use chrono::NaiveDate;
 use config::{engine_parameters, CellSurface};
-use regelrecht_engine::{LawExecutionService, Value};
+use regelrecht_engine::article::CompetentAuthority;
+use regelrecht_engine::{ArticleBasedLaw, LawExecutionService, Value};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
@@ -97,10 +114,26 @@ pub struct Cell {
     /// In een `RefCell`, omdat elke reductie de zichtbare feiten opnieuw op het
     /// gevraagde moment zet; naar buiten toe blijft bevragen een leesactie.
     service: Option<RefCell<LawExecutionService>>,
+    /// De **tweede** engine over dezelfde wetten: die van het besluit-pad.
+    ///
+    /// Twee instanties en niet één, omdat ze niet hetzelfde mogen. De engine van
+    /// [`Self::reduce`] krijgt nooit een `CellResolver` en kan de celgrens dus
+    /// niet over: een cross-cel-pull vanuit een reductie is daarmee een
+    /// ontbrekende capability en geen afspraak (RFC-022 §4.2, tier 3). Deze is
+    /// de enige die er ooit een mag krijgen. Vandaag heeft ook zij er geen — het
+    /// accepteren van een waarde van een andere cel volgt apart — dus het
+    /// verschil is nu een *belofte over wie wat mag*, en de plek waar die
+    /// belofte waargemaakt wordt, staat klaar.
+    ///
+    /// Alleen aanwezig als de cel besluit-definities heeft: een cel die niet
+    /// besluit, heeft aan één engine genoeg.
+    besluit_service: Option<RefCell<LawExecutionService>>,
     /// De eigen feiten. Privé, en dat is het punt.
     chronicles: ChronicleStore,
     /// De gepubliceerde lexostatussen, op naam.
     published: BTreeMap<String, LexostatusDefinition>,
+    /// De besluiten die deze cel kan nemen, op naam.
+    besluiten: BTreeMap<String, BesluitDefinition>,
 }
 
 impl Cell {
@@ -124,26 +157,50 @@ impl Cell {
         regulation_root: &Path,
         fixture_fields: &BTreeMap<String, BTreeSet<String>>,
     ) -> Result<Self> {
-        let chronicles = ChronicleStore::from_streams(&config.id, config.chronicles.clone())?;
+        let mut streams = config.chronicles.clone();
+        if let Some(reserved) = streams
+            .iter()
+            .find(|stream| stream.stream == BESCHIKKINGEN)
+            .map(|stream| stream.stream.clone())
+        {
+            return Err(SimulatorError::ReservedStream {
+                cell: config.id.clone(),
+                stream: reserved,
+            });
+        }
+        if !config.besluit_definitions.is_empty() {
+            streams.push(ChronicleStream {
+                stream: BESCHIKKINGEN.to_string(),
+                key: besluit::ZAAKKENMERK.to_string(),
+                events: Vec::new(),
+            });
+        }
+        let chronicles = ChronicleStore::from_streams(&config.id, streams)?;
 
-        let service = if config.laws.is_empty() {
+        let laws = load_laws(&config.laws, regulation_root)?;
+        // Twee engines over precies dezelfde wetten; zie `besluit_service`. Ze
+        // worden apart opgebouwd en niet gekloond, want een `LawExecutionService`
+        // draagt haar databronnen en straks haar cel-resolver met zich mee, en
+        // dat is nu juist wat de twee uit elkaar houdt.
+        let service = build_service(&laws)?;
+        let besluit_service = if config.besluit_definitions.is_empty() {
             None
         } else {
-            let mut service = LawExecutionService::new();
-            for law in &config.laws {
-                for document in corpus::regulation_versions(regulation_root, law)? {
-                    service.load_law(&document)?;
-                }
-            }
-            Some(service)
+            build_service(&laws)?
         };
 
-        let mut streams = chronicles.declared_fields();
+        let mut declared = chronicles.declared_fields();
         for (stream, fields) in fixture_fields {
-            streams
+            declared
                 .entry(stream.clone())
                 .or_default()
                 .extend(fields.iter().cloned());
+        }
+        if !config.besluit_definitions.is_empty() {
+            declared
+                .entry(BESCHIKKINGEN.to_string())
+                .or_default()
+                .extend(besluit::declared_fields(&config.besluit_definitions));
         }
 
         let surface = CellSurface {
@@ -152,7 +209,12 @@ impl Cell {
                 .as_ref()
                 .map(outputs_per_regulation)
                 .unwrap_or_default(),
-            streams,
+            regulation_inputs: service
+                .as_ref()
+                .map(inputs_per_regulation)
+                .unwrap_or_default(),
+            stream_keys: chronicles.declared_keys(),
+            streams: declared,
         };
 
         let mut published: BTreeMap<String, LexostatusDefinition> = BTreeMap::new();
@@ -169,11 +231,27 @@ impl Cell {
             }
         }
 
+        let mut besluiten: BTreeMap<String, BesluitDefinition> = BTreeMap::new();
+        for definition in &config.besluit_definitions {
+            definition.validate(&config.id, &surface)?;
+            if besluiten
+                .insert(definition.name.clone(), definition.clone())
+                .is_some()
+            {
+                return Err(SimulatorError::DuplicateBesluit {
+                    cell: config.id.clone(),
+                    name: definition.name.clone(),
+                });
+            }
+        }
+
         Ok(Self {
             id: config.id.clone(),
             service: service.map(RefCell::new),
+            besluit_service: besluit_service.map(RefCell::new),
             chronicles,
             published,
+            besluiten,
         })
     }
 
@@ -278,16 +356,14 @@ impl Cell {
         let Some(service) = &self.service else {
             return Err(SimulatorError::ForeignRegulation {
                 cell: self.id.clone(),
-                lexostatus: definition.name.clone(),
+                subject: Subject::Lexostatus,
+                name: definition.name.clone(),
                 regulation: regulation.to_string(),
             });
         };
 
         let mut service = service.borrow_mut();
-        service.clear_data_sources();
-        for stream in self.chronicles.reduce_to(op_moment) {
-            service.register_dict_source(&stream.stream, &stream.key, stream.records)?;
-        }
+        self.register_own_facts(&mut service, op_moment)?;
 
         let result = service.evaluate_law_output(
             regulation,
@@ -299,6 +375,29 @@ impl Cell {
         Ok(LexostatusOutcome::Established(
             definition.project(result.outputs),
         ))
+    }
+
+    /// Zet de eigen feiten zoals ze op dit moment waren klaar als databron.
+    ///
+    /// De stroom met decretogrammen blijft er met opzet buiten. Een besluit is
+    /// geen feit om op te rekenen maar een uitkomst om terug te lezen; zou ze
+    /// als databron meedoen, dan zou een volgende uitvoering stil op de eigen
+    /// uitkomst van een eerder besluit kunnen leunen, en dan weet niemand meer
+    /// of er gerekend of overgeschreven is. Terugzien doe je met een reductie
+    /// over die stroom (`Cell::reduce`), en die komt niet langs de engine.
+    fn register_own_facts(
+        &self,
+        service: &mut LawExecutionService,
+        op_moment: NaiveDate,
+    ) -> Result<()> {
+        service.clear_data_sources();
+        for stream in self.chronicles.reduce_to(op_moment) {
+            if stream.stream == BESCHIKKINGEN {
+                continue;
+            }
+            service.register_dict_source(&stream.stream, &stream.key, stream.records)?;
+        }
+        Ok(())
     }
 
     /// Het kroniekfilter: lees de laatste vastlegging over dit onderwerp.
@@ -324,7 +423,8 @@ impl Cell {
             .get(key)
             .ok_or_else(|| SimulatorError::MissingParameter {
                 cell: self.id.clone(),
-                lexostatus: definition.name.clone(),
+                subject: Subject::Lexostatus,
+                name: definition.name.clone(),
                 parameter: key.to_string(),
             })?;
 
@@ -361,6 +461,281 @@ impl Cell {
 
         Ok(LexostatusOutcome::Established(values))
     }
+
+    /// Neem een besluit: voer een eigen regeling uit en leg de uitkomst vast.
+    ///
+    /// Dit is het derde deel van de lus — informeren, concluderen, **vastleggen**
+    /// — en het enige pad in deze cel dat een gram *maakt* in plaats van er een
+    /// terug te lezen. Wat er gebeurt, in deze volgorde:
+    ///
+    /// 1. de gedocumenteerde parameters worden gecontroleerd, net als bij een vraag;
+    /// 2. de inputs worden verzameld: uit de eigen kronieken zoals ze op
+    ///    `op_moment` waren, en uit de parameters van het besluit;
+    /// 3. de **besluit-engine** voert de regeling uit op dat moment, dus op de
+    ///    wetsversie die toen gold;
+    /// 4. de uitkomst wordt als decretogram vastgelegd in de eigen stroom
+    ///    [`BESCHIKKINGEN`] — één gram, met alle uitkomsten samen (RFC-022 §1.2).
+    ///
+    /// `pub(crate)` en niet `pub`, net als [`Self::record`]: een consument kan een
+    /// cel niet laten besluiten. Dat doet de cel zelf, in deze opstelling
+    /// aangestuurd door [`crate::World`] op een moment dat de klok heeft bereikt.
+    ///
+    /// Een input die op dit moment niet op te halen is, is een fout en geen
+    /// "niets vastgesteld": een besluit dat een feit mist, hoort niet met een gat
+    /// verder te rekenen en al helemaal niet vast te leggen.
+    pub(crate) fn decide(
+        &mut self,
+        besluit: &str,
+        params: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Result<Decretogram> {
+        let definition = self
+            .besluiten
+            .get(besluit)
+            .ok_or_else(|| SimulatorError::UnknownBesluit {
+                cell: self.id.clone(),
+                requested: besluit.to_string(),
+                defined: self
+                    .besluiten
+                    .keys()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            })?
+            .clone();
+
+        definition.check_params(&self.id, params)?;
+
+        let inputs = self.collect_inputs(&definition, params, op_moment)?;
+        let decretogram = self.execute(&definition, params, inputs, op_moment)?;
+
+        let event = decretogram.event()?;
+        self.record(BESCHIKKINGEN, event)?;
+
+        Ok(decretogram)
+    }
+
+    /// Verzamel de inputs van een besluit, elk met de herkomst erbij.
+    ///
+    /// De herkomst is geen versiering: ze gaat mee in het decretogram, zodat
+    /// later te lezen is waarop besloten is en van wanneer dat feit was. Wat hier
+    /// opgehaald wordt, wordt nergens anders opgeslagen — een volgend besluit
+    /// haalt het opnieuw op (RFC-022: geen schaduwboekhouding).
+    fn collect_inputs(
+        &self,
+        definition: &BesluitDefinition,
+        params: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Result<BTreeMap<String, DecretogramInput>> {
+        let mut collected: BTreeMap<String, DecretogramInput> = BTreeMap::new();
+        for (input, origin) in &definition.inputs {
+            let gathered = match origin {
+                BesluitInput::Param { param } => {
+                    // Onbereikbaar: `validate` bindt elke `param` aan een
+                    // gedocumenteerde parameter, en `check_params` eist dat elke
+                    // gedocumenteerde parameter meekomt.
+                    let value = params.get(param).cloned().ok_or_else(|| {
+                        SimulatorError::MissingParameter {
+                            cell: self.id.clone(),
+                            subject: Subject::Besluit,
+                            name: definition.name.clone(),
+                            parameter: param.clone(),
+                        }
+                    })?;
+                    DecretogramInput {
+                        value,
+                        origin: InputOrigin::Parameter {
+                            parameter: param.clone(),
+                        },
+                    }
+                }
+                BesluitInput::FromChronicle { chronicle, field } => {
+                    self.read_own_chronicle(definition, input, chronicle, field, params, op_moment)?
+                }
+            };
+            collected.insert(input.clone(), gathered);
+        }
+        Ok(collected)
+    }
+
+    /// Eén input uit een eigen kroniek: de laatste vastlegging op of vóór het
+    /// moment van het besluit, over het onderwerp dat de parameters aanwijzen.
+    fn read_own_chronicle(
+        &self,
+        definition: &BesluitDefinition,
+        input: &str,
+        chronicle: &str,
+        field: &str,
+        params: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Result<DecretogramInput> {
+        // Onbereikbaar: `validate` eist dat de stroom bestaat en dat haar
+        // sleutelveld een gedocumenteerde parameter is; `check_params` eist dat
+        // die parameter meekomt.
+        let key = self.chronicles.key_of(chronicle).unwrap_or_default();
+        let missing = |reason: String| SimulatorError::BesluitInputMissing {
+            cell: self.id.clone(),
+            besluit: definition.name.clone(),
+            input: input.to_string(),
+            reason,
+        };
+        let key_value = params
+            .get(key)
+            .ok_or_else(|| missing(format!("parameter '{key}' ontbreekt in de vraag")))?;
+
+        let no_conditions = BTreeMap::new();
+        let event = self
+            .chronicles
+            .latest_recording(chronicle, key, key_value, &no_conditions, op_moment)
+            .ok_or_else(|| {
+                missing(nothing_established(
+                    chronicle,
+                    key,
+                    key_value,
+                    &no_conditions,
+                    op_moment,
+                ))
+            })?;
+
+        let value = chronicle::field(&event.fields, field)
+            .cloned()
+            .ok_or_else(|| {
+                missing(format!(
+                    "kroniekstroom '{chronicle}' heeft voor {key} '{key_value}' wel een \
+                     vastlegging (van {}), maar die draagt veld '{field}' niet",
+                    event.op_moment
+                ))
+            })?;
+
+        Ok(DecretogramInput {
+            value,
+            origin: InputOrigin::OwnChronicle {
+                chronicle: chronicle.to_string(),
+                field: field.to_string(),
+                recorded_op_moment: event.op_moment,
+            },
+        })
+    }
+
+    /// Voer de regeling uit op het moment van het besluit en maak het decretogram.
+    ///
+    /// De verzamelde inputs gaan als engine-parameters mee: een waarde onder de
+    /// naam van een input vervangt daar haar `source`, dus het besluit leunt
+    /// aantoonbaar op precies de feiten die het verzamelde. De rest van wat de
+    /// regeling nodig heeft, komt uit de eigen kronieken als databron — dezelfde
+    /// weg als bij een reductie, want dat is nog altijd tier 1.
+    fn execute(
+        &self,
+        definition: &BesluitDefinition,
+        params: &BTreeMap<String, Value>,
+        inputs: BTreeMap<String, DecretogramInput>,
+        op_moment: NaiveDate,
+    ) -> Result<Decretogram> {
+        // Onbereikbaar: `validate` weigert een besluit over een regeling die de
+        // cel niet zelf laadt, en een cel zonder engine laadt er geen enkele.
+        let Some(service) = &self.besluit_service else {
+            return Err(SimulatorError::ForeignRegulation {
+                cell: self.id.clone(),
+                subject: Subject::Besluit,
+                name: definition.name.clone(),
+                regulation: definition.regulation.clone(),
+            });
+        };
+
+        let mut service = service.borrow_mut();
+        self.register_own_facts(&mut service, op_moment)?;
+
+        let engine_params: BTreeMap<String, Value> = inputs
+            .iter()
+            .map(|(name, input)| (name.clone(), input.value.clone()))
+            .collect();
+        let calculation_date = op_moment.format("%Y-%m-%d").to_string();
+        let recorded: Vec<&str> = definition.recorded_outputs().into_iter().collect();
+        let result = service.evaluate_law(
+            &definition.regulation,
+            &recorded,
+            engine_params.clone(),
+            &calculation_date,
+        )?;
+
+        let requested: Vec<String> = recorded.iter().map(|name| (*name).to_string()).collect();
+        let receipt = service.build_receipt_with_outputs(
+            &result,
+            &engine_params,
+            &calculation_date,
+            &requested,
+        );
+
+        let resolver = service.resolver();
+        let law = resolver.get_law_for_date(&definition.regulation, Some(op_moment));
+        // Het rechtskarakter hoort bij het artikel dat de aansturende uitkomst
+        // voortbrengt: díe uitkomst *is* het besluit. Een uitkomst die erbij
+        // meegaat kan uit een ander artikel komen, en dat artikel zegt niets
+        // over het karakter van dit besluit.
+        let legal_character = resolver
+            .get_article_by_output(&definition.regulation, &definition.output, Some(op_moment))
+            .and_then(regelrecht_engine::Article::get_execution_spec)
+            .and_then(|execution| execution.produces.as_ref())
+            .and_then(|produces| produces.legal_character.clone());
+
+        Ok(Decretogram {
+            cell: self.id.clone(),
+            besluit: definition.name.clone(),
+            zaakkenmerk: definition.zaakkenmerk(params),
+            op_moment,
+            regulation: definition.regulation.clone(),
+            regulation_valid_from: result.regulation_valid_from.clone(),
+            competent_authority: law.and_then(competent_authority),
+            legal_character,
+            outputs: definition
+                .recorded_outputs()
+                .into_iter()
+                .filter_map(|name| {
+                    result
+                        .outputs
+                        .get(name)
+                        .map(|value| (name.to_string(), value.clone()))
+                })
+                .collect(),
+            inputs,
+            receipt,
+        })
+    }
+}
+
+/// Het bevoegd gezag dat een regelingversie noemt (RFC-002).
+///
+/// Twee vormen in het schema, en een derde die eruitziet als de eerste: een
+/// naam die met `#` begint is een **verwijzing** naar een uitkomst van de
+/// regeling zelf (`competent_authority: '#bevoegd_gezag'`). Die uitkomst is niet
+/// altijd als `output` gedeclareerd — vaak zet één actie haar rechtstreeks — dus
+/// ze is niet via de engine op te vragen; het geladen law-model is de plek waar
+/// ze wél staat.
+fn competent_authority(law: &ArticleBasedLaw) -> Option<String> {
+    match law.competent_authority.as_ref()? {
+        CompetentAuthority::Structured { name } => Some(name.clone()),
+        CompetentAuthority::String(text) => match text.strip_prefix('#') {
+            Some(reference) => resolve_reference(law, reference),
+            None => Some(text.clone()),
+        },
+    }
+}
+
+/// De letterlijke waarde die een regeling aan een eigen uitkomst toekent.
+///
+/// Zo werkt een `#`-verwijzing in het schema, en zo leest de rest van de
+/// codebase hem ook (zie `regelrecht_corpus::source_map`): zoek de actie die
+/// deze uitkomst zet en neem haar waarde.
+fn resolve_reference(law: &ArticleBasedLaw, reference: &str) -> Option<String> {
+    law.articles
+        .iter()
+        .filter_map(|article| article.get_execution_spec())
+        .flat_map(|execution| execution.actions.iter().flatten())
+        .find(|action| action.output.as_deref() == Some(reference))
+        .and_then(|action| match action.value.as_ref()? {
+            regelrecht_engine::ActionValue::Literal(Value::String(text)) => Some(text.clone()),
+            _ => None,
+        })
 }
 
 /// Waarom het kroniekfilter niets vond, zo precies dat het na te lopen is.
@@ -409,6 +784,60 @@ fn nothing_published(
          (van {recorded}), maar die draagt geen van de gepubliceerde uitkomsten \
          ({published})"
     )
+}
+
+/// Lees elke versie van elke regeling die deze cel laadt, als YAML-tekst.
+///
+/// Eén keer van schijf, want er worden twee engines mee opgebouwd (zie
+/// [`Cell::besluit_service`]) en die moeten per definitie dezelfde wetten
+/// hebben. Twee keer lezen zou dat tot een toevalligheid maken.
+fn load_laws(laws: &[String], regulation_root: &Path) -> Result<Vec<String>> {
+    let mut documents = Vec::new();
+    for law in laws {
+        documents.extend(corpus::regulation_versions(regulation_root, law)?);
+    }
+    Ok(documents)
+}
+
+/// Bouw een engine met deze wetten, of geen engine als er geen wetten zijn.
+///
+/// `laws: []` levert `None`: een bron-cel draait geen engine, en dat is de vorm
+/// van RFC-022 §2 — de engine is een component dat in een cel kán draaien.
+fn build_service(documents: &[String]) -> Result<Option<LawExecutionService>> {
+    if documents.is_empty() {
+        return Ok(None);
+    }
+    let mut service = LawExecutionService::new();
+    for document in documents {
+        service.load_law(document)?;
+    }
+    Ok(Some(service))
+}
+
+/// De namen die een regeling als parameter of input declareert, over alle
+/// geladen versies heen.
+///
+/// Hiermee valt bij het optuigen te toetsen of een besluit de engine iets
+/// aanlevert dat de regeling ook echt vraagt. Alle versies tellen mee, om
+/// dezelfde reden als bij [`outputs_per_regulation`]: een besluit over een
+/// ouder moment landt op een oudere versie.
+fn inputs_per_regulation(service: &LawExecutionService) -> BTreeMap<String, BTreeSet<String>> {
+    let mut per_regulation: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for law in service.resolver().all_law_versions() {
+        let known = per_regulation.entry(law.id.clone()).or_default();
+        for article in &law.articles {
+            let Some(execution) = article.get_execution_spec() else {
+                continue;
+            };
+            for parameter in execution.parameters.iter().flatten() {
+                known.insert(parameter.name.clone());
+            }
+            for input in execution.input.iter().flatten() {
+                known.insert(input.name.clone());
+            }
+        }
+    }
+    per_regulation
 }
 
 /// De uitkomstnamen per regeling, over alle geladen versies heen.
@@ -994,6 +1423,299 @@ lexostatus_definitions:
         assert!(
             matches!(err, SimulatorError::ForeignRegulation { .. }),
             "verwachtte ForeignRegulation, kreeg {err}"
+        );
+    }
+
+    /// Een cel die één besluit kan nemen over haar eigen zorgtoeslagwet.
+    ///
+    /// `besluit` wordt letterlijk ingeplakt, zodat elke test hieronder alleen
+    /// het blok varieert waar ze over gaat. De inkomenslevering ligt op
+    /// 2024-11-15: een besluit dáárvoor mist zijn input, en dat is waar de
+    /// tijdas in dit pad zichtbaar wordt.
+    fn besluitende_cel(besluit: &str) -> CellConfig {
+        config(&format!(
+            r"
+id: toeslagen
+laws:
+  - wet_op_de_zorgtoeslag
+  - algemene_wet_inkomensafhankelijke_regelingen
+  - regeling_standaardpremie
+chronicles:
+  - stream: inkomensleveringen
+    key: bsn
+    events:
+      - name: inkomenslevering
+        intake: levering
+        recording_actor: toeslagen
+        op_moment: 2024-11-15
+        fields:
+          bsn: '999993653'
+          partnerschap_type: GEEN
+          is_verzekerde: true
+          verzamelinkomen: 79547
+          buitenlands_inkomen: 0
+          vermogen: 0
+besluit_definitions:
+  - name: zorgtoeslag_vaststelling
+{besluit}
+"
+        ))
+    }
+
+    /// Het besluit zoals de meeste tests hieronder het bedoelen.
+    const VASTSTELLING: &str = "    regulation: wet_op_de_zorgtoeslag
+    output: heeft_recht_op_zorgtoeslag
+    outputs:
+      - hoogte_zorgtoeslag
+    zaakkenmerk: 'zorgtoeslag/{bsn}'
+    params:
+      - name: bsn
+        type: string
+    inputs:
+      bsn:
+        param: bsn
+      is_verzekerde:
+        from_chronicle: inkomensleveringen
+        field: is_verzekerde";
+
+    fn besluitende_toeslagen(besluit: &str) -> Cell {
+        Cell::from_config(
+            &besluitende_cel(besluit),
+            &regulation_root(),
+            &no_fixtures(),
+        )
+        .unwrap_or_else(|e| panic!("een besluitende cel moet op te tuigen zijn: {e}"))
+    }
+
+    /// Eén besluit is één gram, met alles wat samen ontstond erin.
+    ///
+    /// Dat is de elementariteit van RFC-022 §1.2: wat tegelijk ontstaat, wordt
+    /// samen vastgelegd. Twee grammen — één per uitkomst — zou van één besluit
+    /// twee besluiten maken, en dan is niet meer te zeggen welk bedrag bij welk
+    /// recht hoorde.
+    #[test]
+    fn een_besluit_legt_precies_een_decretogram_vast() {
+        let mut cell = besluitende_toeslagen(VASTSTELLING);
+        let gram = cell
+            .decide("zorgtoeslag_vaststelling", &bsn(), moment())
+            .unwrap_or_else(|e| panic!("het besluit moet genomen kunnen worden: {e}"));
+
+        assert_eq!(
+            cell.chronicles.len_of(BESCHIKKINGEN),
+            Some(1),
+            "één besluit hoort precies één gram vast te leggen"
+        );
+        assert_eq!(gram.zaakkenmerk, "zorgtoeslag/999993653");
+        assert_eq!(gram.op_moment, moment());
+        assert_eq!(
+            gram.outputs.keys().collect::<Vec<_>>(),
+            ["heeft_recht_op_zorgtoeslag", "hoogte_zorgtoeslag"],
+            "beide uitkomsten horen in hetzelfde gram te staan"
+        );
+        assert_eq!(
+            gram.legal_character.as_deref(),
+            Some("BESCHIKKING"),
+            "het rechtskarakter komt uit de wet, niet uit de cel"
+        );
+        assert_eq!(
+            gram.competent_authority.as_deref(),
+            Some("Dienst Toeslagen"),
+            "een `#`-verwijzing naar een eigen uitkomst hoort opgelost te worden"
+        );
+        assert_eq!(
+            gram.regulation_valid_from.as_deref(),
+            Some("2025-01-01"),
+            "de versie die op het moment van het besluit (2025-01-01) gold"
+        );
+    }
+
+    /// Het gram draagt zijn eigen inputs, met de herkomst erbij.
+    ///
+    /// Zonder die herkomst is een besluit niet terug te lezen: dan staat er wel
+    /// een waarde in, maar niet van wanneer ze was of wie haar leverde.
+    #[test]
+    fn het_decretogram_draagt_zijn_inputs_met_herkomst() {
+        let mut cell = besluitende_toeslagen(VASTSTELLING);
+        let gram = cell
+            .decide("zorgtoeslag_vaststelling", &bsn(), moment())
+            .unwrap_or_else(|e| panic!("het besluit moet genomen kunnen worden: {e}"));
+
+        let uit_de_kroniek = gram
+            .inputs
+            .get("is_verzekerde")
+            .unwrap_or_else(|| panic!("de input uit de kroniek hoort in het gram te staan"));
+        assert_eq!(uit_de_kroniek.value, Value::Bool(true));
+        assert_eq!(
+            uit_de_kroniek.origin,
+            InputOrigin::OwnChronicle {
+                chronicle: "inkomensleveringen".to_string(),
+                field: "is_verzekerde".to_string(),
+                recorded_op_moment: date("2024-11-15"),
+            },
+            "de herkomst noemt de stroom, het veld en het moment van de vastlegging"
+        );
+
+        let uit_de_vraag = gram
+            .inputs
+            .get("bsn")
+            .unwrap_or_else(|| panic!("de parameter hoort in het gram te staan"));
+        assert_eq!(
+            uit_de_vraag.origin,
+            InputOrigin::Parameter {
+                parameter: "bsn".to_string()
+            }
+        );
+    }
+
+    /// Een besluit dat een feit niet heeft, rekent niet door en legt niets vast.
+    ///
+    /// Anders dan een reductie: "niets vastgesteld" is een geldig *antwoord*,
+    /// maar geen geldige grondslag om op te besluiten.
+    #[test]
+    fn een_besluit_zonder_zijn_feiten_faalt_en_legt_niets_vast() {
+        let mut cell = besluitende_toeslagen(VASTSTELLING);
+        let err = cell
+            .decide("zorgtoeslag_vaststelling", &bsn(), date("2024-01-01"))
+            .expect_err("vóór de levering is er geen feit om op te besluiten");
+        assert!(
+            matches!(err, SimulatorError::BesluitInputMissing { .. }),
+            "verwachtte BesluitInputMissing, kreeg {err}"
+        );
+        assert_eq!(
+            cell.chronicles.len_of(BESCHIKKINGEN),
+            Some(0),
+            "een besluit dat niet doorging, hoort geen gram achter te laten"
+        );
+    }
+
+    #[test]
+    fn een_onbekend_besluit_noemt_wat_de_cel_wel_kent() {
+        let err = besluitende_toeslagen(VASTSTELLING)
+            .decide("zorgtoeslag_terugvordering", &bsn(), moment())
+            .expect_err("een besluit dat niet gedefinieerd is hoort te falen");
+        let SimulatorError::UnknownBesluit { defined, .. } = &err else {
+            panic!("verwachtte UnknownBesluit, kreeg {err}");
+        };
+        assert_eq!(defined, "zorgtoeslag_vaststelling");
+    }
+
+    #[test]
+    fn een_input_die_de_regeling_niet_declareert_wordt_geweigerd() {
+        let err = Cell::from_config(
+            &besluitende_cel(
+                "    regulation: wet_op_de_zorgtoeslag
+    output: heeft_recht_op_zorgtoeslag
+    zaakkenmerk: 'zorgtoeslag/{bsn}'
+    params:
+      - name: bsn
+        type: string
+    inputs:
+      is_verzekert:
+        from_chronicle: inkomensleveringen
+        field: is_verzekerde",
+            ),
+            &regulation_root(),
+            &no_fixtures(),
+        )
+        .expect_err("een input die de regeling niet kent hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownRegulationInput { .. }),
+            "verwachtte UnknownRegulationInput, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn de_stroom_voor_decretogrammen_is_voorbehouden() {
+        let err = Cell::from_config(
+            &config(
+                r"
+id: toeslagen
+laws: []
+chronicles:
+  - stream: beschikkingen
+    key: zaakkenmerk
+",
+            ),
+            &regulation_root(),
+            &no_fixtures(),
+        )
+        .expect_err("de stroom van het besluit-pad hoort niet zelf gedeclareerd te worden");
+        assert!(
+            matches!(err, SimulatorError::ReservedStream { .. }),
+            "verwachtte ReservedStream, kreeg {err}"
+        );
+    }
+
+    /// Een decretogram is geen feit om op te rekenen.
+    ///
+    /// De stroom met besluiten gaat niet als databron naar de engine. Zou ze dat
+    /// wel doen, dan zou een volgende uitvoering stil op de uitkomst van een
+    /// eerder besluit kunnen leunen — en dan is niet meer te zeggen of er
+    /// gerekend of overgeschreven is.
+    #[test]
+    fn de_eigen_besluiten_gaan_niet_als_databron_naar_de_engine() {
+        let mut cell = besluitende_toeslagen(VASTSTELLING);
+        cell.decide("zorgtoeslag_vaststelling", &bsn(), moment())
+            .unwrap_or_else(|e| panic!("het besluit moet genomen kunnen worden: {e}"));
+
+        let Some(service) = &cell.service else {
+            panic!("deze cel laadt wetten en heeft dus een engine");
+        };
+        let mut service = service.borrow_mut();
+        cell.register_own_facts(&mut service, date("2025-01-01"))
+            .unwrap_or_else(|e| panic!("de eigen feiten moeten klaargezet kunnen worden: {e}"));
+        assert!(
+            !service.list_data_sources().contains(&BESCHIKKINGEN),
+            "de stroom met decretogrammen hoort geen databron te zijn, kreeg {:?}",
+            service.list_data_sources()
+        );
+    }
+
+    /// Een resolver die niets weet; hij hoeft alleen te bestaan.
+    struct GeenPeers;
+
+    impl regelrecht_engine::CellResolver for GeenPeers {
+        fn resolve(
+            &self,
+            _cell_id: &str,
+            _output: &str,
+            _parameters: &BTreeMap<String, Value>,
+            _reference_date: &str,
+        ) -> regelrecht_engine::Result<Option<Value>> {
+            Ok(None)
+        }
+    }
+
+    /// De haak voor tier 3 zit op de besluit-engine, en nergens anders.
+    ///
+    /// Vandaag heeft geen van beide engines een resolver — accepteren van een
+    /// waarde van een andere cel volgt apart — en dit is de test die vastlegt
+    /// waar die ooit terechtkomt. Dat de twee losse instanties zijn, is wat het
+    /// verschil afdwingbaar maakt: een resolver op de ene raakt de andere niet.
+    #[test]
+    fn alleen_de_besluit_engine_kan_de_celgrens_over() {
+        let cell = besluitende_toeslagen(VASTSTELLING);
+        let (Some(reduce), Some(besluit)) = (&cell.service, &cell.besluit_service) else {
+            panic!("een besluitende cel met wetten heeft beide engines");
+        };
+        assert!(
+            reduce.borrow().cell_ids().is_empty() && besluit.borrow().cell_ids().is_empty(),
+            "zonder resolver bestaat tier 3 niet, voor geen van beide engines"
+        );
+
+        besluit
+            .borrow_mut()
+            .set_cell_resolver(["brp"], std::rc::Rc::new(GeenPeers))
+            .unwrap_or_else(|e| panic!("de besluit-engine hoort een resolver te accepteren: {e}"));
+
+        assert_eq!(
+            besluit.borrow().cell_ids(),
+            ["brp"],
+            "de besluit-engine is de plek waar de celgrens open kan"
+        );
+        assert!(
+            reduce.borrow().cell_ids().is_empty(),
+            "en de reduce-engine blijft daar buiten: een reductie raakt geen andere cel"
         );
     }
 }

--- a/packages/simulator/src/error.rs
+++ b/packages/simulator/src/error.rs
@@ -396,6 +396,31 @@ pub enum SimulatorError {
         known: String,
     },
 
+    /// Een besluit wil een input uit de stroom met decretogrammen halen.
+    ///
+    /// Dan zou het nieuwe besluit leunen op een veld van een eerder besluit, en
+    /// is niet meer te zeggen of er gerekend of overgeschreven is — dezelfde
+    /// schaduwboekhouding die de stroom al buiten de databronnen van de engine
+    /// houdt, langs de andere weg. Terugzien doe je met een reductie over deze
+    /// stroom; leunen op een eerder besluit is een eigen stap en geen input.
+    #[error(
+        "cel '{cell}': besluit '{besluit}' haalt input '{input}' uit kroniekstroom \
+         '{stream}' (veld '{field}'), maar daar liggen besluiten en geen feiten; \
+         een besluit leest geen besluit"
+    )]
+    DecretogramAsBesluitInput {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// Het besluit dat uit de verkeerde stroom leest.
+        besluit: String,
+        /// De input die eruit zou komen.
+        input: String,
+        /// De voorbehouden stroomnaam.
+        stream: String,
+        /// Het veld dat gelezen zou worden.
+        field: String,
+    },
+
     /// Een besluit kan een van zijn inputs op dit moment niet ophalen.
     ///
     /// Geen "niets vastgesteld" zoals bij een reductie, maar een fout: een

--- a/packages/simulator/src/error.rs
+++ b/packages/simulator/src/error.rs
@@ -326,6 +326,31 @@ pub enum SimulatorError {
         stream: String,
     },
 
+    /// Een vastlegging van buiten het besluit-pad mikt op de stroom met
+    /// decretogrammen.
+    ///
+    /// Dat de configuratie die stroom niet mag declareren
+    /// ([`SimulatorError::ReservedStream`]) is niet genoeg: zodra een cel
+    /// besluit-definities heeft, bestaat de stroom, en een `fixture` zou er een
+    /// gram in kunnen zetten dat nooit langs een engine kwam — zonder receipt en
+    /// met een `intake` naar keuze. Een reductie erover zou dat niet van een
+    /// besluit kunnen onderscheiden.
+    #[error(
+        "cel '{cell}': kroniekstroom '{stream}' is voorbehouden aan het besluit-pad; \
+         vastlegging '{name}' van {op_moment} hoort daar niet in — een decretogram \
+         ontstaat door te besluiten, niet door het op te schrijven"
+    )]
+    ReservedStreamRecording {
+        /// De cel waarin vastgelegd zou worden.
+        cell: String,
+        /// De voorbehouden stroomnaam.
+        stream: String,
+        /// De naam van de vastlegging die geweigerd wordt.
+        name: String,
+        /// Het moment van die vastlegging.
+        op_moment: String,
+    },
+
     /// Een besluit leest een input uit een stroom waarvan het sleutelveld geen
     /// gedocumenteerde parameter van dat besluit is.
     ///
@@ -440,6 +465,53 @@ pub enum SimulatorError {
         besluit: String,
         /// Het sjabloon zoals het in de configuratie staat.
         template: String,
+    },
+
+    /// Twee verwijzingen in een zaakkenmerk-sjabloon plakken aan elkaar.
+    ///
+    /// `{jaar}{bsn}` levert voor 2024 + 999993653 hetzelfde kenmerk als voor
+    /// 20249 + 99993653: twee zaken, één kenmerk, en een reductie die het besluit
+    /// van de ander teruggeeft. Geen enkele parameterwaarde kan dat repareren,
+    /// dus het is een optuigfout.
+    #[error(
+        "cel '{cell}': zaakkenmerk '{template}' van besluit '{besluit}' zet '{first}' \
+         en '{second}' tegen elkaar aan; zet er iets tussen dat ze scheidt"
+    )]
+    AdjacentZaakkenmerkReferences {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// Het besluit met het dubbelzinnige sjabloon.
+        besluit: String,
+        /// Het sjabloon zoals het in de configuratie staat.
+        template: String,
+        /// De eerste van de twee verwijzingen.
+        first: String,
+        /// De verwijzing die er direct achter staat.
+        second: String,
+    },
+
+    /// Een parameterwaarde bevat het scheidingsteken van het zaakkenmerk-sjabloon.
+    ///
+    /// Dan valt het kenmerk niet meer eenduidig terug te lezen: bij
+    /// `{jaar}/{bsn}` geeft `2024/9` + `99993653` hetzelfde kenmerk als `2024` +
+    /// `999993653`. Het zaakkenmerk is waaronder een zaak terug te vinden is, dus
+    /// twee zaken mogen er nooit één worden.
+    #[error(
+        "cel '{cell}': besluit '{besluit}' krijgt voor parameter '{parameter}' een \
+         waarde met '{separator}' erin, en dat scheidt in zaakkenmerk '{template}' \
+         twee verwijzingen; dan zou dit kenmerk ook bij een andere zaak kunnen horen"
+    )]
+    ZaakkenmerkSeparatorInValue {
+        /// De besluitende cel.
+        cell: String,
+        /// Het besluit dat genomen werd.
+        besluit: String,
+        /// Het sjabloon zoals het in de configuratie staat.
+        template: String,
+        /// De parameter met de dubbelzinnige waarde.
+        parameter: String,
+        /// Het scheidingsteken dat in die waarde voorkomt.
+        separator: String,
     },
 
     /// Het receipt van een besluit kon niet als kroniekveld worden opgeslagen.

--- a/packages/simulator/src/error.rs
+++ b/packages/simulator/src/error.rs
@@ -3,7 +3,33 @@
 //! De teksten zijn Nederlands, net als de rest van de gebruikersgerichte
 //! uitvoer in deze repo; identifiers blijven Engels.
 
+use std::fmt;
 use std::path::PathBuf;
+
+/// Waar een melding over gaat: een gepubliceerde lexostatus of een
+/// besluit-definitie.
+///
+/// De twee delen hun controles — gedocumenteerde parameters, een eigen
+/// regeling, bestaande uitkomsten, bestaande kroniekvelden — en dus ook de
+/// fouten die daaruit komen. Wat er per melding bij hoort te staan is welke van
+/// de twee de configuratie bedoelde, en dat is precies wat dit type draagt. Een
+/// tweede set varianten met dezelfde tekst zou uiteen gaan lopen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Subject {
+    /// Een gepubliceerde lexostatus: een reductie die bevraagd wordt.
+    Lexostatus,
+    /// Een besluit-definitie: een wetsuitvoering die vastgelegd wordt.
+    Besluit,
+}
+
+impl fmt::Display for Subject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Lexostatus => "lexostatus",
+            Self::Besluit => "besluit",
+        })
+    }
+}
 
 /// Alles wat er mis kan gaan bij het optuigen of bevragen van een cel.
 #[derive(Debug, thiserror::Error)]
@@ -23,26 +49,30 @@ pub enum SimulatorError {
     },
 
     /// Een gedocumenteerde parameter ontbreekt in de vraag.
-    #[error("lexostatus '{cell}.{lexostatus}' vereist parameter '{parameter}'")]
+    #[error("{subject} '{cell}.{name}' vereist parameter '{parameter}'")]
     MissingParameter {
         /// Cel waaraan gevraagd werd.
         cell: String,
-        /// De gevraagde lexostatus.
-        lexostatus: String,
+        /// Of dit over een lexostatus of over een besluit gaat.
+        subject: Subject,
+        /// De gevraagde lexostatus of het uitgevoerde besluit.
+        name: String,
         /// De ontbrekende parameter.
         parameter: String,
     },
 
-    /// De vraag bevat een parameter die de lexostatus niet documenteert.
+    /// De vraag bevat een parameter die de definitie niet documenteert.
     #[error(
-        "lexostatus '{cell}.{lexostatus}' kent geen parameter '{parameter}' \
+        "{subject} '{cell}.{name}' kent geen parameter '{parameter}' \
          (gedocumenteerd: {documented})"
     )]
     UndocumentedParameter {
         /// Cel waaraan gevraagd werd.
         cell: String,
-        /// De gevraagde lexostatus.
-        lexostatus: String,
+        /// Of dit over een lexostatus of over een besluit gaat.
+        subject: Subject,
+        /// De gevraagde lexostatus of het uitgevoerde besluit.
+        name: String,
         /// De onbekende parameter.
         parameter: String,
         /// Komma-gescheiden lijst van gedocumenteerde parameters.
@@ -51,14 +81,16 @@ pub enum SimulatorError {
 
     /// Een parameter heeft een ander type dan gedocumenteerd.
     #[error(
-        "parameter '{parameter}' van lexostatus '{cell}.{lexostatus}' is {actual}, \
+        "parameter '{parameter}' van {subject} '{cell}.{name}' is {actual}, \
          verwacht {expected}"
     )]
     ParameterType {
         /// Cel waaraan gevraagd werd.
         cell: String,
-        /// De gevraagde lexostatus.
-        lexostatus: String,
+        /// Of dit over een lexostatus of over een besluit gaat.
+        subject: Subject,
+        /// De gevraagde lexostatus of het uitgevoerde besluit.
+        name: String,
         /// De parameter met het verkeerde type.
         parameter: String,
         /// Het gedocumenteerde type.
@@ -67,16 +99,19 @@ pub enum SimulatorError {
         actual: &'static str,
     },
 
-    /// De reductie verwijst met `$naam` naar een niet-gedocumenteerde parameter.
+    /// De definitie verwijst met `$naam` of `{naam}` naar een
+    /// niet-gedocumenteerde parameter.
     #[error(
-        "cel '{cell}': reductie van '{lexostatus}' verwijst naar '${reference}', \
-         maar dat is geen gedocumenteerde parameter"
+        "cel '{cell}': {subject} '{name}' verwijst naar parameter '{reference}', \
+         maar die is niet gedocumenteerd"
     )]
     UnknownReference {
         /// Cel waarin de definitie staat.
         cell: String,
-        /// De lexostatus met de kapotte verwijzing.
-        lexostatus: String,
+        /// Of dit over een lexostatus of over een besluit gaat.
+        subject: Subject,
+        /// De definitie met de kapotte verwijzing.
+        name: String,
         /// De naam waarnaar verwezen wordt.
         reference: String,
     },
@@ -90,24 +125,28 @@ pub enum SimulatorError {
         name: String,
     },
 
-    /// Een reductie grijpt naar een regeling die deze cel niet zelf geladen heeft.
+    /// Een definitie grijpt naar een regeling die deze cel niet zelf geladen heeft.
     ///
     /// Een reductie raakt uitsluitend de eigen feiten van de cel; combineren over
-    /// cellen heen is synthese en hoort bij een consument (RFC-022 §4.1).
+    /// cellen heen is synthese en hoort bij een consument (RFC-022 §4.1). Een
+    /// besluit voert een eigen regeling uit, om dezelfde reden: de cel besluit
+    /// op haar eigen recht.
     #[error(
-        "cel '{cell}': reductie van '{lexostatus}' gebruikt regeling '{regulation}', \
+        "cel '{cell}': {subject} '{name}' gebruikt regeling '{regulation}', \
          die deze cel niet zelf geladen heeft"
     )]
     ForeignRegulation {
         /// Cel waarin de definitie staat.
         cell: String,
-        /// De lexostatus met de vreemde regeling.
-        lexostatus: String,
+        /// Of dit over een lexostatus of over een besluit gaat.
+        subject: Subject,
+        /// De definitie met de vreemde regeling.
+        name: String,
         /// De regeling waarnaar verwezen wordt.
         regulation: String,
     },
 
-    /// Een lexostatus publiceert een uitkomst die haar bron niet kent.
+    /// Een definitie publiceert een uitkomst die haar bron niet kent.
     ///
     /// Wat een cel publiceert is een belofte aan de consument; een naam die
     /// geen enkele geladen versie van de regeling oplevert — of die in geen
@@ -115,14 +154,16 @@ pub enum SimulatorError {
     /// waarmaken. Dat blijkt bij het optuigen, net als bij
     /// [`SimulatorError::ForeignRegulation`], en niet pas bij de eerste vraag.
     #[error(
-        "cel '{cell}': lexostatus '{lexostatus}' publiceert uitkomst '{output}', \
+        "cel '{cell}': {subject} '{name}' publiceert uitkomst '{output}', \
          maar {origin} kent die niet (wel: {known})"
     )]
     UnknownOutput {
         /// Cel waarin de definitie staat.
         cell: String,
-        /// De lexostatus met de onbekende uitkomst.
-        lexostatus: String,
+        /// Of dit over een lexostatus of over een besluit gaat.
+        subject: Subject,
+        /// De definitie met de onbekende uitkomst.
+        name: String,
         /// Waar de uitkomst uit had moeten komen: `regeling '…'` of
         /// `kroniekstroom '…'`. Niet `source`: dat veld zou thiserror als de
         /// onderliggende fout lezen.
@@ -133,20 +174,23 @@ pub enum SimulatorError {
         known: String,
     },
 
-    /// Een kroniekfilter verwijst naar een stroom die de cel niet houdt.
+    /// Een definitie verwijst naar een kroniekstroom die de cel niet houdt.
     ///
-    /// Een reductie raakt uitsluitend de eigen feiten van de cel. Een onbekende
-    /// stroomnaam is de kroniek-tegenhanger van
-    /// [`SimulatorError::ForeignRegulation`] en blijkt op hetzelfde moment.
+    /// Een reductie raakt uitsluitend de eigen feiten van de cel, en een besluit
+    /// leest zijn inputs uit die eigen kronieken. Een onbekende stroomnaam is de
+    /// kroniek-tegenhanger van [`SimulatorError::ForeignRegulation`] en blijkt op
+    /// hetzelfde moment.
     #[error(
-        "cel '{cell}': kroniekfilter van '{lexostatus}' verwijst naar kroniekstroom \
+        "cel '{cell}': {subject} '{name}' verwijst naar kroniekstroom \
          '{stream}', die deze cel niet houdt (wel: {known})"
     )]
     UnknownStream {
         /// Cel waarin de definitie staat.
         cell: String,
-        /// De lexostatus met de onbekende stroom.
-        lexostatus: String,
+        /// Of dit over een lexostatus of over een besluit gaat.
+        subject: Subject,
+        /// De definitie met de onbekende stroom.
+        name: String,
         /// De stroomnaam die niet bestaat.
         stream: String,
         /// Komma-gescheiden lijst van stromen die de cel wél houdt.
@@ -172,19 +216,22 @@ pub enum SimulatorError {
         stream: String,
     },
 
-    /// Een kroniekfilter sleutelt of filtert op een veld dat de stroom niet kent.
+    /// Een definitie sleutelt, filtert of leest op een veld dat de stroom niet kent.
     ///
     /// Zo'n filter zou stil "niets vastgesteld" antwoorden op elke vraag, en dat
-    /// is niet te onderscheiden van een leeg verleden.
+    /// is niet te onderscheiden van een leeg verleden; een besluit zou een input
+    /// missen zonder dat iemand de typfout ziet.
     #[error(
-        "cel '{cell}': kroniekfilter van '{lexostatus}' gebruikt veld '{field}', \
+        "cel '{cell}': {subject} '{name}' gebruikt veld '{field}', \
          maar kroniekstroom '{stream}' kent dat niet (wel: {known})"
     )]
     UnknownFilterField {
         /// Cel waarin de definitie staat.
         cell: String,
-        /// De lexostatus met het onbekende veld.
-        lexostatus: String,
+        /// Of dit over een lexostatus of over een besluit gaat.
+        subject: Subject,
+        /// De definitie met het onbekende veld.
+        name: String,
         /// De stroom waarover gefilterd wordt.
         stream: String,
         /// Het veld dat de stroom niet kent.
@@ -233,6 +280,177 @@ pub enum SimulatorError {
         key: String,
         /// Komma-gescheiden lijst van gedocumenteerde parameters.
         documented: String,
+    },
+
+    /// Er wordt een besluit gevraagd dat deze cel niet kent.
+    ///
+    /// De tegenhanger van [`SimulatorError::UnknownLexostatus`]: een cel voert
+    /// uitsluitend besluiten uit die als definitie in haar configuratie staan.
+    /// Een besluit dat nergens gedefinieerd is, is geen besluit.
+    #[error("cel '{cell}' kent geen besluit '{requested}' (wel: {defined})")]
+    UnknownBesluit {
+        /// De cel waaraan het besluit gevraagd werd.
+        cell: String,
+        /// De gevraagde naam.
+        requested: String,
+        /// Komma-gescheiden lijst van besluiten die de cel wél kent.
+        defined: String,
+    },
+
+    /// Twee besluit-definities met dezelfde naam in één cel.
+    #[error("cel '{cell}' definieert besluit '{name}' twee keer")]
+    DuplicateBesluit {
+        /// Cel waarin het dubbel staat.
+        cell: String,
+        /// De dubbele naam.
+        name: String,
+    },
+
+    /// De configuratie declareert een kroniekstroom met een naam die het
+    /// platform zelf gebruikt.
+    ///
+    /// De stroom voor decretogrammen hoort bij het besluit-pad en wordt
+    /// automatisch aangemaakt zodra een cel besluit-definities heeft. Wie haar
+    /// zelf declareert, zou een tweede stroom met dezelfde naam krijgen (waar de
+    /// ene de andere stil schaduwt) of vastleggingen tussen de decretogrammen
+    /// zetten die geen besluit zijn.
+    #[error(
+        "cel '{cell}': kroniekstroom '{stream}' is voorbehouden aan het besluit-pad \
+         en wordt automatisch aangemaakt zodra de cel besluit-definities heeft; \
+         kies een andere naam"
+    )]
+    ReservedStream {
+        /// Cel waarin de stroom gedeclareerd staat.
+        cell: String,
+        /// De voorbehouden stroomnaam.
+        stream: String,
+    },
+
+    /// Een besluit leest een input uit een stroom waarvan het sleutelveld geen
+    /// gedocumenteerde parameter van dat besluit is.
+    ///
+    /// Het besluit levert de sleutelwaarde aan; zonder parameter is er niets dat
+    /// haar aanlevert en gaat de vraag naar de kroniek over geen enkel onderwerp.
+    #[error(
+        "cel '{cell}': besluit '{besluit}' leest uit kroniekstroom '{stream}', \
+         die sleutelt op '{key}'; dat moet een gedocumenteerde parameter van het \
+         besluit zijn (gedocumenteerd: {documented})"
+    )]
+    BesluitStreamKeyWithoutParameter {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// Het besluit met de onbereikbare sleutel.
+        besluit: String,
+        /// De stroom waaruit gelezen wordt.
+        stream: String,
+        /// Het sleutelveld van die stroom.
+        key: String,
+        /// Komma-gescheiden lijst van gedocumenteerde parameters.
+        documented: String,
+    },
+
+    /// Een besluit geeft de engine een input die de regeling niet declareert.
+    ///
+    /// Dan wordt de waarde opgehaald, in het decretogram vastgelegd en door de
+    /// engine genegeerd: een besluit dat zegt te leunen op een feit dat niets
+    /// deed. Dat is een typfout, en die hoort bij het optuigen te blijken.
+    #[error(
+        "cel '{cell}': besluit '{besluit}' levert input '{input}', maar regeling \
+         '{regulation}' kent geen parameter of input met die naam (wel: {known})"
+    )]
+    UnknownRegulationInput {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// Het besluit met de onbekende input.
+        besluit: String,
+        /// De inputnaam die de regeling niet kent.
+        input: String,
+        /// De regeling die het besluit uitvoert.
+        regulation: String,
+        /// Komma-gescheiden lijst van namen die de regeling wél kent.
+        known: String,
+    },
+
+    /// Een besluit kan een van zijn inputs op dit moment niet ophalen.
+    ///
+    /// Geen "niets vastgesteld" zoals bij een reductie, maar een fout: een
+    /// besluit dat een feit nodig heeft en het niet heeft, mag niet met een
+    /// gat verder rekenen en al niet vastleggen.
+    #[error("cel '{cell}': besluit '{besluit}' mist input '{input}': {reason}")]
+    BesluitInputMissing {
+        /// De besluitende cel.
+        cell: String,
+        /// Het besluit dat de input nodig had.
+        besluit: String,
+        /// De input die niet op te halen was.
+        input: String,
+        /// Waarom niet, in de woorden van de cel.
+        reason: String,
+    },
+
+    /// Een besluit legt een uitkomst vast onder de naam van een vast veld van
+    /// een decretogram.
+    ///
+    /// Dan zou de uitkomst dat veld overschrijven: het gram zou bijvoorbeeld
+    /// zeggen dat de regeling `true` heet, of zijn receipt kwijt zijn. Een
+    /// naamsbotsing hoort bij het optuigen te blijken en niet stil in een gram te
+    /// eindigen.
+    #[error(
+        "cel '{cell}': besluit '{besluit}' legt uitkomst '{output}' vast, maar zo heet \
+         een vast veld van elk decretogram ({fixed})"
+    )]
+    ReservedDecretogramField {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// Het besluit met de botsende uitkomst.
+        besluit: String,
+        /// De uitkomstnaam die botst.
+        output: String,
+        /// Komma-gescheiden lijst van de vaste velden.
+        fixed: String,
+    },
+
+    /// Het zaakkenmerk-sjabloon heeft een accolade die niet sluit.
+    #[error(
+        "cel '{cell}': zaakkenmerk '{template}' van besluit '{besluit}' heeft een \
+         accolade die niet sluit; een verwijzing schrijf je als {{parameter}}"
+    )]
+    MalformedZaakkenmerk {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// Het besluit met het kapotte sjabloon.
+        besluit: String,
+        /// Het sjabloon zoals het in de configuratie staat.
+        template: String,
+    },
+
+    /// Het zaakkenmerk-sjabloon verwijst naar geen enkele parameter.
+    ///
+    /// Dan krijgt elke zaak hetzelfde kenmerk, en valt het ene besluit niet van
+    /// het andere te onderscheiden: een reductie over de stroom zou het laatste
+    /// besluit over wie dan ook opleveren.
+    #[error(
+        "cel '{cell}': zaakkenmerk '{template}' van besluit '{besluit}' verwijst naar \
+         geen enkele parameter, dus elke zaak zou hetzelfde kenmerk krijgen"
+    )]
+    ZaakkenmerkWithoutReference {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// Het besluit met het te algemene sjabloon.
+        besluit: String,
+        /// Het sjabloon zoals het in de configuratie staat.
+        template: String,
+    },
+
+    /// Het receipt van een besluit kon niet als kroniekveld worden opgeslagen.
+    #[error("cel '{cell}': kon het receipt van besluit '{besluit}' niet vastleggen: {source}")]
+    ReceiptEncoding {
+        /// De besluitende cel.
+        cell: String,
+        /// Het besluit waarvan het receipt niet opgeslagen kon worden.
+        besluit: String,
+        /// De onderliggende serialisatiefout.
+        source: serde_yaml_ng::Error,
     },
 
     /// Geen regelingmap met deze naam in het corpus.
@@ -309,20 +527,23 @@ pub enum SimulatorError {
         to: String,
     },
 
-    /// Er wordt gereduceerd over een moment dat nog niet gebeurd is.
+    /// Er wordt gereduceerd of besloten over een moment dat nog niet gebeurd is.
     ///
     /// De wereld weet niet wat er na haar klok gebeurt: triggers die nog moeten
     /// afgaan hebben niets vastgelegd. Een antwoord "op" zo'n moment zou een
-    /// voorspelling zijn die zich voordoet als een reductie.
+    /// voorspelling zijn die zich voordoet als een reductie, en een besluit "op"
+    /// zo'n moment zou een gram in de toekomst leggen.
     #[error(
-        "cel '{cell}': reductie van '{lexostatus}' op {op_moment} vraagt een moment ná de klok \
+        "cel '{cell}': {subject} '{name}' op {op_moment} vraagt een moment ná de klok \
          van de wereld ({clock})"
     )]
     MomentAfterClock {
         /// De bevraagde cel.
         cell: String,
-        /// De gevraagde lexostatus.
-        lexostatus: String,
+        /// Of dit over een lexostatus of over een besluit gaat.
+        subject: Subject,
+        /// De gevraagde lexostatus of het uitgevoerde besluit.
+        name: String,
         /// Het gevraagde moment.
         op_moment: String,
         /// Waar de klok staat.

--- a/packages/simulator/src/lib.rs
+++ b/packages/simulator/src/lib.rs
@@ -22,6 +22,13 @@
 //! wereld, nooit de wandklok, en [`World::advance`] laat de tijd lopen zodat
 //! triggers op hun eigen moment vastleggen.
 //!
+//! De lus is rond: een cel kan ook **besluiten**. [`World::decide`] laat haar een
+//! eigen regeling uitvoeren en legt het resultaat vast als [`Decretogram`] — het
+//! RFC-013 Execution Receipt plus moment en zaakkenmerk — in haar eigen kroniek.
+//! Terugzien doe je met een gewone reductie over die kroniek: ligt er geen
+//! decretogram, dan is het antwoord "niets vastgesteld" en nooit een
+//! herberekening onder een inmiddels andere wetsversie.
+//!
 //! ```no_run
 //! use regelrecht_simulator::{regulation_root, Scenario};
 //! use std::path::Path;
@@ -50,14 +57,15 @@ mod values;
 pub mod world;
 
 pub use cell::{
-    Cell, CellConfig, ChronicleEvent, ChronicleStore, ChronicleStream, Intake, Lexostatus,
-    LexostatusDefinition, LexostatusInput, LexostatusOutcome, ParameterType, Reduction,
+    BesluitDefinition, BesluitInput, Cell, CellConfig, ChronicleEvent, ChronicleStore,
+    ChronicleStream, Decretogram, DecretogramInput, DocumentedParameter, InputOrigin, Intake,
+    Lexostatus, LexostatusDefinition, LexostatusOutcome, ParameterType, Reduction, BESCHIKKINGEN,
 };
 pub use corpus::regulation_root;
-pub use error::{Result, SimulatorError};
+pub use error::{Result, SimulatorError, Subject};
 pub use scenario::{
-    ExpectationFailure, Query, QueryOutcome, Scenario, ScenarioRun, TransportOutcome,
-    TransportQuery,
+    Decision, DecisionOutcome, ExpectationFailure, Query, QueryOutcome, Scenario, ScenarioRun,
+    TransportOutcome, TransportQuery,
 };
 pub use security::{Identity, SecurityContext, Signature, SignedAnswer};
 pub use transport::{CellTransport, InProcessTransport};

--- a/packages/simulator/src/scenario.rs
+++ b/packages/simulator/src/scenario.rs
@@ -1,11 +1,11 @@
-//! Het wereldbestand: de klok, de cellen, de startstand, de vragen die gesteld
-//! worden en wat die vragen moeten opleveren.
+//! Het wereldbestand: de klok, de cellen, de startstand, de besluiten die
+//! genomen worden, de vragen die gesteld worden en wat dat alles moet opleveren.
 //!
 //! Een wereld is data. De assertie hoort erbij: wat een run moet opleveren
 //! staat in het bestand, niet in Rust. Zo blijft een testgeval een bestand dat
 //! iemand kan lezen en wijzigen zonder de crate te kennen.
 
-use crate::cell::{CellConfig, Lexostatus, LexostatusOutcome};
+use crate::cell::{CellConfig, Decretogram, Lexostatus, LexostatusOutcome};
 use crate::error::{Result, SimulatorError};
 use crate::security::{Identity, SecurityContext, SignedAnswer};
 use crate::transport::InProcessTransport;
@@ -37,6 +37,16 @@ pub struct Scenario {
     /// klok die datum passeert.
     #[serde(default)]
     pub fixtures: Vec<Fixture>,
+    /// De besluiten die in deze run genomen worden, elk op een moment.
+    ///
+    /// Dit is de aansturing van het besluit-pad zolang een cel nog geen actie
+    /// van een actor kent: het scenario zegt wie wanneer waarover besluit. Ze
+    /// gaan vóór de vragen, en dat is de volgorde die past bij wat ze zijn — een
+    /// besluit is een gebeurtenis op de tijdlijn, een vraag kijkt erop terug. Wie
+    /// een vraag over een moment *vóór* een besluit stelt, krijgt nog altijd het
+    /// beeld van toen: de reductie filtert zelf op `op_moment`.
+    #[serde(default)]
+    pub decide: Vec<Decision>,
     /// De vragen die een consument stelt.
     #[serde(default)]
     pub queries: Vec<Query>,
@@ -44,11 +54,12 @@ pub struct Scenario {
     ///
     /// **Test-only stap, en dat is tijdelijk.** In de opstelling die we bouwen
     /// stelt een cel zo'n vraag uitsluitend vanuit haar besluit-pad: ze heeft een
-    /// input nodig die een andere organisatie vaststelt. Dat pad bestaat nog niet
-    /// — een cel kan nog niets vastleggen en dus niets accepteren — en tot die tijd
-    /// is dit de enige manier om het verkeer te laten zien en erop te asserteren.
-    /// Zodra het besluit-pad er is, verhuist de aanroep daarheen en is deze stap
-    /// hoogstens nog een sonde.
+    /// input nodig die een andere organisatie vaststelt. Dat pad bestaat inmiddels
+    /// ([`Self::decide`]), maar het accepteren van een waarde van een andere cel
+    /// nog niet: een besluit haalt zijn inputs uit de eigen kronieken en uit zijn
+    /// parameters. Tot dat er is, is deze stap de enige manier om het verkeer te
+    /// laten zien en erop te asserteren; daarna verhuist de aanroep naar het
+    /// besluit-pad en is ze hoogstens nog een sonde.
     #[serde(default)]
     pub query_via_transport: Vec<TransportQuery>,
 }
@@ -81,6 +92,37 @@ pub struct Query {
     /// scenario moet erop kunnen asserteren. Sluit `expect` uit.
     #[serde(default)]
     pub expect_not_established: bool,
+}
+
+/// Eén besluit dat een cel in deze run neemt.
+///
+/// De tegenhanger van een [`Query`]: geen vraag maar een gebeurtenis. Wat eruit
+/// komt is een decretogram in de eigen kroniek van de cel, en dat is ook waar
+/// het daarna vandaan gehaald wordt — met een gewone vraag over een lexostatus
+/// die over die stroom reduceert.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Decision {
+    /// Vrije omschrijving, verschijnt in het verslag.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// De cel die besluit.
+    pub cell: String,
+    /// De besluit-definitie die uitgevoerd wordt.
+    pub besluit: String,
+    /// De gedocumenteerde parameters van dat besluit.
+    #[serde(default)]
+    pub params: BTreeMap<String, Value>,
+    /// Het moment waarop besloten wordt. Expliciet, nooit de wandklok: het
+    /// bepaalt zowel welke feiten de cel kent als welke wetsversie geldt.
+    pub op_moment: NaiveDate,
+    /// De verwachte uitkomsten in het decretogram.
+    ///
+    /// Mag leeg blijven, anders dan bij een vraag: een besluit legt iets vast,
+    /// dus het bewijst ook zonder verwachting iets — namelijk dat de vragen
+    /// erna iets te vinden hebben.
+    #[serde(default)]
+    pub expect: BTreeMap<String, Value>,
 }
 
 /// Eén vraag van een cel aan een andere cel, over de celgrens.
@@ -157,6 +199,17 @@ pub struct TransportOutcome {
     pub failures: Vec<ExpectationFailure>,
 }
 
+/// Het resultaat van één besluit.
+#[derive(Debug, Clone)]
+pub struct DecisionOutcome {
+    /// De omschrijving uit het scenario, als die er stond.
+    pub description: Option<String>,
+    /// Het vastgelegde decretogram.
+    pub decretogram: Decretogram,
+    /// De verwachtingen die niet uitkwamen; leeg is goed.
+    pub failures: Vec<ExpectationFailure>,
+}
+
 /// Het resultaat van een hele run.
 #[derive(Debug, Clone)]
 pub struct ScenarioRun {
@@ -168,6 +221,8 @@ pub struct ScenarioRun {
     /// ligt. De runner loopt de tijd af tot de laatste vraag, dus een fixture
     /// verder in de toekomst gebeurt in deze run niet.
     pub pending_triggers: usize,
+    /// De besluiten die genomen zijn, in scenariovolgorde.
+    pub decisions: Vec<DecisionOutcome>,
     /// De uitkomsten van de vragen van een consument, in scenariovolgorde.
     pub outcomes: Vec<QueryOutcome>,
     /// De uitkomsten van de vragen over een celgrens, in scenariovolgorde.
@@ -177,7 +232,8 @@ pub struct ScenarioRun {
 impl ScenarioRun {
     /// Kwamen alle verwachtingen uit?
     pub fn passed(&self) -> bool {
-        self.outcomes.iter().all(|o| o.failures.is_empty())
+        self.decisions.iter().all(|o| o.failures.is_empty())
+            && self.outcomes.iter().all(|o| o.failures.is_empty())
             && self
                 .transport_outcomes
                 .iter()
@@ -185,6 +241,10 @@ impl ScenarioRun {
     }
 
     /// Heeft deze run iets vastgelegd? Een run zonder vragen bewijst niets.
+    ///
+    /// Besluiten tellen hier met opzet niet mee. Een besluit legt iets vast, maar
+    /// wat het waard is blijkt pas als iemand het terugvraagt: een scenario dat
+    /// alleen besluit en niets vraagt, laat de hele tijdreductie onbeproefd.
     pub fn proved_something(&self) -> bool {
         !self.outcomes.is_empty() || !self.transport_outcomes.is_empty()
     }
@@ -192,6 +252,48 @@ impl ScenarioRun {
     /// Leesbaar verslag van de run, geschikt voor een terminal of een testfout.
     pub fn report(&self) -> String {
         let mut out = format!("scenario '{}':\n", self.name);
+        for decision in &self.decisions {
+            let mark = if decision.failures.is_empty() {
+                "ok"
+            } else {
+                "FOUT"
+            };
+            let gram = &decision.decretogram;
+            // Het rechtskarakter en het bevoegd gezag staan erbij, want dat is
+            // het verschil tussen een berekening en een besluit. Wat er níet
+            // bij staat is het tijdstempel van het receipt: dat is wandkloktijd,
+            // en een verslag dat per run verschilt is geen verslag.
+            let _ = writeln!(
+                out,
+                "  [{mark}] {} besluit '{}' op {} -> zaakkenmerk '{}' ({}{}{})",
+                gram.cell,
+                gram.besluit,
+                gram.op_moment,
+                gram.zaakkenmerk,
+                gram.regulation,
+                gram.regulation_valid_from
+                    .as_ref()
+                    .map(|valid_from| format!(", versie {valid_from}"))
+                    .unwrap_or_default(),
+                describe_authority(gram),
+            );
+            if let Some(description) = &decision.description {
+                let _ = writeln!(out, "        {description}");
+            }
+            for (name, value) in &gram.outputs {
+                let _ = writeln!(out, "        {name} = {value}");
+            }
+            for (name, input) in &gram.inputs {
+                let _ = writeln!(
+                    out,
+                    "        input {name} = {} ({})",
+                    input.value,
+                    input.origin.describe()
+                );
+            }
+            write_failures(&mut out, &decision.failures);
+        }
+
         for outcome in &self.outcomes {
             let mark = if outcome.failures.is_empty() {
                 "ok"
@@ -255,6 +357,20 @@ impl ScenarioRun {
             );
         }
         out
+    }
+}
+
+/// Het rechtskarakter en het bevoegd gezag van een decretogram, voor het verslag.
+///
+/// Leeg als de regeling er niets over zegt, en dan staat het er ook niet:
+/// een besluit waarvan de wet het karakter niet noemt, hoort niet met een lege
+/// haak te suggereren dat het er wel een heeft.
+fn describe_authority(gram: &Decretogram) -> String {
+    match (&gram.legal_character, &gram.competent_authority) {
+        (Some(character), Some(authority)) => format!(", {character} door {authority}"),
+        (Some(character), None) => format!(", {character}"),
+        (None, Some(authority)) => format!(", door {authority}"),
+        (None, None) => String::new(),
     }
 }
 
@@ -368,6 +484,8 @@ impl Scenario {
     pub fn run(&self, regulation_root: &Path) -> Result<ScenarioRun> {
         let mut world = self.world(regulation_root)?;
 
+        let decisions = self.take_decisions(&mut world)?;
+
         let mut outcomes = Vec::with_capacity(self.queries.len());
         for query in &self.queries {
             if query.op_moment > world.now() {
@@ -397,9 +515,39 @@ impl Scenario {
             name: self.name.clone(),
             clock: world.now(),
             pending_triggers: world.pending_triggers(),
+            decisions,
             outcomes,
             transport_outcomes,
         })
+    }
+
+    /// Laat de cellen hun besluiten nemen, elk op zijn eigen moment.
+    ///
+    /// De klok gaat eerst vooruit tot dat moment, zodat een levering die
+    /// ertussen valt eerst landt: een besluit rekent op de feiten die de cel op
+    /// dat moment heeft, en op de wetsversie die dan geldt.
+    fn take_decisions(&self, world: &mut World) -> Result<Vec<DecisionOutcome>> {
+        let mut decisions = Vec::with_capacity(self.decide.len());
+        for decision in &self.decide {
+            if decision.op_moment > world.now() {
+                world.advance(decision.op_moment)?;
+            }
+
+            let decretogram = world.decide(
+                &decision.cell,
+                &decision.besluit,
+                &decision.params,
+                decision.op_moment,
+            )?;
+            let failures = check_values(&decision.expect, &decretogram.outputs);
+
+            decisions.push(DecisionOutcome {
+                description: decision.description.clone(),
+                decretogram,
+                failures,
+            });
+        }
+        Ok(decisions)
     }
 
     /// Stel de cross-cel-vragen, elk vanuit de veiligheidscontext van de vrager.
@@ -461,22 +609,34 @@ fn check_expectations(query: &Query, outcome: &LexostatusOutcome) -> Vec<Expecta
                 values: values.clone(),
             }]
         }
-        (LexostatusOutcome::Established(values), false) => query
-            .expect
-            .iter()
-            .filter_map(|(output, expected)| {
-                let found = values.get(output);
-                match found {
-                    Some(value) if equivalent(expected, value) => None,
-                    _ => Some(ExpectationFailure::Value {
-                        output: output.clone(),
-                        expected: expected.clone(),
-                        actual: found.cloned(),
-                    }),
-                }
-            })
-            .collect(),
+        (LexostatusOutcome::Established(values), false) => check_values(&query.expect, values),
     }
+}
+
+/// Vergelijk verwachte waarden met wat er werkelijk uitkwam.
+///
+/// Eén plek, want een besluit wordt op zijn uitkomsten afgerekend zoals een
+/// vraag op haar antwoord: uitkomsten waarover niets verwacht wordt, worden niet
+/// gecontroleerd, en een uitkomst die ontbreekt is een gemiste verwachting en
+/// geen stilte.
+fn check_values(
+    expect: &BTreeMap<String, Value>,
+    values: &BTreeMap<String, Value>,
+) -> Vec<ExpectationFailure> {
+    expect
+        .iter()
+        .filter_map(|(output, expected)| {
+            let found = values.get(output);
+            match found {
+                Some(value) if equivalent(expected, value) => None,
+                _ => Some(ExpectationFailure::Value {
+                    output: output.clone(),
+                    expected: expected.clone(),
+                    actual: found.cloned(),
+                }),
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -657,6 +817,7 @@ query_via_transport:
             name: "tijd".to_string(),
             clock: moment(),
             pending_triggers,
+            decisions: Vec::new(),
             outcomes: Vec::new(),
             transport_outcomes: Vec::new(),
         };
@@ -692,6 +853,7 @@ query_via_transport:
             name: "tijd".to_string(),
             clock: moment,
             pending_triggers: 0,
+            decisions: Vec::new(),
             outcomes: vec![outcome("vóór de vastlegging"), outcome("erna, ongewijzigd")],
             transport_outcomes: Vec::new(),
         };

--- a/packages/simulator/src/world.rs
+++ b/packages/simulator/src/world.rs
@@ -15,9 +15,16 @@
 //! die bij het passeren wordt vastgelegd. De lus is generiek — een gesorteerde
 //! lijst van `(datum, trigger)` — zodat vervallende verplichtingen en gemiste
 //! termijnen er later naast passen zonder dat de klok verandert.
+//!
+//! De wereld is ook de enige die een cel kan laten **besluiten**
+//! ([`World::decide`]). Dat is geen trigger op de klok maar een aansturing van
+//! buiten: in deze opstelling zegt het scenario wie wanneer waarover besluit,
+//! omdat een actie van een actor nog niet bestaat. De wereld houdt zelf geen
+//! register van wat er besloten is; het decretogram ligt in de kroniek van de
+//! cel die besloot.
 
-use crate::cell::{Cell, CellConfig, ChronicleEvent, Intake, Lexostatus};
-use crate::error::{Result, SimulatorError};
+use crate::cell::{Cell, CellConfig, ChronicleEvent, Decretogram, Intake, Lexostatus};
+use crate::error::{Result, SimulatorError, Subject};
 use chrono::NaiveDate;
 use regelrecht_engine::Value;
 use serde::Deserialize;
@@ -251,7 +258,8 @@ impl World {
         if op_moment > self.clock {
             return Err(SimulatorError::MomentAfterClock {
                 cell: cell.to_string(),
-                lexostatus: lexostatus.to_string(),
+                subject: Subject::Lexostatus,
+                name: lexostatus.to_string(),
                 op_moment: op_moment.to_string(),
                 clock: self.clock.to_string(),
             });
@@ -262,6 +270,43 @@ impl World {
                 cell: cell.to_string(),
             })?
             .reduce(lexostatus, params, op_moment)
+    }
+
+    /// Laat één cel een besluit nemen, op één moment.
+    ///
+    /// De enige weg naar `Cell::decide`: net als vastleggen is besluiten iets
+    /// dat een cel zelf doet, niet iets dat een consument bij haar bestelt. De
+    /// wereld is hier de aansturing die er in de opstelling nog niet is — een
+    /// actie op de tijdlijn, een verplichting die vervalt — en verder niets: ze
+    /// kiest de cel op, geeft het moment door en houdt zelf geen register bij
+    /// van wat er besloten is. Het decretogram ligt in de kroniek van de cel die
+    /// besloot, en nergens anders.
+    ///
+    /// `op_moment` mag niet ná de klok liggen, om dezelfde reden als bij
+    /// [`World::reduce`]: een besluit "op" een moment dat nog niet gebeurd is,
+    /// zou een gram in de toekomst leggen.
+    pub fn decide(
+        &mut self,
+        cell: &str,
+        besluit: &str,
+        params: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Result<Decretogram> {
+        if op_moment > self.clock {
+            return Err(SimulatorError::MomentAfterClock {
+                cell: cell.to_string(),
+                subject: Subject::Besluit,
+                name: besluit.to_string(),
+                op_moment: op_moment.to_string(),
+                clock: self.clock.to_string(),
+            });
+        }
+        self.cells
+            .get_mut(cell)
+            .ok_or_else(|| SimulatorError::UnknownCell {
+                cell: cell.to_string(),
+            })?
+            .decide(besluit, params, op_moment)
     }
 
     /// Laat alles afgaan wat op of vóór `tot` valt, in datumvolgorde.

--- a/packages/simulator/src/world.rs
+++ b/packages/simulator/src/world.rs
@@ -660,6 +660,68 @@ record:
         );
     }
 
+    /// De stroom met decretogrammen is niet met een `fixture` te vullen.
+    ///
+    /// Dat de configuratie haar niet mag declareren is niet genoeg: zodra een cel
+    /// besluit-definities heeft, bestáát de stroom, en zonder deze poort zou een
+    /// wereldbestand er een "besluit" in kunnen zetten dat nooit langs een engine
+    /// kwam — zonder receipt, zonder herkomst, met een `intake` naar keuze. Een
+    /// reductie erover zou dat niet van een echt besluit kunnen onderscheiden, en
+    /// dan bewijst het kernscenario niets meer.
+    #[test]
+    fn een_fixture_kan_geen_decretogram_verzinnen() {
+        let config: CellConfig = serde_yaml_ng::from_str(
+            r"
+id: toeslagen
+laws:
+  - wet_op_de_zorgtoeslag
+  - algemene_wet_inkomensafhankelijke_regelingen
+  - regeling_standaardpremie
+besluit_definitions:
+  - name: zorgtoeslag_vaststelling
+    regulation: wet_op_de_zorgtoeslag
+    output: heeft_recht_op_zorgtoeslag
+    zaakkenmerk: 'zorgtoeslag/{bsn}'
+    params:
+      - name: bsn
+        type: string
+",
+        )
+        .unwrap_or_else(|e| panic!("testconfig moet parsen: {e}"));
+
+        let verzonnen = Fixture {
+            at: date("2024-06-01"),
+            record: Recording {
+                cell: "toeslagen".to_string(),
+                chronicle: crate::cell::BESCHIKKINGEN.to_string(),
+                name: "zorgtoeslag_vaststelling".to_string(),
+                intake: Intake::Levering,
+                grondslag: String::new(),
+                fields: BTreeMap::from([
+                    (
+                        "zaakkenmerk".to_string(),
+                        Value::String("zorgtoeslag/999993653".to_string()),
+                    ),
+                    ("heeft_recht_op_zorgtoeslag".to_string(), Value::Bool(true)),
+                ]),
+            },
+        };
+
+        let err = World::new(
+            &[config],
+            Clock {
+                start: date("2024-01-01"),
+            },
+            &[verzonnen],
+            &regulation_root(),
+        )
+        .expect_err("een verzonnen decretogram hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::ReservedStreamRecording { .. }),
+            "verwachtte ReservedStreamRecording, kreeg {err}"
+        );
+    }
+
     #[test]
     fn een_fixture_naar_een_onbekende_cel_faalt_bij_het_optuigen() {
         let mut elders = fixture("2030-01-01", "relaties", "GEEN");


### PR DESCRIPTION
## Wat

De lus van chronolexografie sluit: informeren → concluderen → **vastleggen**. Een cel kan nu een eigen regeling uitvoeren en het resultaat als **decretogram** in haar eigen kroniek vastleggen. Terugzien is een gewone reductie over die kroniek — nooit een herberekening.

- **`besluit_definitions` in het wereldbestand** (data, geen Rust): een eigen regeling, de uitkomst die het besluit *is*, wat er in hetzelfde gram meegaat, een zaakkenmerk-sjabloon met `{parameter}`, en per input waar hij vandaan komt (`{ from_chronicle, field }` of `{ param }`). Alles wordt bij het optuigen getoetst: eigen regeling, bestaande uitkomsten én inputs, bestaande stromen en velden, en een sjabloon dat naar minstens één gedocumenteerde parameter verwijst.
- **`Cell::decide` is `pub(crate)`** en alleen bereikbaar via `World::decide`, net als het vastleggen zelf: een consument kan een cel niet laten besluiten. Het legt precies één gram vast — wat samen ontstaat, wordt samen vastgelegd — in de voorbehouden stroom `beschikkingen`, met zaakkenmerk, moment, regeling + `valid_from`, bevoegd gezag, rechtskarakter, alle uitkomsten, de inputs met hun herkomst en het volledige RFC-013 Execution Receipt. Een `#`-verwijzing in `competent_authority` wordt uit het geladen law-model opgelost.
- **Twee engines over dezelfde wetten.** Die van het reduce-pad krijgt nooit een cel-resolver; die van het besluit-pad is de enige die er ooit een mag krijgen. Een cross-cel-pull vanuit een reductie is daarmee een *ontbrekende capability* en geen afspraak. Vandaag heeft geen van beide er een; een test legt vast waar de haak zit.
- **Geen schaduwboekhouding.** Wat een besluit ophaalt gaat mét zijn herkomst ín het gram en niet als los feit in een kroniek; een volgend besluit haalt het opnieuw op. En de stroom met decretogrammen gaat niet als databron naar de engine: een besluit is geen feit om op te rekenen.

## Waarom

Zonder vastleggen is elk antwoord een herberekening, en dan verandert "wat is er destijds beslist" zodra de wet verandert. Dat verschil is de hele reden dat een decretogram naast een lexogram bestaat.

Het nieuwe scenario `scenarios/toeslagen_besluit.yaml` maakt het hard, op de publieke testwereld: een besluit op T1 onder wetsversie V1, en op T2 — waar V2 geldt en een herberekening een ander bedrag zou geven — nog steeds het gram van T1, met `regulation_valid_from: 2024-01-01` erin. Het tegenscenario staat ernaast: een nieuw besluit op T2 levert wél V2. Vóór het eerste besluit is het antwoord "niets vastgesteld", met een reden.

Een nieuwe scenario-stap `decide: { cell, besluit, params, op_moment }` triggert een besluit; een actie van een actor bestaat nog niet.

## Verder

De controles die een lexostatus en een besluit delen (gedocumenteerde parameters, eigen regeling, bestaande uitkomsten, bestaande kroniekvelden) staan nu op één plek, met `Subject` in de foutmelding om te zeggen over welke van de twee het gaat. `LexostatusInput` heet daarom `DocumentedParameter`.

De README beschrijft de lus, de twee paden met hun twee engines, wat een decretogram draagt, en welk deel van RFC-022 §1.2 hier wel (elementair, moment, zaakkenmerk, `legal_character`) en niet (RFC-008-stages, `modality`, rechtsbeschermingsroute, ondertekening) is overgenomen.

## Checks

`just format`, `just lint`, `just build-check`, `just validate`, `just test-no-docker` en pre-commit: groen.