### PR TITLE
feat: verplichtingen uit een besluit, nagekomen door de klok

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -4229,6 +4229,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "regelrecht-engine",
+ "rust_decimal",
  "serde",
  "serde_yaml_ng",
  "thiserror 2.0.20",

--- a/packages/simulator/Cargo.toml
+++ b/packages/simulator/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["simulation"]
 [dependencies]
 regelrecht-engine = { path = "../engine" }
 chrono.workspace = true
+rust_decimal.workspace = true
 serde.workspace = true
 serde_yaml_ng.workspace = true
 thiserror.workspace = true

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -12,7 +12,9 @@ en reduceert, zonder engine. Zie [Een bron-cel](#een-bron-cel).
 
 Een cel met eigen wetten kan ook **besluiten**: ze voert een regeling uit en legt
 de uitkomst vast als decretogram in haar eigen kroniek. Zie
-[Het besluit-pad](#het-besluit-pad).
+[Het besluit-pad](#het-besluit-pad). Wat zo'n besluit aan **verplichtingen**
+achterlaat, komt de klok later nakomen:
+[Verplichtingen](#verplichtingen-wat-een-besluit-achterlaat).
 
 Gaat een vraag over een celgrens, dan loopt hij langs de **veiligheidscontext**
 van de vragende cel naar het **transport**, en dat is de enige weg. Zie
@@ -37,10 +39,10 @@ kaart van paper naar code:
   nu zelf vast, in haar eigen kroniek: zie [Het besluit-pad](#het-besluit-pad).
 
 En de vierde term, de **reductie**: de huidige vormen (één uitkomst van één
-eigen regeling, of één kroniekfilter dat per sleutelwaarde de laatste
-vastlegging kiest) zijn een eerste benadering van wat de paper en RFC-022 §4.1
-bedoelen, namelijk filteren en aggregeren over kronieken. Het filteren staat er
-nu; aggregeren (som, telling) nog niet.
+eigen regeling, of een kroniekfilter dat per sleutelwaarde de laatste
+vastlegging kiest of één veld optelt) zijn een eerste benadering van wat de paper
+en RFC-022 §4.1 bedoelen, namelijk filteren en aggregeren over kronieken. Het
+filteren staat er; van het aggregeren staat de som er, en verder nog niets.
 
 ## Wat een cel is
 
@@ -162,9 +164,14 @@ reduction:                        # wetsvorm: laat een eigen regeling rekenen
 reduction:                        # kroniekfilter: lees een eigen kroniek
   chronicle: relaties
   key: bsn
-  latest: true                    # de enige modus; mag weggelaten worden
+  latest: true                    # de laatste vastlegging; mag weggelaten worden
   where:                          # optioneel, gelijkheid op velden
     partnerschap_type: HUWELIJK
+
+reduction:                        # de som over een eigen kroniek
+  chronicle: betalingen
+  key: zaakkenmerk
+  sum: bedrag                     # in plaats van `latest`, nooit samen
 ```
 
 De configuratie kiest door te noemen wat ze bedoelt; er is geen `kind`-veld dat
@@ -198,6 +205,26 @@ niet een record dat uit verschillende momenten is samengeraapt. Wat samen
 vastgelegd is, blijft samen. Een gepubliceerd veld dat déze vastlegging niet
 draagt, blijft uit het antwoord; de cel vult niets aan. Draagt ze er géén van,
 dan is er niets vastgesteld — zie hieronder.
+
+`sum: <veld>` is de andere kant: geen vastlegging maar één getal, opgeteld over
+**alle** vastleggingen die op of vóór `op_moment` aan het filter voldoen. Dat is
+de eerste aggregatie van de simulator, en ze bestaat voor één soort vraag: "hoeveel
+is er tot nu toe betaald". Vier dingen leggen dat vast:
+
+- `outputs` noemt precies het gesommeerde veld. Een som levert één waarde op, dus
+  iets anders publiceren is een belofte die nooit nagekomen wordt, en dat wordt bij
+  het optuigen geweigerd.
+- `latest` en `sum` tegelijk is een fout: het zijn twee reducties, niet twee
+  schrijfwijzen. `key` en `where` horen bij beide en betekenen hetzelfde.
+- Nul vastleggingen is **niet** nul: dan is er niets vastgesteld. Een 0 zou "er is
+  niets betaald" niet kunnen onderscheiden van "over deze zaak ligt hier niets".
+- Een vastlegging zonder getal in dat veld is een fout en geen nul. Een som die
+  zo'n vastlegging overslaat valt stil te laag uit, en dat is aan het getal niet
+  te zien.
+
+Dat dit een reductie is en geen teller, is het hele punt: "betaald tot nu toe" op
+een moment in het verleden blijft exact hetzelfde antwoord geven nadat er meer
+betaald is. Een saldo dat naast de kroniek wordt bijgehouden kan dat niet.
 
 ### "Niets vastgesteld" is een antwoord
 
@@ -245,7 +272,10 @@ gebeurt, in deze volgorde:
    waren, en uit de parameters van het besluit;
 3. de **besluit-engine** voert de regeling uit op dat moment, dus op de wetsversie
    die toen gold;
-4. de uitkomst gaat als één gram de stroom `beschikkingen` in.
+4. de verplichtingen worden uitgerekend tot een schema van termijnen, op de
+   uitkomsten waarop besloten is (zie
+   [Verplichtingen](#verplichtingen-wat-een-besluit-achterlaat));
+5. de uitkomst gaat als één gram de stroom `beschikkingen` in, met het schema erin.
 
 Die stroom is **voorbehouden**, aan drie kanten:
 
@@ -294,6 +324,7 @@ uitbreiding van RFC-013 stil achterlopen.
 | `legal_character` | wat de wet ervan maakt: `BESCHIKKING`, `TOETS`, … |
 | de uitkomsten | de uitkomst die het besluit *is*, plus wat `outputs` erbij noemt |
 | `inputs` | elke waarde waarop besloten is, **met haar herkomst** |
+| `obligations` | het betalingsschema dat uit dit besluit volgt: per termijn een vervaldatum, een bedrag en een volgnummer |
 | `receipt` | het volledige Execution Receipt |
 
 De herkomst per input is geen versiering. Zonder haar staat er wel een waarde in
@@ -306,6 +337,64 @@ cel zelf overkwam (zie [Wat een cel is](#wat-een-cel-is)).
 Eén besluit is één gram. Wat tegelijk ontstaat, wordt samen vastgelegd (RFC-022
 §1.2 — elk chronolexogram is *elementair*): het recht en het bedrag staan in
 hetzelfde gram, niet in twee.
+
+### Verplichtingen: wat een besluit achterlaat
+
+Een beschikking die een bedrag toekent, laat iets achter dat later moet gebeuren.
+Dat hoort bij het gram (RFC-022 §1.2), dus het schema wordt bij het besluit
+uitgerekend en er in vastgelegd:
+
+```yaml
+obligations:
+  - amount: $hoogte_zorgtoeslag      # een uitkomst van dít besluit
+    payer: belastingdienst           # de cel die de verplichting draagt
+    schedule: $betalingsritme        # ineens | kwartaal | maand, of een instelling
+    from: '{jaar}-02-01'             # optioneel; standaard het moment van het besluit
+```
+
+- **`amount` is een uitkomst, geen bedrag.** Wat betaald moet worden komt uit de
+  wet die het besluit uitvoert. Een letterlijk bedrag zou naast die uitkomst gaan
+  leven, en dan zegt het gram twee dingen over hetzelfde geld.
+- **Een ritme beschrijft één jaar**: `ineens` één termijn, `kwartaal` vier,
+  `maand` twaalf. Elke termijn krijgt hetzelfde bedrag in hele eenheden en het
+  restant gaat naar de laatste, dus de som van de termijnen is exact het
+  toegekende bedrag. Dat is de eigenschap waarop "betaald tot nu toe" rust.
+- **Het ritme mag een instelling zijn.** Een betalingsritme is doorgaans beleid en
+  geen wet; `schedule: $betalingsritme` leest uit `settings` van het
+  wereldbestand, zodat de besluit-definitie niet beweert dat de wet per kwartaal
+  betaalt. Een instelling die niet bestaat of geen ritme noemt, sneuvelt bij het
+  optuigen van de wereld.
+- **`from` is een sjabloon over de gedocumenteerde parameters**, net als het
+  zaakkenmerk, en wat het oplevert moet een datum zijn. Het mag niet vóór het
+  besluit liggen: een termijn in het verleden zou bij het nakomen een betaling op
+  een moment vastleggen dat al geweest is, en dan verandert het beeld van toen
+  alsnog.
+
+Nakomen doet de klok, niet het besluit. Op elke vervaldatum legt de **betalende**
+cel een executogram vast in haar eigen stroom `betalingen` (`intake: betaling`,
+met zaakkenmerk, bedrag, volgnummer en de verwijzing naar het decretogram), en de
+**besluitende** cel een levering in de hare: *betaling ontvangen gemeld*. Twee
+vastleggingen, elk in de kroniek van de cel die haar deed — beide kanten weten wat
+er gebeurde, en niemand kopieert de staat van een ander.
+
+`betalingen` is een naam van het platform, zoals `intake` platformvocabulaire is:
+beide cellen declareren een stroom met die naam en `zaakkenmerk` als sleutel, en
+een verplichting naar een cel die dat niet doet wordt bij het optuigen geweigerd —
+niet op de eerste vervaldatum, halverwege de tijdlijn. Anders dan `beschikkingen`
+is de stroom níet voorbehouden: een betaling is een gewoon feit, en een wereld mag
+er een startstand in hebben staan.
+
+**Eén termijn wordt één keer nagekomen.** Dezelfde zaak met hetzelfde volgnummer is
+dezelfde termijn: de klok mag in zo kleine stappen langskomen als ze wil, en een
+besluit dat op dezelfde dag wordt overgedaan levert geen tweede betaling. Zonder die
+regel zou de som dubbel tellen, en dat is aan het getal niet te zien.
+
+Het staat als scenario in
+[`scenarios/toeslagen_verplichtingen.yaml`](scenarios/toeslagen_verplichtingen.yaml)
+(vier kwartaaltermijnen, met de vraag over een eerder moment die ná een jaar nog
+hetzelfde antwoordt) en
+[`scenarios/toeslagen_verplichtingen_ritmes.yaml`](scenarios/toeslagen_verplichtingen_ritmes.yaml)
+(hetzelfde bedrag `ineens` en per `maand` — het ritme bepaalt wanneer, niet hoeveel).
 
 ### Het zaakkenmerk moet bij precies één zaak horen
 
@@ -385,8 +474,7 @@ en geen stage-decretogrammen, dus "de huidige stap" bestaat hier niet); `modalit
 (`is_intrekking_van`, `is_wijziging_van`); de afgeleide rechtsbeschermingsroute
 (§3.3); `decision_type` als open vocabulaire; `extensions`; en de handtekening —
 het gram wordt niet ondertekend, want er is geen sleutelmateriaal (zie
-[Ondertekening is gesimuleerd](#ondertekening-is-gesimuleerd)). Verplichtingen
-die uit een besluit volgen horen ook bij §1.2 en staan er nog niet.
+[Ondertekening is gesimuleerd](#ondertekening-is-gesimuleerd)).
 
 ## Over een celgrens
 
@@ -598,9 +686,16 @@ Vier eigenschappen, en ze hangen samen:
 - **`advance` loopt de triggers af in datumvolgorde**, en tijdens een trigger
   staat de klok op het moment van die trigger. Een vastlegging krijgt dus haar
   eigen datum als `op_moment`, niet de eindstand van de sprong. De lus is
-  generiek — een gesorteerde lijst van `(datum, trigger)` — zodat vervallende
-  verplichtingen en gemiste termijnen er later naast passen. Vandaag bestaat er
-  één soort: een `fixture` die bij het passeren wordt vastgelegd.
+  generiek — een gesorteerde lijst van `(datum, trigger)` — dus een soort erbij is
+  een variant erbij en geen andere klok. Er zijn er twee: een `fixture` die bij
+  het passeren wordt vastgelegd, en een **vervallende verplichting** die de cel
+  die haar draagt laat betalen (zie
+  [Verplichtingen](#verplichtingen-wat-een-besluit-achterlaat)).
+- **Dat de wachtrij oplopend is, is een invariant en geen toestand.** Een besluit
+  tijdens de run plant nieuwe vervaldata, en die gaan op datumpositie de rij in.
+  Achteraan bijzetten zou een termijn die vóór een al wachtende trigger valt te
+  laat of helemaal niet laten afgaan — en met alleen een fixture ná hen in de rij
+  is dat niet te zien.
 - **Een trigger voegt toe en wijzigt nooit een bestaand gram.** Daarom verandert
   het beeld van een eerder moment niet doordat de wereld verder loopt. Dat is de
   kernassertie, en ze staat als scenario in
@@ -629,11 +724,11 @@ bereikt geen stille regel in het bestand is.
 ## Het wereldbestand
 
 Een wereld is één YAML-bestand: `clock` (de tijdlijn), `cells` (wie er zijn),
-`fixtures` (de startstand), `decide` (welke cel wanneer waarover besluit) en twee
-soorten vraag: `queries` (een consument bevraagt een cel) en
-`query_via_transport` (een cel bevraagt een andere cel). Elk draagt zijn eigen
-verwachting. De assertie hoort bij het bestand, niet bij Rust: een nieuw
-testgeval is een nieuw bestand.
+`settings` (casusdata die geen wet is), `fixtures` (de startstand), `decide`
+(welke cel wanneer waarover besluit) en twee soorten vraag: `queries` (een
+consument bevraagt een cel) en `query_via_transport` (een cel bevraagt een andere
+cel). Elk draagt zijn eigen verwachting. De assertie hoort bij het bestand, niet
+bij Rust: een nieuw testgeval is een nieuw bestand.
 
 ```yaml
 name: korte naam van het scenario
@@ -641,6 +736,9 @@ description: waarom dit scenario bestaat        # optioneel
 
 clock:
   start: 2024-01-01                             # waar de klok begint; verplicht
+
+settings:                                       # instellingen van deze wereld
+  betalingsritme: kwartaal                      # waar een $naam naar verwijst
 
 cells:
   - id: toeslagen                               # het cel-id
@@ -685,7 +783,18 @@ cells:
         reduction:
           chronicle: relaties                   # een eigen stroom
           key: bsn                              # sleutel = naam van een input
-          latest: true                          # de enige modus; mag weg
+          latest: true                          # de laatste vastlegging; mag weg
+
+      - name: betaald_tot_nu_toe                # de som over een eigen stroom
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:                                # precies het gesommeerde veld
+          - bedrag
+        reduction:
+          chronicle: betalingen
+          key: zaakkenmerk
+          sum: bedrag                           # in plaats van `latest`
 
     besluit_definitions:                        # wat de cel kan besluiten
       - name: zorgtoeslag_vaststelling
@@ -699,6 +808,8 @@ cells:
         params:                                 # de gedocumenteerde parameters
           - name: bsn
             type: string
+          - name: jaar
+            type: string
         inputs:                                 # wat de cel de engine aanlevert
           bsn:
             param: bsn                          # uit de parameters van het besluit
@@ -711,6 +822,13 @@ cells:
             field: toetsingsinkomen             # de uitkomst daarvan
             params:
               bsn: $bsn                         # $naam = parameter van dit besluit
+        obligations:                            # wat er betaald moet worden
+          - amount: $hoogte_zorgtoeslag         # een uitkomst van dit besluit
+            payer: belastingdienst              # de cel die de verplichting draagt
+            schedule: $betalingsritme           # ineens | kwartaal | maand, of
+                                                # een $instelling
+            from: '{jaar}-02-01'                # optioneel; standaard het moment
+                                                # van het besluit
 
     accepts_from:                               # wat de wétten bij een cel halen
       - cell: brp                               # het cel-id uit source.regulation
@@ -925,11 +1043,12 @@ overschaduwen.
 
 ## Wat hier nog niet staat
 
-**Een besluit trekt nog geen verplichtingen na zich aan.** Een beschikking die
-een bedrag toekent, brengt in de echte wereld betalingen voort met een
-vervaldatum; die horen bij het decretogram (RFC-022 §1.2) en worden bij het
-verstrijken van de tijd executogrammen. De trigger-lus in de wereld is er al op
-gebouwd, maar er is nog geen soort trigger voor.
+**Een verplichting kent geen rente, verrekening of terugvordering.** Een termijn
+vervalt en wordt betaald; wat er gebeurt als er te laat, te veel of niet betaald
+wordt, staat er niet. Een terugvordering is in deze opzet een gewoon besluit met
+een eigen verplichting, en dat is nog nergens uitgewerkt. Een verplichting kan ook
+niet gewijzigd of ingetrokken worden: het schema staat in het gram, en een gram
+verandert niet.
 
 **Een besluit wordt nog niet door een actie uitgelokt.** Het scenario zegt in
 `decide` wie wanneer waarover besluit; er is nog geen `World::act` waarmee een

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -384,10 +384,19 @@ niet op de eerste vervaldatum, halverwege de tijdlijn. Anders dan `beschikkingen
 is de stroom níet voorbehouden: een betaling is een gewoon feit, en een wereld mag
 er een startstand in hebben staan.
 
-**Eén termijn wordt één keer nagekomen.** Dezelfde zaak met hetzelfde volgnummer is
-dezelfde termijn: de klok mag in zo kleine stappen langskomen als ze wil, en een
-besluit dat op dezelfde dag wordt overgedaan levert geen tweede betaling. Zonder die
-regel zou de som dubbel tellen, en dat is aan het getal niet te zien.
+**Eén termijn wordt één keer nagekomen.** Dezelfde zaak, hetzelfde besluit en
+hetzelfde volgnummer is dezelfde termijn: de klok mag in zo kleine stappen
+langskomen als ze wil, en een besluit dat wordt overgedaan levert geen tweede
+betaling. Zonder die regel zou de som dubbel tellen, en dat is aan het getal niet
+te zien.
+
+Dat het besluit in die vergelijking staat en niet alleen het volgnummer, is de
+andere helft: over één zaak worden meer besluiten genomen — een verlening en later
+een vaststelling — en elk draagt een eigen schema dat bij termijn 1 begint. Op
+zaak en volgnummer alléén zou de eerste termijn van het tweede besluit voor die
+van het eerste doorgaan en stil wegvallen. Om dezelfde reden lopen de volgnummers
+binnen één gram dóór over álle verplichtingen die het besluit oplegt, en beginnen
+ze niet per verplichting opnieuw.
 
 Het staat als scenario in
 [`scenarios/toeslagen_verplichtingen.yaml`](scenarios/toeslagen_verplichtingen.yaml)

--- a/packages/simulator/scenarios/toeslagen_verplichtingen.yaml
+++ b/packages/simulator/scenarios/toeslagen_verplichtingen.yaml
@@ -1,0 +1,240 @@
+---
+name: een besluit brengt verplichtingen voort die de tijd nakomt
+description: >-
+  Een beschikking die een bedrag toekent, laat iets achter dat later moet
+  gebeuren. De cel `toeslagen` besluit op T1 en legt in hetzelfde gram het
+  betalingsschema vast: vier termijnen, elk kwartaal één. Daarna doet de klok
+  het werk. Op elke vervaldatum legt `belastingdienst` vast dat zij betaalde, en
+  `toeslagen` dat het haar gemeld is — twee vastleggingen, elk in de eigen
+  kroniek van de cel die haar deed.
+
+  Wat dit scenario moet weerleggen is dat er ergens een saldo bijgehouden wordt.
+  "Betaald tot nu toe" is een **reductie over vastleggingen** (`sum: bedrag`),
+  geen teller: de vraag over een eerder moment blijft daarom exact hetzelfde
+  antwoord geven nadat er meer betaald is, en over een zaak waarover niets
+  vastligt is het antwoord "niets vastgesteld" en geen nul.
+
+clock:
+  # De feiten van deze persoon staan als `events` in de celconfiguratie en
+  # liggen allemaal vóór dit moment. Het besluit valt op het startmoment, dus
+  # de eerste termijn vervalt meteen: zonder `from` begint een verplichting bij
+  # het besluit waaruit ze volgt.
+  start: 2024-01-01
+
+settings:
+  # Een betalingsritme is beleid en geen wet. Het staat daarom hier, bij de
+  # wereld, en niet in de besluit-definitie: die zou anders zeggen dat de wet
+  # per kwartaal betaalt, en dat staat er niet.
+  betalingsritme: kwartaal
+
+cells:
+  - id: toeslagen
+    laws:
+      - wet_op_de_zorgtoeslag
+      - algemene_wet_inkomensafhankelijke_regelingen
+      - regeling_standaardpremie
+
+    chronicles:
+      - stream: relaties
+        key: bsn
+        events:
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: toeslagen
+            grondslag: melding uit de basisregistratie personen
+            op_moment: 2023-01-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: GEEN
+
+      - stream: inkomensleveringen
+        key: bsn
+        events:
+          - name: inkomenslevering
+            intake: levering
+            recording_actor: toeslagen
+            grondslag: jaarlijkse inkomenslevering
+            op_moment: 2023-11-15
+            fields:
+              bsn: '999993653'
+              is_verzekerde: true
+              verzamelinkomen: 79547
+              buitenlands_inkomen: 0
+              vermogen: 0
+
+      # De besluitende cel houdt zelf ook een betalingsstroom: zij legt vast dat
+      # haar gemeld is dat er betaald is. Dat is een eigen feit — een levering —
+      # en geen kopie van de kroniek van de betaler. De stroom blijft hier leeg;
+      # wat erin komt, komt van de klok.
+      - stream: betalingen
+        key: zaakkenmerk
+
+    besluit_definitions:
+      - name: zorgtoeslag_vaststelling
+        regulation: wet_op_de_zorgtoeslag
+        output: heeft_recht_op_zorgtoeslag
+        outputs:
+          - hoogte_zorgtoeslag
+        zaakkenmerk: zorgtoeslag/{bsn}
+        params:
+          - name: bsn
+            type: string
+        inputs:
+          bsn:
+            param: bsn
+          is_verzekerde:
+            from_chronicle: inkomensleveringen
+            field: is_verzekerde
+        obligations:
+          # Het bedrag komt uit de wet, niet uit dit bestand: `$hoogte_zorgtoeslag`
+          # is de uitkomst waarop besloten is. Een letterlijk bedrag zou ernaast
+          # gaan leven, en dan zegt het gram twee dingen over hetzelfde geld.
+          - amount: $hoogte_zorgtoeslag
+            payer: belastingdienst
+            schedule: $betalingsritme
+
+    lexostatus_definitions:
+      - name: betaald_tot_nu_toe
+        doc: >-
+          Wat er op deze zaak betaald is, voor zover deze cel dat weet. Een som
+          over haar eigen meldingen, en dus een reductie — geen saldo dat naast
+          de kroniek wordt bijgehouden.
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - bedrag
+        reduction:
+          chronicle: betalingen
+          key: zaakkenmerk
+          sum: bedrag
+
+  - id: belastingdienst
+    # Een bron-cel: geen wetten, geen engine. Ze legt vast en reduceert, en dat
+    # is genoeg om een verplichting na te komen.
+    laws: []
+    chronicles:
+      - stream: betalingen
+        key: zaakkenmerk
+
+    lexostatus_definitions:
+      - name: betaald_tot_nu_toe
+        doc: Wat deze cel op deze zaak betaald heeft, opgeteld.
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - bedrag
+        reduction:
+          chronicle: betalingen
+          key: zaakkenmerk
+          sum: bedrag
+
+      - name: laatste_betaling
+        doc: >-
+          De laatste termijn die deze cel betaalde. Een gewoon kroniekfilter
+          ernaast, zodat te zien is dat de som over dezelfde vastleggingen gaat
+          als het filter dat er één uitkiest.
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - bedrag
+          - volgnummer
+          - besluit
+          - besluit_cel
+        reduction:
+          chronicle: betalingen
+          key: zaakkenmerk
+          latest: true
+
+decide:
+  - description: >-
+      De cel kent zorgtoeslag toe en legt in hetzelfde gram vast wat er daarmee
+      betaald moet worden: vier termijnen van € 493,01, plus de rest op de
+      laatste. De som van de termijnen is exact het toegekende bedrag.
+    cell: toeslagen
+    besluit: zorgtoeslag_vaststelling
+    params:
+      bsn: '999993653'
+    op_moment: 2024-01-01
+    expect:
+      heeft_recht_op_zorgtoeslag: true
+      hoogte_zorgtoeslag: 197205.31187
+
+queries:
+  - description: >-
+      De eerste termijn vervalt op het moment van het besluit zelf, dus er is op
+      dat moment al één betaling. De besluitende cel weet dat uit haar eigen
+      kroniek: het is haar gemeld, ze heeft het niet elders opgevraagd.
+    cell: toeslagen
+    lexostatus: betaald_tot_nu_toe
+    params:
+      zaakkenmerk: zorgtoeslag/999993653
+    op_moment: 2024-01-01
+    expect:
+      bedrag: 49301
+
+  - description: >-
+      Halverwege het jaar zijn er twee termijnen verstreken (januari en april).
+      De betalende cel telt hetzelfde op, over haar eigen betalingen — dezelfde
+      uitkomst, twee kronieken, geen gedeelde staat.
+    cell: belastingdienst
+    lexostatus: betaald_tot_nu_toe
+    params:
+      zaakkenmerk: zorgtoeslag/999993653
+    op_moment: 2024-06-15
+    expect:
+      bedrag: 98602
+
+  - description: >-
+      Op datzelfde moment is de laatste termijn die van april: volgnummer 2, met
+      de verwijzing naar het besluit waaruit ze volgt.
+    cell: belastingdienst
+    lexostatus: laatste_betaling
+    params:
+      zaakkenmerk: zorgtoeslag/999993653
+    op_moment: 2024-06-15
+    expect:
+      volgnummer: 2
+      bedrag: 49301
+      besluit: zorgtoeslag_vaststelling
+      besluit_cel: toeslagen
+
+  - description: >-
+      Ná het jaar zijn alle vier de termijnen verstreken, en dan is er precies
+      het toegekende bedrag betaald — inclusief de rest die op de laatste termijn
+      landde. Een verdeling die niet optelt tot de beschikking zou hier zichtbaar
+      worden.
+    cell: toeslagen
+    lexostatus: betaald_tot_nu_toe
+    params:
+      zaakkenmerk: zorgtoeslag/999993653
+    op_moment: 2025-01-05
+    expect:
+      bedrag: 197205.31187
+
+  - description: >-
+      De kernassertie. Dezelfde vraag over halverwege het jaar, nu gesteld
+      terwijl de klok een jaar verder staat, geeft nog steeds twee termijnen. Een
+      saldo zou hier de eindstand melden; een reductie over vastleggingen kan dat
+      niet, want de latere betalingen dragen een later moment.
+    cell: belastingdienst
+    lexostatus: betaald_tot_nu_toe
+    params:
+      zaakkenmerk: zorgtoeslag/999993653
+    op_moment: 2024-06-15
+    expect:
+      bedrag: 98602
+
+  - description: >-
+      En over een zaak waarover niets vastligt is het antwoord "niets
+      vastgesteld" — geen nul. Een som van nul euro en een zaak die hier niet
+      bestaat zijn twee verschillende dingen, en een 0 zou ze niet uit elkaar
+      houden.
+    cell: belastingdienst
+    lexostatus: betaald_tot_nu_toe
+    params:
+      zaakkenmerk: zorgtoeslag/999993999
+    op_moment: 2025-01-05
+    expect_not_established: true

--- a/packages/simulator/scenarios/toeslagen_verplichtingen_ritmes.yaml
+++ b/packages/simulator/scenarios/toeslagen_verplichtingen_ritmes.yaml
@@ -1,0 +1,214 @@
+---
+name: hetzelfde bedrag in een ander ritme
+description: >-
+  Het tegenscenario naast `toeslagen_verplichtingen.yaml`. Hetzelfde besluit,
+  hetzelfde bedrag, twee andere ritmes: `ineens` staat letterlijk in de
+  besluit-definitie, `maand` komt uit `settings` van het wereldbestand. Het
+  ritme verandert de vervaldata en de termijnbedragen; het verandert niet wat er
+  in totaal betaald wordt.
+
+  Verder laat dit scenario `from` zien: de maandelijkse verplichting begint niet
+  bij het besluit maar op een datum die uit een parameter volgt. Zolang die
+  datum niet vóór het besluit ligt, mag dat — een verplichting kan niet
+  vervallen vóór het besluit waaruit ze volgt.
+
+clock:
+  start: 2024-01-01
+
+settings:
+  betalingsritme: maand
+
+cells:
+  - id: toeslagen
+    laws:
+      - wet_op_de_zorgtoeslag
+      - algemene_wet_inkomensafhankelijke_regelingen
+      - regeling_standaardpremie
+
+    chronicles:
+      - stream: relaties
+        key: bsn
+        events:
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: toeslagen
+            grondslag: melding uit de basisregistratie personen
+            op_moment: 2023-01-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: GEEN
+
+      - stream: inkomensleveringen
+        key: bsn
+        events:
+          - name: inkomenslevering
+            intake: levering
+            recording_actor: toeslagen
+            grondslag: jaarlijkse inkomenslevering
+            op_moment: 2023-11-15
+            fields:
+              bsn: '999993653'
+              is_verzekerde: true
+              verzamelinkomen: 79547
+              buitenlands_inkomen: 0
+              vermogen: 0
+
+      - stream: betalingen
+        key: zaakkenmerk
+
+    besluit_definitions:
+      - name: zorgtoeslag_ineens
+        doc: >-
+          Eén termijn, op het moment van het besluit. Het ritme staat hier
+          letterlijk: deze beschikking betaalt nu eenmaal in één keer, ongeacht
+          wat de wereld als standaardritme heeft ingesteld.
+        regulation: wet_op_de_zorgtoeslag
+        output: heeft_recht_op_zorgtoeslag
+        outputs:
+          - hoogte_zorgtoeslag
+        zaakkenmerk: zorgtoeslag-ineens/{bsn}
+        params:
+          - name: bsn
+            type: string
+        inputs:
+          bsn:
+            param: bsn
+          is_verzekerde:
+            from_chronicle: inkomensleveringen
+            field: is_verzekerde
+        obligations:
+          - amount: $hoogte_zorgtoeslag
+            payer: belastingdienst
+            schedule: ineens
+
+      - name: zorgtoeslag_maandelijks
+        doc: >-
+          Twaalf termijnen, vanaf een datum die het besluit meekrijgt. `from` is
+          een sjabloon over de gedocumenteerde parameters, net als het
+          zaakkenmerk; wat het oplevert moet een datum zijn.
+        regulation: wet_op_de_zorgtoeslag
+        output: heeft_recht_op_zorgtoeslag
+        outputs:
+          - hoogte_zorgtoeslag
+        zaakkenmerk: zorgtoeslag-maand/{bsn}
+        params:
+          - name: bsn
+            type: string
+          - name: jaar
+            type: string
+        inputs:
+          bsn:
+            param: bsn
+          is_verzekerde:
+            from_chronicle: inkomensleveringen
+            field: is_verzekerde
+        obligations:
+          - amount: $hoogte_zorgtoeslag
+            payer: belastingdienst
+            schedule: $betalingsritme
+            from: '{jaar}-02-01'
+
+    lexostatus_definitions:
+      - name: betaald_tot_nu_toe
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - bedrag
+        reduction:
+          chronicle: betalingen
+          key: zaakkenmerk
+          sum: bedrag
+
+  - id: belastingdienst
+    laws: []
+    chronicles:
+      - stream: betalingen
+        key: zaakkenmerk
+
+    lexostatus_definitions:
+      - name: betaald_tot_nu_toe
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - bedrag
+        reduction:
+          chronicle: betalingen
+          key: zaakkenmerk
+          sum: bedrag
+
+decide:
+  - description: ineens - één termijn, meteen
+    cell: toeslagen
+    besluit: zorgtoeslag_ineens
+    params:
+      bsn: '999993653'
+    op_moment: 2024-01-01
+    expect:
+      hoogte_zorgtoeslag: 197205.31187
+
+  - description: maandelijks - twaalf termijnen, vanaf februari
+    cell: toeslagen
+    besluit: zorgtoeslag_maandelijks
+    params:
+      bsn: '999993653'
+      jaar: '2024'
+    op_moment: 2024-01-01
+    expect:
+      hoogte_zorgtoeslag: 197205.31187
+
+queries:
+  - description: >-
+      `ineens` betaalt op de dag van het besluit het hele bedrag; er is geen
+      termijn die later vervalt.
+    cell: belastingdienst
+    lexostatus: betaald_tot_nu_toe
+    params:
+      zaakkenmerk: zorgtoeslag-ineens/999993653
+    op_moment: 2024-01-01
+    expect:
+      bedrag: 197205.31187
+
+  - description: >-
+      De maandelijkse verplichting begint pas in februari, dus halverwege januari
+      ligt er over die zaak nog niets vast.
+    cell: belastingdienst
+    lexostatus: betaald_tot_nu_toe
+    params:
+      zaakkenmerk: zorgtoeslag-maand/999993653
+    op_moment: 2024-01-15
+    expect_not_established: true
+
+  - description: >-
+      Halverwege juni zijn er vijf maandtermijnen verstreken (februari tot en met
+      juni). Deze vraag staat hier ook om de klok in kleine stappen te laten
+      lopen: elke termijn gaat één keer af, hoe vaak de tijd ook wordt opgedeeld.
+    cell: belastingdienst
+    lexostatus: betaald_tot_nu_toe
+    params:
+      zaakkenmerk: zorgtoeslag-maand/999993653
+    op_moment: 2024-06-15
+    expect:
+      bedrag: 82165
+
+  - description: na september acht termijnen
+    cell: belastingdienst
+    lexostatus: betaald_tot_nu_toe
+    params:
+      zaakkenmerk: zorgtoeslag-maand/999993653
+    op_moment: 2024-09-15
+    expect:
+      bedrag: 131464
+
+  - description: >-
+      Na de twaalfde termijn (januari van het volgende jaar) is er precies
+      hetzelfde betaald als in het scenario met kwartalen, en als bij `ineens`.
+      Het ritme bepaalt wanneer, niet hoeveel.
+    cell: toeslagen
+    lexostatus: betaald_tot_nu_toe
+    params:
+      zaakkenmerk: zorgtoeslag-maand/999993653
+    op_moment: 2025-01-05
+    expect:
+      bedrag: 197205.31187

--- a/packages/simulator/src/cell/besluit.rs
+++ b/packages/simulator/src/cell/besluit.rs
@@ -19,6 +19,13 @@
 //!   decretogram terug als kroniekfeit; ligt er geen, dan is het antwoord
 //!   "niets vastgesteld". Nooit een herberekening onder een inmiddels andere
 //!   wetsversie.
+//!
+//! Een besluit kan ook **verplichtingen** voortbrengen: een bedrag dat op
+//! vervaldata nagekomen moet worden (RFC-022 §1.2). Het schema daarvan wordt
+//! hier uitgerekend — bij het besluit, op de uitkomst waarop besloten is — en
+//! gaat mee in het gram. Het *nakomen* gebeurt elders: de klok laat een termijn
+//! vervallen en dan legt de cel die de verplichting draagt een betaling vast.
+//! Zie [`ObligationDue`].
 
 use crate::cell::config::{
     binding_name, check_documented_params, documents, engine_parameters, parameter_listing,
@@ -26,8 +33,10 @@ use crate::cell::config::{
 };
 use crate::cell::{ChronicleEvent, Intake};
 use crate::error::{Result, SimulatorError, Subject};
-use chrono::NaiveDate;
+use crate::values::amount;
+use chrono::{Months, NaiveDate};
 use regelrecht_engine::{ExecutionReceipt, Value};
+use rust_decimal::Decimal;
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -38,6 +47,17 @@ use std::collections::{BTreeMap, BTreeSet};
 /// declareert wordt geweigerd. Dat de naam vastligt, is wat een reductie erover
 /// mogelijk maakt zonder dat elke casus hem opnieuw verzint.
 pub const BESCHIKKINGEN: &str = "beschikkingen";
+
+/// De kroniekstroom waarin betalingen op verplichtingen landen.
+///
+/// Platformvocabulaire, net als [`Intake`]: een cel die een verplichting draagt
+/// of er een oplegt, houdt een stroom met deze naam. Anders dan
+/// [`BESCHIKKINGEN`] wordt ze niet automatisch aangemaakt — een betaling is een
+/// gewoon feit dat een cel overkomt, en een wereld mag er een startstand in
+/// hebben staan. Wat wél vastligt is de naam en de sleutel ([`ZAAKKENMERK`]):
+/// daarop reduceert "betaald tot nu toe", en die hoeft geen casus opnieuw te
+/// verzinnen.
+pub const BETALINGEN: &str = "betalingen";
 
 /// De veldnamen die elk decretogram draagt, naast de uitkomsten van het besluit.
 ///
@@ -58,11 +78,13 @@ pub const COMPETENT_AUTHORITY: &str = "competent_authority";
 pub const LEGAL_CHARACTER: &str = "legal_character";
 /// Veld met de inputs van het besluit, elk met hun herkomst.
 pub const INPUTS: &str = "inputs";
+/// Veld met het uitgerekende betalingsschema van dit besluit.
+pub const OBLIGATIONS: &str = "obligations";
 /// Veld met het volledige RFC-013 Execution Receipt.
 pub const RECEIPT: &str = "receipt";
 
 /// De vaste velden van een decretogram, in de volgorde waarin ze hierboven staan.
-const FIXED_FIELDS: [&str; 8] = [
+const FIXED_FIELDS: [&str; 9] = [
     ZAAKKENMERK,
     BESLUIT,
     REGULATION,
@@ -70,8 +92,37 @@ const FIXED_FIELDS: [&str; 8] = [
     COMPETENT_AUTHORITY,
     LEGAL_CHARACTER,
     INPUTS,
+    OBLIGATIONS,
     RECEIPT,
 ];
+
+/// Veld met het bedrag van één betalingstermijn.
+pub const BEDRAG: &str = "bedrag";
+/// Veld met het volgnummer van een termijn binnen één verplichting.
+pub const VOLGNUMMER: &str = "volgnummer";
+/// Veld met de cel die het besluit nam waaruit deze betaling volgt.
+pub const BESLUIT_CEL: &str = "besluit_cel";
+/// Veld met het moment van dat besluit.
+pub const BESLUIT_OP_MOMENT: &str = "besluit_op_moment";
+
+/// De velden die elke vastlegging in [`BETALINGEN`] draagt.
+///
+/// Bekend vóór de eerste betaling, om dezelfde reden als bij
+/// [`declared_fields`]: een lexostatus die over deze stroom sommeert wordt bij
+/// het optuigen getoetst, en dan is de stroom nog leeg.
+pub(crate) fn betaling_fields() -> BTreeSet<String> {
+    [
+        ZAAKKENMERK,
+        BEDRAG,
+        VOLGNUMMER,
+        BESLUIT,
+        BESLUIT_CEL,
+        BESLUIT_OP_MOMENT,
+    ]
+    .iter()
+    .map(|field| (*field).to_string())
+    .collect()
+}
 
 /// Eén besluit dat een cel kan nemen.
 #[derive(Debug, Clone, Deserialize)]
@@ -110,6 +161,246 @@ pub struct BesluitDefinition {
     /// (`accept_from`).
     #[serde(default)]
     pub inputs: BTreeMap<String, BesluitInput>,
+    /// De verplichtingen die uit dit besluit volgen: wat er betaald moet worden,
+    /// door wie, in welk ritme en vanaf wanneer.
+    ///
+    /// Leeg is het gewone geval: niet elk besluit kent iets toe. Wat hier staat
+    /// wordt bij het besluit uitgerekend tot een schema van termijnen en gaat
+    /// mee in het decretogram; het nakomen gebeurt op de klok.
+    #[serde(default)]
+    pub obligations: Vec<ObligationDefinition>,
+}
+
+/// Eén verplichting die een besluit oplegt.
+///
+/// De vorm is casusdata: een bedrag uit de eigen uitkomsten, een cel die
+/// betaalt, een ritme en een startdatum. Wat er niet in staat is even
+/// belangrijk: geen kroniekstroom (die heet [`BETALINGEN`], overal), geen
+/// bedrag met de hand (dat zou naast de wetsuitkomst gaan leven) en geen
+/// vervaldata per stuk (die volgen uit het ritme).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObligationDefinition {
+    /// Het bedrag, als `$uitkomst` van dít besluit.
+    ///
+    /// Geen letterlijk bedrag en geen parameter: wat betaald moet worden, komt
+    /// uit de wet die het besluit uitvoert. Een bedrag dat de configuratie zelf
+    /// noemt zou naast de uitkomst gaan leven, en dan zegt het gram twee dingen.
+    pub amount: String,
+    /// De cel die de verplichting draagt en dus betaalt.
+    ///
+    /// Mag de besluitende cel zelf zijn; meestal is het een andere organisatie,
+    /// en dan weten beide kanten wat er gebeurde zonder elkaars kroniek te lezen.
+    pub payer: String,
+    /// Het ritme: `ineens`, `kwartaal` of `maand`, of `$instelling` — een
+    /// verwijzing naar `settings` in het wereldbestand.
+    ///
+    /// Dat een ritme een instelling mag zijn, is geen gemak: een betalingsritme
+    /// is doorgaans beleid en geen wet, en beleid hoort niet in een
+    /// besluit-definitie vast te staan alsof de wet het voorschrijft.
+    pub schedule: String,
+    /// Vanaf wanneer de termijnen lopen, als sjabloon met `{parameter}`.
+    ///
+    /// Weggelaten betekent: het moment van het besluit. Wat er staat moet een
+    /// datum opleveren (`JJJJ-MM-DD`) die niet vóór het besluit ligt — een
+    /// verplichting kan niet vervallen vóór het besluit dat haar schept.
+    #[serde(default)]
+    pub from: Option<String>,
+}
+
+/// Het ritme waarin een verplichting vervalt.
+///
+/// Drie soorten, en ze beschrijven alle drie **één jaar**: ineens is één
+/// termijn, kwartaal vier, maand twaalf. Platformvocabulaire zoals [`Intake`]:
+/// een ritme erbij is een variant erbij, en een typfout in een ritmenaam hoort
+/// niet stil als "ineens" te eindigen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Schedule {
+    /// Eén termijn, op de startdatum.
+    Ineens,
+    /// Vier termijnen, elk kwartaal één.
+    Kwartaal,
+    /// Twaalf termijnen, elke maand één.
+    Maand,
+}
+
+impl Schedule {
+    /// De ritmes die de simulator kent, met hun naam in een wereldbestand.
+    const ALL: [(&'static str, Self); 3] = [
+        ("ineens", Self::Ineens),
+        ("kwartaal", Self::Kwartaal),
+        ("maand", Self::Maand),
+    ];
+
+    /// Het ritme met deze naam, of `None` als er geen zo heet.
+    pub fn from_name(name: &str) -> Option<Self> {
+        Self::ALL
+            .iter()
+            .find(|(known, _)| *known == name)
+            .map(|(_, schedule)| *schedule)
+    }
+
+    /// De naam waaronder dit ritme in een wereldbestand staat.
+    pub fn name(self) -> &'static str {
+        // Onbereikbaar leeg: elke variant staat in `ALL`.
+        Self::ALL
+            .iter()
+            .find(|(_, known)| *known == self)
+            .map_or("", |(name, _)| *name)
+    }
+
+    /// Komma-gescheiden opsomming van de ritmes, voor foutmeldingen.
+    pub(crate) fn listing() -> String {
+        Self::ALL
+            .iter()
+            .map(|(name, _)| *name)
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    /// Hoeveel termijnen dit ritme over een jaar kent.
+    fn terms(self) -> u32 {
+        match self {
+            Self::Ineens => 1,
+            Self::Kwartaal => 4,
+            Self::Maand => 12,
+        }
+    }
+
+    /// Hoeveel maanden er tussen twee termijnen zitten.
+    fn step_months(self) -> u32 {
+        match self {
+            Self::Ineens => 0,
+            Self::Kwartaal => 3,
+            Self::Maand => 1,
+        }
+    }
+}
+
+/// Eén termijn van één verplichting: wat er op een vervaldatum moet gebeuren.
+///
+/// Uitgerekend bij het besluit en vastgelegd in het decretogram, zodat te lezen
+/// is wat er beloofd is voordat er iets betaald is. De verwijzing naar het
+/// besluit reist mee: een betaling zonder de zaak, het besluit en het moment
+/// waaruit ze volgt, is een bedrag zonder grondslag.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObligationDue {
+    /// De cel die betaalt.
+    pub payer: String,
+    /// De cel die het besluit nam.
+    pub decided_by: String,
+    /// De besluit-definitie waaruit deze verplichting volgt.
+    pub besluit: String,
+    /// Het zaakkenmerk van dat besluit; hierop groepeert [`BETALINGEN`].
+    pub zaakkenmerk: String,
+    /// Het moment van dat besluit.
+    pub decided_op_moment: NaiveDate,
+    /// Het ritme waarin deze termijn valt.
+    pub schedule: Schedule,
+    /// De dag waarop deze termijn vervalt.
+    pub vervaldatum: NaiveDate,
+    /// Het bedrag van deze termijn.
+    pub bedrag: Value,
+    /// Het volgnummer binnen deze verplichting, vanaf 1.
+    ///
+    /// Hierop is een betaling te herkennen: dezelfde zaak en hetzelfde
+    /// volgnummer is dezelfde termijn, ook als de klok er in kleine stappen
+    /// langs komt.
+    pub volgnummer: i64,
+}
+
+impl ObligationDue {
+    /// De velden die beide kanten van een betaling vastleggen.
+    fn fields(&self) -> BTreeMap<String, Value> {
+        BTreeMap::from([
+            (
+                ZAAKKENMERK.to_string(),
+                Value::String(self.zaakkenmerk.clone()),
+            ),
+            (BEDRAG.to_string(), self.bedrag.clone()),
+            (VOLGNUMMER.to_string(), Value::Int(self.volgnummer)),
+            (BESLUIT.to_string(), Value::String(self.besluit.clone())),
+            (
+                BESLUIT_CEL.to_string(),
+                Value::String(self.decided_by.clone()),
+            ),
+            (
+                BESLUIT_OP_MOMENT.to_string(),
+                Value::String(self.decided_op_moment.to_string()),
+            ),
+        ])
+    }
+
+    /// De grondslag van beide vastleggingen: het besluit waaruit ze volgen.
+    fn grondslag(&self) -> String {
+        format!(
+            "verplichting uit besluit '{}' van cel '{}' ({}), termijn {} van {}",
+            self.besluit,
+            self.decided_by,
+            self.decided_op_moment,
+            self.volgnummer,
+            self.schedule.terms()
+        )
+    }
+
+    /// Het executogram van de betalende cel: zij betaalde.
+    pub(crate) fn payment_event(&self) -> ChronicleEvent {
+        ChronicleEvent {
+            name: "betaling".to_string(),
+            intake: Intake::Betaling,
+            recording_actor: self.payer.clone(),
+            grondslag: self.grondslag(),
+            op_moment: self.vervaldatum,
+            fields: self.fields(),
+        }
+    }
+
+    /// Het executogram van de besluitende cel: haar werd gemeld dat er betaald is.
+    ///
+    /// Een eigen vastlegging met een eigen kanaal, en geen kopie van het gram
+    /// hiernaast: wat de betalende cel deed staat in háár kroniek, en wat deze
+    /// cel overkwam in de hare. Zo weten beide kanten wat er gebeurde zonder dat
+    /// er één staat is die twee cellen delen.
+    pub(crate) fn delivery_event(&self) -> ChronicleEvent {
+        ChronicleEvent {
+            name: "betaling_ontvangen_gemeld".to_string(),
+            intake: Intake::Levering,
+            recording_actor: self.decided_by.clone(),
+            grondslag: self.grondslag(),
+            op_moment: self.vervaldatum,
+            fields: self.fields(),
+        }
+    }
+
+    /// Deze termijn als vastlegbare waarde, voor in het decretogram.
+    fn as_value(&self) -> Value {
+        Value::Object(BTreeMap::from([
+            (
+                "vervaldatum".to_string(),
+                Value::String(self.vervaldatum.to_string()),
+            ),
+            (BEDRAG.to_string(), self.bedrag.clone()),
+            (VOLGNUMMER.to_string(), Value::Int(self.volgnummer)),
+            ("payer".to_string(), Value::String(self.payer.clone())),
+            (
+                "schedule".to_string(),
+                Value::String(self.schedule.name().to_string()),
+            ),
+        ]))
+    }
+
+    /// Leesbare termijn voor een verslag.
+    pub fn describe(&self) -> String {
+        format!(
+            "termijn {}/{} van {} op {}, te betalen door {} ({})",
+            self.volgnummer,
+            self.schedule.terms(),
+            self.bedrag,
+            self.vervaldatum,
+            self.payer,
+            self.schedule.name()
+        )
+    }
 }
 
 /// De drie vormen die een input van een besluit kan hebben, voor foutmeldingen.
@@ -487,6 +778,12 @@ pub struct Decretogram {
     pub outputs: BTreeMap<String, Value>,
     /// De inputs waarop besloten is, met hun herkomst.
     pub inputs: BTreeMap<String, DecretogramInput>,
+    /// De verplichtingen die uit dit besluit volgen, uitgerekend tot termijnen.
+    ///
+    /// Het schema hoort bij het besluit en niet bij de betaling: wat beloofd is,
+    /// staat er vóórdat er iets betaald is, en verandert niet meer doordat er
+    /// betaald wordt. Leeg als het besluit niets toekent.
+    pub obligations: Vec<ObligationDue>,
     /// Het volledige receipt van de uitvoering.
     pub receipt: ExecutionReceipt,
 }
@@ -557,6 +854,15 @@ impl Decretogram {
                                 ])),
                             )
                         })
+                        .collect(),
+                ),
+            ),
+            (
+                OBLIGATIONS.to_string(),
+                Value::Array(
+                    self.obligations
+                        .iter()
+                        .map(ObligationDue::as_value)
                         .collect(),
                 ),
             ),
@@ -643,16 +949,87 @@ impl BesluitDefinition {
     ) -> Result<String> {
         let template = Template::parse(&self.zaakkenmerk);
         template.check_separators_absent(cell, &self.name, &self.zaakkenmerk, params)?;
+        Ok(template.fill(params))
+    }
 
-        let mut out = String::with_capacity(self.zaakkenmerk.len());
-        out.push_str(template.leading);
-        for part in &template.parts {
-            if let Some(value) = params.get(part.reference) {
-                out.push_str(&value.to_string());
+    /// Reken de verplichtingen van dit besluit uit tot termijnen.
+    ///
+    /// Aanroepen ná de uitvoering: het bedrag komt uit de uitkomsten waarop
+    /// besloten is, en niet uit de configuratie. Wat hier ontstaat is het
+    /// volledige schema — alle vervaldata, alle bedragen, alle volgnummers —
+    /// zodat het in het gram kan en niemand later hoeft te raden wat er beloofd
+    /// was.
+    pub(crate) fn schedule_obligations(
+        &self,
+        cell: &str,
+        zaakkenmerk: &str,
+        outputs: &BTreeMap<String, Value>,
+        params: &BTreeMap<String, Value>,
+        settings: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Result<Vec<ObligationDue>> {
+        let mut due = Vec::new();
+        for obligation in &self.obligations {
+            let schedule = obligation.schedule(cell, &self.name, settings)?;
+            let start = obligation.start(cell, &self.name, params, op_moment)?;
+            let total = obligation.total(cell, &self.name, outputs)?;
+
+            for (index, bedrag) in split(total, schedule.terms()).into_iter().enumerate() {
+                // `index` telt de termijnen van dit ritme en komt nooit in de
+                // buurt van de grenzen van u32 of i64.
+                let step = u32::try_from(index).unwrap_or(u32::MAX);
+                let vervaldatum = start
+                    .checked_add_months(Months::new(step * schedule.step_months()))
+                    .ok_or_else(|| SimulatorError::MalformedObligationDate {
+                        cell: cell.to_string(),
+                        besluit: self.name.clone(),
+                        template: obligation.from.clone().unwrap_or_else(|| start.to_string()),
+                        reason: format!(
+                            "de termijn {} maanden na {start} valt buiten het bereik van de kalender",
+                            step * schedule.step_months()
+                        ),
+                    })?;
+
+                due.push(ObligationDue {
+                    payer: obligation.payer.clone(),
+                    decided_by: cell.to_string(),
+                    besluit: self.name.clone(),
+                    zaakkenmerk: zaakkenmerk.to_string(),
+                    decided_op_moment: op_moment,
+                    schedule,
+                    vervaldatum,
+                    bedrag: amount(bedrag),
+                    volgnummer: i64::try_from(index + 1).unwrap_or(i64::MAX),
+                });
             }
-            out.push_str(part.literal);
         }
-        Ok(out)
+        Ok(due)
+    }
+
+    /// Controleer de verplichtingen tegen de instellingen van de wereld.
+    ///
+    /// Apart van [`Self::validate`], omdat het antwoord niet in de cel staat: een
+    /// `schedule: $betalingsritme` verwijst naar het wereldbestand, en een cel
+    /// kent dat niet. De wereld roept dit aan bij het optuigen, zodat een
+    /// instelling die niet bestaat of geen ritme is meteen blijkt en niet pas bij
+    /// het besluit dat erop leunt.
+    pub(crate) fn check_settings(
+        &self,
+        cell: &str,
+        settings: &BTreeMap<String, Value>,
+    ) -> Result<()> {
+        for obligation in &self.obligations {
+            obligation.schedule(cell, &self.name, settings)?;
+        }
+        Ok(())
+    }
+
+    /// De cellen die een verplichting van dit besluit moeten dragen.
+    pub(crate) fn payers(&self) -> BTreeSet<&str> {
+        self.obligations
+            .iter()
+            .map(|obligation| obligation.payer.as_str())
+            .collect()
     }
 
     /// Controleer de definitie tegen de cel waarin ze staat.
@@ -708,6 +1085,10 @@ impl BesluitDefinition {
                 });
             }
             self.validate_input(cell, surface, input, origin)?;
+        }
+
+        for obligation in &self.obligations {
+            obligation.validate(cell, &self.name, self.recorded_outputs(), &self.params)?;
         }
 
         self.validate_zaakkenmerk(cell)
@@ -886,6 +1267,196 @@ impl BesluitDefinition {
     }
 }
 
+impl ObligationDefinition {
+    /// Controleer deze verplichting tegen het besluit waarin ze staat.
+    ///
+    /// Alles wat de cel zelf kan weten valt hier: het bedrag moet een uitkomst
+    /// van dít besluit zijn, een letterlijk ritme moet bestaan, en `from` moet
+    /// een datum kunnen opleveren. Wat de cel *niet* kan weten — bestaat de
+    /// betalende cel, bestaat de instelling — toetst de wereld.
+    fn validate(
+        &self,
+        cell: &str,
+        besluit: &str,
+        outputs: BTreeSet<&str>,
+        params: &[DocumentedParameter],
+    ) -> Result<()> {
+        let amount_error = || SimulatorError::ObligationAmount {
+            cell: cell.to_string(),
+            besluit: besluit.to_string(),
+            amount: self.amount.clone(),
+            outputs: outputs.iter().copied().collect::<Vec<_>>().join(", "),
+        };
+        let output = self.amount.strip_prefix('$').ok_or_else(amount_error)?;
+        if !outputs.contains(output) {
+            return Err(amount_error());
+        }
+
+        // Een `$instelling` kan de cel niet nakijken; een letterlijk ritme wel,
+        // en dan hoort een typfout hier te vallen en niet bij het besluit.
+        if !self.schedule.starts_with('$') && Schedule::from_name(&self.schedule).is_none() {
+            return Err(SimulatorError::UnknownSchedule {
+                cell: cell.to_string(),
+                besluit: besluit.to_string(),
+                schedule: self.schedule.clone(),
+                known: Schedule::listing(),
+            });
+        }
+
+        let Some(from) = &self.from else {
+            return Ok(());
+        };
+        if !closing_braces_match(from) {
+            return Err(SimulatorError::MalformedObligationDate {
+                cell: cell.to_string(),
+                besluit: besluit.to_string(),
+                template: from.clone(),
+                reason: "een accolade sluit niet".to_string(),
+            });
+        }
+
+        let template = Template::parse(from);
+        for part in &template.parts {
+            if !documents(params, part.reference) {
+                return Err(SimulatorError::UnknownReference {
+                    cell: cell.to_string(),
+                    subject: Subject::Besluit,
+                    name: besluit.to_string(),
+                    reference: part.reference.to_string(),
+                });
+            }
+        }
+
+        // Zonder verwijzingen staat de datum hier al vast, dus een sjabloon dat
+        // nooit een datum kan opleveren hoort bij het optuigen te vallen en niet
+        // pas bij het besluit dat erop rekent.
+        if template.parts.is_empty() {
+            parse_date(from).ok_or_else(|| SimulatorError::MalformedObligationDate {
+                cell: cell.to_string(),
+                besluit: besluit.to_string(),
+                template: from.clone(),
+                reason: "dat is geen datum (JJJJ-MM-DD)".to_string(),
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Het ritme van deze verplichting, met de instellingen van de wereld erbij.
+    fn schedule(
+        &self,
+        cell: &str,
+        besluit: &str,
+        settings: &BTreeMap<String, Value>,
+    ) -> Result<Schedule> {
+        let name = match self.schedule.strip_prefix('$') {
+            None => self.schedule.clone(),
+            Some(setting) => settings
+                .get(setting)
+                .ok_or_else(|| SimulatorError::UnknownSetting {
+                    cell: cell.to_string(),
+                    besluit: besluit.to_string(),
+                    setting: setting.to_string(),
+                    known: settings
+                        .keys()
+                        .map(String::as_str)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                })?
+                .to_string(),
+        };
+
+        Schedule::from_name(&name).ok_or_else(|| SimulatorError::UnknownSchedule {
+            cell: cell.to_string(),
+            besluit: besluit.to_string(),
+            schedule: name,
+            known: Schedule::listing(),
+        })
+    }
+
+    /// De dag waarop de eerste termijn vervalt.
+    ///
+    /// Zonder `from` is dat het moment van het besluit. Met `from` is het wat
+    /// het sjabloon oplevert — en dat mag niet vóór het besluit liggen: een
+    /// termijn in het verleden zou bij het vastleggen het beeld van een eerder
+    /// moment veranderen, en dat is precies wat een kroniek niet doet.
+    fn start(
+        &self,
+        cell: &str,
+        besluit: &str,
+        params: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Result<NaiveDate> {
+        let Some(from) = &self.from else {
+            return Ok(op_moment);
+        };
+
+        let filled = Template::parse(from).fill(params);
+        let start = parse_date(&filled).ok_or_else(|| SimulatorError::MalformedObligationDate {
+            cell: cell.to_string(),
+            besluit: besluit.to_string(),
+            template: from.clone(),
+            reason: format!("ingevuld levert dat '{filled}' op, en dat is geen datum (JJJJ-MM-DD)"),
+        })?;
+
+        if start < op_moment {
+            return Err(SimulatorError::ObligationBeforeDecision {
+                cell: cell.to_string(),
+                besluit: besluit.to_string(),
+                from: start.to_string(),
+                op_moment: op_moment.to_string(),
+            });
+        }
+        Ok(start)
+    }
+
+    /// Het bedrag waarover deze verplichting gaat, uit de uitkomsten van het
+    /// besluit.
+    fn total(
+        &self,
+        cell: &str,
+        besluit: &str,
+        outputs: &BTreeMap<String, Value>,
+    ) -> Result<Decimal> {
+        // Onbereikbaar zonder `$`: `validate` weigert een bedrag dat niet naar
+        // een uitkomst verwijst.
+        let output = self.amount.strip_prefix('$').unwrap_or(&self.amount);
+        let found = outputs.get(output);
+        found
+            .and_then(Value::as_decimal)
+            .ok_or_else(|| SimulatorError::ObligationAmountValue {
+                cell: cell.to_string(),
+                besluit: besluit.to_string(),
+                output: output.to_string(),
+                found: found.map_or_else(
+                    || "niet in de uitkomsten van dit besluit".to_string(),
+                    |value| format!("{} ({})", value, value.type_name()),
+                ),
+            })
+    }
+}
+
+/// Verdeel een bedrag over een aantal termijnen, zonder een cent te verliezen.
+///
+/// Elke termijn krijgt hetzelfde bedrag in hele eenheden (de eenheid van de wet
+/// — in dit corpus de eurocent), en wat niet deelbaar is gaat naar de laatste.
+/// De som van de termijnen is dus exact het bedrag waarover besloten is; dat is
+/// de eigenschap die telt, want "betaald tot nu toe" wordt eroverheen
+/// gesommeerd en moet aan het eind uitkomen op wat toegekend is.
+fn split(total: Decimal, terms: u32) -> Vec<Decimal> {
+    if terms <= 1 {
+        return vec![total];
+    }
+    let each = (total / Decimal::from(terms)).trunc();
+    let mut amounts = vec![each; (terms - 1) as usize];
+    amounts.push(total - each * Decimal::from(terms - 1));
+    amounts
+}
+
+/// Een datum uit een sjabloon, of `None` als het er geen is.
+fn parse_date(text: &str) -> Option<NaiveDate> {
+    NaiveDate::parse_from_str(text, "%Y-%m-%d").ok()
+}
+
 /// Eén verwijzing uit een zaakkenmerk-sjabloon, met de letterlijke tekst erachter.
 struct TemplatePart<'a> {
     /// De parameternaam tussen de accolades.
@@ -933,6 +1504,23 @@ impl<'a> Template<'a> {
             rest = remainder;
         }
         Self { leading, parts }
+    }
+
+    /// Vul het sjabloon in met deze parameters.
+    ///
+    /// Eén invuller voor het zaakkenmerk én voor de startdatum van een
+    /// verplichting: twee sjablonen met dezelfde vorm horen niet op twee manieren
+    /// ingevuld te worden. Een verwijzing zonder waarde levert niets op — dat
+    /// geval is bij het optuigen al geweigerd, hier zou het een lege plek zijn.
+    fn fill(&self, params: &BTreeMap<String, Value>) -> String {
+        let mut out = String::from(self.leading);
+        for part in &self.parts {
+            if let Some(value) = params.get(part.reference) {
+                out.push_str(&value.to_string());
+            }
+            out.push_str(part.literal);
+        }
+        out
     }
 
     /// De letterlijke stukken die twee verwijzingen uit elkaar houden.
@@ -1380,6 +1968,154 @@ params:
             matches!(err, SimulatorError::ReservedDecretogramField { .. }),
             "verwachtte ReservedDecretogramField, kreeg {err}"
         );
+    }
+
+    /// Een verplichting zoals ze in een wereldbestand staat.
+    fn obligation(yaml: &str) -> ObligationDefinition {
+        serde_yaml_ng::from_str(yaml)
+            .unwrap_or_else(|e| panic!("testverplichting moet parsen: {e}"))
+    }
+
+    /// De uitkomsten en parameters van het besluit waarin de verplichtingen
+    /// hieronder staan.
+    fn valideer(obligation: &ObligationDefinition) -> Result<()> {
+        let params = vec![DocumentedParameter {
+            name: "jaar".to_string(),
+            value_type: crate::cell::ParameterType::String,
+        }];
+        obligation.validate(
+            "toeslagen",
+            "toekenning",
+            BTreeSet::from(["hoogte_zorgtoeslag"]),
+            &params,
+        )
+    }
+
+    /// De som van de termijnen is exact het bedrag waarover besloten is.
+    ///
+    /// Dat is de eigenschap waarop "betaald tot nu toe" rust: wie de rest laat
+    /// vallen, betaalt aan het eind minder uit dan de beschikking toekende, en
+    /// dat is dan nergens aan te zien behalve aan het totaal.
+    #[test]
+    fn de_termijnen_tellen_op_tot_het_hele_bedrag() {
+        for bedrag in ["100000", "197205.31187", "1", "-4000"] {
+            let total: Decimal = bedrag
+                .parse()
+                .unwrap_or_else(|e| panic!("testbedrag '{bedrag}' moet leesbaar zijn: {e}"));
+            for terms in [1_u32, 4, 12] {
+                let amounts = split(total, terms);
+                assert_eq!(amounts.len(), terms as usize);
+                assert_eq!(
+                    amounts.iter().sum::<Decimal>(),
+                    total,
+                    "{bedrag} over {terms} termijnen hoort exact op te tellen"
+                );
+            }
+        }
+    }
+
+    /// Gelijke termijnen, en het restant op de laatste. Zonder deze assertie zou
+    /// een verdeling die alles op de eerste termijn zet ook "exact optellen".
+    #[test]
+    fn de_termijnen_zijn_gelijk_op_het_restant_na() {
+        let amounts = split(Decimal::from(100_000), 12);
+        assert_eq!(&amounts[..11], &[Decimal::from(8333); 11]);
+        assert_eq!(amounts[11], Decimal::from(8337));
+    }
+
+    #[test]
+    fn een_ritme_beschrijft_een_jaar() {
+        assert_eq!(Schedule::Ineens.terms(), 1);
+        assert_eq!(Schedule::Kwartaal.terms(), 4);
+        assert_eq!(Schedule::Maand.terms(), 12);
+        assert_eq!(Schedule::from_name("kwartaal"), Some(Schedule::Kwartaal));
+        assert_eq!(Schedule::from_name("per_week"), None);
+        assert_eq!(Schedule::Maand.name(), "maand");
+    }
+
+    /// Het bedrag komt uit de wet die het besluit uitvoert, en nergens anders
+    /// vandaan.
+    #[test]
+    fn een_bedrag_dat_geen_uitkomst_van_het_besluit_is_wordt_geweigerd() {
+        for amount in ["100000", "$verzamelinkomen"] {
+            let err = valideer(&obligation(&format!(
+                "amount: '{amount}'\npayer: belastingdienst\nschedule: ineens\n"
+            )))
+            .expect_err("een bedrag buiten de uitkomsten hoort te falen");
+            assert!(
+                matches!(err, SimulatorError::ObligationAmount { .. }),
+                "verwachtte ObligationAmount voor '{amount}', kreeg {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn een_letterlijk_ritme_dat_niet_bestaat_wordt_geweigerd() {
+        let err = valideer(&obligation(
+            "amount: $hoogte_zorgtoeslag\npayer: belastingdienst\nschedule: per_week\n",
+        ))
+        .expect_err("een ritme dat niet bestaat hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownSchedule { .. }),
+            "verwachtte UnknownSchedule, kreeg {err}"
+        );
+    }
+
+    /// Een `$instelling` kan de cel niet nakijken — dat doet de wereld — dus hier
+    /// hoort ze door te komen.
+    #[test]
+    fn een_ritme_uit_een_instelling_komt_langs_de_cel() {
+        valideer(&obligation(
+            "amount: $hoogte_zorgtoeslag\npayer: belastingdienst\nschedule: $betalingsritme\n",
+        ))
+        .unwrap_or_else(|e| panic!("een verwijzing naar een instelling hoort te mogen: {e}"));
+    }
+
+    /// Staat er geen verwijzing in, dan ligt de datum bij het optuigen al vast en
+    /// hoort een tekst die geen datum is daar te sneuvelen.
+    #[test]
+    fn een_vaste_from_die_geen_datum_is_wordt_geweigerd() {
+        let err = valideer(&obligation(
+            "amount: $hoogte_zorgtoeslag\npayer: belastingdienst\nschedule: ineens\nfrom: volgend jaar\n",
+        ))
+        .expect_err("een `from` die geen datum is hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::MalformedObligationDate { .. }),
+            "verwachtte MalformedObligationDate, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn een_from_die_naar_een_onbekende_parameter_verwijst_wordt_geweigerd() {
+        let err = valideer(&obligation(
+            "amount: $hoogte_zorgtoeslag\npayer: belastingdienst\nschedule: maand\nfrom: '{toeslagjaar}-01-01'\n",
+        ))
+        .expect_err("een verwijzing zonder gedocumenteerde parameter hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownReference { .. }),
+            "verwachtte UnknownReference, kreeg {err}"
+        );
+    }
+
+    /// Een sjabloon dat wél een datum oplevert, levert hem ook op het moment dat
+    /// het ingevuld wordt.
+    #[test]
+    fn een_from_met_een_parameter_levert_de_datum_op() {
+        let obligation = obligation(
+            "amount: $hoogte_zorgtoeslag\npayer: belastingdienst\nschedule: maand\nfrom: '{jaar}-02-01'\n",
+        );
+        valideer(&obligation).unwrap_or_else(|e| panic!("dit sjabloon hoort te mogen: {e}"));
+
+        let params = BTreeMap::from([("jaar".to_string(), Value::String("2027".to_string()))]);
+        let start = obligation
+            .start(
+                "toeslagen",
+                "toekenning",
+                &params,
+                parse_date("2026-12-15").unwrap_or_default(),
+            )
+            .unwrap_or_else(|e| panic!("de startdatum moet uit te rekenen zijn: {e}"));
+        assert_eq!(start, parse_date("2027-02-01").unwrap_or_default());
     }
 
     #[test]

--- a/packages/simulator/src/cell/besluit.rs
+++ b/packages/simulator/src/cell/besluit.rs
@@ -301,12 +301,23 @@ pub struct ObligationDue {
     pub vervaldatum: NaiveDate,
     /// Het bedrag van deze termijn.
     pub bedrag: Value,
-    /// Het volgnummer binnen deze verplichting, vanaf 1.
+    /// Het volgnummer binnen het schema van dít besluit, vanaf 1.
     ///
-    /// Hierop is een betaling te herkennen: dezelfde zaak en hetzelfde
-    /// volgnummer is dezelfde termijn, ook als de klok er in kleine stappen
-    /// langs komt.
+    /// Hierop plus de verwijzing naar het besluit is een betaling te herkennen:
+    /// dezelfde zaak, hetzelfde besluit en hetzelfde volgnummer is dezelfde
+    /// termijn, ook als de klok er in kleine stappen langs komt.
+    ///
+    /// Doorgenummerd over álle verplichtingen van het besluit, en niet per
+    /// verplichting opnieuw. Dat moet ook: legt één besluit twee verplichtingen
+    /// op, dan zouden twee termijnen met hetzelfde nummer bij het nakomen voor
+    /// elkaar doorgaan en zou de tweede stil wegvallen.
     pub volgnummer: i64,
+    /// Hoeveel termijnen het schema van dit besluit in totaal kent.
+    ///
+    /// Alleen om een termijn leesbaar te kunnen benoemen ("termijn 2 van 4"),
+    /// en niet uit [`Self::schedule`] af te leiden: een besluit mag meer dan één
+    /// verplichting opleggen, elk met een eigen ritme.
+    pub termijnen: i64,
 }
 
 impl ObligationDue {
@@ -335,11 +346,7 @@ impl ObligationDue {
     fn grondslag(&self) -> String {
         format!(
             "verplichting uit besluit '{}' van cel '{}' ({}), termijn {} van {}",
-            self.besluit,
-            self.decided_by,
-            self.decided_op_moment,
-            self.volgnummer,
-            self.schedule.terms()
+            self.besluit, self.decided_by, self.decided_op_moment, self.volgnummer, self.termijnen
         )
     }
 
@@ -394,7 +401,7 @@ impl ObligationDue {
         format!(
             "termijn {}/{} van {} op {}, te betalen door {} ({})",
             self.volgnummer,
-            self.schedule.terms(),
+            self.termijnen,
             self.bedrag,
             self.vervaldatum,
             self.payer,
@@ -968,15 +975,31 @@ impl BesluitDefinition {
         settings: &BTreeMap<String, Value>,
         op_moment: NaiveDate,
     ) -> Result<Vec<ObligationDue>> {
-        let mut due = Vec::new();
+        // Eerst elke verplichting oplossen, dan pas termijnen maken: het aantal
+        // termijnen van het hele schema staat in elke termijn, en dat is pas
+        // bekend als alle ritmes eruit zijn.
+        let mut resolved = Vec::with_capacity(self.obligations.len());
         for obligation in &self.obligations {
             let schedule = obligation.schedule(cell, &self.name, settings)?;
             let start = obligation.start(cell, &self.name, params, op_moment)?;
             let total = obligation.total(cell, &self.name, outputs)?;
+            resolved.push((obligation, schedule, start, total));
+        }
+        // De termijnen van dit besluit tellen nooit zo hoog dat ze de grenzen van
+        // i64 raken: het zijn er ten hoogste twaalf per verplichting.
+        let termijnen = i64::try_from(
+            resolved
+                .iter()
+                .map(|(_, schedule, _, _)| schedule.terms() as usize)
+                .sum::<usize>(),
+        )
+        .unwrap_or(i64::MAX);
 
+        let mut due = Vec::new();
+        for (obligation, schedule, start, total) in resolved {
             for (index, bedrag) in split(total, schedule.terms()).into_iter().enumerate() {
                 // `index` telt de termijnen van dit ritme en komt nooit in de
-                // buurt van de grenzen van u32 of i64.
+                // buurt van de grens van u32.
                 let step = u32::try_from(index).unwrap_or(u32::MAX);
                 let vervaldatum = start
                     .checked_add_months(Months::new(step * schedule.step_months()))
@@ -999,7 +1022,10 @@ impl BesluitDefinition {
                     schedule,
                     vervaldatum,
                     bedrag: amount(bedrag),
-                    volgnummer: i64::try_from(index + 1).unwrap_or(i64::MAX),
+                    // Door het hele schema heen, niet per verplichting opnieuw:
+                    // zie [`ObligationDue::volgnummer`].
+                    volgnummer: i64::try_from(due.len() + 1).unwrap_or(i64::MAX),
+                    termijnen,
                 });
             }
         }

--- a/packages/simulator/src/cell/chronicle.rs
+++ b/packages/simulator/src/cell/chronicle.rs
@@ -216,11 +216,31 @@ impl ChronicleStore {
         // waarin de cel zelf vastlegt (zie [`Self::record`]) de volgorde waarin
         // dat gebeurde. Twee besluiten op één dag over dezelfde zaak leveren dus
         // het laatstgenomen besluit — de dag is hier de fijnste korrel.
+        self.recordings(stream, key, key_value, conditions, op_moment)
+            .into_iter()
+            .max_by_key(|event| event.op_moment)
+    }
+
+    /// Álle vastleggingen die op of vóór `op_moment` aan dit filter voldoen, in
+    /// de volgorde waarin ze vastgelegd zijn.
+    ///
+    /// De basis onder [`Self::latest_recording`] en onder een som: welke
+    /// vastleggingen meedoen is dezelfde vraag, of je er daarna één uitkiest of
+    /// ze allemaal optelt. Twee filters die uit elkaar lopen zouden een som
+    /// opleveren over een andere groep dan waaruit "de laatste" komt.
+    pub(crate) fn recordings(
+        &self,
+        stream: &str,
+        key: &str,
+        key_value: &Value,
+        conditions: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Vec<&ChronicleEvent> {
         self.streams
             .iter()
-            .find(|candidate| candidate.stream == stream)?
-            .events
-            .iter()
+            .find(|candidate| candidate.stream == stream)
+            .into_iter()
+            .flat_map(|found| found.events.iter())
             .filter(|event| event.op_moment <= op_moment)
             .filter(|event| field_equals(&event.fields, key, key_value))
             .filter(|event| {
@@ -228,7 +248,7 @@ impl ChronicleStore {
                     .iter()
                     .all(|(field, expected)| field_equals(&event.fields, field, expected))
             })
-            .max_by_key(|event| event.op_moment)
+            .collect()
     }
 
     /// Zou deze vastlegging in deze stroom mogen?

--- a/packages/simulator/src/cell/config.rs
+++ b/packages/simulator/src/cell/config.rs
@@ -174,8 +174,9 @@ impl ParameterType {
 /// lexostatussen zijn filters over haar eigen vastleggingen (RFC-022 §2 — de
 /// engine is een component dat in een cel kán draaien, niet de cel zelf).
 ///
-/// Aggregeren (som, telling) over kronieken hoort in deze plek thuis en bestaat
-/// nog niet; `latest: true` is het enige filter dat er nu is.
+/// Het kroniekfilter kent twee manieren om met de gevonden vastleggingen om te
+/// gaan: `latest: true` neemt er één, `sum: <veld>` telt ze op. Zie
+/// [`Aggregate`].
 #[derive(Debug, Clone, Deserialize)]
 #[serde(try_from = "ReductionFields")]
 pub enum Reduction {
@@ -195,8 +196,8 @@ pub enum Reduction {
         /// een letterlijke tekst.
         parameters: BTreeMap<String, String>,
     },
-    /// Een filter over één eigen kroniek: per sleutelwaarde de laatste
-    /// vastlegging op of vóór het gevraagde moment.
+    /// Een filter over één eigen kroniek: de vastleggingen over één onderwerp,
+    /// zoals ze op het gevraagde moment bekend waren.
     Chronicle {
         /// De kroniekstroom waarover gefilterd wordt. Moet een stroom van
         /// dezelfde cel zijn.
@@ -207,10 +208,36 @@ pub enum Reduction {
         /// Extra gelijkheidsvoorwaarden op velden van de vastlegging (`where`).
         ///
         /// Ze bepalen wélke vastleggingen het filter in beschouwing neemt;
-        /// daarna wint de laatste. Een voorwaarde op een veld dat over tijd
-        /// verandert levert dus de laatste vastlegging die eraan voldeed, niet
-        /// de huidige stand.
+        /// daarna wint de laatste, of wordt er opgeteld. Een voorwaarde op een
+        /// veld dat over tijd verandert levert dus de laatste vastlegging die
+        /// eraan voldeed, niet de huidige stand.
         conditions: BTreeMap<String, Value>,
+        /// Wat het filter met de gevonden vastleggingen doet.
+        aggregate: Aggregate,
+    },
+}
+
+/// Wat een kroniekfilter met de vastleggingen doet die het vindt.
+///
+/// De twee zijn niet uitwisselbaar, en dat is het punt. [`Self::Latest`] levert
+/// één vastlegging in haar geheel — wat samen vastgelegd is blijft samen — en
+/// [`Self::Sum`] levert één getal over alle vastleggingen. Een reductie die "wat
+/// staat er nu vast" vraagt, hoort de eerste te zijn; een reductie die "hoeveel
+/// is er in totaal" vraagt, de tweede.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Aggregate {
+    /// De laatste vastlegging op of vóór het gevraagde moment (`latest: true`).
+    Latest,
+    /// De som van één veld over alle vastleggingen op of vóór dat moment
+    /// (`sum: <veld>`).
+    ///
+    /// De eerste aggregatie van de simulator, en met opzet de kleinste die iets
+    /// bewijst: "betaald tot nu toe" is hiermee een reductie over eigen
+    /// vastleggingen en geen los bijgehouden saldo. Een saldo zou een tweede
+    /// waarheid naast de kroniek zijn.
+    Sum {
+        /// Het veld dat opgeteld wordt.
+        field: String,
     },
 }
 
@@ -233,8 +260,10 @@ struct ReductionFields {
     chronicle: Option<String>,
     /// Zie [`Reduction::Chronicle::key`].
     key: Option<String>,
-    /// Alleen `true` heeft betekenis; zie [`Reduction`].
+    /// Alleen `true` heeft betekenis; zie [`Aggregate::Latest`].
     latest: Option<bool>,
+    /// Het veld waarover gesommeerd wordt; zie [`Aggregate::Sum`].
+    sum: Option<String>,
     /// Zie [`Reduction::Chronicle::conditions`].
     #[serde(rename = "where")]
     conditions: Option<BTreeMap<String, Value>>,
@@ -251,10 +280,14 @@ impl TryFrom<ReductionFields> for Reduction {
                  óf een kroniekfilter (`chronicle` + `key`)"
             )),
             (Some(regulation), None) => {
-                if fields.key.is_some() || fields.latest.is_some() || fields.conditions.is_some() {
+                if fields.key.is_some()
+                    || fields.latest.is_some()
+                    || fields.sum.is_some()
+                    || fields.conditions.is_some()
+                {
                     return Err(format!(
-                        "`key`, `latest` en `where` horen bij een kroniekfilter (`chronicle`), \
-                         niet bij de reductie over regeling '{regulation}'"
+                        "`key`, `latest`, `sum` en `where` horen bij een kroniekfilter \
+                         (`chronicle`), niet bij de reductie over regeling '{regulation}'"
                     ));
                 }
                 let output = fields.output.ok_or_else(|| {
@@ -277,12 +310,23 @@ impl TryFrom<ReductionFields> for Reduction {
                          wat een kroniekfilter oplevert staat in `outputs`"
                     ));
                 }
-                if fields.latest == Some(false) {
-                    return Err(format!(
-                        "kroniekfilter op '{chronicle}' kent alleen `latest: true`: \
-                         aggregeren over kronieken (som, telling) bestaat nog niet"
-                    ));
-                }
+                let aggregate = match (fields.latest, fields.sum) {
+                    (Some(true), Some(sum)) => {
+                        return Err(format!(
+                            "kroniekfilter op '{chronicle}' vraagt `latest: true` én \
+                             `sum: {sum}`; dat zijn twee reducties — één vastlegging \
+                             in haar geheel, of één getal over alle vastleggingen"
+                        ))
+                    }
+                    (_, Some(field)) => Aggregate::Sum { field },
+                    (Some(false), None) => {
+                        return Err(format!(
+                            "kroniekfilter op '{chronicle}' kent `latest: true` of \
+                             `sum: <veld>`; `latest: false` is geen derde vorm"
+                        ))
+                    }
+                    (_, None) => Aggregate::Latest,
+                };
                 let key = fields.key.ok_or_else(|| {
                     format!(
                         "kroniekfilter op '{chronicle}' mist `key`: zonder sleutelveld \
@@ -293,6 +337,7 @@ impl TryFrom<ReductionFields> for Reduction {
                     chronicle,
                     key,
                     conditions: fields.conditions.unwrap_or_default(),
+                    aggregate,
                 })
             }
             (None, None) => Err(
@@ -576,7 +621,8 @@ impl LexostatusDefinition {
                 chronicle,
                 key,
                 conditions,
-            } => self.validate_chronicle(cell, surface, chronicle, key, conditions),
+                aggregate,
+            } => self.validate_chronicle(cell, surface, chronicle, key, conditions, aggregate),
         }
     }
 
@@ -623,6 +669,7 @@ impl LexostatusDefinition {
         chronicle: &str,
         key: &str,
         conditions: &BTreeMap<String, Value>,
+        aggregate: &Aggregate,
     ) -> Result<()> {
         let fields = surface.fields_of_stream(cell, Subject::Lexostatus, &self.name, chronicle)?;
 
@@ -632,6 +679,19 @@ impl LexostatusDefinition {
                 lexostatus: self.name.clone(),
                 stream: chronicle.to_string(),
             });
+        }
+
+        // Een som levert precies één waarde op. Publiceert de definitie iets
+        // anders, dan belooft ze een uitkomst die er nooit komt.
+        if let Aggregate::Sum { field } = aggregate {
+            if self.outputs.len() != 1 || !self.outputs[0].eq_ignore_ascii_case(field) {
+                return Err(SimulatorError::SumOutputMismatch {
+                    cell: cell.to_string(),
+                    lexostatus: self.name.clone(),
+                    field: field.clone(),
+                    outputs: self.outputs.join(", "),
+                });
+            }
         }
 
         for published in self.published_outputs() {
@@ -766,15 +826,45 @@ where:
             chronicle,
             key,
             conditions,
+            aggregate,
         } = parsed
         else {
             panic!("verwachtte een kroniekfilter, kreeg {parsed:?}");
         };
         assert_eq!(chronicle, "relaties");
         assert_eq!(key, "bsn");
+        assert_eq!(aggregate, Aggregate::Latest);
         assert_eq!(
             conditions.get("partnerschap_type"),
             Some(&Value::String("HUWELIJK".to_string()))
+        );
+    }
+
+    #[test]
+    fn de_som_wordt_gelezen() {
+        let parsed = reduction("chronicle: betalingen\nkey: zaakkenmerk\nsum: bedrag\n")
+            .unwrap_or_else(|e| panic!("de som moet gelezen worden: {e}"));
+        let Reduction::Chronicle { aggregate, .. } = parsed else {
+            panic!("verwachtte een kroniekfilter, kreeg {parsed:?}");
+        };
+        assert_eq!(
+            aggregate,
+            Aggregate::Sum {
+                field: "bedrag".to_string()
+            }
+        );
+    }
+
+    /// `latest` en `sum` zijn twee reducties en geen twee schrijfwijzen: de een
+    /// levert één vastlegging in haar geheel, de ander één getal over alles.
+    /// Wie ze allebei noemt, bedoelt iets dat niet bestaat.
+    #[test]
+    fn latest_en_sum_tegelijk_worden_geweigerd() {
+        let err = reduction("chronicle: betalingen\nkey: zaakkenmerk\nlatest: true\nsum: bedrag\n")
+            .expect_err("twee reducties in één filter hoort te falen");
+        assert!(
+            err.contains("`latest: true`") && err.contains("bedrag"),
+            "de melding moet beide noemen, kreeg: {err}"
         );
     }
 
@@ -836,12 +926,12 @@ where:
     }
 
     #[test]
-    fn aggregeren_bestaat_nog_niet_en_zegt_dat() {
+    fn latest_false_wijst_naar_de_som() {
         let err = reduction("chronicle: relaties\nkey: bsn\nlatest: false\n")
-            .expect_err("`latest: false` hoort te falen zolang er niets te aggregeren valt");
+            .expect_err("`latest: false` is geen derde vorm en hoort te falen");
         assert!(
-            err.contains("aggregeren"),
-            "de melding moet zeggen wat er ontbreekt, kreeg: {err}"
+            err.contains("`sum: <veld>`"),
+            "de melding moet naar de andere vorm wijzen, kreeg: {err}"
         );
     }
 

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -31,19 +31,22 @@ mod config;
 
 pub use besluit::{
     AcceptanceRequest, BesluitDefinition, BesluitInput, Decretogram, DecretogramInput, InputOrigin,
-    BESCHIKKINGEN,
+    ObligationDefinition, ObligationDue, Schedule, BESCHIKKINGEN, BETALINGEN, ZAAKKENMERK,
 };
 pub use chronicle::{ChronicleEvent, ChronicleStore, ChronicleStream, Intake};
 pub use config::{
-    AcceptedSource, CellConfig, DocumentedParameter, LexostatusDefinition, ParameterType, Reduction,
+    AcceptedSource, Aggregate, CellConfig, DocumentedParameter, LexostatusDefinition,
+    ParameterType, Reduction,
 };
 
 use crate::corpus;
 use crate::error::{Result, SimulatorError, Subject};
+use crate::values::amount;
 use chrono::NaiveDate;
 use config::{engine_parameters, CellSurface};
 use regelrecht_engine::article::CompetentAuthority;
 use regelrecht_engine::{ArticleBasedLaw, CellResolver, LawExecutionService, Value};
+use rust_decimal::Decimal;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
@@ -224,6 +227,13 @@ impl Cell {
                 .or_default()
                 .extend(besluit::declared_fields(&config.besluit_definitions));
         }
+        // De betalingsstroom declareert de cel zelf, maar wát er in komt bepaalt
+        // het platform (zie [`BETALINGEN`]). Zonder deze regel zou een som over
+        // `bedrag` als typfout geweigerd worden zolang er nog niets betaald is —
+        // en dat is precies het moment waarop een wereld opgetuigd wordt.
+        if let Some(fields) = declared.get_mut(BETALINGEN) {
+            fields.extend(besluit::betaling_fields());
+        }
 
         let surface = CellSurface {
             laws: &config.laws,
@@ -399,8 +409,20 @@ impl Cell {
                 chronicle,
                 key,
                 conditions,
+                aggregate,
             } => {
-                self.filter_chronicle(definition, chronicle, key, conditions, params, op_moment)?
+                let query = ChronicleQuery {
+                    chronicle,
+                    key,
+                    key_value: self.key_value(definition, key, params)?,
+                    conditions,
+                };
+                match aggregate {
+                    Aggregate::Latest => self.filter_chronicle(definition, &query, op_moment)?,
+                    Aggregate::Sum { field } => {
+                        self.sum_chronicle(definition, &query, field, op_moment)?
+                    }
+                }
             }
         };
 
@@ -566,30 +588,18 @@ impl Cell {
     fn filter_chronicle(
         &self,
         definition: &LexostatusDefinition,
-        chronicle: &str,
-        key: &str,
-        conditions: &BTreeMap<String, Value>,
-        params: &BTreeMap<String, Value>,
+        query: &ChronicleQuery<'_>,
         op_moment: NaiveDate,
     ) -> Result<LexostatusOutcome> {
-        // Onbereikbaar: `validate` eist dat de sleutel een gedocumenteerde
-        // parameter is, en `check_params` dat elke gedocumenteerde parameter
-        // meekomt.
-        let key_value = params
-            .get(key)
-            .ok_or_else(|| SimulatorError::MissingParameter {
-                cell: self.id.clone(),
-                subject: Subject::Lexostatus,
-                name: definition.name.clone(),
-                parameter: key.to_string(),
-            })?;
-
-        let Some(event) = self
-            .chronicles
-            .latest_recording(chronicle, key, key_value, conditions, op_moment)
-        else {
+        let Some(event) = self.chronicles.latest_recording(
+            query.chronicle,
+            query.key,
+            query.key_value,
+            query.conditions,
+            op_moment,
+        ) else {
             return Ok(LexostatusOutcome::NotEstablished {
-                reason: nothing_established(chronicle, key, key_value, conditions, op_moment),
+                reason: query.nothing_established(op_moment),
             });
         };
 
@@ -611,11 +621,93 @@ impl Cell {
         // over datgene wat gevraagd werd.
         if values.is_empty() {
             return Ok(LexostatusOutcome::NotEstablished {
-                reason: nothing_published(definition, chronicle, key, key_value, event.op_moment),
+                reason: nothing_published(definition, query, event.op_moment),
             });
         }
 
         Ok(LexostatusOutcome::Established(values))
+    }
+
+    /// De som over een eigen kroniek: tel één veld op over alles wat op dit
+    /// moment vastlag.
+    ///
+    /// De eerste aggregatie van de simulator. Ze bestaat zodat een totaal — wat
+    /// er tot nu toe betaald is — een **reductie over vastleggingen** kan zijn in
+    /// plaats van een saldo dat ergens bijgehouden wordt. Een saldo zou een
+    /// tweede waarheid naast de kroniek zijn, en dan verandert het beeld van een
+    /// eerder moment zodra er iets bijkomt.
+    ///
+    /// Een vastlegging die het veld niet draagt of er iets anders dan een getal
+    /// in heeft, is een fout en geen nul: een som die zo'n vastlegging overslaat
+    /// valt stil te laag uit.
+    fn sum_chronicle(
+        &self,
+        definition: &LexostatusDefinition,
+        query: &ChronicleQuery<'_>,
+        field: &str,
+        op_moment: NaiveDate,
+    ) -> Result<LexostatusOutcome> {
+        let events = self.chronicles.recordings(
+            query.chronicle,
+            query.key,
+            query.key_value,
+            query.conditions,
+            op_moment,
+        );
+
+        // Nul vastleggingen is niet "nul euro": deze cel heeft over dit
+        // onderwerp niets vastgelegd, en dat is hetzelfde antwoord als bij elk
+        // ander kroniekfilter. Een 0 zou "er is niets betaald" niet kunnen
+        // onderscheiden van "hier is geen zaak".
+        if events.is_empty() {
+            return Ok(LexostatusOutcome::NotEstablished {
+                reason: query.nothing_established(op_moment),
+            });
+        }
+
+        let mut total = Decimal::ZERO;
+        for event in events {
+            let found = chronicle::field(&event.fields, field);
+            let value = found.and_then(Value::as_decimal).ok_or_else(|| {
+                SimulatorError::SumOfNonNumber {
+                    cell: self.id.clone(),
+                    lexostatus: definition.name.clone(),
+                    field: format!("{}.{field}", query.chronicle),
+                    op_moment: event.op_moment.to_string(),
+                    found: found.map_or_else(
+                        || "dat veld niet".to_string(),
+                        |value| format!("{} ({})", value, value.type_name()),
+                    ),
+                }
+            })?;
+            total += value;
+        }
+
+        Ok(LexostatusOutcome::Established(BTreeMap::from([(
+            field.to_string(),
+            amount(total),
+        )])))
+    }
+
+    /// De waarde van het sleutelveld uit de vraag.
+    ///
+    /// Onbereikbaar leeg: `validate` eist dat de sleutel een gedocumenteerde
+    /// parameter is, en `check_params` dat elke gedocumenteerde parameter
+    /// meekomt. Eén plek, want beide kroniekfilters stellen dezelfde vraag.
+    fn key_value<'a>(
+        &self,
+        definition: &LexostatusDefinition,
+        key: &str,
+        params: &'a BTreeMap<String, Value>,
+    ) -> Result<&'a Value> {
+        params
+            .get(key)
+            .ok_or_else(|| SimulatorError::MissingParameter {
+                cell: self.id.clone(),
+                subject: Subject::Lexostatus,
+                name: definition.name.clone(),
+                parameter: key.to_string(),
+            })
     }
 
     /// Neem een besluit: voer een eigen regeling uit en leg de uitkomst vast.
@@ -629,8 +721,11 @@ impl Cell {
     ///    `op_moment` waren, en uit de parameters van het besluit;
     /// 3. de **besluit-engine** voert de regeling uit op dat moment, dus op de
     ///    wetsversie die toen gold;
-    /// 4. de uitkomst wordt als decretogram vastgelegd in de eigen stroom
-    ///    [`BESCHIKKINGEN`] — één gram, met alle uitkomsten samen (RFC-022 §1.2).
+    /// 4. de verplichtingen worden uitgerekend tot een schema van termijnen, op
+    ///    de uitkomsten waarop besloten is en met de instellingen van de wereld;
+    /// 5. de uitkomst wordt als decretogram vastgelegd in de eigen stroom
+    ///    [`BESCHIKKINGEN`] — één gram, met alle uitkomsten en het hele schema
+    ///    samen (RFC-022 §1.2).
     ///
     /// `pub(crate)` en niet `pub`, net als [`Self::record`]: een consument kan een
     /// cel niet laten besluiten. Dat doet de cel zelf, in deze opstelling
@@ -647,10 +742,16 @@ impl Cell {
     /// `resolver` is dezelfde weg, maar voor de verwijzingen die *de wet* legt
     /// (tier 3): de besluit-engine krijgt hem voor de duur van dit ene besluit,
     /// en de reduce-engine nooit.
+    ///
+    /// `settings` zijn de instellingen van het wereldbestand; een verplichting
+    /// met `schedule: $betalingsritme` leest eruit. De cel houdt ze niet — ze
+    /// zijn van de wereld, en een besluit krijgt ze aangereikt zoals het zijn
+    /// moment aangereikt krijgt.
     pub(crate) fn decide(
         &mut self,
         besluit: &str,
         params: &BTreeMap<String, Value>,
+        settings: &BTreeMap<String, Value>,
         op_moment: NaiveDate,
         accepted: &BTreeMap<String, DecretogramInput>,
         resolver: Option<Rc<dyn CellResolver>>,
@@ -664,7 +765,18 @@ impl Cell {
         let zaakkenmerk = definition.zaakkenmerk(&self.id, params)?;
 
         let inputs = self.collect_inputs(&definition, params, accepted, op_moment)?;
-        let decretogram = self.execute(&definition, zaakkenmerk, inputs, resolver, op_moment)?;
+        let mut decretogram =
+            self.execute(&definition, zaakkenmerk, inputs, resolver, op_moment)?;
+        // Ná de uitvoering, want het bedrag komt uit de uitkomst waarop besloten
+        // is; vóór het vastleggen, want het schema hoort ín het gram.
+        decretogram.obligations = definition.schedule_obligations(
+            &self.id,
+            &decretogram.zaakkenmerk,
+            &decretogram.outputs,
+            params,
+            settings,
+            op_moment,
+        )?;
 
         let event = decretogram.event()?;
         self.record_own(BESCHIKKINGEN, event)?;
@@ -928,8 +1040,73 @@ impl Cell {
                 })
                 .collect(),
             inputs,
+            // Het schema komt er in `decide` bij: het hangt aan de uitkomsten
+            // hierboven, en die zijn hier net pas bekend.
+            obligations: Vec::new(),
             receipt,
         })
+    }
+
+    /// Kom één vervallen verplichting na: leg de betaling vast.
+    ///
+    /// Dit is wat de cel die de verplichting draagt doet als de klok een
+    /// vervaldatum passeert. Ze legt vast wat zíj deed — een executogram met
+    /// `intake: betaling` in haar eigen stroom [`BETALINGEN`] — en niets over een
+    /// ander.
+    ///
+    /// Levert `false` als deze termijn er al lag: zie [`Self::already_settled`].
+    pub(crate) fn pay_obligation(&mut self, due: &ObligationDue) -> Result<bool> {
+        self.record_obligation(due, due.payment_event())
+    }
+
+    /// Leg vast dat gemeld is dat er op een verplichting betaald is.
+    ///
+    /// De tegenhanger van [`Self::pay_obligation`], bij de cel die besloot. Ook
+    /// dit is een eigen vastlegging (`intake: levering`) en geen kopie van het
+    /// gram van de betaler: beide kanten weten wat er gebeurde, en geen van
+    /// beide leest de kroniek van de ander.
+    pub(crate) fn note_obligation_paid(&mut self, due: &ObligationDue) -> Result<bool> {
+        self.record_obligation(due, due.delivery_event())
+    }
+
+    /// Leg één kant van een vervallen termijn vast, tenzij ze er al ligt.
+    fn record_obligation(&mut self, due: &ObligationDue, event: ChronicleEvent) -> Result<bool> {
+        if self.already_settled(due) {
+            return Ok(false);
+        }
+        self.chronicles.record(&self.id, BETALINGEN, event)?;
+        Ok(true)
+    }
+
+    /// Ligt deze termijn hier al?
+    ///
+    /// Eén zaak plus één volgnummer is één termijn. Dat is wat een executogram
+    /// twee keer vastleggen tegenhoudt: de klok mag in kleine stappen langskomen,
+    /// een besluit mag op dezelfde dag overgedaan worden en een wereld mag de
+    /// betaling al als startstand hebben staan — betaald is betaald, en een
+    /// kroniek die hetzelfde feit twee keer draagt telt het in een som ook twee
+    /// keer mee.
+    fn already_settled(&self, due: &ObligationDue) -> bool {
+        self.chronicles
+            .latest_recording(
+                BETALINGEN,
+                besluit::ZAAKKENMERK,
+                &Value::String(due.zaakkenmerk.clone()),
+                &BTreeMap::from([(besluit::VOLGNUMMER.to_string(), Value::Int(due.volgnummer))]),
+                due.vervaldatum,
+            )
+            .is_some()
+    }
+
+    /// Het sleutelveld van een stroom die deze cel houdt; `None` als ze haar
+    /// niet houdt.
+    ///
+    /// `pub(crate)`, en alleen voor het optuigen: de wereld moet kunnen toetsen
+    /// dat een cel die een verplichting draagt een betalingsstroom heeft met de
+    /// sleutel waarop een zaak terug te vinden is. Geeft niets prijs over wat er
+    /// in die stroom staat.
+    pub(crate) fn stream_key(&self, stream: &str) -> Option<&str> {
+        self.chronicles.key_of(stream)
     }
 }
 
@@ -968,7 +1145,41 @@ fn resolve_reference(law: &ArticleBasedLaw, reference: &str) -> Option<String> {
         })
 }
 
+/// Waar een kroniekfilter naar kijkt: één stroom, één onderwerp, één filter.
+///
+/// De twee reductievormen over een kroniek — de laatste vastlegging en de som —
+/// stellen dezelfde vraag en verschillen alleen in wat ze met het antwoord doen.
+/// Dat ze hier dezelfde vraag dragen, houdt ze bij elkaar: een filter dat voor de
+/// som iets anders zou betekenen dan voor `latest`, zou twee reducties opleveren
+/// die niet over dezelfde vastleggingen gaan.
+struct ChronicleQuery<'a> {
+    /// De eigen stroom waarover gefilterd wordt.
+    chronicle: &'a str,
+    /// Het sleutelveld van die stroom.
+    key: &'a str,
+    /// De sleutelwaarde uit de vraag.
+    key_value: &'a Value,
+    /// De extra gelijkheidsvoorwaarden (`where`).
+    conditions: &'a BTreeMap<String, Value>,
+}
+
+impl ChronicleQuery<'_> {
+    /// Waarom dit filter niets vond, zo precies dat het na te lopen is.
+    fn nothing_established(&self, op_moment: NaiveDate) -> String {
+        nothing_established(
+            self.chronicle,
+            self.key,
+            self.key_value,
+            self.conditions,
+            op_moment,
+        )
+    }
+}
+
 /// Waarom het kroniekfilter niets vond, zo precies dat het na te lopen is.
+///
+/// Los van [`ChronicleQuery`], omdat het besluit-pad dezelfde reden nodig heeft
+/// voor een input die het niet kon ophalen, en daar is geen lexostatus in zicht.
 fn nothing_established(
     chronicle: &str,
     key: &str,
@@ -999,9 +1210,7 @@ fn nothing_established(
 /// tijdas.
 fn nothing_published(
     definition: &LexostatusDefinition,
-    chronicle: &str,
-    key: &str,
-    key_value: &Value,
+    query: &ChronicleQuery<'_>,
     recorded: NaiveDate,
 ) -> String {
     let published = definition
@@ -1010,9 +1219,9 @@ fn nothing_published(
         .collect::<Vec<_>>()
         .join(", ");
     format!(
-        "kroniekstroom '{chronicle}' heeft voor {key} '{key_value}' wel een vastlegging \
-         (van {recorded}), maar die draagt geen van de gepubliceerde uitkomsten \
-         ({published})"
+        "kroniekstroom '{}' heeft voor {} '{}' wel een vastlegging (van {recorded}), \
+         maar die draagt geen van de gepubliceerde uitkomsten ({published})",
+        query.chronicle, query.key, query.key_value
     )
 }
 
@@ -1261,6 +1470,12 @@ lexostatus_definitions:
 
     fn bsn() -> BTreeMap<String, Value> {
         BTreeMap::from([("bsn".to_string(), Value::String("999993653".to_string()))])
+    }
+
+    /// Een wereld zonder instellingen: geen van de besluiten hieronder legt een
+    /// verplichting op, dus er is niets om naar te verwijzen.
+    fn no_settings() -> BTreeMap<String, Value> {
+        BTreeMap::new()
     }
 
     fn moment() -> NaiveDate {
@@ -1747,6 +1962,138 @@ laws:
         );
     }
 
+    /// Een bron-cel met betalingen in haar kroniek.
+    ///
+    /// `bedrag` van de tweede vastlegging wordt letterlijk ingeplakt, zodat de
+    /// test over een som die niet op te tellen valt dezelfde stroom gebruikt als
+    /// de test die wél optelt.
+    fn betaalcel(tweede_bedrag: &str) -> CellConfig {
+        config(&format!(
+            r"
+id: belastingdienst
+laws: []
+chronicles:
+  - stream: betalingen
+    key: zaakkenmerk
+    events:
+      - name: betaling
+        intake: betaling
+        recording_actor: belastingdienst
+        op_moment: 2024-01-01
+        fields:
+          zaakkenmerk: zorgtoeslag/999993653
+          bedrag: 1000
+          volgnummer: 1
+      - name: betaling
+        intake: betaling
+        recording_actor: belastingdienst
+        op_moment: 2024-04-01
+        fields:
+          zaakkenmerk: zorgtoeslag/999993653
+          bedrag: {tweede_bedrag}
+          volgnummer: 2
+lexostatus_definitions:
+  - name: betaald_tot_nu_toe
+    inputs:
+      - name: zaakkenmerk
+        type: string
+    outputs:
+      - bedrag
+    reduction:
+      chronicle: betalingen
+      key: zaakkenmerk
+      sum: bedrag
+"
+        ))
+    }
+
+    fn zaak(zaakkenmerk: &str) -> BTreeMap<String, Value> {
+        BTreeMap::from([(
+            "zaakkenmerk".to_string(),
+            Value::String(zaakkenmerk.to_string()),
+        )])
+    }
+
+    /// De som is een reductie over de tijdas, net als elk ander kroniekfilter: ze
+    /// telt op wat op het gevraagde moment vastlag en niet wat er inmiddels bij
+    /// is gekomen.
+    #[test]
+    fn de_som_telt_op_wat_op_dat_moment_vastlag() {
+        let cell = Cell::from_config(&betaalcel("500"), &regulation_root(), &no_fixtures())
+            .unwrap_or_else(|e| panic!("de cel moet op te tuigen zijn: {e}"));
+
+        let vroeg = cell
+            .reduce(
+                "betaald_tot_nu_toe",
+                &zaak("zorgtoeslag/999993653"),
+                date("2024-02-01"),
+            )
+            .unwrap_or_else(|e| panic!("de som moet te maken zijn: {e}"));
+        assert_eq!(values(&vroeg).get("bedrag"), Some(&Value::Int(1000)));
+
+        let laat = cell
+            .reduce(
+                "betaald_tot_nu_toe",
+                &zaak("zorgtoeslag/999993653"),
+                date("2024-06-01"),
+            )
+            .unwrap_or_else(|e| panic!("de som moet te maken zijn: {e}"));
+        assert_eq!(values(&laat).get("bedrag"), Some(&Value::Int(1500)));
+    }
+
+    /// Nul vastleggingen is niet nul euro. Een 0 zou "er is niets betaald" niet
+    /// kunnen onderscheiden van "over deze zaak ligt hier niets".
+    #[test]
+    fn de_som_over_niets_is_geen_nul() {
+        let cell = Cell::from_config(&betaalcel("500"), &regulation_root(), &no_fixtures())
+            .unwrap_or_else(|e| panic!("de cel moet op te tuigen zijn: {e}"));
+        let answer = cell
+            .reduce(
+                "betaald_tot_nu_toe",
+                &zaak("zorgtoeslag/999993999"),
+                date("2024-06-01"),
+            )
+            .unwrap_or_else(|e| panic!("de som moet te maken zijn: {e}"));
+        assert!(
+            answer.not_established().is_some(),
+            "verwachtte 'niets vastgesteld', kreeg {:?}",
+            answer.outcome
+        );
+    }
+
+    /// Een vastlegging zonder getal in het veld is een fout en geen nul: een som
+    /// die haar overslaat valt stil te laag uit.
+    #[test]
+    fn een_som_over_een_veld_zonder_getal_faalt() {
+        let cell = Cell::from_config(&betaalcel("veel"), &regulation_root(), &no_fixtures())
+            .unwrap_or_else(|e| panic!("de cel moet op te tuigen zijn: {e}"));
+        let err = cell
+            .reduce(
+                "betaald_tot_nu_toe",
+                &zaak("zorgtoeslag/999993653"),
+                date("2024-06-01"),
+            )
+            .expect_err("een som over tekst hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::SumOfNonNumber { .. }),
+            "verwachtte SumOfNonNumber, kreeg {err}"
+        );
+    }
+
+    /// Een som levert precies één waarde op, dus `outputs` hoort precies dat veld
+    /// te noemen. Al het andere is een belofte die nooit nagekomen wordt.
+    #[test]
+    fn een_som_die_iets_anders_publiceert_dan_ze_optelt_wordt_geweigerd() {
+        let mut config = betaalcel("500");
+        config.lexostatus_definitions[0].outputs = vec!["volgnummer".to_string()];
+        let err = Cell::from_config(&config, &regulation_root(), &no_fixtures())
+            .expect_err("een som die iets anders publiceert hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::SumOutputMismatch { .. }),
+            "verwachtte SumOutputMismatch, kreeg {err}"
+        );
+    }
+
     #[test]
     fn een_output_die_de_stroom_niet_kent_wordt_geweigerd() {
         let err = Cell::from_config(
@@ -1938,6 +2285,7 @@ besluit_definitions:
             .decide(
                 "zorgtoeslag_vaststelling",
                 &bsn(),
+                &no_settings(),
                 moment(),
                 &no_accepted(),
                 None,
@@ -1984,6 +2332,7 @@ besluit_definitions:
             .decide(
                 "zorgtoeslag_vaststelling",
                 &bsn(),
+                &no_settings(),
                 moment(),
                 &no_accepted(),
                 None,
@@ -2028,6 +2377,7 @@ besluit_definitions:
             .decide(
                 "zorgtoeslag_vaststelling",
                 &bsn(),
+                &no_settings(),
                 date("2024-01-01"),
                 &no_accepted(),
                 None,
@@ -2058,6 +2408,7 @@ besluit_definitions:
             cell.decide(
                 "zorgtoeslag_vaststelling",
                 &bsn(),
+                &no_settings(),
                 moment(),
                 &no_accepted(),
                 None,
@@ -2097,6 +2448,7 @@ besluit_definitions:
             .decide(
                 "zorgtoeslag_terugvordering",
                 &bsn(),
+                &no_settings(),
                 moment(),
                 &no_accepted(),
                 None,
@@ -2199,6 +2551,7 @@ chronicles:
         cell.decide(
             "zorgtoeslag_vaststelling",
             &bsn(),
+            &no_settings(),
             moment(),
             &no_accepted(),
             None,

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -683,8 +683,20 @@ impl Cell {
             total += value;
         }
 
+        // Onder de gepubliceerde naam en niet onder de naam in `sum`. Het filter
+        // hiernaast doet dat ook, en die twee mogen niet uiteenlopen: het optuigen
+        // vergelijkt `outputs` met het gesommeerde veld zonder op kapitalen te
+        // letten, dus de twee schrijfwijzen kunnen verschillen — en dan zou het
+        // antwoord onder een naam staan die de definitie niet publiceert.
+        // Onbereikbaar leeg: `validate_chronicle` eist precies één uitkomst.
+        let published = definition
+            .published_outputs()
+            .into_iter()
+            .next()
+            .unwrap_or(field);
+
         Ok(LexostatusOutcome::Established(BTreeMap::from([(
-            field.to_string(),
+            published.to_string(),
             amount(total),
         )])))
     }
@@ -1070,29 +1082,56 @@ impl Cell {
     }
 
     /// Leg één kant van een vervallen termijn vast, tenzij ze er al ligt.
+    ///
+    /// Langs [`Self::record`] en niet rechtstreeks naar de store: dat is de poort
+    /// waar elke vastlegging langs hoort, ook een die het platform zelf maakt.
     fn record_obligation(&mut self, due: &ObligationDue, event: ChronicleEvent) -> Result<bool> {
         if self.already_settled(due) {
             return Ok(false);
         }
-        self.chronicles.record(&self.id, BETALINGEN, event)?;
+        self.record(BETALINGEN, event)?;
         Ok(true)
     }
 
     /// Ligt deze termijn hier al?
     ///
-    /// Eén zaak plus één volgnummer is één termijn. Dat is wat een executogram
-    /// twee keer vastleggen tegenhoudt: de klok mag in kleine stappen langskomen,
-    /// een besluit mag op dezelfde dag overgedaan worden en een wereld mag de
-    /// betaling al als startstand hebben staan — betaald is betaald, en een
-    /// kroniek die hetzelfde feit twee keer draagt telt het in een som ook twee
-    /// keer mee.
+    /// Eén zaak, één besluit en één volgnummer is één termijn. Dat is wat een
+    /// executogram twee keer vastleggen tegenhoudt: de klok mag in kleine stappen
+    /// langskomen, een besluit mag overgedaan worden, en een wereld mag de
+    /// betaling al als startstand hebben staan mits die dezelfde verwijzing naar
+    /// het besluit draagt — betaald is betaald, en een kroniek die hetzelfde feit
+    /// twee keer draagt telt het in een som ook twee keer mee.
+    ///
+    /// Het besluit hoort in die sleutel en niet alleen het volgnummer: over één
+    /// zaak worden meer besluiten genomen (een verlening en later een
+    /// vaststelling), en die dragen elk hun eigen schema dat bij 1 begint. Op
+    /// alleen zaak en volgnummer zou de termijn van het tweede besluit voor die
+    /// van het eerste doorgaan en stil wegvallen. Dat het volgnummer bínnen een
+    /// besluit uniek is, komt van de andere kant — zie
+    /// [`ObligationDue::volgnummer`].
+    ///
+    /// Het *moment* van het besluit zit er met opzet niet in. Hetzelfde besluit
+    /// over dezelfde zaak nog eens nemen levert daardoor geen tweede betaling,
+    /// ook niet op een latere dag. Een herzieningsbesluit dat een eerder schema
+    /// vervángt, is iets anders — dat vraagt om intrekken, en intrekken bestaat
+    /// hier nog niet.
     fn already_settled(&self, due: &ObligationDue) -> bool {
         self.chronicles
             .latest_recording(
                 BETALINGEN,
                 besluit::ZAAKKENMERK,
                 &Value::String(due.zaakkenmerk.clone()),
-                &BTreeMap::from([(besluit::VOLGNUMMER.to_string(), Value::Int(due.volgnummer))]),
+                &BTreeMap::from([
+                    (besluit::VOLGNUMMER.to_string(), Value::Int(due.volgnummer)),
+                    (
+                        besluit::BESLUIT.to_string(),
+                        Value::String(due.besluit.clone()),
+                    ),
+                    (
+                        besluit::BESLUIT_CEL.to_string(),
+                        Value::String(due.decided_by.clone()),
+                    ),
+                ]),
                 due.vervaldatum,
             )
             .is_some()
@@ -2092,6 +2131,30 @@ lexostatus_definitions:
             matches!(err, SimulatorError::SumOutputMismatch { .. }),
             "verwachtte SumOutputMismatch, kreeg {err}"
         );
+    }
+
+    /// Het antwoord staat onder de naam die de definitie publiceert, ook als
+    /// `sum` die naam anders schrijft.
+    ///
+    /// Het optuigen vergelijkt de twee zonder op kapitalen te letten, net als bij
+    /// elke andere gepubliceerde uitkomst. Zou de som onder de naam uit `sum`
+    /// antwoorden, dan lag het getal er wel maar onder een naam die de definitie
+    /// niet noemt — en dan vindt een consument niets.
+    #[test]
+    fn de_som_antwoordt_onder_de_gepubliceerde_naam() {
+        let mut config = betaalcel("500");
+        config.lexostatus_definitions[0].outputs = vec!["Bedrag".to_string()];
+        let cell = Cell::from_config(&config, &regulation_root(), &no_fixtures())
+            .unwrap_or_else(|e| panic!("de cel moet op te tuigen zijn: {e}"));
+
+        let answer = cell
+            .reduce(
+                "betaald_tot_nu_toe",
+                &zaak("zorgtoeslag/999993653"),
+                date("2024-06-01"),
+            )
+            .unwrap_or_else(|e| panic!("de som moet te maken zijn: {e}"));
+        assert_eq!(values(&answer).get("Bedrag"), Some(&Value::Int(1500)));
     }
 
     #[test]

--- a/packages/simulator/src/error.rs
+++ b/packages/simulator/src/error.rs
@@ -216,6 +216,49 @@ pub enum SimulatorError {
         stream: String,
     },
 
+    /// Een som publiceert iets anders dan het veld waarover ze sommeert.
+    ///
+    /// Een som levert precies één waarde op: het totaal van dat ene veld. Een
+    /// `outputs` met iets anders erin belooft een uitkomst die nooit in het
+    /// antwoord komt, en die belofte hoort bij het optuigen te sneuvelen.
+    #[error(
+        "cel '{cell}': '{lexostatus}' sommeert veld '{field}', dus `outputs` hoort \
+         precies dat veld te noemen (nu: {outputs})"
+    )]
+    SumOutputMismatch {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// De lexostatus met de som.
+        lexostatus: String,
+        /// Het veld waarover gesommeerd wordt.
+        field: String,
+        /// Komma-gescheiden lijst van wat er nu in `outputs` staat.
+        outputs: String,
+    },
+
+    /// Een som stuit op een vastlegging zonder getal in het veld.
+    ///
+    /// Een som die zo'n vastlegging overslaat, valt stil te laag uit, en dan is
+    /// "betaald tot nu toe" een getal dat er goed uitziet en niet klopt. Een
+    /// stroom die zich niet laat sommeren is een fout in de wereld, niet een
+    /// reden om te gokken.
+    #[error(
+        "cel '{cell}': '{lexostatus}' sommeert '{field}', maar de vastlegging van \
+         {op_moment} heeft daar {found}"
+    )]
+    SumOfNonNumber {
+        /// Cel waaraan gevraagd werd.
+        cell: String,
+        /// De lexostatus met de som.
+        lexostatus: String,
+        /// Stroom en veld die een getal moesten leveren, als `stroom.veld`.
+        field: String,
+        /// Het moment van de vastlegging die niet meekon.
+        op_moment: String,
+        /// Wat er in plaats van een getal stond.
+        found: String,
+    },
+
     /// Een definitie sleutelt, filtert of leest op een veld dat de stroom niet kent.
     ///
     /// Zo'n filter zou stil "niets vastgesteld" antwoorden op elke vraag, en dat
@@ -458,6 +501,141 @@ pub enum SimulatorError {
         output: String,
         /// Komma-gescheiden lijst van de vaste velden.
         fixed: String,
+    },
+
+    /// Een verplichting noemt een bedrag dat geen uitkomst van haar besluit is.
+    ///
+    /// Wat betaald moet worden, komt uit de wet die het besluit uitvoert. Een
+    /// letterlijk bedrag of een parameter zou naast die uitkomst gaan leven, en
+    /// dan zegt het gram twee dingen over hetzelfde geld.
+    #[error(
+        "cel '{cell}': verplichting van besluit '{besluit}' noemt bedrag '{amount}'; \
+         dat moet een uitkomst van dit besluit zijn, als $naam (uitkomsten: {outputs})"
+    )]
+    ObligationAmount {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// Het besluit met de verplichting.
+        besluit: String,
+        /// Wat er als bedrag stond.
+        amount: String,
+        /// Komma-gescheiden lijst van de uitkomsten die het besluit vastlegt.
+        outputs: String,
+    },
+
+    /// De uitkomst waarnaar een verplichting verwijst is geen bedrag.
+    ///
+    /// Bij het besluit, niet bij het optuigen: dat de uitkomst bestaat is daar al
+    /// getoetst, maar welke waarde ze heeft blijkt pas als de engine gedraaid
+    /// heeft. Een schema uit een ontbrekende of niet-numerieke uitkomst zou een
+    /// betaling van "niets" opleveren.
+    #[error(
+        "cel '{cell}': besluit '{besluit}' kan geen betalingsschema maken, want \
+         uitkomst '{output}' is {found}"
+    )]
+    ObligationAmountValue {
+        /// Cel die besloot.
+        cell: String,
+        /// Het besluit met de verplichting.
+        besluit: String,
+        /// De uitkomst die het bedrag moest leveren.
+        output: String,
+        /// Wat er in plaats van een bedrag stond.
+        found: String,
+    },
+
+    /// Een verplichting noemt een ritme dat de simulator niet kent.
+    #[error(
+        "cel '{cell}': verplichting van besluit '{besluit}' noemt ritme '{schedule}' \
+         (bekend: {known})"
+    )]
+    UnknownSchedule {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// Het besluit met de verplichting.
+        besluit: String,
+        /// Het onbekende ritme.
+        schedule: String,
+        /// Komma-gescheiden lijst van de ritmes die wél bestaan.
+        known: String,
+    },
+
+    /// Een verplichting verwijst naar een instelling die het wereldbestand niet
+    /// heeft.
+    #[error(
+        "cel '{cell}': verplichting van besluit '{besluit}' verwijst naar instelling \
+         '{setting}', maar die staat niet in `settings` van het wereldbestand \
+         (wel: {known})"
+    )]
+    UnknownSetting {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// Het besluit met de verplichting.
+        besluit: String,
+        /// De instelling waarnaar verwezen wordt.
+        setting: String,
+        /// Komma-gescheiden lijst van de instellingen die er wél zijn.
+        known: String,
+    },
+
+    /// De `from` van een verplichting levert geen datum op.
+    #[error(
+        "cel '{cell}': verplichting van besluit '{besluit}' begint bij '{template}', \
+         maar {reason}"
+    )]
+    MalformedObligationDate {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// Het besluit met de verplichting.
+        besluit: String,
+        /// Het sjabloon zoals het in de configuratie staat.
+        template: String,
+        /// Wat er mis is.
+        reason: String,
+    },
+
+    /// Een verplichting zou vervallen vóór het besluit dat haar schept.
+    ///
+    /// Een termijn met een datum in het verleden zou bij het nakomen een
+    /// vastlegging op dat eerdere moment opleveren, en dan verandert het beeld van
+    /// toen doordat de wereld verder loopt — precies wat een kroniek niet doet.
+    #[error(
+        "cel '{cell}': verplichting van besluit '{besluit}' vervalt op {from}, \
+         vóór het besluit van {op_moment}; een verplichting kan niet vervallen \
+         vóór het besluit waaruit ze volgt"
+    )]
+    ObligationBeforeDecision {
+        /// Cel die besluit.
+        cell: String,
+        /// Het besluit met de verplichting.
+        besluit: String,
+        /// De uitgerekende startdatum.
+        from: String,
+        /// Het moment van het besluit.
+        op_moment: String,
+    },
+
+    /// Een cel die een verplichting moet dragen houdt geen betalingsstroom.
+    ///
+    /// Beide kanten van een verplichting leggen vast: de betalende cel dat ze
+    /// betaalde, de besluitende dat het haar gemeld is. Dat kan alleen in een
+    /// stroom die er is, met de sleutel waarop een zaak terug te vinden is — en
+    /// dat hoort bij het optuigen te blijken en niet op de eerste vervaldatum.
+    #[error(
+        "cel '{cell}': verplichting van besluit '{besluit}' vraagt dat cel '{holder}' \
+         {expected} houdt, maar {found}"
+    )]
+    ObligationStream {
+        /// Cel waarin de definitie staat.
+        cell: String,
+        /// Het besluit met de verplichting.
+        besluit: String,
+        /// De cel die de stroom zou moeten houden.
+        holder: String,
+        /// De stroom met de sleutel die het platform verwacht.
+        expected: String,
+        /// Wat er in plaats daarvan is.
+        found: String,
     },
 
     /// Het zaakkenmerk-sjabloon heeft een accolade die niet sluit.

--- a/packages/simulator/src/lib.rs
+++ b/packages/simulator/src/lib.rs
@@ -38,6 +38,13 @@
 //! transport; de reduce-engine kan geen van beide, en dat is een ontbrekende
 //! capability en geen afspraak.
 //!
+//! Een besluit laat iets achter dat later moet gebeuren. Een [`ObligationDue`]
+//! is één termijn van een verplichting uit een decretogram; [`World::advance`]
+//! laat haar op de vervaldatum nakomen, en dan legt de betalende cel een
+//! betaling vast en de besluitende cel dat het haar gemeld is. Wat er betaald is,
+//! is daarna een **reductie** over die vastleggingen (`sum: bedrag`) en geen
+//! saldo dat ernaast wordt bijgehouden.
+//!
 //! ```no_run
 //! use regelrecht_simulator::{regulation_root, Scenario};
 //! use std::path::Path;
@@ -67,10 +74,11 @@ mod values;
 pub mod world;
 
 pub use cell::{
-    AcceptanceRequest, AcceptedSource, BesluitDefinition, BesluitInput, Cell, CellConfig,
-    ChronicleEvent, ChronicleStore, ChronicleStream, Decretogram, DecretogramInput,
+    AcceptanceRequest, AcceptedSource, Aggregate, BesluitDefinition, BesluitInput, Cell,
+    CellConfig, ChronicleEvent, ChronicleStore, ChronicleStream, Decretogram, DecretogramInput,
     DocumentedParameter, InputOrigin, Intake, Lexostatus, LexostatusDefinition, LexostatusOutcome,
-    ParameterType, Reduction, BESCHIKKINGEN,
+    ObligationDefinition, ObligationDue, ParameterType, Reduction, Schedule, BESCHIKKINGEN,
+    BETALINGEN,
 };
 pub use corpus::regulation_root;
 pub use error::{Result, SimulatorError, Subject};

--- a/packages/simulator/src/scenario.rs
+++ b/packages/simulator/src/scenario.rs
@@ -32,6 +32,13 @@ pub struct Scenario {
     pub clock: Clock,
     /// De cellen in deze run.
     pub cells: Vec<CellConfig>,
+    /// De instellingen van deze wereld: casusdata die geen wet is.
+    ///
+    /// Een `schedule: $betalingsritme` in een verplichting leest hieruit. Dat
+    /// zo'n keuze hier staat en niet in de besluit-definitie, is het verschil
+    /// tussen wat de wet voorschrijft en wat een organisatie als beleid kiest.
+    #[serde(default)]
+    pub settings: BTreeMap<String, Value>,
     /// De startstand: vastleggingen met een moment. Wat vóór het startmoment
     /// van de klok valt staat er bij het optuigen al; de rest landt zodra de
     /// klok die datum passeert.
@@ -335,6 +342,11 @@ impl ScenarioRun {
                     crossing.signature,
                 );
             }
+            // Het schema hoort bij het gram en dus in het verslag: wat beloofd is,
+            // staat er vóórdat er iets betaald is.
+            for due in &gram.obligations {
+                let _ = writeln!(out, "        verplichting: {}", due.describe());
+            }
             write_failures(&mut out, &decision.failures);
         }
 
@@ -512,7 +524,13 @@ impl Scenario {
     /// Tuig de wereld op: de cellen, de klok op haar startmoment en de
     /// startstand die op dat moment al gebeurd was.
     pub fn world(&self, regulation_root: &Path) -> Result<World> {
-        World::new(&self.cells, self.clock, &self.fixtures, regulation_root)
+        World::new(
+            &self.cells,
+            self.clock,
+            &self.fixtures,
+            &self.settings,
+            regulation_root,
+        )
     }
 
     /// Tuig de wereld op, laat de tijd lopen en stel alle vragen.

--- a/packages/simulator/src/values.rs
+++ b/packages/simulator/src/values.rs
@@ -1,11 +1,18 @@
-//! Waarden vergelijken zoals een leesbaar bestand ze bedoelt.
+//! Waarden vergelijken en opschrijven zoals een leesbaar bestand ze bedoelt.
 //!
 //! Eén plek, want er zijn twee plekken die dezelfde vraag stellen: het
 //! kroniekfilter (voldoet dit veld aan deze voorwaarde?) en de scenario-runner
 //! (kwam deze verwachting uit?). Wie ze uit elkaar laat lopen, krijgt een
 //! scenario dat iets anders vergelijkt dan de cel.
+//!
+//! Hier staat ook de omgekeerde weg: een uitgerekend bedrag als vastlegbare
+//! waarde ([`amount`]). Ook die hoort op één plek, want een betalingstermijn en
+//! een som over betalingen moeten dezelfde waarde opleveren voor hetzelfde
+//! getal — anders klopt "betaald tot nu toe" op het oog wel en op de variant niet.
 
 use regelrecht_engine::Value;
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
 
 /// Gelijkheid met één versoepeling: getallen vergelijken op waarde, niet op
 /// variant. YAML kent geen verschil tussen `1` en `1.0`, de engine wel.
@@ -16,9 +23,35 @@ pub(crate) fn equivalent(left: &Value, right: &Value) -> bool {
     }
 }
 
+/// Een uitgerekend bedrag als vastlegbare waarde.
+///
+/// Een geheel bedrag blijft geheel: `Value::Int(25000)` en niet
+/// `Value::Decimal(25000)`. Voor de vergelijking maakt dat niets uit (zie
+/// [`equivalent`]), voor wat een lezer in een verslag of een gram ziet wel — en
+/// een bedrag in hele eenheden hoort er niet uit te zien als een breuk.
+pub(crate) fn amount(value: Decimal) -> Value {
+    if value.fract() == Decimal::ZERO {
+        if let Some(whole) = value.to_i64() {
+            return Value::Int(whole);
+        }
+    }
+    Value::Decimal(value)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn een_heel_bedrag_blijft_geheel() {
+        assert_eq!(amount(Decimal::new(25000, 0)), Value::Int(25000));
+    }
+
+    #[test]
+    fn een_bedrag_met_een_breuk_houdt_zijn_breuk() {
+        let met_breuk = Decimal::new(4930231187, 5);
+        assert_eq!(amount(met_breuk), Value::Decimal(met_breuk));
+    }
 
     #[test]
     fn getallen_vergelijken_op_waarde() {

--- a/packages/simulator/src/world.rs
+++ b/packages/simulator/src/world.rs
@@ -665,6 +665,7 @@ fn check_obligations(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cell::ObligationDefinition;
     use crate::corpus::regulation_root;
 
     fn date(text: &str) -> NaiveDate {
@@ -1326,9 +1327,111 @@ laws: []
         );
     }
 
+    /// Eén besluit mag meer dan één verplichting opleggen, en dan hoort elke
+    /// termijn van elk van beide nagekomen te worden.
+    ///
+    /// Zonder doorlopende volgnummers begint elke verplichting weer bij 1, en dan
+    /// gaat de eerste termijn van de tweede verplichting door voor die van de
+    /// eerste: hij wordt als "al betaald" overgeslagen en valt stil weg. De som
+    /// is het enige waar dat aan te zien is.
+    #[test]
+    fn twee_verplichtingen_in_een_besluit_worden_beide_nagekomen() {
+        let twee = "      - amount: $hoogte_zorgtoeslag
+        payer: belastingdienst
+        schedule: kwartaal
+      - amount: $hoogte_zorgtoeslag
+        payer: belastingdienst
+        schedule: ineens";
+        let mut world = verplichting_wereld(twee, &no_settings())
+            .unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+
+        let gram = beslis(&mut world);
+        assert_eq!(
+            gram.obligations.len(),
+            5,
+            "vier kwartaaltermijnen plus één ineens"
+        );
+        let volgnummers: Vec<i64> = gram
+            .obligations
+            .iter()
+            .map(|due| due.volgnummer)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        assert_eq!(
+            volgnummers,
+            vec![1, 2, 3, 4, 5],
+            "de volgnummers van één gram horen uniek te zijn"
+        );
+
+        world
+            .advance(date("2025-01-01"))
+            .unwrap_or_else(|e| panic!("de klok moet vooruit kunnen: {e}"));
+        assert_eq!(
+            betaald(&world, "belastingdienst", "2025-01-01"),
+            Some(Value::Decimal("394410.62374".parse().unwrap_or_default())),
+            "beide verplichtingen zijn opgelegd, dus beide horen betaald te zijn"
+        );
+        assert_eq!(
+            betaald(&world, "toeslagen", "2025-01-01"),
+            Some(Value::Decimal("394410.62374".parse().unwrap_or_default())),
+            "en de besluitende cel hoort van beide de melding te hebben"
+        );
+    }
+
+    /// Over één zaak worden meer besluiten genomen, elk met een eigen schema dat
+    /// bij termijn 1 begint. Dat tweede schema hoort óók nagekomen te worden.
+    ///
+    /// Herkende de idempotentie een termijn op zaak en volgnummer alleen, dan zou
+    /// de eerste termijn van het tweede besluit voor die van het eerste doorgaan
+    /// — precies het geval van een verlening met daarna een vaststelling.
+    #[test]
+    fn een_tweede_besluit_over_dezelfde_zaak_wordt_ook_nagekomen() {
+        let mut configs = verplichting_configs(KWARTAAL, true);
+        let mut tweede = configs[0].besluit_definitions[0].clone();
+        tweede.name = "zorgtoeslag_herziening".to_string();
+        tweede.obligations = vec![ObligationDefinition {
+            amount: "$hoogte_zorgtoeslag".to_string(),
+            payer: "belastingdienst".to_string(),
+            schedule: "ineens".to_string(),
+            from: None,
+        }];
+        configs[0].besluit_definitions.push(tweede);
+
+        let mut world = World::new(
+            &configs,
+            Clock {
+                start: date("2024-01-01"),
+            },
+            &[],
+            &no_settings(),
+            &regulation_root(),
+        )
+        .unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+
+        beslis(&mut world);
+        world
+            .decide(
+                "toeslagen",
+                "zorgtoeslag_herziening",
+                &bsn(),
+                date("2024-01-01"),
+            )
+            .unwrap_or_else(|e| panic!("het tweede besluit moet genomen kunnen worden: {e}"));
+        world
+            .advance(date("2025-01-01"))
+            .unwrap_or_else(|e| panic!("de klok moet vooruit kunnen: {e}"));
+
+        assert_eq!(
+            betaald(&world, "belastingdienst", "2025-01-01"),
+            Some(Value::Decimal("394410.62374".parse().unwrap_or_default())),
+            "twee besluiten, twee schema's, twee keer het toegekende bedrag"
+        );
+    }
+
     /// Twee keer hetzelfde besluit op dezelfde dag plant twee keer hetzelfde
-    /// schema. Nagekomen wordt het één keer: dezelfde zaak met hetzelfde
-    /// volgnummer is dezelfde termijn.
+    /// schema. Nagekomen wordt het één keer: dezelfde zaak, hetzelfde besluit en
+    /// hetzelfde volgnummer is dezelfde termijn.
     #[test]
     fn een_tweede_besluit_op_dezelfde_dag_levert_geen_tweede_betaling() {
         let mut world = verplichting_wereld(KWARTAAL, &no_settings())

--- a/packages/simulator/src/world.rs
+++ b/packages/simulator/src/world.rs
@@ -11,10 +11,13 @@
 //! haar aangereikt worden. Zij houdt geen klok, precies zoals ze geen sleutels
 //! en geen bevoegdheid houdt (RFC-022 §2).
 //!
-//! In deze versie bestaat één trigger-soort: een [`Fixture`] met een `at`-datum
-//! die bij het passeren wordt vastgelegd. De lus is generiek — een gesorteerde
-//! lijst van `(datum, trigger)` — zodat vervallende verplichtingen en gemiste
-//! termijnen er later naast passen zonder dat de klok verandert.
+//! Er zijn twee trigger-soorten. Een [`Fixture`] met een `at`-datum wordt bij
+//! het passeren vastgelegd, en een **vervallende verplichting** laat de cel die
+//! haar draagt betalen. De lus is generiek — een gesorteerde lijst van
+//! `(datum, trigger)` — zodat een soort erbij een variant erbij is en geen
+//! andere klok. Dat de lijst gesorteerd blijft is een invariant en geen
+//! toestand: een besluit tijdens de run plant nieuwe vervaldata, en die horen op
+//! datumpositie en niet achteraan (zie [`World::plan`]).
 //!
 //! De wereld is ook de enige die een cel kan laten **besluiten**
 //! ([`World::decide`]). Dat is geen trigger op de klok maar een aansturing van
@@ -31,7 +34,10 @@
 //! zien zonder dat een cel het kent.
 
 use crate::accept::CellBridge;
-use crate::cell::{Cell, CellConfig, ChronicleEvent, Decretogram, Intake, Lexostatus};
+use crate::cell::{
+    Cell, CellConfig, ChronicleEvent, Decretogram, Intake, Lexostatus, ObligationDue, BETALINGEN,
+    ZAAKKENMERK,
+};
 use crate::error::{Result, SimulatorError, Subject};
 use crate::security::{Identity, SignedAnswer};
 use chrono::NaiveDate;
@@ -107,12 +113,19 @@ impl Recording {
 
 /// Wat er gebeurt als de klok een moment passeert.
 ///
-/// Eén soort in deze versie. De lus die ze afloopt is generiek, dus een soort
-/// erbij is een variant erbij en geen andere klok.
+/// De lus die ze afloopt is generiek, dus een soort erbij is een variant erbij
+/// en geen andere klok.
 #[derive(Debug, Clone)]
 enum Trigger {
     /// Er wordt een executogram vastgelegd.
     Record(Recording),
+    /// Een termijn van een verplichting vervalt en wordt nagekomen.
+    ///
+    /// Anders dan een [`Fixture`] staat deze niet in het wereldbestand: hij
+    /// ontstaat tíjdens de run, op het moment dat een besluit de verplichting
+    /// oplegt. Dat is meteen de reden dat [`World::pending`] gesorteerd moet
+    /// blijven bij het bijzetten.
+    Obligation(ObligationDue),
 }
 
 /// Wat één besluit opleverde: het gram, en wat ervoor over de celgrens ging.
@@ -141,6 +154,13 @@ pub struct DecisionRecord {
 pub struct World {
     /// De cellen, op id.
     cells: BTreeMap<String, Cell>,
+    /// De instellingen van deze wereld: casusdata die geen wet is.
+    ///
+    /// Een betalingsritme is doorgaans beleid en geen wet, en beleid hoort niet
+    /// in een besluit-definitie vast te staan alsof de wet het voorschrijft.
+    /// Daarom staan ze hier, bij de wereld, en niet in een cel: een cel leest ze
+    /// niet, ze krijgt ze aangereikt bij het besluit dat erop leunt.
+    settings: BTreeMap<String, Value>,
     /// Waar de logische klok staat.
     clock: NaiveDate,
     /// Wat er nog moet gebeuren, oplopend op datum. Bij een gelijke datum
@@ -167,10 +187,16 @@ impl World {
     /// haar datum nog jaren weg is. Een typfout in een startstand hoort niet
     /// halverwege een tijdlijn op te duiken, en of dat gebeurt mag niet afhangen
     /// van hoe ver die datum weg ligt.
+    ///
+    /// De verplichtingen van elk besluit worden hier ook getoetst, en om dezelfde
+    /// reden: of een instelling bestaat en of de betalende cel een
+    /// betalingsstroom houdt, is niet iets om op de eerste vervaldatum achter te
+    /// komen. Zie [`check_obligations`].
     pub fn new(
         configs: &[CellConfig],
         clock: Clock,
         fixtures: &[Fixture],
+        settings: &BTreeMap<String, Value>,
         regulation_root: &Path,
     ) -> Result<Self> {
         // Per cel, per stroom: de veldnamen die een `fixture` erin zet. Een
@@ -215,6 +241,7 @@ impl World {
         }
 
         check_peers_exist(configs, &cells)?;
+        check_obligations(configs, &cells, settings)?;
 
         let mut pending: Vec<(NaiveDate, Trigger)> = fixtures
             .iter()
@@ -224,6 +251,7 @@ impl World {
 
         let mut world = Self {
             cells,
+            settings: settings.clone(),
             clock: clock.start,
             pending: pending.into(),
         };
@@ -357,7 +385,14 @@ impl World {
             std::mem::take(&mut self.cells),
         ));
 
-        let outcome = Self::accept_and_decide(&bridge, &mut deciding, besluit, params, op_moment);
+        let outcome = Self::accept_and_decide(
+            &bridge,
+            &mut deciding,
+            besluit,
+            params,
+            &self.settings,
+            op_moment,
+        );
 
         // Ook als het besluit omviel: de wereld krijgt haar cellen terug zoals ze
         // waren. Een mislukt besluit legt niets vast, maar het mag al helemaal
@@ -372,8 +407,25 @@ impl World {
         // die er een foutantwoord van maakt), dan mist het log precies de vragen
         // van de besluiten die niet lukten, en dat is de gevaarlijke kant op: dan
         // horen de contacten met de fout mee naar buiten.
+        let decretogram = outcome?;
+
+        // De verplichtingen uit dit besluit worden triggers. Een termijn die nu
+        // al vervalt — en de eerste termijn valt op het moment van het besluit,
+        // tenzij `from` anders zegt — gaat meteen af: de klok staat er al, dus
+        // wachten zou hem tot de volgende `advance` laten liggen en dan pas met
+        // terugwerkende kracht laten vastleggen.
+        //
+        // Dit moet ná het herstel van `self.cells` hierboven: `settle` zoekt
+        // zowel de betalende als de besluitende cel op via `self.cells`, en de
+        // besluitende cel stond tot dat herstel nog niet terug, en de rest zat
+        // nog in de brug.
+        for due in &decretogram.obligations {
+            self.plan(due.vervaldatum, Trigger::Obligation(due.clone()));
+        }
+        self.fire_due(self.clock)?;
+
         Ok(DecisionRecord {
-            decretogram: outcome?,
+            decretogram,
             crossings: bridge.crossings(),
         })
     }
@@ -390,13 +442,33 @@ impl World {
         deciding: &mut Cell,
         besluit: &str,
         params: &BTreeMap<String, Value>,
+        settings: &BTreeMap<String, Value>,
         op_moment: NaiveDate,
     ) -> Result<Decretogram> {
         let requests = deciding.acceptance_requests(besluit, params)?;
         let accepted = bridge.accept_all(&requests, op_moment)?;
         let shared: Rc<CellBridge> = Rc::clone(bridge);
         let resolver: Rc<dyn CellResolver> = shared;
-        deciding.decide(besluit, params, op_moment, &accepted, Some(resolver))
+        deciding.decide(
+            besluit,
+            params,
+            settings,
+            op_moment,
+            &accepted,
+            Some(resolver),
+        )
+    }
+
+    /// Zet een trigger op zijn datumpositie in de wachtrij.
+    ///
+    /// [`Self::pending`] is oplopend, en dat is een invariant: [`Self::fire_due`]
+    /// leest alleen de kop. Achteraan bijzetten zou een vervaldatum die vóór een
+    /// al wachtende trigger valt te laat of helemaal niet laten afgaan. Bij een
+    /// gelijke datum komt de nieuwe achter de bestaande — dezelfde regel als
+    /// overal: wie later vastlegt, legt later vast.
+    fn plan(&mut self, at: NaiveDate, trigger: Trigger) {
+        let position = self.pending.partition_point(|(pending, _)| *pending <= at);
+        self.pending.insert(position, (at, trigger));
     }
 
     /// Laat alles afgaan wat op of vóór `tot` valt, in datumvolgorde.
@@ -406,10 +478,7 @@ impl World {
     ///
     /// Eén voor één van de kop af, en niet een hele kop in één keer weggehaald:
     /// valt een trigger om, dan blijven de triggers ná hem gewoon staan in
-    /// plaats van met de fout te verdwijnen. Vandaag kan een trigger niet
-    /// omvallen — [`World::new`] toetst elke fixture met dezelfde toets die het
-    /// vastleggen gebruikt — maar dat is een eigenschap van de enige
-    /// trigger-soort die er nu is, geen eigenschap van de lus.
+    /// plaats van met de fout te verdwijnen.
     fn fire_due(&mut self, tot: NaiveDate) -> Result<()> {
         while let Some((at, trigger)) = self.next_due(tot) {
             self.clock = self.clock.max(at);
@@ -423,8 +492,41 @@ impl World {
                     })?;
                     cell.record(&recording.chronicle, event)?;
                 }
+                Trigger::Obligation(due) => self.settle(&due)?,
             }
         }
+        Ok(())
+    }
+
+    /// Laat een vervallen termijn nakomen, aan beide kanten.
+    ///
+    /// De betalende cel legt vast dat zij betaalde, de besluitende dat het haar
+    /// gemeld is. Twee vastleggingen, elk in de eigen kroniek van de cel die ze
+    /// deed: niemand kopieert andermans staat, en beide kanten weten wat er
+    /// gebeurde.
+    ///
+    /// Lag de betaling er al, dan gebeurt er niets — ook niet aan de andere kant.
+    /// Dat is de idempotentie per volgnummer: dezelfde zaak met hetzelfde
+    /// volgnummer is dezelfde termijn, en die wordt één keer nagekomen. Is de
+    /// betaler de besluitende cel zelf, dan blijft het bij de betaling: een
+    /// melding aan jezelf over wat je zelf deed is geen tweede feit.
+    fn settle(&mut self, due: &ObligationDue) -> Result<()> {
+        let payer = self
+            .cells
+            .get_mut(&due.payer)
+            .ok_or_else(|| SimulatorError::UnknownCell {
+                cell: due.payer.clone(),
+            })?;
+        if !payer.pay_obligation(due)? {
+            return Ok(());
+        }
+
+        self.cells
+            .get_mut(&due.decided_by)
+            .ok_or_else(|| SimulatorError::UnknownCell {
+                cell: due.decided_by.clone(),
+            })?
+            .note_obligation_paid(due)?;
         Ok(())
     }
 
@@ -498,6 +600,68 @@ fn check_peers_exist(configs: &[CellConfig], cells: &BTreeMap<String, Cell>) -> 
     Ok(())
 }
 
+/// Toets de verplichtingen van elk besluit tegen de wereld waarin ze staan.
+///
+/// Wat een cel zelf kan nakijken — is het bedrag een eigen uitkomst, bestaat dit
+/// ritme, levert `from` een datum op — is bij het optuigen van de cel al
+/// gebeurd. Wat er hier bij komt, weet alleen de wereld:
+///
+/// - verwijst `schedule: $naam` naar een instelling die bestaat, en is die een
+///   ritme;
+/// - bestaat de betalende cel;
+/// - houden de betalende én de besluitende cel een stroom [`BETALINGEN`] met
+///   [`ZAAKKENMERK`] als sleutel? Beide leggen op een vervaldatum vast, en een
+///   stroom die er niet is zou dat op de eerste vervaldatum laten omvallen —
+///   halverwege de tijdlijn, in plaats van hier.
+fn check_obligations(
+    configs: &[CellConfig],
+    cells: &BTreeMap<String, Cell>,
+    settings: &BTreeMap<String, Value>,
+) -> Result<()> {
+    for config in configs {
+        for definition in &config.besluit_definitions {
+            definition.check_settings(&config.id, settings)?;
+
+            let payers = definition.payers();
+            if payers.is_empty() {
+                continue;
+            }
+
+            // De besluitende cel legt de melding vast dat er betaald is, dus zij
+            // heeft de stroom net zo goed nodig als de betaler.
+            for holder in payers
+                .iter()
+                .copied()
+                .chain(std::iter::once(config.id.as_str()))
+            {
+                let found = match cells.get(holder) {
+                    None => {
+                        return Err(SimulatorError::UnknownCell {
+                            cell: holder.to_string(),
+                        })
+                    }
+                    Some(cell) => cell.stream_key(BETALINGEN),
+                };
+                let reason = match found {
+                    Some(key) if key == ZAAKKENMERK => continue,
+                    Some(key) => format!("die stroom heeft sleutel '{key}'"),
+                    None => "die cel houdt geen stroom met die naam".to_string(),
+                };
+                return Err(SimulatorError::ObligationStream {
+                    cell: config.id.clone(),
+                    besluit: definition.name.clone(),
+                    holder: holder.to_string(),
+                    expected: format!(
+                        "een kroniekstroom '{BETALINGEN}' met sleutel '{ZAAKKENMERK}'"
+                    ),
+                    found: reason,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -560,6 +724,7 @@ lexostatus_definitions:
                 start: date(clock_start),
             },
             fixtures,
+            &no_settings(),
             &regulation_root(),
         )
         .unwrap_or_else(|e| panic!("wereld moet op te tuigen zijn: {e}"))
@@ -567,6 +732,11 @@ lexostatus_definitions:
 
     fn bsn() -> BTreeMap<String, Value> {
         BTreeMap::from([("bsn".to_string(), Value::String("999993653".to_string()))])
+    }
+
+    /// Een wereld zonder instellingen, voor elke test die geen verplichting kent.
+    fn no_settings() -> BTreeMap<String, Value> {
+        BTreeMap::new()
     }
 
     fn partner(world: &World, op_moment: &str) -> Value {
@@ -789,6 +959,7 @@ record:
                 start: date("2024-01-01"),
             },
             &[fixture("2030-01-01", "betalingen", "GEEN")],
+            &no_settings(),
             &regulation_root(),
         )
         .expect_err("een stroom die de cel niet houdt hoort te falen");
@@ -851,6 +1022,7 @@ besluit_definitions:
                 start: date("2024-01-01"),
             },
             &[verzonnen],
+            &no_settings(),
             &regulation_root(),
         )
         .expect_err("een verzonnen decretogram hoort te falen");
@@ -870,6 +1042,7 @@ besluit_definitions:
                 start: date("2024-01-01"),
             },
             &[elders],
+            &no_settings(),
             &regulation_root(),
         )
         .expect_err("een cel die de wereld niet kent hoort te falen");
@@ -895,6 +1068,7 @@ besluit_definitions:
                     start: date("2024-01-01"),
                 },
                 &[zonder_sleutel],
+                &no_settings(),
                 &regulation_root(),
             )
             .expect_err("een vastlegging zonder sleutelveld hoort te falen");
@@ -943,6 +1117,7 @@ lexostatus_definitions:
                 start: date("2024-01-01"),
             },
             &[fixture("2023-01-01", "relaties", "HUWELIJK")],
+            &no_settings(),
             &regulation_root(),
         )
         .unwrap_or_else(|e| panic!("een wereld met dit kroniekfilter moet op te tuigen zijn: {e}"));
@@ -957,6 +1132,382 @@ lexostatus_definitions:
                 .get("partnerschap_type"),
             Some(&Value::String("HUWELIJK".to_string())),
             "de fixture-waarde hoort in het antwoord van het kroniekfilter"
+        );
+    }
+
+    /// Een wereld waarin één besluit een verplichting oplegt.
+    ///
+    /// `schedule` wordt letterlijk ingeplakt, zodat elke test hieronder alleen
+    /// varieert waar ze over gaat. De betalende cel is een bron-cel zonder
+    /// wetten: een verplichting nakomen vraagt geen engine.
+    fn verplichting_configs(schedule: &str, betaler_houdt_betalingen: bool) -> Vec<CellConfig> {
+        // Zonder stroom valt er ook niets over te reduceren: de lexostatus gaat
+        // dan mee weg, anders struikelt de cel over haar eigen definitie voordat
+        // de wereld aan de verplichting toekomt.
+        let betaler_streams = if betaler_houdt_betalingen {
+            "chronicles:
+  - stream: betalingen
+    key: zaakkenmerk
+lexostatus_definitions:
+  - name: betaald
+    inputs:
+      - name: zaakkenmerk
+        type: string
+    outputs:
+      - bedrag
+    reduction:
+      chronicle: betalingen
+      key: zaakkenmerk
+      sum: bedrag
+"
+        } else {
+            "chronicles: []\n"
+        };
+        let parse = |yaml: &str| -> CellConfig {
+            serde_yaml_ng::from_str(yaml)
+                .unwrap_or_else(|e| panic!("testconfig moet parsen: {e}\n{yaml}"))
+        };
+        vec![
+            parse(&format!(
+                r"
+id: toeslagen
+laws:
+  - wet_op_de_zorgtoeslag
+  - algemene_wet_inkomensafhankelijke_regelingen
+  - regeling_standaardpremie
+chronicles:
+  - stream: inkomensleveringen
+    key: bsn
+    events:
+      - name: inkomenslevering
+        intake: levering
+        recording_actor: toeslagen
+        op_moment: 2023-11-15
+        fields:
+          bsn: '999993653'
+          partnerschap_type: GEEN
+          is_verzekerde: true
+          verzamelinkomen: 79547
+          buitenlands_inkomen: 0
+          vermogen: 0
+  - stream: betalingen
+    key: zaakkenmerk
+besluit_definitions:
+  - name: zorgtoeslag_vaststelling
+    regulation: wet_op_de_zorgtoeslag
+    output: heeft_recht_op_zorgtoeslag
+    outputs:
+      - hoogte_zorgtoeslag
+    zaakkenmerk: 'zorgtoeslag/{{bsn}}'
+    params:
+      - name: bsn
+        type: string
+    inputs:
+      bsn:
+        param: bsn
+      is_verzekerde:
+        from_chronicle: inkomensleveringen
+        field: is_verzekerde
+    obligations:
+{schedule}
+lexostatus_definitions:
+  - name: betaald
+    inputs:
+      - name: zaakkenmerk
+        type: string
+    outputs:
+      - bedrag
+    reduction:
+      chronicle: betalingen
+      key: zaakkenmerk
+      sum: bedrag
+"
+            )),
+            parse(&format!(
+                r"
+id: belastingdienst
+laws: []
+{betaler_streams}"
+            )),
+        ]
+    }
+
+    /// De gewone verplichting van de tests hieronder: vier kwartaaltermijnen.
+    const KWARTAAL: &str = "      - amount: $hoogte_zorgtoeslag
+        payer: belastingdienst
+        schedule: kwartaal";
+
+    fn verplichting_wereld(schedule: &str, settings: &BTreeMap<String, Value>) -> Result<World> {
+        World::new(
+            &verplichting_configs(schedule, true),
+            Clock {
+                start: date("2024-01-01"),
+            },
+            &[],
+            settings,
+            &regulation_root(),
+        )
+    }
+
+    /// Wat er op `op_moment` betaald is volgens deze cel; `None` is "niets
+    /// vastgesteld".
+    fn betaald(world: &World, cell: &str, op_moment: &str) -> Option<Value> {
+        let params = BTreeMap::from([(
+            "zaakkenmerk".to_string(),
+            Value::String("zorgtoeslag/999993653".to_string()),
+        )]);
+        world
+            .reduce(cell, "betaald", &params, date(op_moment))
+            .unwrap_or_else(|e| panic!("de som moet te maken zijn: {e}"))
+            .values()
+            .and_then(|values| values.get("bedrag").cloned())
+    }
+
+    fn beslis(world: &mut World) -> Decretogram {
+        world
+            .decide(
+                "toeslagen",
+                "zorgtoeslag_vaststelling",
+                &bsn(),
+                date("2024-01-01"),
+            )
+            .unwrap_or_else(|e| panic!("het besluit moet genomen kunnen worden: {e}"))
+            .decretogram
+    }
+
+    /// De eerste termijn vervalt op het moment van het besluit, dus ze wordt
+    /// meteen nagekomen. Zou ze blijven wachten tot de volgende `advance`, dan
+    /// werd ze dáár met terugwerkende kracht vastgelegd — en dan verandert het
+    /// beeld van een moment dat al geweest is.
+    #[test]
+    fn de_eerste_termijn_gaat_af_op_het_moment_van_het_besluit() {
+        let mut world = verplichting_wereld(KWARTAAL, &no_settings())
+            .unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+        let gram = beslis(&mut world);
+
+        assert_eq!(gram.obligations.len(), 4, "kwartaal kent vier termijnen");
+        assert_eq!(gram.obligations[0].vervaldatum, date("2024-01-01"));
+        assert_eq!(
+            betaald(&world, "belastingdienst", "2024-01-01"),
+            Some(Value::Int(49301))
+        );
+        assert_eq!(
+            betaald(&world, "toeslagen", "2024-01-01"),
+            Some(Value::Int(49301)),
+            "de besluitende cel legt vast dat het haar gemeld is, in haar eigen kroniek"
+        );
+    }
+
+    /// De klok mag in zo kleine stappen langskomen als ze wil: elke termijn
+    /// wordt één keer nagekomen. Zonder deze test zou een `advance` die een
+    /// vervaldatum twee keer passeert er twee betalingen van maken, en dan telt
+    /// de som dubbel.
+    #[test]
+    fn kleine_stappen_leveren_niet_meer_betalingen_op() {
+        let mut world = verplichting_wereld(KWARTAAL, &no_settings())
+            .unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+        beslis(&mut world);
+
+        let mut dag = date("2024-01-01");
+        let eind = date("2024-12-31");
+        while dag <= eind {
+            world
+                .advance(dag)
+                .unwrap_or_else(|e| panic!("de klok moet vooruit kunnen: {e}"));
+            dag = dag
+                .succ_opt()
+                .unwrap_or_else(|| panic!("{dag} moet een volgende dag hebben"));
+        }
+
+        assert_eq!(
+            betaald(&world, "belastingdienst", "2024-12-31"),
+            Some(Value::Decimal("197205.31187".parse().unwrap_or_default())),
+            "vier termijnen, precies het toegekende bedrag, ook na 366 stappen"
+        );
+    }
+
+    /// Twee keer hetzelfde besluit op dezelfde dag plant twee keer hetzelfde
+    /// schema. Nagekomen wordt het één keer: dezelfde zaak met hetzelfde
+    /// volgnummer is dezelfde termijn.
+    #[test]
+    fn een_tweede_besluit_op_dezelfde_dag_levert_geen_tweede_betaling() {
+        let mut world = verplichting_wereld(KWARTAAL, &no_settings())
+            .unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+        beslis(&mut world);
+        beslis(&mut world);
+        world
+            .advance(date("2025-01-01"))
+            .unwrap_or_else(|e| panic!("de klok moet vooruit kunnen: {e}"));
+
+        assert_eq!(
+            betaald(&world, "belastingdienst", "2025-01-01"),
+            Some(Value::Decimal("197205.31187".parse().unwrap_or_default())),
+            "het bedrag is één keer toegekend, dus het wordt één keer betaald"
+        );
+    }
+
+    /// Een verplichting die tijdens de run ingepland wordt, moet vóór een al
+    /// wachtende trigger met een latere datum afgaan.
+    ///
+    /// Dit is de invariant van de wachtrij, en ze is stil te breken: wie een
+    /// nieuwe trigger achteraan zet, ziet drie van de vier betalingen gewoon
+    /// gebeuren. Pas als er iets anders ná hen staat, blijkt dat ze te laat of
+    /// helemaal niet afgaan.
+    #[test]
+    fn een_verplichting_wordt_op_datumpositie_ingepland() {
+        let laat = Fixture {
+            at: date("2030-01-01"),
+            record: Recording {
+                cell: "toeslagen".to_string(),
+                chronicle: "inkomensleveringen".to_string(),
+                name: "inkomenslevering".to_string(),
+                intake: Intake::Levering,
+                grondslag: String::new(),
+                fields: BTreeMap::from([(
+                    "bsn".to_string(),
+                    Value::String("999993653".to_string()),
+                )]),
+            },
+        };
+        let mut world = World::new(
+            &verplichting_configs(KWARTAAL, true),
+            Clock {
+                start: date("2024-01-01"),
+            },
+            &[laat],
+            &no_settings(),
+            &regulation_root(),
+        )
+        .unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+
+        beslis(&mut world);
+        world
+            .advance(date("2025-01-01"))
+            .unwrap_or_else(|e| panic!("de klok moet vooruit kunnen: {e}"));
+
+        assert_eq!(
+            betaald(&world, "belastingdienst", "2025-01-01"),
+            Some(Value::Decimal("197205.31187".parse().unwrap_or_default())),
+            "alle vier de termijnen horen af te gaan, ook met een trigger van 2030 in de rij"
+        );
+        assert_eq!(
+            world.pending_triggers(),
+            1,
+            "alleen de fixture van 2030 hoort nog te wachten"
+        );
+    }
+
+    /// Het ritme mag een instelling van de wereld zijn; een instelling die niet
+    /// bestaat hoort bij het optuigen te vallen en niet bij het besluit dat erop
+    /// leunt.
+    #[test]
+    fn een_ritme_uit_de_instellingen_wordt_gelezen_en_een_onbekende_geweigerd() {
+        let uit_instelling = "      - amount: $hoogte_zorgtoeslag
+        payer: belastingdienst
+        schedule: $betalingsritme";
+
+        let settings = BTreeMap::from([(
+            "betalingsritme".to_string(),
+            Value::String("maand".to_string()),
+        )]);
+        let mut world = verplichting_wereld(uit_instelling, &settings)
+            .unwrap_or_else(|e| panic!("een ritme uit de instellingen moet werken: {e}"));
+        assert_eq!(
+            beslis(&mut world).obligations.len(),
+            12,
+            "de instelling zegt 'maand', dus twaalf termijnen"
+        );
+
+        let err = verplichting_wereld(uit_instelling, &no_settings())
+            .expect_err("een instelling die niet bestaat hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownSetting { .. }),
+            "verwachtte UnknownSetting, kreeg {err}"
+        );
+    }
+
+    /// Een instelling die geen ritme is, is even fout als een typfout in de
+    /// definitie zelf — en hoort op hetzelfde moment te blijken.
+    #[test]
+    fn een_instelling_die_geen_ritme_is_wordt_geweigerd() {
+        let settings = BTreeMap::from([(
+            "betalingsritme".to_string(),
+            Value::String("per_week".to_string()),
+        )]);
+        let err = verplichting_wereld(
+            "      - amount: $hoogte_zorgtoeslag
+        payer: belastingdienst
+        schedule: $betalingsritme",
+            &settings,
+        )
+        .expect_err("een instelling die geen ritme noemt hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownSchedule { .. }),
+            "verwachtte UnknownSchedule, kreeg {err}"
+        );
+    }
+
+    /// Zonder betalingsstroom bij de betaler zou de eerste vervaldatum omvallen,
+    /// halverwege de tijdlijn. Dat hoort bij het optuigen te blijken.
+    #[test]
+    fn een_betaler_zonder_betalingsstroom_faalt_bij_het_optuigen() {
+        let err = World::new(
+            &verplichting_configs(KWARTAAL, false),
+            Clock {
+                start: date("2024-01-01"),
+            },
+            &[],
+            &no_settings(),
+            &regulation_root(),
+        )
+        .expect_err("een betaler zonder betalingsstroom hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::ObligationStream { .. }),
+            "verwachtte ObligationStream, kreeg {err}"
+        );
+    }
+
+    /// De betalende cel moet bestaan. Een typfout in `payer` zou anders een
+    /// verplichting opleveren die aan niemand is opgelegd.
+    #[test]
+    fn een_onbekende_betaler_faalt_bij_het_optuigen() {
+        let err = verplichting_wereld(
+            "      - amount: $hoogte_zorgtoeslag
+        payer: betaalsysteem
+        schedule: kwartaal",
+            &no_settings(),
+        )
+        .expect_err("een betaler die de wereld niet kent hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownCell { .. }),
+            "verwachtte UnknownCell, kreeg {err}"
+        );
+    }
+
+    /// Een `from` vóór het besluit zou een betaling op een moment vastleggen dat
+    /// al geweest is, en dan verandert het beeld van toen alsnog.
+    #[test]
+    fn een_verplichting_die_voor_het_besluit_vervalt_wordt_geweigerd() {
+        let mut world = verplichting_wereld(
+            "      - amount: $hoogte_zorgtoeslag
+        payer: belastingdienst
+        schedule: kwartaal
+        from: '2023-01-01'",
+            &no_settings(),
+        )
+        .unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+
+        let err = world
+            .decide(
+                "toeslagen",
+                "zorgtoeslag_vaststelling",
+                &bsn(),
+                date("2024-01-01"),
+            )
+            .expect_err("een termijn vóór het besluit hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::ObligationBeforeDecision { .. }),
+            "verwachtte ObligationBeforeDecision, kreeg {err}"
         );
     }
 }


### PR DESCRIPTION
## Wat

Een besluit in de simulator kan nu **verplichtingen** opleggen: een bedrag dat op vervaldata nagekomen moet worden. De besluit-definitie krijgt een `obligations`-blok:

```yaml
obligations:
  - amount: $hoogte_zorgtoeslag      # een uitkomst van dít besluit
    payer: belastingdienst           # de cel die de verplichting draagt
    schedule: $betalingsritme        # ineens | kwartaal | maand, of een instelling
    from: '{jaar}-02-01'             # optioneel; standaard het moment van het besluit
```

Het schema wordt bij `decide` uitgerekend — vervaldatum, bedrag en volgnummer per termijn — en gaat mee ín het decretogram. Wat beloofd is, staat er dus vóórdat er iets betaald is.

**Nakomen doet de klok.** `World::advance` kent een tweede trigger-soort: op een vervaldatum legt de betalende cel een executogram vast in haar eigen stroom `betalingen` (`intake: betaling`, met zaakkenmerk, bedrag, volgnummer en de verwijzing naar het besluit), en de besluitende cel een levering in de hare: *betaling ontvangen gemeld*. Twee vastleggingen, elk in de kroniek van de cel die haar deed — beide kanten weten wat er gebeurde, en niemand kopieert de staat van een ander.

## Waarom zo

- **Het bedrag komt uit de wet, niet uit het wereldbestand.** `amount` moet een uitkomst van het besluit zijn; een letterlijk bedrag zou naast die uitkomst gaan leven en dan zegt het gram twee dingen over hetzelfde geld.
- **Het ritme mag beleid zijn.** Een betalingsritme is doorgaans geen wet, dus het wereldbestand krijgt `settings: { <naam>: <waarde> }` en `schedule: $betalingsritme` verwijst ernaar. Zo beweert de besluit-definitie niet dat de wet per kwartaal betaalt.
- **"Betaald tot nu toe" is een reductie, geen saldo.** Het kroniekfilter krijgt naast `latest: true` een tweede vorm: `sum: <veld>`, de eerste aggregatie. De vraag over een eerder moment blijft daardoor exact hetzelfde antwoorden nadat er meer betaald is — een teller naast de kroniek kan dat niet. Nul vastleggingen is "niets vastgesteld" en geen 0, en een vastlegging zonder getal in dat veld is een fout en geen nul.
- **Eén termijn wordt één keer nagekomen.** Dezelfde zaak met hetzelfde volgnummer is dezelfde termijn: de klok mag in zo kleine stappen langskomen als ze wil, en een besluit dat op dezelfde dag wordt overgedaan levert geen tweede betaling.
- **Termijnen tellen exact op tot het toegekende bedrag**: gelijke termijnen in hele eenheden, het restant op de laatste.
- **Een termijn kan niet vóór haar besluit vervallen.** Dat zou bij het nakomen een betaling op een moment vastleggen dat al geweest is, en dan verandert het beeld van toen alsnog — precies wat een kroniek niet doet.

Wat de cel zelf kan nakijken (is het bedrag een eigen uitkomst, bestaat dit ritme, levert `from` een datum op) valt bij het optuigen van de cel; wat alleen de wereld weet (bestaat de instelling, bestaat de betalende cel, houden beide kanten een `betalingen`-stroom met `zaakkenmerk` als sleutel) bij het optuigen van de wereld. Niet halverwege een tijdlijn.

Eén invariant verdient aandacht: de trigger-wachtrij moet oplopend blijven. Een besluit tijdens de run plant nieuwe vervaldata, en die gaan op datumpositie de rij in — achteraan bijzetten zou een termijn die vóór een al wachtende trigger valt te laat of helemaal niet laten afgaan, en met alleen een fixture ná hen is dat niet te zien. Daar staat een test op.

## Testen

Twee scenario's over de publieke testwereld (`toeslagen` besluit, `belastingdienst` betaalt), plus unittests:

- `scenarios/toeslagen_verplichtingen.yaml` — kwartaal: halverwege het jaar twee termijnen, na het jaar vier, en dezelfde vraag over halverwege het jaar geeft ná een jaar nog steeds twee. Over een zaak waarover niets vastligt: "niets vastgesteld".
- `scenarios/toeslagen_verplichtingen_ritmes.yaml` — hetzelfde bedrag `ineens` en per `maand`, met `from` als sjabloon. Het ritme bepaalt wanneer, niet hoeveel.
- Unittests op de idempotentie (dag-voor-dag over een jaar; een besluit twee keer op dezelfde dag), op de datumpositie in de wachtrij, op de exacte verdeling van een bedrag, en op elke weigering bij het optuigen.

Lokaal groen: `just format`, `just lint`, `just build-check`, `just test-no-docker`.