### PR TITLE
feat: een besluit in de simulator accepteert een waarde van een andere cel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,11 @@ repos:
         entry: just validate
         language: system
         pass_filenames: true
-        files: ^corpus/(regulation|demo/regulation)/.*\.yaml$
+        # The simulator's fixture regulations are law files too: the same loader
+        # reads them and the same schema applies. Left out, they would be the only
+        # laws in the repo that no gate validates, and a drift there surfaces as a
+        # puzzling scenario failure instead of a schema error.
+        files: ^(corpus/(regulation|demo/regulation)|packages/simulator/fixtures/regulation)/.*\.yaml$
         # Skip dot-prefixed sidecars (.enrichment.yaml, .enrichment-result.yaml):
         # enrichment metadata/result envelopes, not law files.
         exclude: (^|/)\.[^/]*\.yaml$

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -115,9 +115,12 @@ Drie dingen dwingen dat af in code in plaats van in proza:
    definitie die naar een vreemde regeling wijst, wordt geweigerd bij het
    optuigen van de cel — niet pas bij de eerste vraag.
 3. `Cell` heeft **geen veld en geen parameter** voor een transport of een
-   veiligheidscontext. `Cell::reduce` kan de grens dus niet bereiken; dat is een
+   veiligheidscontext. Ze kan de grens dus niet bereiken; dat is een
    compileerfout en geen afspraak. Een test grept `src/cell/` erop, zodat ook een
-   latere toevoeging die de weg zou openen meteen rood wordt.
+   latere toevoeging die de weg zou openen meteen rood wordt. Dat geldt ook op het
+   besluit-pad: een waarde *accepteren* van een andere cel kan wel, maar het
+   ophalen gebeurt buiten de cel — zie
+   [Accepteren in plaats van narekenen](#accepteren-in-plaats-van-narekenen-i5).
 
 ## De publieke ingang
 
@@ -266,15 +269,15 @@ paden afdwingbaar wordt (RFC-022 §4.2):
 | pad | engine | mag de celgrens over |
 |---|---|---|
 | `Cell::reduce` (publiek) | reduce-engine, **nooit** een `CellResolver` | nee — tier 1 en 2 |
-| `Cell::decide` (intern) | besluit-engine, de enige die er ooit een krijgt | ja, straks — tier 3 |
+| `Cell::decide` (intern) | besluit-engine, krijgt er een voor de duur van één besluit | ja — tier 3 |
 
 Een cross-cel-pull vanuit een reductie is daarmee een *ontbrekende capability* en
 geen afspraak: de engine van het reduce-pad heeft geen resolver, dus ze kan een
 `source.regulation` die een andere cel aanwijst niet beantwoorden en levert geen
-antwoord in plaats van een geraden antwoord. Vandaag heeft géén van beide engines
-een resolver — het accepteren van een waarde van een andere cel volgt apart — dus
-het verschil is nu een belofte over wie wat mag, met de haak op zijn plek en een
-test eromheen.
+antwoord in plaats van een geraden antwoord. Dezelfde lexostatus over dezelfde
+regeling faalt daar dus waar een besluit slaagt, en dat staat vast in
+[`tests/accepteren.rs`](tests/accepteren.rs) — met een melding die zegt wat er aan
+de hand is: *een reductie reikt niet buiten de eigen cel*.
 
 ### Wat een decretogram draagt
 
@@ -406,14 +409,87 @@ let signed = context.query("brp", "partnerschap", &params, op_moment)?;
 
 Wat de context teruggeeft is geen antwoord maar een **bewijsstuk**
 (`SignedAnswer`): wie vroeg, ondertekend door welke identiteit, met welke
-parameters, en wat de peer antwoordde. Dat is geen gemak. Een cel die straks een
-waarde van een andere cel *accepteert* in plaats van narekent, moet precies dat in
-haar decretogram vastleggen (RFC-013 `accepted_values`), en het observatielog wil
-hetzelfde weten.
+parameters, en wat de peer antwoordde. Dat is geen gemak. Een cel die een waarde
+van een andere cel *accepteert* in plaats van narekent, legt precies dat in haar
+decretogram vast (RFC-013 `accepted_values`), en het observatielog wil hetzelfde
+weten.
 
 Een vraag aan de eigen cel wordt geweigerd: voor eigen feiten is er een reductie.
 Zonder die weigering zou een cel haar eigen kroniek als cross-cel-contact in het
 log krijgen en daarmee het vraaggraf vervuilen.
+
+### Accepteren in plaats van narekenen (I5)
+
+Stelt een andere organisatie een feit vast, dan rekent deze cel het niet na. Ze
+vraagt het op, legt vast bij wie ze het ophaalde en op welk moment, en rekent
+daarmee verder. Dat is stap 4 van de RFC-009-beslisboom, en het is geen nuance: een
+beschikking van een ander bevoegd gezag opnieuw uitrekenen is dat gezag overrulen.
+
+Twee dingen kunnen zeggen dat een waarde van een ander komt, en ze lopen langs
+dezelfde context, hetzelfde transport en hetzelfde log:
+
+| wie zegt het | waar | wat je schrijft |
+|---|---|---|
+| de **besluit-definitie** | `inputs` van het besluit | `accept_from` + `lexostatus` + `field` (+ `params`) |
+| de **wet** (tier 3) | `source.regulation` die een cel-id noemt | `accepts_from` op de cel: welke lexostatus bij welke uitkomst hoort |
+
+Dat de tweede vorm een afspraak in de celconfiguratie nodig heeft, is geen
+omissie. De wet noemt een cel-id en een uitkomstnaam; welke *gepubliceerde
+lexostatus* daarbij hoort, is een afspraak tussen twee organisaties en geen recht,
+dus ze staat niet in de wet. Diezelfde lijst is wat de engine haar cel-tier geeft:
+alleen gedeclareerde cel-ids bereiken de resolver, dus een cel die er niet in staat
+kan niet per ongeluk bevraagd worden — invariant I3 als capability. Een afspraak
+die géén van de eigen wetten noemt, wordt bij het optuigen geweigerd, en een cel-id
+dat een eigen regeling overschaduwt ook.
+
+**Een cel haalt niets zelf op.** Ook op het besluit-pad niet: ze zegt wat ze nodig
+heeft (`Cell::acceptance_requests`) en krijgt het aangereikt. Het ophalen gebeurt
+in `accept.rs`, buiten `src/cell/`, want een veiligheidscontext en een transport
+houdt een cel niet (RFC-022 §2) — en dat is een compileerfout plus een grep-poort
+in [`tests/observation_log.rs`](tests/observation_log.rs), geen afspraak.
+
+Wat er met de waarde gebeurt, en vooral wat er níet met haar gebeurt:
+
+- ze gaat als parameter de besluit-engine in, en met bron, naam, moment en
+  ondertekening het decretogram in (`InputOrigin::Accepted`; bij tier 3 zet de
+  engine haar in `accepted_values` van het receipt);
+- ze belandt **niet** in een kroniek en **niet** in het databronregister. Een
+  volgend besluit vraagt opnieuw bij de bron. Anders zou er een
+  schaduwboekhouding ontstaan die niet van eigen wetenschap te onderscheiden is;
+- antwoordt de bron "niets vastgesteld", dan **valt het besluit om** met een
+  melding die zegt welke input van welke cel ontbrak, en er wordt niets
+  vastgelegd. Doorrekenen met een gat is erger dan geen besluit.
+
+De scenario-runner rekent elk besluit af op de herkomst van zijn waarden — per
+waarde `computed` of `accepted`, met bron — en dat is invariant I5 als gate:
+
+```yaml
+decide:
+  - cell: toeslagen
+    besluit: zorgtoeslag_vaststelling
+    params: { bsn: '999993653' }
+    op_moment: 2024-06-01
+    expect_accepted:
+      toetsingsinkomen: belastingdienst   # van die cel, en hier niet nagerekend
+    expect_computed:
+      - is_verzekerde                     # eigen feit, dus eigen werk
+```
+
+De gate draait bij élk besluit, ook zonder deze verwachtingen: een geaccepteerde
+waarde moet naar een ánder wijzen dan de besluitende cel, en ze mag niet óók als
+eigen uitkomst in hetzelfde gram staan — dan is ze alsnog nagerekend en is
+"accepteren" een etiket.
+
+De scenario's staan naast elkaar, en dat is de bedoeling:
+[`toeslagen_accepteert_toetsingsinkomen.yaml`](scenarios/toeslagen_accepteert_toetsingsinkomen.yaml)
+zet één besluit dat accepteert naast één dat hetzelfde getal uit de eigen kroniek
+haalt — met twee verschillende cijfers, dus twee verschillende bedragen, want
+zonder dat tegenbewijs bewijst het eerste niets.
+[`toeslagen_accepteert_via_de_wet.yaml`](scenarios/toeslagen_accepteert_via_de_wet.yaml)
+doet hetzelfde langs tier 3, met een testregeling uit
+[`fixtures/regulation/`](fixtures/regulation/) in plaats van een corpuswet: geen
+enkele echte wet hoort verbouwd te worden omdat een testopstelling iets wil laten
+zien.
 
 ### Ondertekening is gesimuleerd
 
@@ -477,9 +553,11 @@ Daar hangt een prijs aan, en die hoort er expliciet bij te staan: **volledigheid
 is niet afgedwongen.** De veiligheidscontext geeft haar bewijsstuk terug aan wie
 vroeg, en of dat bewijsstuk in het log belandt beslist die aanroeper. Vandaag is
 dat de scenario-runner, die elk bewijsstuk teruggeeft, dus voor een run klopt het
-nu. Zodra een cel zelf kan besluiten, verhuist de vraag naar dat pad en moet het
-vastleggen mee; gebeurt dat niet, dan is het log stil incompleet in plaats van
-rood.
+nu. Dat gold ook toen het besluit-pad ging accepteren: die vragen gaan over
+dezelfde grens, dus `World::decide` geeft ze mee (`DecisionRecord::crossings`) en
+de runner zet ze in het log. Was dat vergeten, dan was het log stil incompleet
+geworden in plaats van rood — de gevaarlijke kant op, want het vraaggraf zou
+schoner lijken dan het is.
 
 De invarianten-gate die het gedeclareerde vraaggraf met het feitelijke vergelijkt
 (I3) staat er nog niet. Dit is het instrument waar die op gaat rusten, en daar
@@ -612,6 +690,18 @@ cells:
           is_verzekerde:
             from_chronicle: inkomensleveringen  # uit een eigen stroom: de laatste
             field: is_verzekerde                # vastlegging op of vóór het moment
+          toetsingsinkomen:                     # geaccepteerd van een andere cel
+            accept_from: belastingdienst        # de cel die het vaststelt
+            lexostatus: toetsingsinkomen        # de naam die zij publiceert
+            field: toetsingsinkomen             # de uitkomst daarvan
+            params:
+              bsn: $bsn                         # $naam = parameter van dit besluit
+
+    accepts_from:                               # wat de wétten bij een cel halen
+      - cell: brp                               # het cel-id uit source.regulation
+        output: partnerschap                    # de uitkomst die de wet vraagt
+        lexostatus: partnerschap                # wat daar gevraagd moet worden
+        field: partnerschap_type                # en welke uitkomst de waarde is
 
 fixtures:                                       # de startstand van de wereld
   - at: 2024-07-01                              # het moment van de vastlegging
@@ -635,6 +725,10 @@ decide:                                         # besluiten, elk op een moment
                                                 # kent én welke wetsversie geldt
     expect:                                     # optioneel: wat het gram draagt
       heeft_recht_op_zorgtoeslag: true
+    expect_accepted:                            # optioneel: herkomst per waarde
+      toetsingsinkomen: belastingdienst         # van die cel, niet hier berekend
+    expect_computed:                            # en wat hier wél vastgesteld is
+      - is_verzekerde
 
 queries:
   - description: vrije omschrijving             # optioneel
@@ -668,13 +762,13 @@ query_via_transport:                            # vragen over een celgrens
       partnerschap_type: HUWELIJK               # een gewone vraag
 ```
 
-`query_via_transport` is een **test-only stap, en dat is tijdelijk**. In de
-opstelling die we bouwen stelt een cel zo'n vraag uitsluitend vanuit haar
-besluit-pad: ze heeft een input nodig die een andere organisatie vaststelt. Dat
-pad bestaat inmiddels, maar het *accepteren* van zo'n waarde nog niet — een
-besluit haalt zijn inputs uit de eigen kronieken en uit zijn parameters — en tot
-die tijd is dit de enige manier om het verkeer te laten zien en erop te
-asserteren. Zodra accepteren er is, verhuist de aanroep naar het besluit-pad.
+`query_via_transport` is een **sonde, geen onderdeel van de opstelling**. In de
+opstelling stelt een cel zo'n vraag uitsluitend vanuit haar besluit-pad: ze heeft
+een input nodig die een andere organisatie vaststelt, en dan *accepteert* ze die —
+zie [Accepteren in plaats van narekenen](#accepteren-in-plaats-van-narekenen-i5).
+Wat deze stap overhoudt, is één vraag los kunnen stellen en op haar antwoord
+asserteren zonder er een besluit omheen te bouwen: handig om de naad zelf te
+beproeven, en verder niets.
 
 De stappen lopen in deze volgorde: eerst de besluiten, dan de vragen van een
 consument, dan die over een celgrens. Dat past bij wat ze zijn — een besluit is
@@ -808,7 +902,11 @@ cd packages && cargo test -p regelrecht-simulator
 ```
 
 Het corpus wordt standaard naast de crate gezocht (`corpus/regulation`);
-`REGULATION_PATH` overschrijft dat.
+`REGULATION_PATH` overschrijft dat. Vindt een cel haar regeling daar niet, dan
+wordt nog in [`fixtures/regulation/`](fixtures/regulation/) gekeken: een handvol
+**testregelingen** die een eigenschap van de opstelling aantonen en geen recht
+weergeven. Het corpus gaat voor, dus een fixture kan nooit een echte regeling
+overschaduwen.
 
 ## Wat hier nog niet staat
 
@@ -823,16 +921,19 @@ gebouwd, maar er is nog geen soort trigger voor.
 actor (een aanvraag indienen, een opgave doen) een cel aan het werk zet. Dat is
 de reden dat `decide` een stap in het bestand is en geen gevolg van iets anders.
 
-**Een besluit accepteert nog niets van een andere cel** (I5). De inputs komen uit
-de eigen kronieken en uit de parameters; de haak voor tier 3 zit op de
-besluit-engine en het bewijsstuk van de veiligheidscontext heeft al de vorm die
-`accepted_values` vraagt, maar de twee zijn nog niet verbonden. Het besluit-pad is
-wel de plek waar dat gaat gebeuren, en de enige.
+**Onbetrouwbaar gedrag tussen cellen bestaat niet.** Een bron-cel is er altijd, ze
+antwoordt meteen, en haar antwoord is nooit verouderd of in tegenspraak met dat van
+een ander. Accepteren is dus alleen uitgewerkt voor het geval dat goed gaat plus het
+geval "niets vastgesteld"; het moeilijkste deel van elk decentraal systeem staat
+nog open. Zo ook **echte ondertekening** en de RFC-009-modi als configuratie: de
+ondertekening in een geaccepteerde waarde is de placeholder uit
+[Ondertekening is gesimuleerd](#ondertekening-is-gesimuleerd).
 
 Aan de kant van de celgrens ontbreken verder de **invarianten-gate** die het
 gedeclareerde vraaggraf uit het scenario vergelijkt met het feitelijke uit het
-observatielog (I3), en **autorisatie**: de veiligheidscontext kent identiteit en
-ondertekening, en beslist nog niets over wat mag.
+observatielog (I3) — de herkomstgate van I5 draait wel, bij elk besluit — en
+**autorisatie**: de veiligheidscontext kent identiteit en ondertekening, en beslist
+nog niets over wat mag.
 
 Ook een **HTTP-transport** is er niet; dat is het punt van de trait. Komt het er,
 dan is dat een tweede implementatie naast `InProcessTransport` en geen wijziging in

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -458,7 +458,22 @@ Wat er met de waarde gebeurt, en vooral wat er níet met haar gebeurt:
   schaduwboekhouding ontstaan die niet van eigen wetenschap te onderscheiden is;
 - antwoordt de bron "niets vastgesteld", dan **valt het besluit om** met een
   melding die zegt welke input van welke cel ontbrak, en er wordt niets
-  vastgelegd. Doorrekenen met een gat is erger dan geen besluit.
+  vastgelegd. Doorrekenen met een gat is erger dan geen besluit. De vraag zelf
+  staat dan wél als contact vast: ze is gesteld en de peer heeft haar gezien, dus
+  ze hoort in het vraaggraf — juist dít geval.
+
+Het zaakkenmerk wordt met opzet ingevuld en gecontroleerd *vóór* de eerste vraag:
+een besluit dat om zijn eigen kenmerk niet genomen kan worden, hoort een andere
+organisatie niet te laten zien dat er iets over iemand werd opgevraagd.
+
+Mist er een afspraak, dan zegt de melding dat ook. Noemt een wet een naam die de
+cel niet laadt en die niet in `accepts_from` staat, dan bereikt de engine de cel
+niet en heet dat daar een onbekende regeling — letterlijk waar, en het verkeerde
+spoor: wie het leest gaat een corpusbestand zoeken dat er niet hoort te zijn. Het
+besluit-pad noemt daarom beide uitwegen (laad de regeling, of leg de lexostatus in
+`accepts_from` vast). Dat dit pas bij het besluit blijkt en niet bij het optuigen,
+is geen slordigheid: een besluit-definitie mag zo'n input zelf aanleveren, en dan
+komt de verwijzing nooit aan bod.
 
 De scenario-runner rekent elk besluit af op de herkomst van zijn waarden — per
 waarde `computed` of `accepted`, met bron — en dat is invariant I5 als gate:

--- a/packages/simulator/fixtures/regulation/test_partnerschapstoets/2024-01-01.yaml
+++ b/packages/simulator/fixtures/regulation/test_partnerschapstoets/2024-01-01.yaml
@@ -1,0 +1,58 @@
+---
+$schema: >-
+  https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.8/schema/v0.5.8/schema.json
+$id: test_partnerschapstoets
+name: Testregeling partnerschapstoets
+regulatory_layer: WET
+bwb_id: BWBR9999901
+publication_date: '2024-01-01'
+valid_from: '2024-01-01'
+url: https://example.com/test_partnerschapstoets
+competent_authority: Dienst Toeslagen
+
+# Een testregeling, met opzet **niet** in het corpus: ze bestaat om een
+# eigenschap van de opstelling aan te tonen en niet om recht weer te geven.
+#
+# Wat ze aantoont is tier 3 van RFC-022 §4.2: `source.regulation` noemt hier
+# geen regeling maar een **cel** (`brp`). De besluit-engine heeft daar een
+# resolver voor en lost het op langs de veiligheidscontext en het transport; de
+# reduce-engine heeft die resolver niet en komt op dezelfde regel niet verder
+# dan "niets vastgesteld". Dat verschil is met een echte corpuswet niet te laten
+# zien zonder die wet te verbouwen, en een wet verbouwen voor een testopstelling
+# is precies wat je niet wilt.
+articles:
+  - number: '1'
+    url: https://example.com/test_partnerschapstoets#Artikel1
+    text: >-
+      De uitkomst is waar indien de relatievorm van de betrokkene een huwelijk
+      is, zoals de basisregistratie personen die vaststelt.
+    machine_readable:
+      execution:
+        produces:
+          legal_character: BESCHIKKING
+        parameters:
+          - name: bsn
+            type: string
+            required: true
+        input:
+          # De verwijzing waar het om gaat. `brp` is geen regeling die deze cel
+          # laadt, dus dit is geen cross-law-vraag maar een vraag aan een andere
+          # organisatie. Welke lexostatus daar gevraagd wordt, staat niet hier —
+          # dat is een afspraak tussen twee organisaties en geen recht — maar in
+          # `accepts_from` van de cel.
+          - name: partnerschap_type
+            type: string
+            source:
+              regulation: brp
+              output: partnerschap
+              parameters:
+                bsn: $bsn
+        output:
+          - name: is_gehuwd
+            type: boolean
+        actions:
+          - output: is_gehuwd
+            value:
+              operation: EQUALS
+              subject: $partnerschap_type
+              value: HUWELIJK

--- a/packages/simulator/scenarios/toeslagen_accepteert_toetsingsinkomen.yaml
+++ b/packages/simulator/scenarios/toeslagen_accepteert_toetsingsinkomen.yaml
@@ -1,0 +1,244 @@
+---
+name: accepteren versus narekenen, in twee besluiten naast elkaar
+description: >-
+  Invariant I5, en het tegenbewijs erbij. Het toetsingsinkomen is vastgesteld
+  door een andere organisatie, met een eigen bevoegd gezag. De cel `toeslagen`
+  rekent dat niet na: ze vraagt het op bij de cel die het vaststelde, legt in
+  haar decretogram vast bij wie ze het ophaalde en op welk moment, en rekent
+  daarmee verder. Dat is stap 4 van de RFC-009-beslisboom — een beschikking van
+  een ander bevoegd gezag opnieuw uitrekenen is dat gezag overrulen.
+
+  Het tweede besluit is het tegenbewijs, en zonder dat bewijst het eerste niets:
+  daar komt hetzelfde getal uit de **eigen** kroniek van `toeslagen`, en dan is
+  het berekend en niet geaccepteerd. De twee cijfers verschillen met opzet, dus
+  de uitkomsten van de twee besluiten verschillen ook: haalde het eerste besluit
+  stilletjes zijn eigen feit op, dan zou het exact het tweede antwoord geven.
+
+  Wat er níet gebeurt: de opgehaalde waarde belandt nergens in een kroniek van
+  `toeslagen`. Ze zit in het decretogram, met haar herkomst, en een volgend
+  besluit vraagt opnieuw bij de bron.
+
+clock:
+  # Alle vastleggingen staan als `events` in de celconfiguraties en liggen vóór
+  # dit moment; de besluiten hieronder liggen erna en nemen de klok mee.
+  start: 2024-01-01
+
+cells:
+  # De bron-cel. Geen engine: wat zij publiceert is een vastlegging, geen
+  # berekening. Haar kroniek is beschikking-achtig — ze legde vast wat ze zelf
+  # vaststelde, met haar eigen bevoegd gezag erbij — en dat gezag is een ander
+  # dan dat van de cel die hieronder besluit. Precies daarom mag `toeslagen` het
+  # getal niet overdoen.
+  - id: belastingdienst
+    laws: []
+
+    chronicles:
+      - stream: aanslagen
+        key: bsn
+        events:
+          - name: aanslag_vastgesteld
+            intake: eigen_besluit
+            recording_actor: belastingdienst
+            grondslag: Wet inkomstenbelasting 2001, hoofdstuk 2
+            op_moment: 2024-03-01
+            fields:
+              bsn: '999993653'
+              toetsingsinkomen: 81000
+              competent_authority: Belastingdienst
+
+    lexostatus_definitions:
+      - name: toetsingsinkomen
+        doc: >-
+          Het vastgestelde toetsingsinkomen van één persoon op één moment, zoals
+          deze cel het vaststelde. Het bevoegd gezag staat erbij: een consument
+          die hierop leunt, hoort te kunnen zien wiens vaststelling dit is.
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - toetsingsinkomen
+          - competent_authority
+        reduction:
+          chronicle: aanslagen
+          key: bsn
+          latest: true
+
+  - id: toeslagen
+    laws:
+      - wet_op_de_zorgtoeslag
+      - algemene_wet_inkomensafhankelijke_regelingen
+      - regeling_standaardpremie
+
+    chronicles:
+      - stream: relaties
+        key: bsn
+        events:
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: toeslagen
+            grondslag: melding uit de basisregistratie personen
+            op_moment: 2023-01-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: GEEN
+
+      # Wat de cel zelf over deze persoon vastlegde. Let op het
+      # `toetsingsinkomen`: dat is een ander getal dan de belastingdienst
+      # vaststelde, en dat verschil is de hele assertie. Een besluit dat zegt te
+      # accepteren maar stiekem dit veld pakt, valt door de mand op het bedrag.
+      - stream: inkomensleveringen
+        key: bsn
+        events:
+          - name: inkomenslevering
+            intake: levering
+            recording_actor: toeslagen
+            grondslag: jaarlijkse inkomenslevering
+            op_moment: 2023-11-15
+            fields:
+              bsn: '999993653'
+              is_verzekerde: true
+              toetsingsinkomen: 79547
+              vermogen: 0
+
+    besluit_definitions:
+      - name: zorgtoeslag_vaststelling
+        doc: >-
+          Het besluit dat accepteert. Het toetsingsinkomen komt van de cel die
+          het vaststelde; de rest komt uit eigen feiten en uit de eigen wet.
+        regulation: wet_op_de_zorgtoeslag
+        output: heeft_recht_op_zorgtoeslag
+        outputs:
+          - hoogte_zorgtoeslag
+        zaakkenmerk: zorgtoeslag/{bsn}
+        params:
+          - name: bsn
+            type: string
+        inputs:
+          bsn:
+            param: bsn
+          is_verzekerde:
+            from_chronicle: inkomensleveringen
+            field: is_verzekerde
+          # De kern van dit scenario. De vraag gaat niet van cel naar cel: de
+          # veiligheidscontext van `toeslagen` ondertekent hem en het transport
+          # brengt hem bij de publieke ingang van `belastingdienst`. Wat
+          # terugkomt gaat als parameter de engine in en met bron, naam, moment
+          # en ondertekening het decretogram in.
+          toetsingsinkomen:
+            accept_from: belastingdienst
+            lexostatus: toetsingsinkomen
+            field: toetsingsinkomen
+            params:
+              bsn: $bsn
+
+      - name: zorgtoeslag_vaststelling_eigen_inkomen
+        doc: >-
+          Het tegenbewijs: exact hetzelfde besluit, maar met het
+          toetsingsinkomen uit de eigen kroniek. Niets wordt hier geaccepteerd,
+          en er gaat geen enkele vraag over een celgrens.
+        regulation: wet_op_de_zorgtoeslag
+        output: heeft_recht_op_zorgtoeslag
+        outputs:
+          - hoogte_zorgtoeslag
+        zaakkenmerk: zorgtoeslag-eigen/{bsn}
+        params:
+          - name: bsn
+            type: string
+        inputs:
+          bsn:
+            param: bsn
+          is_verzekerde:
+            from_chronicle: inkomensleveringen
+            field: is_verzekerde
+          toetsingsinkomen:
+            from_chronicle: inkomensleveringen
+            field: toetsingsinkomen
+
+    lexostatus_definitions:
+      - name: zorgtoeslagbeschikking
+        doc: wat deze cel over deze zaak besloten heeft, op het gevraagde moment
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - heeft_recht_op_zorgtoeslag
+          - hoogte_zorgtoeslag
+        reduction:
+          chronicle: beschikkingen
+          key: zaakkenmerk
+          latest: true
+
+decide:
+  - description: >-
+      Accepteren. Het toetsingsinkomen komt van de belastingdienst, en het gram
+      zegt van wie en van wanneer.
+    cell: toeslagen
+    besluit: zorgtoeslag_vaststelling
+    params:
+      bsn: '999993653'
+    op_moment: 2024-06-01
+    expect:
+      heeft_recht_op_zorgtoeslag: true
+      # Berekend op 81000 — het getal van de belastingdienst. Het bedrag van het
+      # besluit hieronder is een ander, en dat is het bewijs dat er geaccepteerd
+      # is en niet stilletjes een eigen feit gepakt.
+      hoogte_zorgtoeslag: 197178.01
+    expect_accepted:
+      toetsingsinkomen: belastingdienst
+    expect_computed:
+      # Alles wat deze cel zelf vaststelde, blijft eigen werk — anders zou
+      # "geaccepteerd" een etiket zijn dat overal op past.
+      - is_verzekerde
+      - heeft_recht_op_zorgtoeslag
+      - hoogte_zorgtoeslag
+
+  - description: >-
+      Narekenen. Zelfde wet, zelfde persoon, zelfde moment; alleen komt het
+      toetsingsinkomen nu uit de eigen kroniek. Er gaat niets over een celgrens.
+    cell: toeslagen
+    besluit: zorgtoeslag_vaststelling_eigen_inkomen
+    params:
+      bsn: '999993653'
+    op_moment: 2024-06-01
+    expect:
+      heeft_recht_op_zorgtoeslag: true
+      # Berekend op 79547 — het eigen getal, en dus een ander bedrag.
+      hoogte_zorgtoeslag: 197205.31187
+    expect_computed:
+      - toetsingsinkomen
+
+queries:
+  - description: >-
+      Het geaccepteerde besluit terugvragen: een gewone reductie over de eigen
+      kroniek, die het gram van toen oplevert.
+    cell: toeslagen
+    lexostatus: zorgtoeslagbeschikking
+    params:
+      zaakkenmerk: zorgtoeslag/999993653
+    op_moment: 2024-06-01
+    expect:
+      hoogte_zorgtoeslag: 197178.01
+
+  - description: >-
+      En het nagerekende besluit, onder zijn eigen zaakkenmerk. Twee zaken, twee
+      grammen, twee bedragen — in dezelfde kroniek van dezelfde cel.
+    cell: toeslagen
+    lexostatus: zorgtoeslagbeschikking
+    params:
+      zaakkenmerk: zorgtoeslag-eigen/999993653
+    op_moment: 2024-06-01
+    expect:
+      hoogte_zorgtoeslag: 197205.31187
+
+  - description: >-
+      De bron-cel zelf, rechtstreeks bevraagd: dit is wat zij vaststelde, en
+      onder wiens gezag. Dat gezag is niet dat van `toeslagen`, en dat is de
+      reden dat het getal geaccepteerd hoort te worden.
+    cell: belastingdienst
+    lexostatus: toetsingsinkomen
+    params:
+      bsn: '999993653'
+    op_moment: 2024-06-01
+    expect:
+      toetsingsinkomen: 81000
+      competent_authority: Belastingdienst

--- a/packages/simulator/scenarios/toeslagen_accepteert_via_de_wet.yaml
+++ b/packages/simulator/scenarios/toeslagen_accepteert_via_de_wet.yaml
@@ -1,0 +1,163 @@
+---
+name: de wet wijst een andere cel aan, en het besluit accepteert wat die zegt
+description: >-
+  Tier 3 van de resolutievolgorde (RFC-022 §4.2). Hier zegt niet de
+  besluit-definitie dat een waarde van een ander komt, maar de **wet**: een
+  `source.regulation` die geen regeling is maar een cel-id. De besluit-engine
+  heeft daar een resolver voor en lost het op langs dezelfde veiligheidscontext
+  en hetzelfde transport als `accept_from`; de waarde landt als geaccepteerde
+  waarde in het decretogram en nergens anders.
+
+  De cel `toeslagen` voert hier een **testregeling** uit
+  (`fixtures/regulation/test_partnerschapstoets`), niet een corpuswet. Dat is
+  met opzet: geen enkele echte wet hoort verbouwd te worden omdat een
+  testopstelling iets wil laten zien, en het corpus is geen plek voor een wet
+  die alleen bestaat om een engine-eigenschap aan te tonen.
+
+  Let op wat de wet níet zegt: ze noemt `brp` en een uitkomstnaam, en verder
+  niets. Welke gepubliceerde lexostatus daar bij hoort, staat in `accepts_from`
+  van de cel — dat is een afspraak tussen twee organisaties en geen recht.
+
+clock:
+  # De vastlegging van `brp` staat als `events` in haar configuratie en ligt
+  # ervóór; er is geen fixture die nog moet landen.
+  start: 2024-01-01
+
+cells:
+  # De bron-cel: geen engine, één kroniek, één gepubliceerde lexostatus. Ze
+  # merkt niet dat de vraag uit een besluit van een ander kwam — het transport
+  # is de naad, en aan haar kant ziet elke vraag er hetzelfde uit.
+  - id: brp
+    laws: []
+
+    chronicles:
+      - stream: relaties
+        key: bsn
+        events:
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: brp
+            grondslag: eigen registratie
+            op_moment: 2023-03-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: HUWELIJK
+
+    lexostatus_definitions:
+      - name: partnerschap
+        doc: >-
+          De relatievorm van één persoon op één moment, zoals deze cel die
+          vastlegde.
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - partnerschap_type
+        reduction:
+          chronicle: relaties
+          key: bsn
+          latest: true
+
+  - id: toeslagen
+    laws:
+      - test_partnerschapstoets
+
+    # Wat de wet bij een andere cel haalt, en hoe daar te vragen. Zonder deze
+    # afspraak bereikt de engine `brp` niet: alleen gedeclareerde cel-ids komen
+    # bij de resolver uit, dus een cel die hier niet staat kan niet per ongeluk
+    # bevraagd worden.
+    accepts_from:
+      - cell: brp
+        output: partnerschap
+        lexostatus: partnerschap
+        field: partnerschap_type
+        doc: >-
+          `test_partnerschapstoets` art. 1 vraagt `partnerschap` bij de cel
+          `brp`; die publiceert dat als lexostatus met dezelfde naam, en de
+          waarde zit in haar uitkomst `partnerschap_type`.
+
+    besluit_definitions:
+      - name: partnerschapstoets
+        doc: >-
+          De cel voert haar eigen regeling uit. De enige input die de wet nodig
+          heeft, komt van een andere organisatie — en die wordt geaccepteerd,
+          niet nagerekend: `toeslagen` laadt de BRP-wet niet en voert haar dus
+          ook niet uit.
+        regulation: test_partnerschapstoets
+        output: is_gehuwd
+        zaakkenmerk: partnerschapstoets/{bsn}
+        params:
+          - name: bsn
+            type: string
+        inputs:
+          # Alleen de parameter. `partnerschap_type` staat hier met opzet
+          # níet: een input die het besluit zelf aanlevert, vervangt haar
+          # `source`, en dan zou de tier-3-verwijzing nooit aan bod komen.
+          bsn:
+            param: bsn
+
+    lexostatus_definitions:
+      - name: partnerschapsbeschikking
+        doc: wat deze cel over deze zaak besloten heeft, op het gevraagde moment
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - is_gehuwd
+          - legal_character
+        reduction:
+          chronicle: beschikkingen
+          key: zaakkenmerk
+          latest: true
+
+      - name: partnerschap_nu
+        doc: >-
+          Dezelfde regeling, maar als **reductie** in plaats van als besluit. Ze
+          staat hier om te laten zien dat dat niet werkt: de reduce-engine heeft
+          geen resolver, dus ze kan de `source.regulation` naar `brp` niet
+          beantwoorden en komt niet buiten deze cel. Daarom staat er hieronder
+          geen vraag naar deze naam — die zou de run laten omvallen. Wat er
+          precies gebeurt, staat vast in `tests/accepteren.rs`; het is een
+          eigenschap van de opstelling en niet van dit bestand.
+        inputs:
+          - name: bsn
+            type: string
+        reduction:
+          regulation: test_partnerschapstoets
+          output: is_gehuwd
+          parameters:
+            bsn: $bsn
+
+decide:
+  - description: >-
+      Het besluit leunt op een feit van `brp`, en het gram zegt dat ook: de
+      waarde is geaccepteerd van die cel en hier niet uitgerekend.
+    cell: toeslagen
+    besluit: partnerschapstoets
+    params:
+      bsn: '999993653'
+    op_moment: 2024-06-01
+    expect:
+      is_gehuwd: true
+    expect_accepted:
+      # De naam is die van de uitkomst zoals de wet erom vroeg; de engine zet
+      # haar in `accepted_values` van het receipt, en het gram draagt dat
+      # receipt.
+      partnerschap: brp
+    expect_computed:
+      # De uitkomst van het besluit is wél eigen werk: die rekende deze cel uit
+      # met haar eigen regeling, op de waarde die ze accepteerde.
+      - is_gehuwd
+
+queries:
+  - description: >-
+      Terugzien is een reductie over de eigen kroniek: het besluit ligt er, met
+      het rechtskarakter dat de regeling eraan geeft.
+    cell: toeslagen
+    lexostatus: partnerschapsbeschikking
+    params:
+      zaakkenmerk: partnerschapstoets/999993653
+    op_moment: 2024-06-01
+    expect:
+      is_gehuwd: true
+      legal_character: BESCHIKKING

--- a/packages/simulator/src/accept.rs
+++ b/packages/simulator/src/accept.rs
@@ -1,0 +1,412 @@
+//! Accepteren: een waarde van een andere cel overnemen in plaats van narekenen.
+//!
+//! Dit is stap 4 van de RFC-009-beslisboom en invariant I5. Stelt een andere
+//! organisatie een feit vast, dan rekent deze cel het niet na: ze vraagt het op,
+//! legt vast bij wie ze het ophaalde en op welk moment, en rekent daarmee verder.
+//! Het verschil met narekenen is geen nuance — een beschikking van een ander
+//! bevoegd gezag opnieuw uitrekenen is het overrulen van dat gezag.
+//!
+//! Deze module woont **buiten** [`crate::cell`], en dat is de kern van de
+//! opzet. Een cel houdt geen veiligheidscontext en geen transport (RFC-022 §2),
+//! dus ze kan de grens niet over. Wat ze wel kan, is *zeggen* wat ze nodig heeft
+//! ([`crate::AcceptanceRequest`]) en een aangereikte waarde met haar herkomst
+//! vastleggen. Het ophalen zelf gebeurt hier, in de laag die de peers kent en
+//! de identiteit van de vragende cel draagt: in deze opstelling
+//! [`crate::World::decide`].
+//!
+//! Twee wegen komen hier samen, en ze lopen langs dezelfde context en hetzelfde
+//! transport:
+//!
+//! 1. **`accept_from` in de besluit-definitie** — de cel zegt zelf dat een input
+//!    van een andere cel komt. Het besluit vraagt hem op vóór het rekenen.
+//! 2. **`source.regulation` in de wet** — het *recht* wijst een andere cel aan
+//!    (tier 3 van RFC-022 §4.2). Dan vraagt de engine er tijdens de uitvoering
+//!    om, langs de [`CellResolver`] die [`CellBridge`] hier implementeert.
+//!
+//! Wat er in beide gevallen **niet** gebeurt: de waarde belandt nergens als
+//! eigen feit. Niet in een kroniek, niet in het databronregister van de engine.
+//! Ze gaat in het decretogram met haar herkomst, en een volgend besluit vraagt
+//! opnieuw. Anders zou er een schaduwboekhouding ontstaan die er precies
+//! uitziet als eigen wetenschap (RFC-022).
+
+use crate::cell::{AcceptanceRequest, AcceptedSource, Cell, DecretogramInput, InputOrigin};
+use crate::error::{Result, SimulatorError};
+use crate::security::{Identity, SecurityContext, SignedAnswer};
+use crate::transport::{CellTransport, InProcessTransport};
+use chrono::NaiveDate;
+use regelrecht_engine::{CellResolver, EngineError, Value};
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+
+/// Vraag één waarde op bij een andere cel en maak er een vastlegbare input van.
+///
+/// Geeft twee dingen terug, en dat is geen gemak: de waarde met haar herkomst
+/// voor het decretogram, en het volledige bewijsstuk voor wie het verkeer meet.
+/// Het observatielog staat buiten de band (zie [`crate::observation`]), dus het
+/// kan het bewijsstuk niet zelf komen halen; wie accepteert, geeft het door.
+///
+/// Een bron-cel die "niets vastgesteld" antwoordt, laat het besluit omvallen. Dat
+/// is geen defect maar een leesbare weigering: welke input van welke cel
+/// ontbrak, en wat de bron-cel als reden gaf. Er wordt dan niets vastgelegd — een
+/// besluit dat met een gat verder rekent, is erger dan geen besluit.
+fn accept_one(
+    context: &SecurityContext<'_>,
+    cell: &str,
+    besluit: &str,
+    request: &AcceptanceRequest,
+    op_moment: NaiveDate,
+) -> Result<(DecretogramInput, SignedAnswer)> {
+    let signed = context.query(
+        &request.cell,
+        &request.lexostatus,
+        &request.params,
+        op_moment,
+    )?;
+
+    let answer = &signed.answer;
+    let missing = |reason: String| SimulatorError::AcceptedInputMissing {
+        cell: cell.to_string(),
+        besluit: besluit.to_string(),
+        input: request.input.clone(),
+        peer: request.cell.clone(),
+        reason,
+    };
+
+    let values = answer.values().ok_or_else(|| {
+        missing(format!(
+            "die stelde voor lexostatus '{}' op {op_moment} niets vast ({})",
+            request.lexostatus,
+            answer.not_established().unwrap_or_default()
+        ))
+    })?;
+
+    let value = values.get(&request.field).cloned().ok_or_else(|| {
+        missing(format!(
+            "haar lexostatus '{}' publiceert geen uitkomst '{}' (wel: {})",
+            request.lexostatus,
+            request.field,
+            values
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+    })?;
+
+    let origin = InputOrigin::Accepted {
+        cell: answer.cell.clone(),
+        lexostatus: answer.name.clone(),
+        field: request.field.clone(),
+        op_moment: answer.op_moment,
+        asked_by: signed.asked_by.to_string(),
+        signature: signed.signature.to_string(),
+    };
+
+    Ok((DecretogramInput { value, origin }, signed))
+}
+
+/// De cel-tier van de besluit-engine: een [`CellResolver`] die een
+/// `source.regulation` naar een andere cel langs dezelfde veiligheidscontext en
+/// hetzelfde transport oplost als `accept_from`.
+///
+/// De brug **bezit** de peers zolang hij bestaat. Dat is geen implementatietruc
+/// maar wat de engine vraagt: een geregistreerde resolver moet de uitvoering
+/// overleven, dus hij kan de cellen niet lenen. De wereld geeft ze mee voor de
+/// duur van één besluit en neemt ze daarna terug ([`Self::release`]). Zolang de
+/// brug ze houdt, is de besluitende cel er zelf niet bij — die is uit de map
+/// gehaald — en dus is een cel die zichzelf over de grens bevraagt geen
+/// afspraak maar een onbereikbaarheid.
+///
+/// Hij is `pub(crate)`: niemand buiten deze crate hoort een resolver in handen te
+/// krijgen, want dat is precies de capability die het reduce-pad níet heeft.
+pub(crate) struct CellBridge {
+    /// De identiteit van de besluitende cel; zij ondertekent elke vraag.
+    identity: Identity,
+    /// Het besluit waarvoor gevraagd wordt, voor de foutmeldingen.
+    besluit: String,
+    /// De afspraken uit de configuratie van de besluitende cel, op
+    /// `(cel, uitkomst)` zoals de engine ernaar vraagt.
+    sources: BTreeMap<(String, String), AcceptedSource>,
+    /// De andere cellen van de wereld, in bezit van de brug tot
+    /// [`Self::release`] ze teruggeeft.
+    peers: RefCell<BTreeMap<String, Cell>>,
+    /// Elk contact dat over de grens ging, in volgorde. Voor het verslag en voor
+    /// het observatielog: het log kan niet zelf komen halen wat de engine
+    /// onderweg vroeg.
+    crossings: RefCell<Vec<SignedAnswer>>,
+}
+
+impl CellBridge {
+    /// Bouw een brug voor één besluit van één cel.
+    pub(crate) fn new(
+        identity: Identity,
+        besluit: &str,
+        sources: impl IntoIterator<Item = AcceptedSource>,
+        peers: BTreeMap<String, Cell>,
+    ) -> Self {
+        Self {
+            identity,
+            besluit: besluit.to_string(),
+            sources: sources
+                .into_iter()
+                .map(|source| ((source.cell.clone(), source.output.clone()), source))
+                .collect(),
+            peers: RefCell::new(peers),
+            crossings: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Vraag één waarde op bij een peer, met een verse context en een vers
+    /// transport over de cellen die de brug houdt.
+    ///
+    /// Het transport wordt per vraag opnieuw gemaakt en niet bewaard: het leent
+    /// de peers, en dat is de naad waarlangs later een HTTP-transport aanschuift
+    /// zonder dat hier iets verandert.
+    fn ask(&self, request: &AcceptanceRequest, op_moment: NaiveDate) -> Result<DecretogramInput> {
+        let peers = self.peers.borrow();
+        let transport = InProcessTransport::over(&peers);
+        let accepted = self.ask_over(&transport, request, op_moment);
+        accepted.map(|(input, _)| input)
+    }
+
+    /// Dezelfde vraag, met het transport van de aanroeper.
+    ///
+    /// Apart, zodat het vastleggen van het contact op één plek staat: wat er over
+    /// de grens ging, komt in [`Self::crossings`] of het komt nergens, en dan is
+    /// het log stil incompleet in plaats van rood.
+    fn ask_over(
+        &self,
+        transport: &dyn CellTransport,
+        request: &AcceptanceRequest,
+        op_moment: NaiveDate,
+    ) -> Result<(DecretogramInput, SignedAnswer)> {
+        let context = SecurityContext::new(self.identity.clone(), transport);
+        let accepted = accept_one(
+            &context,
+            self.identity.cell(),
+            &self.besluit,
+            request,
+            op_moment,
+        );
+        if let Ok((_, signed)) = &accepted {
+            self.crossings.borrow_mut().push(signed.clone());
+        }
+        accepted
+    }
+
+    /// Willig elk verzoek van een besluit-definitie in (`accept_from`).
+    ///
+    /// Dezelfde weg als de tier-3-vragen hierboven, dus hetzelfde log en dezelfde
+    /// herkomst. Falen doet het geheel: een besluit met één ontbrekende input
+    /// wordt niet genomen.
+    pub(crate) fn accept_all(
+        &self,
+        requests: &[AcceptanceRequest],
+        op_moment: NaiveDate,
+    ) -> Result<BTreeMap<String, DecretogramInput>> {
+        let peers = self.peers.borrow();
+        let transport = InProcessTransport::over(&peers);
+        let mut accepted = BTreeMap::new();
+        for request in requests {
+            let (input, _) = self.ask_over(&transport, request, op_moment)?;
+            accepted.insert(request.input.clone(), input);
+        }
+        Ok(accepted)
+    }
+
+    /// De contacten die over de grens gingen, in volgorde.
+    pub(crate) fn crossings(&self) -> Vec<SignedAnswer> {
+        self.crossings.borrow().clone()
+    }
+
+    /// Geef de peers terug aan de wereld.
+    ///
+    /// De brug blijft daarna bestaan — de engine houdt zijn registratie — maar
+    /// zonder peers, en een volgend besluit krijgt een verse brug. Dat de engine
+    /// een resolver vasthoudt die niets meer kan, is de veilige kant op: een
+    /// vraag langs een afgedankte brug loopt dood in plaats van stil een oude
+    /// wereld te bevragen.
+    pub(crate) fn release(&self) -> BTreeMap<String, Cell> {
+        std::mem::take(&mut self.peers.borrow_mut())
+    }
+}
+
+impl CellResolver for CellBridge {
+    fn resolve(
+        &self,
+        cell_id: &str,
+        output: &str,
+        parameters: &BTreeMap<String, Value>,
+        reference_date: &str,
+    ) -> std::result::Result<Option<Value>, EngineError> {
+        // De engine laat alleen gedeclareerde cel-ids hier komen, maar niet elke
+        // uitkomst van zo'n cel hoeft gedeclareerd te zijn. Een naam zonder
+        // afspraak is geen "niets vastgesteld" maar een gat in de configuratie.
+        let source = self
+            .sources
+            .get(&(cell_id.to_string(), output.to_string()))
+            .ok_or_else(|| {
+                EngineError::ResolutionError(format!(
+                    "cel '{}' heeft geen afspraak voor uitkomst '{output}' van cel \
+                     '{cell_id}'; vul `accepts_from` aan met de lexostatus die daar \
+                     gevraagd moet worden",
+                    self.identity.cell()
+                ))
+            })?;
+
+        let op_moment = NaiveDate::parse_from_str(reference_date, "%Y-%m-%d")
+            .map_err(|e| EngineError::InvalidDate(format!("{reference_date}: {e}")))?;
+
+        // De parameters gaan door zoals de engine ze uit `source.parameters`
+        // bouwde. De bevraagde cel toetst ze tegen wat zij documenteert, en dat
+        // hoort ook: een vraag die niet bij haar gepubliceerde vorm past, mag
+        // niet alsnog langs een vertaling hier binnenkomen.
+        let request = AcceptanceRequest {
+            input: output.to_string(),
+            cell: source.cell.clone(),
+            lexostatus: source.lexostatus.clone(),
+            field: source.field.clone(),
+            params: parameters.clone(),
+        };
+
+        // De waarde gaat terug naar de engine, die haar in `accepted_values` van
+        // het receipt zet en nooit in het databronregister (RFC-013, RFC-022
+        // §4.2). Deze brug zet er zelf ook niets neer.
+        let accepted = self.ask(&request, op_moment).map_err(|e| match e {
+            SimulatorError::Engine(engine) => engine,
+            other => EngineError::ResolutionError(other.to_string()),
+        })?;
+        Ok(Some(accepted.value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cell::CellConfig;
+    use std::collections::BTreeSet;
+    use std::path::Path;
+
+    /// Een bron-cel met één kroniekfilter; geen corpus nodig, dus geen engine.
+    fn brp() -> BTreeMap<String, Cell> {
+        let config: CellConfig = serde_yaml_ng::from_str(
+            r"
+id: brp
+laws: []
+chronicles:
+  - stream: relaties
+    key: bsn
+    events:
+      - name: relatie_gewijzigd
+        intake: levering
+        recording_actor: brp
+        op_moment: 2023-03-01
+        fields:
+          bsn: '999993653'
+          partnerschap_type: HUWELIJK
+lexostatus_definitions:
+  - name: partnerschap
+    inputs:
+      - name: bsn
+        type: string
+    outputs:
+      - partnerschap_type
+    reduction:
+      chronicle: relaties
+      key: bsn
+      latest: true
+",
+        )
+        .expect("de testconfiguratie hoort te lezen");
+        let cell = Cell::from_config(&config, Path::new("/bestaat-niet"), &BTreeMap::new())
+            .expect("een bron-cel heeft geen corpus nodig");
+        BTreeMap::from([("brp".to_string(), cell)])
+    }
+
+    fn source() -> AcceptedSource {
+        AcceptedSource {
+            cell: "brp".to_string(),
+            output: "partnerschap".to_string(),
+            lexostatus: "partnerschap".to_string(),
+            field: "partnerschap_type".to_string(),
+            doc: None,
+        }
+    }
+
+    fn bridge() -> CellBridge {
+        CellBridge::new(
+            Identity::for_cell("toeslagen"),
+            "toekenning",
+            [source()],
+            brp(),
+        )
+    }
+
+    fn bsn() -> BTreeMap<String, Value> {
+        BTreeMap::from([("bsn".to_string(), Value::String("999993653".to_string()))])
+    }
+
+    #[test]
+    fn een_tier_3_verwijzing_komt_bij_de_lexostatus_van_de_peer_uit() {
+        let bridge = bridge();
+        let answer = bridge
+            .resolve("brp", "partnerschap", &bsn(), "2024-01-01")
+            .expect("de afspraak wijst naar een lexostatus die de peer publiceert");
+
+        assert_eq!(answer, Some(Value::String("HUWELIJK".to_string())));
+        assert_eq!(
+            bridge.crossings().len(),
+            1,
+            "één vraag hoort één contact te zijn"
+        );
+        let crossing = &bridge.crossings()[0];
+        assert_eq!(crossing.asked_by.cell(), "toeslagen");
+        assert_eq!(crossing.answer.cell, "brp");
+        assert!(
+            crossing.signature.is_simulated(),
+            "ook een tier-3-vraag gaat ondertekend over de grens: {}",
+            crossing.signature
+        );
+    }
+
+    #[test]
+    fn een_uitkomst_zonder_afspraak_is_een_fout_en_geen_leeg_antwoord() {
+        let err = bridge()
+            .resolve("brp", "nationaliteit", &bsn(), "2024-01-01")
+            .expect_err("een uitkomst die `accepts_from` niet noemt hoort te falen");
+        assert!(
+            err.to_string().contains("accepts_from"),
+            "de melding hoort naar de afspraak te wijzen, kreeg: {err}"
+        );
+    }
+
+    #[test]
+    fn niets_vastgesteld_bij_de_bron_laat_het_besluit_omvallen() {
+        // Vóór de vastlegging van de peer: die had toen niets vastgesteld, en dat
+        // is haar goed recht. Doorrekenen met een gat is dat niet.
+        let err = bridge()
+            .resolve("brp", "partnerschap", &bsn(), "2022-01-01")
+            .expect_err("zonder feit bij de bron hoort het besluit om te vallen");
+        assert!(
+            err.to_string().contains("niets vast"),
+            "de melding hoort te zeggen dat de bron niets vaststelde, kreeg: {err}"
+        );
+    }
+
+    #[test]
+    fn de_brug_geeft_de_peers_terug() {
+        let bridge = bridge();
+        let peers = bridge.release();
+        assert_eq!(
+            peers.keys().map(String::as_str).collect::<BTreeSet<_>>(),
+            BTreeSet::from(["brp"]),
+            "de wereld hoort haar cellen ongeschonden terug te krijgen"
+        );
+        assert!(
+            bridge
+                .resolve("brp", "partnerschap", &bsn(), "2024-01-01")
+                .is_err(),
+            "een afgedankte brug hoort dood te lopen en geen oude wereld te bevragen"
+        );
+    }
+}

--- a/packages/simulator/src/accept.rs
+++ b/packages/simulator/src/accept.rs
@@ -38,32 +38,25 @@ use regelrecht_engine::{CellResolver, EngineError, Value};
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 
-/// Vraag één waarde op bij een andere cel en maak er een vastlegbare input van.
+/// Maak van een bewijsstuk de vastlegbare input die het besluit nodig heeft.
 ///
-/// Geeft twee dingen terug, en dat is geen gemak: de waarde met haar herkomst
-/// voor het decretogram, en het volledige bewijsstuk voor wie het verkeer meet.
-/// Het observatielog staat buiten de band (zie [`crate::observation`]), dus het
-/// kan het bewijsstuk niet zelf komen halen; wie accepteert, geeft het door.
+/// Losgekoppeld van het stellen van de vraag, en dat is het hele punt van de
+/// splitsing: het contact over de grens is al een feit als deze functie begint.
+/// Wat hier nog kan mislukken, is het *lezen* van het antwoord — en dat mag het
+/// bewijs van de vraag niet meer wissen.
 ///
 /// Een bron-cel die "niets vastgesteld" antwoordt, laat het besluit omvallen. Dat
 /// is geen defect maar een leesbare weigering: welke input van welke cel
 /// ontbrak, en wat de bron-cel als reden gaf. Er wordt dan niets vastgelegd — een
 /// besluit dat met een gat verder rekent, is erger dan geen besluit.
-fn accept_one(
-    context: &SecurityContext<'_>,
+fn accepted_input(
     cell: &str,
     besluit: &str,
     request: &AcceptanceRequest,
-    op_moment: NaiveDate,
-) -> Result<(DecretogramInput, SignedAnswer)> {
-    let signed = context.query(
-        &request.cell,
-        &request.lexostatus,
-        &request.params,
-        op_moment,
-    )?;
-
+    signed: &SignedAnswer,
+) -> Result<DecretogramInput> {
     let answer = &signed.answer;
+    let op_moment = answer.op_moment;
     let missing = |reason: String| SimulatorError::AcceptedInputMissing {
         cell: cell.to_string(),
         besluit: besluit.to_string(),
@@ -102,7 +95,7 @@ fn accept_one(
         signature: signed.signature.to_string(),
     };
 
-    Ok((DecretogramInput { value, origin }, signed))
+    Ok(DecretogramInput { value, origin })
 }
 
 /// De cel-tier van de besluit-engine: een [`CellResolver`] die een
@@ -174,6 +167,13 @@ impl CellBridge {
     /// Apart, zodat het vastleggen van het contact op één plek staat: wat er over
     /// de grens ging, komt in [`Self::crossings`] of het komt nergens, en dan is
     /// het log stil incompleet in plaats van rood.
+    ///
+    /// Het contact wordt vastgelegd zodra de peer antwoordde, en niet pas als dat
+    /// antwoord bruikbaar blijkt. Een "niets vastgesteld" is óók over de grens
+    /// gegaan: de vraag is gesteld, ondertekend, en de peer heeft haar gezien.
+    /// Zou het bewijsstuk pas bij een bruikbare waarde opgeschreven worden, dan
+    /// zou precies het geval dat het besluit doet omvallen in het vraaggraf
+    /// onzichtbaar blijven — en dat is de gevaarlijke kant op.
     fn ask_over(
         &self,
         transport: &dyn CellTransport,
@@ -181,17 +181,16 @@ impl CellBridge {
         op_moment: NaiveDate,
     ) -> Result<(DecretogramInput, SignedAnswer)> {
         let context = SecurityContext::new(self.identity.clone(), transport);
-        let accepted = accept_one(
-            &context,
-            self.identity.cell(),
-            &self.besluit,
-            request,
+        let signed = context.query(
+            &request.cell,
+            &request.lexostatus,
+            &request.params,
             op_moment,
-        );
-        if let Ok((_, signed)) = &accepted {
-            self.crossings.borrow_mut().push(signed.clone());
-        }
-        accepted
+        )?;
+        self.crossings.borrow_mut().push(signed.clone());
+
+        let input = accepted_input(self.identity.cell(), &self.besluit, request, &signed)?;
+        Ok((input, signed))
     }
 
     /// Willig elk verzoek van een besluit-definitie in (`accept_from`).
@@ -384,12 +383,28 @@ lexostatus_definitions:
     fn niets_vastgesteld_bij_de_bron_laat_het_besluit_omvallen() {
         // Vóór de vastlegging van de peer: die had toen niets vastgesteld, en dat
         // is haar goed recht. Doorrekenen met een gat is dat niet.
-        let err = bridge()
+        let bridge = bridge();
+        let err = bridge
             .resolve("brp", "partnerschap", &bsn(), "2022-01-01")
             .expect_err("zonder feit bij de bron hoort het besluit om te vallen");
         assert!(
             err.to_string().contains("niets vast"),
             "de melding hoort te zeggen dat de bron niets vaststelde, kreeg: {err}"
+        );
+
+        // En de vraag stáát er, want ze is gesteld. Dat het antwoord het besluit
+        // niet verder helpt, maakt het contact niet ongedaan: wie het vraaggraf
+        // meet, hoort juist dit geval te zien.
+        assert_eq!(
+            bridge.crossings().len(),
+            1,
+            "een 'niets vastgesteld' is óók over de grens gegaan"
+        );
+        let crossing = &bridge.crossings()[0];
+        assert_eq!(crossing.answer.cell, "brp");
+        assert!(
+            crossing.answer.not_established().is_some(),
+            "en het bewijsstuk hoort te dragen wat de peer antwoordde"
         );
     }
 

--- a/packages/simulator/src/cell/besluit.rs
+++ b/packages/simulator/src/cell/besluit.rs
@@ -21,8 +21,8 @@
 //!   wetsversie.
 
 use crate::cell::config::{
-    check_documented_params, documents, parameter_listing, published_outputs, CellSurface,
-    DocumentedParameter,
+    binding_name, check_documented_params, documents, engine_parameters, parameter_listing,
+    published_outputs, CellSurface, DocumentedParameter,
 };
 use crate::cell::{ChronicleEvent, Intake};
 use crate::error::{Result, SimulatorError, Subject};
@@ -105,12 +105,20 @@ pub struct BesluitDefinition {
     /// Wat het besluit aan de engine aanlevert, op inputnaam.
     ///
     /// De naam is die van een parameter of input van de regeling; de waarde
-    /// zegt waar hij vandaan komt. In deze versie zijn dat de eigen kronieken
-    /// van de cel en de parameters van het besluit; een waarde van een andere
-    /// cel accepteren volgt apart.
+    /// zegt waar hij vandaan komt: uit een eigen kroniek van de cel, uit de
+    /// parameters van het besluit, of **geaccepteerd** van een andere cel
+    /// (`accept_from`).
     #[serde(default)]
     pub inputs: BTreeMap<String, BesluitInput>,
 }
+
+/// De drie vormen die een input van een besluit kan hebben, voor foutmeldingen.
+///
+/// Eén tekst, want elke weigering hieronder somt ze op: wie er twee door elkaar
+/// haalt, hoort in dezelfde melding te lezen wat de keuze was.
+const INPUT_FORMS: &str = "een input komt uit een eigen kroniek (`from_chronicle` + `field`), \
+                           uit een parameter (`param`), of van een andere cel \
+                           (`accept_from` + `lexostatus` + `field`)";
 
 /// Waar één input van een besluit vandaan komt.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -132,9 +140,46 @@ pub enum BesluitInput {
         /// De gedocumenteerde parameter die de waarde levert.
         param: String,
     },
+    /// **Geaccepteerd** van een andere cel: die cel stelt de waarde vast, deze
+    /// cel rekent haar niet na (RFC-009 beslisboom stap 4, invariant I5).
+    ///
+    /// De vraag gaat niet vanuit de cel: ze gaat langs de veiligheidscontext
+    /// van de besluitende cel naar het transport, en die twee houdt een cel
+    /// niet (RFC-022 §2). Wat de cel hier declareert is dus een *verzoek* —
+    /// [`AcceptanceRequest`] — en wie het inwilligt staat buiten de cel.
+    ///
+    /// Wat terugkomt gaat als parameter de engine in en met haar herkomst het
+    /// decretogram in ([`InputOrigin::Accepted`]); nergens anders. Een volgend
+    /// besluit vraagt opnieuw.
+    AcceptFrom {
+        /// De cel die de waarde vaststelt.
+        cell: String,
+        /// De lexostatus die daar opgevraagd wordt.
+        lexostatus: String,
+        /// De uitkomst van die lexostatus die de waarde draagt.
+        field: String,
+        /// De parameters van die vraag, op de naam die de bevraagde cel
+        /// documenteert. Een waarde `$naam` verwijst naar een gedocumenteerde
+        /// parameter van dít besluit; elke andere waarde is letterlijke tekst —
+        /// dezelfde vorm als de parameters van een reductie.
+        params: BTreeMap<String, String>,
+    },
 }
 
-/// Het YAML-oppervlak van een input: alle velden van beide vormen, los.
+impl BesluitInput {
+    /// De cel waarvan deze input geaccepteerd wordt, als dat er een is.
+    ///
+    /// Voor wie de afspraken van buiten wil nalopen — de wereld toetst ermee of
+    /// de peer bestaat — zonder de vorm van de variant na te bouwen.
+    pub fn accepts_from(&self) -> Option<&str> {
+        match self {
+            Self::AcceptFrom { cell, .. } => Some(cell),
+            Self::FromChronicle { .. } | Self::Param { .. } => None,
+        }
+    }
+}
+
+/// Het YAML-oppervlak van een input: alle velden van alle vormen, los.
 ///
 /// Zelfde keuze als bij [`crate::Reduction`]: de vorm valt hieronder en niet in
 /// serde, zodat er in de foutmelding staat wat er mis is in plaats van "data did
@@ -145,44 +190,120 @@ struct BesluitInputFields {
     from_chronicle: Option<String>,
     field: Option<String>,
     param: Option<String>,
+    accept_from: Option<String>,
+    lexostatus: Option<String>,
+    params: Option<BTreeMap<String, String>>,
 }
 
 impl TryFrom<BesluitInputFields> for BesluitInput {
     type Error = String;
 
     fn try_from(fields: BesluitInputFields) -> std::result::Result<Self, Self::Error> {
-        match (fields.from_chronicle, fields.param) {
-            (Some(chronicle), Some(param)) => Err(format!(
-                "input noemt zowel kroniekstroom '{chronicle}' als parameter '{param}'; \
-                 een input komt óf uit een eigen kroniek (`from_chronicle` + `field`) \
-                 óf uit een parameter (`param`)"
-            )),
-            (Some(chronicle), None) => {
+        // Precies één van de drie ankers wijst de vorm aan. Twee ankers is geen
+        // vorm met een extraatje maar een input waarvan niemand kan zeggen waar
+        // ze vandaan komt, dus de melding noemt ze beide bij hun waarde.
+        let anchors: Vec<(&str, &str)> = [
+            ("from_chronicle", fields.from_chronicle.as_deref()),
+            ("param", fields.param.as_deref()),
+            ("accept_from", fields.accept_from.as_deref()),
+        ]
+        .into_iter()
+        .filter_map(|(key, value)| value.map(|value| (key, value)))
+        .collect();
+
+        let (kind, value) = match anchors.as_slice() {
+            [] => return Err(format!("input noemt geen bron: {INPUT_FORMS}")),
+            [single] => *single,
+            named => {
+                let listed = named
+                    .iter()
+                    .map(|(key, value)| format!("`{key}` '{value}'"))
+                    .collect::<Vec<_>>()
+                    .join(" en ");
+                return Err(format!("input noemt {listed}; {INPUT_FORMS}"));
+            }
+        };
+
+        match kind {
+            "from_chronicle" => {
+                reject_unused(kind, fields.lexostatus.is_some(), "`lexostatus`")?;
+                reject_unused(kind, fields.params.is_some(), "`params`")?;
                 let field = fields.field.ok_or_else(|| {
                     format!(
-                        "input uit kroniekstroom '{chronicle}' mist `field`: zonder veld \
+                        "input uit kroniekstroom '{value}' mist `field`: zonder veld \
                          weet de cel niet welke waarde van de vastlegging ze bedoelt"
                     )
                 })?;
-                Ok(Self::FromChronicle { chronicle, field })
+                Ok(Self::FromChronicle {
+                    chronicle: value.to_string(),
+                    field,
+                })
             }
-            (None, Some(param)) => {
-                if fields.field.is_some() {
-                    return Err(format!(
-                        "`field` hoort bij een input uit een kroniekstroom \
-                         (`from_chronicle`), niet bij parameter '{param}'"
-                    ));
-                }
-                Ok(Self::Param { param })
+            "accept_from" => {
+                let lexostatus = fields.lexostatus.ok_or_else(|| {
+                    format!(
+                        "input die van cel '{value}' geaccepteerd wordt mist `lexostatus`: \
+                         een cel is alleen te bevragen langs een naam die ze publiceert"
+                    )
+                })?;
+                let field = fields.field.ok_or_else(|| {
+                    format!(
+                        "input die van cel '{value}' geaccepteerd wordt mist `field`: \
+                         een lexostatus levert de uitkomsten die ze publiceert, en \
+                         zonder veld weet de cel niet welke daarvan ze bedoelt"
+                    )
+                })?;
+                Ok(Self::AcceptFrom {
+                    cell: value.to_string(),
+                    lexostatus,
+                    field,
+                    params: fields.params.unwrap_or_default(),
+                })
             }
-            (None, None) => Err(
-                "input noemt geen `from_chronicle` en geen `param`: een input komt uit \
-                 een eigen kroniek (`from_chronicle` + `field`) of uit een parameter \
-                 (`param`)"
-                    .to_string(),
-            ),
+            // Onbereikbaar: de lijst hierboven kent geen vierde anker.
+            _ => {
+                reject_unused(kind, fields.field.is_some(), "`field`")?;
+                reject_unused(kind, fields.lexostatus.is_some(), "`lexostatus`")?;
+                reject_unused(kind, fields.params.is_some(), "`params`")?;
+                Ok(Self::Param {
+                    param: value.to_string(),
+                })
+            }
         }
     }
+}
+
+/// Weiger een veld dat bij een andere vorm hoort dan de gekozen.
+///
+/// Stil laten liggen zou erger zijn dan streng zijn: een `lexostatus` naast een
+/// `param` leest als een vraag over de celgrens en is er geen.
+fn reject_unused(kind: &str, present: bool, field: &str) -> std::result::Result<(), String> {
+    if present {
+        return Err(format!(
+            "{field} hoort niet bij een input met `{kind}`; {INPUT_FORMS}"
+        ));
+    }
+    Ok(())
+}
+
+/// Eén waarde die een besluit bij een andere cel gaat ophalen.
+///
+/// De cel stelt dit verzoek samen en zet het **niet** zelf door: ze houdt geen
+/// veiligheidscontext en geen transport (RFC-022 §2). Wie het inwilligt — in
+/// deze opstelling [`crate::World::decide`] — geeft de waarde met haar herkomst
+/// terug aan het besluit.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AcceptanceRequest {
+    /// De input van het besluit die met deze waarde gevuld wordt.
+    pub input: String,
+    /// De cel aan wie gevraagd wordt.
+    pub cell: String,
+    /// De lexostatus die daar opgevraagd wordt.
+    pub lexostatus: String,
+    /// De uitkomst van die lexostatus die de waarde draagt.
+    pub field: String,
+    /// De parameters van de vraag, met de verwijzingen al ingevuld.
+    pub params: BTreeMap<String, Value>,
 }
 
 /// Waar één waarde in een decretogram vandaan kwam.
@@ -208,6 +329,27 @@ pub enum InputOrigin {
     Parameter {
         /// De parameter die de waarde leverde.
         parameter: String,
+    },
+    /// **Geaccepteerd** van een andere cel, en dus niet hier uitgerekend
+    /// (invariant I5).
+    ///
+    /// Dit is het bewijsstuk van die ene vraag, uitgeschreven in gewone velden:
+    /// bij wie, onder welke naam, op welk moment, en ondertekend door wie. Niet
+    /// als geleend type uit de veiligheidscontext — een cel kent die niet — maar
+    /// als wat het gram draagt en een lezer later nakijkt.
+    Accepted {
+        /// De cel die de waarde vaststelde.
+        cell: String,
+        /// De lexostatus waaronder ze dat publiceert.
+        lexostatus: String,
+        /// De uitkomst van die lexostatus die de waarde droeg.
+        field: String,
+        /// Het moment waarop het antwoord geldt.
+        op_moment: NaiveDate,
+        /// De identiteit die de vraag stelde en ondertekende.
+        asked_by: String,
+        /// De (gesimuleerde) ondertekening van die vraag.
+        signature: String,
     },
 }
 
@@ -238,6 +380,41 @@ impl InputOrigin {
                 ),
                 ("parameter".to_string(), Value::String(parameter.clone())),
             ])),
+            Self::Accepted {
+                cell,
+                lexostatus,
+                field,
+                op_moment,
+                asked_by,
+                signature,
+            } => Value::Object(BTreeMap::from([
+                (
+                    "herkomst".to_string(),
+                    Value::String("geaccepteerd".to_string()),
+                ),
+                ("cell".to_string(), Value::String(cell.clone())),
+                ("lexostatus".to_string(), Value::String(lexostatus.clone())),
+                ("field".to_string(), Value::String(field.clone())),
+                (
+                    "op_moment".to_string(),
+                    Value::String(op_moment.to_string()),
+                ),
+                ("asked_by".to_string(), Value::String(asked_by.clone())),
+                ("signature".to_string(), Value::String(signature.clone())),
+            ])),
+        }
+    }
+
+    /// Is deze waarde van een andere cel geaccepteerd in plaats van hier
+    /// uitgerekend?
+    ///
+    /// Het onderscheid van invariant I5, op één plek: een scenario, een verslag
+    /// en de invarianten-gate stellen alle drie deze vraag, en ze horen hem niet
+    /// elk op hun eigen manier te stellen.
+    pub fn accepted_from(&self) -> Option<&str> {
+        match self {
+            Self::Accepted { cell, .. } => Some(cell),
+            Self::OwnChronicle { .. } | Self::Parameter { .. } => None,
         }
     }
 
@@ -250,6 +427,17 @@ impl InputOrigin {
                 recorded_op_moment,
             } => format!("eigen kroniek '{chronicle}.{field}', vastgelegd {recorded_op_moment}"),
             Self::Parameter { parameter } => format!("parameter '{parameter}'"),
+            Self::Accepted {
+                cell,
+                lexostatus,
+                field,
+                op_moment,
+                asked_by,
+                signature,
+            } => format!(
+                "geaccepteerd van cel '{cell}' ({lexostatus}.{field} op {op_moment}), \
+                 gevraagd door {asked_by} [{signature}]"
+            ),
         }
     }
 }
@@ -304,6 +492,28 @@ pub struct Decretogram {
 }
 
 impl Decretogram {
+    /// Elke waarde in dit gram die van een andere cel **geaccepteerd** is, op
+    /// naam, met de cel die haar vaststelde.
+    ///
+    /// Twee wegen komen hier samen, en dat is met opzet één lijst: een input die
+    /// de besluit-definitie met `accept_from` vulde, en een waarde die de
+    /// *regeling* via een `source.regulation` naar een cel haalde (tier 3, die
+    /// de engine in `accepted_values` van het receipt zet). Voor de vraag van
+    /// invariant I5 — is dit narekenen of accepteren? — zijn ze hetzelfde, en
+    /// wie ze apart houdt, controleert er straks maar één.
+    pub fn accepted_values(&self) -> BTreeMap<&str, &str> {
+        let from_inputs = self
+            .inputs
+            .iter()
+            .filter_map(|(name, input)| Some((name.as_str(), input.origin.accepted_from()?)));
+        let from_receipt = self
+            .receipt
+            .accepted_values
+            .iter()
+            .map(|accepted| (accepted.output.as_str(), accepted.authority.as_str()));
+        from_inputs.chain(from_receipt).collect()
+    }
+
     /// Het decretogram als kroniekgebeurtenis.
     ///
     /// Een gewoon executogram met `intake: eigen_besluit`, zodat de tijdreductie
@@ -559,7 +769,69 @@ impl BesluitDefinition {
                     reference: param.clone(),
                 })
             }
+            BesluitInput::AcceptFrom {
+                cell: peer, params, ..
+            } => {
+                // De eigen cel is geen peer. Voor eigen feiten is er een
+                // kroniek of een eigen wet; wie zichzelf over de grens
+                // bevraagt, zet een cross-cel-contact in het vraaggraf dat er
+                // niet hoort en zou bij de veiligheidscontext alsnog stuklopen
+                // — beter hier, bij het optuigen.
+                if peer == cell {
+                    return Err(SimulatorError::AcceptFromSelf {
+                        cell: cell.to_string(),
+                        besluit: self.name.clone(),
+                        input: input.to_string(),
+                    });
+                }
+                for reference in params.values().filter_map(|binding| binding_name(binding)) {
+                    if !documents(&self.params, reference) {
+                        return Err(SimulatorError::UnknownReference {
+                            cell: cell.to_string(),
+                            subject: Subject::Besluit,
+                            name: self.name.clone(),
+                            reference: reference.to_string(),
+                        });
+                    }
+                }
+                // Of de peer bestaat en deze naam publiceert, weet de cel niet:
+                // ze kent geen andere cel. Dat valt bij de wereld (die de peers
+                // kent) en anders bij het transport.
+                Ok(())
+            }
         }
+    }
+
+    /// De waarden die dit besluit bij een andere cel moet ophalen.
+    ///
+    /// Aanroepen ná [`Self::check_params`]: de verwijzingen in `params` zijn bij
+    /// het optuigen aan gedocumenteerde parameters gebonden, en die zijn dan
+    /// aanwezig.
+    ///
+    /// Leeg is het normale geval: een besluit dat alles zelf weet, vraagt
+    /// niemand iets.
+    pub(crate) fn acceptance_requests(
+        &self,
+        params: &BTreeMap<String, Value>,
+    ) -> Vec<AcceptanceRequest> {
+        self.inputs
+            .iter()
+            .filter_map(|(input, origin)| match origin {
+                BesluitInput::AcceptFrom {
+                    cell,
+                    lexostatus,
+                    field,
+                    params: bindings,
+                } => Some(AcceptanceRequest {
+                    input: input.clone(),
+                    cell: cell.clone(),
+                    lexostatus: lexostatus.clone(),
+                    field: field.clone(),
+                    params: engine_parameters(bindings, params),
+                }),
+                BesluitInput::FromChronicle { .. } | BesluitInput::Param { .. } => None,
+            })
+            .collect()
     }
 
     /// Het zaakkenmerk-sjabloon: sluitende accolades, minstens één verwijzing,
@@ -809,11 +1081,159 @@ mod tests {
     }
 
     #[test]
-    fn een_input_zonder_vorm_noemt_de_twee_vormen() {
+    fn een_input_zonder_vorm_noemt_de_drie_vormen() {
         let err = input("{}\n").expect_err("een input zonder vorm hoort te falen");
         assert!(
-            err.contains("`from_chronicle`") && err.contains("`param`"),
-            "de melding moet vertellen welke twee vormen er zijn, kreeg: {err}"
+            err.contains("`from_chronicle`")
+                && err.contains("`param`")
+                && err.contains("`accept_from`"),
+            "de melding moet vertellen welke vormen er zijn, kreeg: {err}"
+        );
+    }
+
+    #[test]
+    fn een_input_die_van_een_andere_cel_geaccepteerd_wordt_wordt_gelezen() {
+        let parsed = input(
+            "accept_from: belastingdienst\nlexostatus: toetsingsinkomen\n\
+             field: toetsingsinkomen\nparams:\n  bsn: $bsn\n",
+        )
+        .unwrap_or_else(|e| panic!("de accepteervorm moet gelezen worden: {e}"));
+        assert_eq!(
+            parsed,
+            BesluitInput::AcceptFrom {
+                cell: "belastingdienst".to_string(),
+                lexostatus: "toetsingsinkomen".to_string(),
+                field: "toetsingsinkomen".to_string(),
+                params: BTreeMap::from([("bsn".to_string(), "$bsn".to_string())]),
+            }
+        );
+        assert_eq!(parsed.accepts_from(), Some("belastingdienst"));
+    }
+
+    #[test]
+    fn accepteren_zonder_lexostatus_wordt_geweigerd() {
+        // Een cel is alleen te bevragen langs een naam die ze publiceert; zonder
+        // die naam is er geen vraag om te stellen.
+        let err = input("accept_from: belastingdienst\nfield: toetsingsinkomen\n")
+            .expect_err("zonder `lexostatus` hoort het te falen");
+        assert!(
+            err.contains("`lexostatus`") && err.contains("belastingdienst"),
+            "de melding moet zeggen wat er mist en bij wie, kreeg: {err}"
+        );
+    }
+
+    #[test]
+    fn accepteren_zonder_veld_wordt_geweigerd() {
+        let err = input("accept_from: belastingdienst\nlexostatus: toetsingsinkomen\n")
+            .expect_err("zonder `field` hoort het te falen");
+        assert!(
+            err.contains("`field`"),
+            "de melding moet `field` noemen, kreeg: {err}"
+        );
+    }
+
+    /// Een `lexostatus` naast een `param` leest als een vraag over de celgrens en
+    /// is er geen. Stil laten liggen zou een input opleveren die iets anders doet
+    /// dan er staat.
+    #[test]
+    fn een_veld_van_een_andere_vorm_wordt_geweigerd() {
+        let err = input("param: bsn\nlexostatus: toetsingsinkomen\n")
+            .expect_err("een veld van een andere vorm hoort te falen");
+        assert!(
+            err.contains("`lexostatus`") && err.contains("param"),
+            "de melding moet zeggen welk veld niet bij welke vorm hoort, kreeg: {err}"
+        );
+    }
+
+    #[test]
+    fn accepteren_van_de_eigen_cel_wordt_geweigerd() {
+        let mut definition = definition("zorgtoeslag/{bsn}");
+        definition.inputs.insert(
+            "toetsingsinkomen".to_string(),
+            BesluitInput::AcceptFrom {
+                cell: "toeslagen".to_string(),
+                lexostatus: "toetsingsinkomen".to_string(),
+                field: "toetsingsinkomen".to_string(),
+                params: BTreeMap::new(),
+            },
+        );
+
+        let err = definition
+            .validate_input(
+                "toeslagen",
+                &surface_met_uitkomst(&[], "heeft_recht_op_zorgtoeslag"),
+                "toetsingsinkomen",
+                &definition.inputs["toetsingsinkomen"],
+            )
+            .expect_err("de eigen cel is geen peer");
+        assert!(
+            matches!(err, SimulatorError::AcceptFromSelf { .. }),
+            "verwachtte AcceptFromSelf, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn een_verwijzing_in_de_parameters_van_een_accepteervraag_moet_gedocumenteerd_zijn() {
+        let definition = definition("zorgtoeslag/{bsn}");
+        let origin = BesluitInput::AcceptFrom {
+            cell: "belastingdienst".to_string(),
+            lexostatus: "toetsingsinkomen".to_string(),
+            field: "toetsingsinkomen".to_string(),
+            params: BTreeMap::from([("bsn".to_string(), "$burgerservicenummer".to_string())]),
+        };
+
+        let err = definition
+            .validate_input(
+                "toeslagen",
+                &surface_met_uitkomst(&[], "heeft_recht_op_zorgtoeslag"),
+                "toetsingsinkomen",
+                &origin,
+            )
+            .expect_err("een verwijzing zonder gedocumenteerde parameter hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownReference { .. }),
+            "verwachtte UnknownReference, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn de_verzoeken_van_een_besluit_vullen_hun_verwijzingen_in() {
+        let mut definition = definition("zorgtoeslag/{bsn}");
+        definition.inputs.insert(
+            "toetsingsinkomen".to_string(),
+            BesluitInput::AcceptFrom {
+                cell: "belastingdienst".to_string(),
+                lexostatus: "toetsingsinkomen".to_string(),
+                field: "toetsingsinkomen".to_string(),
+                params: BTreeMap::from([("bsn".to_string(), "$bsn".to_string())]),
+            },
+        );
+        definition.inputs.insert(
+            "is_verzekerde".to_string(),
+            BesluitInput::Param {
+                param: "bsn".to_string(),
+            },
+        );
+
+        let params = BTreeMap::from([
+            ("bsn".to_string(), Value::String("999993653".to_string())),
+            ("jaar".to_string(), Value::String("2024".to_string())),
+        ]);
+        let requests = definition.acceptance_requests(&params);
+
+        assert_eq!(
+            requests,
+            vec![AcceptanceRequest {
+                input: "toetsingsinkomen".to_string(),
+                cell: "belastingdienst".to_string(),
+                lexostatus: "toetsingsinkomen".to_string(),
+                field: "toetsingsinkomen".to_string(),
+                params: BTreeMap::from([(
+                    "bsn".to_string(),
+                    Value::String("999993653".to_string())
+                )]),
+            }],
+            "alleen de accepteervorm levert een verzoek, met de waarde erin"
         );
     }
 

--- a/packages/simulator/src/cell/config.rs
+++ b/packages/simulator/src/cell/config.rs
@@ -42,6 +42,46 @@ pub struct CellConfig {
     /// via een reductie over de eigen kroniek.
     #[serde(default)]
     pub besluit_definitions: Vec<BesluitDefinition>,
+    /// De cellen die de **wetten** van deze cel aanwijzen, en hoe daar te
+    /// vragen (tier 3 van RFC-022 §4.2).
+    ///
+    /// Dit is de andere manier waarop een cel aan een waarde van een ander komt.
+    /// Bij `accept_from` zegt de besluit-definitie het; hier zegt de wet het, met
+    /// een `source.regulation` die geen regeling is maar een cel-id. De engine
+    /// bereikt zo'n bron alleen langs een geregistreerde resolver, en alleen voor
+    /// de cel-ids die hier staan: een cel die niet gedeclareerd is, kan niet per
+    /// ongeluk bevraagd worden.
+    ///
+    /// Waarom dit niet uit de wet te lezen is: de wet noemt een cel-id en een
+    /// uitkomstnaam, maar wat die naam bij de bevraagde cel is — welke
+    /// gepubliceerde lexostatus, en welke uitkomst daarvan — is een afspraak
+    /// tussen twee organisaties en geen eigenschap van het recht.
+    #[serde(default)]
+    pub accepts_from: Vec<AcceptedSource>,
+}
+
+/// Eén afspraak over een cel-bron van de wetten van deze cel (tier 3).
+///
+/// Leest als: *noemt een van mijn wetten `source.regulation: <cell>` voor
+/// uitkomst `<output>`, dan vraag ik daarvoor lexostatus `<lexostatus>` bij die
+/// cel en neem ik uitkomst `<field>` van het antwoord.*
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AcceptedSource {
+    /// Het cel-id zoals de wet het in `source.regulation` noemt.
+    pub cell: String,
+    /// De uitkomstnaam die de wet vraagt: `source.output`, of — als de wet die
+    /// niet noemt — de naam van de input zelf. Dat is precies wat de engine aan
+    /// de resolver doorgeeft.
+    pub output: String,
+    /// De gepubliceerde lexostatus waarmee die uitkomst bij de peer op te vragen
+    /// is.
+    pub lexostatus: String,
+    /// De uitkomst van die lexostatus die de waarde draagt.
+    pub field: String,
+    /// Vrije toelichting; verschijnt nergens in een antwoord.
+    #[serde(default)]
+    pub doc: Option<String>,
 }
 
 /// Eén gepubliceerde lexostatus met haar gedocumenteerde parameters en reductie.
@@ -679,7 +719,7 @@ pub(crate) fn engine_parameters(
 }
 
 /// `"$bsn"` → `Some("bsn")`; alles zonder `$` is een letterlijke waarde.
-fn binding_name(binding: &str) -> Option<&str> {
+pub(crate) fn binding_name(binding: &str) -> Option<&str> {
     binding.strip_prefix('$')
 }
 

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -148,6 +148,14 @@ pub struct Cell {
     /// Het is de afspraak die de wereld nodig heeft om een tier-3-verwijzing bij
     /// de juiste lexostatus van de juiste peer uit te laten komen.
     accepts_from: BTreeMap<(String, String), AcceptedSource>,
+    /// Elke naam die de wetten van deze cel in een `source.regulation` noemen en
+    /// die geen regeling is die zij zelf laadt.
+    ///
+    /// Niet om er iets mee te bereiken — dat kan de cel niet — maar om een
+    /// engine-melding te kunnen plaatsen. "Regeling niet gevonden" over een naam
+    /// die in de eigen wet staat, stuurt de lezer naar een corpusbestand terwijl
+    /// er een afspraak mist; zie [`Self::explain_undeclared_source`].
+    foreign_sources: BTreeSet<String>,
 }
 
 impl Cell {
@@ -259,7 +267,10 @@ impl Cell {
             }
         }
 
-        let accepts_from = check_accepted_sources(config, service.as_ref())?;
+        let CellSources {
+            declared: accepts_from,
+            foreign: foreign_sources,
+        } = check_accepted_sources(config, service.as_ref())?;
 
         Ok(Self {
             id: config.id.clone(),
@@ -269,6 +280,7 @@ impl Cell {
             published,
             besluiten,
             accepts_from,
+            foreign_sources,
         })
     }
 
@@ -464,6 +476,32 @@ impl Cell {
         error.into()
     }
 
+    /// Vertaal "onbekende regeling" naar "die naam staat in je eigen wet" waar dat
+    /// zo is.
+    ///
+    /// Het tegenhanger van [`Self::explain_reach`], voor het besluit-pad. Daar
+    /// gaat het om een cel die de cel-tier wél bereikt maar de reductie niet; hier
+    /// om een naam die de cel-tier helemaal niet bereikt, omdat `accepts_from`
+    /// haar niet declareert. De engine noemt dat een ontbrekende regeling, wat de
+    /// lezer een corpusbestand laat zoeken dat er niet hoort te zijn.
+    fn explain_undeclared_source(
+        &self,
+        definition: &BesluitDefinition,
+        error: regelrecht_engine::EngineError,
+    ) -> SimulatorError {
+        if let regelrecht_engine::EngineError::LawNotFound(name) = &error {
+            let declared = self.accepts_from.keys().any(|(cell, _)| cell == name);
+            if !declared && self.foreign_sources.contains(name) {
+                return SimulatorError::UndeclaredCellSource {
+                    cell: self.id.clone(),
+                    besluit: definition.name.clone(),
+                    name: name.clone(),
+                };
+            }
+        }
+        error.into()
+    }
+
     /// Zet de eigen feiten zoals ze op dit moment waren klaar als databron.
     ///
     /// De stroom met decretogrammen blijft er met opzet buiten. Een besluit is
@@ -641,6 +679,14 @@ impl Cell {
     /// haalt de antwoorden op en geeft ze aan [`Self::decide`] terug. Dat die
     /// twee stappen buiten de cel bij elkaar komen, is geen omweg maar de vorm
     /// van RFC-022 §2.
+    ///
+    /// Dat die splitsing de weigeringen van [`Self::decide`] niet mag verschuiven,
+    /// is de reden dat het zaakkenmerk hier al langskomt. Een vraag over een
+    /// celgrens is bij de bevraagde organisatie een gebeurtenis — zij ziet wie er
+    /// iets over wie kwam opvragen — en die hoort niet te vallen voor een besluit
+    /// dat om zijn eigen kenmerk toch al niet genomen kan worden. Zonder deze
+    /// regel zou de orde van `decide` ("eerst het kenmerk, dan ophalen en
+    /// rekenen") wél in de cel staan en niet meer gelden.
     pub(crate) fn acceptance_requests(
         &self,
         besluit: &str,
@@ -648,6 +694,7 @@ impl Cell {
     ) -> Result<Vec<AcceptanceRequest>> {
         let definition = self.definition(besluit)?;
         definition.check_params(&self.id, params)?;
+        definition.zaakkenmerk(&self.id, params)?;
         Ok(definition.acceptance_requests(params))
     }
 
@@ -832,12 +879,14 @@ impl Cell {
             .collect();
         let calculation_date = op_moment.format("%Y-%m-%d").to_string();
         let recorded: Vec<&str> = definition.recorded_outputs().into_iter().collect();
-        let result = service.evaluate_law(
-            &definition.regulation,
-            &recorded,
-            engine_params.clone(),
-            &calculation_date,
-        )?;
+        let result = service
+            .evaluate_law(
+                &definition.regulation,
+                &recorded,
+                engine_params.clone(),
+                &calculation_date,
+            )
+            .map_err(|error| self.explain_undeclared_source(definition, error))?;
 
         let requested: Vec<String> = recorded.iter().map(|name| (*name).to_string()).collect();
         let receipt = service.build_receipt_with_outputs(
@@ -1008,10 +1057,14 @@ fn build_service(documents: &[String]) -> Result<Option<LawExecutionService>> {
 ///   voor de cel zou anders door de gelijknamige regeling beantwoord worden;
 /// - **twee afspraken over dezelfde `(cel, uitkomst)`**, want dan beslist de
 ///   volgorde in het bestand welke lexostatus gevraagd wordt.
+///
+/// Geeft naast de afspraken op sleutel ook de namen terug die de wetten aanwijzen
+/// en die de cel niet laadt. Die lijst is wat een engine-melding over een
+/// "onbekende regeling" van een verdwaalde naam kan onderscheiden.
 fn check_accepted_sources(
     config: &CellConfig,
     service: Option<&LawExecutionService>,
-) -> Result<BTreeMap<(String, String), AcceptedSource>> {
+) -> Result<CellSources> {
     let asked = service
         .map(|service| cell_sources_in_laws(service, &config.laws))
         .unwrap_or_default();
@@ -1045,7 +1098,26 @@ fn check_accepted_sources(
             });
         }
     }
-    Ok(sources)
+
+    Ok(CellSources {
+        foreign: asked.into_iter().map(|(cell, _)| cell).collect(),
+        declared: sources,
+    })
+}
+
+/// Wat de wetten van een cel buiten zichzelf aanwijzen, en wat daarover is
+/// afgesproken.
+///
+/// De twee horen bij elkaar: de afspraken zijn een deelverzameling van wat de
+/// wetten vragen, en alleen samen kunnen ze een engine-melding over een onbekende
+/// naam plaatsen.
+struct CellSources {
+    /// De afspraken uit `accepts_from`, op `(cel, uitkomst)` zoals de engine
+    /// ernaar vraagt.
+    declared: BTreeMap<(String, String), AcceptedSource>,
+    /// Elke naam die de wetten in een `source.regulation` noemen en die de cel
+    /// niet zelf laadt — met en zonder afspraak.
+    foreign: BTreeSet<String>,
 }
 
 /// De `(cel, uitkomst)`-paren die de wetten van deze cel bij een **andere cel**

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -13,8 +13,14 @@
 //!   berekening over de eigen kronieken met de eigen wetten, zonder enige weg
 //!   naar een andere cel;
 //! - **besluiten** (`Cell::decide`) is intern: de cel voert een eigen regeling
-//!   uit en legt de uitkomst vast als decretogram. Dit is het pad waar straks
-//!   een waarde van een andere cel binnenkomt, en het enige.
+//!   uit en legt de uitkomst vast als decretogram. Dit is het enige pad waar een
+//!   waarde van een andere cel binnenkomt — *geaccepteerd*, met haar herkomst in
+//!   het gram (invariant I5).
+//!
+//! Ook op dat tweede pad reikt de cel niet zelf over haar grens. Ze zegt wat ze
+//! van een ander nodig heeft ([`Cell::acceptance_requests`]) en krijgt het
+//! aangereikt; het ophalen gebeurt buiten de cel, want een veiligheidscontext en
+//! een transport houdt ze niet. Zie `accept.rs` en [`crate::World::decide`].
 //!
 //! Zie [`Decretogram`] voor wat een besluit vastlegt, en waarom dat het
 //! RFC-013 Execution Receipt is en geen eigen formaat ernaast.
@@ -24,21 +30,25 @@ mod chronicle;
 mod config;
 
 pub use besluit::{
-    BesluitDefinition, BesluitInput, Decretogram, DecretogramInput, InputOrigin, BESCHIKKINGEN,
+    AcceptanceRequest, BesluitDefinition, BesluitInput, Decretogram, DecretogramInput, InputOrigin,
+    BESCHIKKINGEN,
 };
 pub use chronicle::{ChronicleEvent, ChronicleStore, ChronicleStream, Intake};
-pub use config::{CellConfig, DocumentedParameter, LexostatusDefinition, ParameterType, Reduction};
+pub use config::{
+    AcceptedSource, CellConfig, DocumentedParameter, LexostatusDefinition, ParameterType, Reduction,
+};
 
 use crate::corpus;
 use crate::error::{Result, SimulatorError, Subject};
 use chrono::NaiveDate;
 use config::{engine_parameters, CellSurface};
 use regelrecht_engine::article::CompetentAuthority;
-use regelrecht_engine::{ArticleBasedLaw, LawExecutionService, Value};
+use regelrecht_engine::{ArticleBasedLaw, CellResolver, LawExecutionService, Value};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 use std::path::Path;
+use std::rc::Rc;
 
 /// Het antwoord van een cel: de rechtstoestand vanuit een gevraagd perspectief,
 /// op de feiten die in die cel bekend zijn.
@@ -117,13 +127,11 @@ pub struct Cell {
     /// De **tweede** engine over dezelfde wetten: die van het besluit-pad.
     ///
     /// Twee instanties en niet één, omdat ze niet hetzelfde mogen. De engine van
-    /// [`Self::reduce`] krijgt nooit een `CellResolver` en kan de celgrens dus
+    /// [`Self::reduce`] krijgt nooit een [`CellResolver`] en kan de celgrens dus
     /// niet over: een cross-cel-pull vanuit een reductie is daarmee een
     /// ontbrekende capability en geen afspraak (RFC-022 §4.2, tier 3). Deze is
-    /// de enige die er ooit een mag krijgen. Vandaag heeft ook zij er geen — het
-    /// accepteren van een waarde van een andere cel volgt apart — dus het
-    /// verschil is nu een *belofte over wie wat mag*, en de plek waar die
-    /// belofte waargemaakt wordt, staat klaar.
+    /// de enige die er een krijgt, en alleen voor de duur van één besluit — zie
+    /// [`Self::decide`].
     ///
     /// Alleen aanwezig als de cel besluit-definities heeft: een cel die niet
     /// besluit, heeft aan één engine genoeg.
@@ -134,6 +142,12 @@ pub struct Cell {
     published: BTreeMap<String, LexostatusDefinition>,
     /// De besluiten die deze cel kan nemen, op naam.
     besluiten: BTreeMap<String, BesluitDefinition>,
+    /// De cel-bronnen van haar wetten (tier 3), op `(cel, uitkomst)`.
+    ///
+    /// Wat de cel hiermee doet is niets: ze kan geen van deze cellen bereiken.
+    /// Het is de afspraak die de wereld nodig heeft om een tier-3-verwijzing bij
+    /// de juiste lexostatus van de juiste peer uit te laten komen.
+    accepts_from: BTreeMap<(String, String), AcceptedSource>,
 }
 
 impl Cell {
@@ -245,6 +259,8 @@ impl Cell {
             }
         }
 
+        let accepts_from = check_accepted_sources(config, service.as_ref())?;
+
         Ok(Self {
             id: config.id.clone(),
             service: service.map(RefCell::new),
@@ -252,7 +268,17 @@ impl Cell {
             chronicles,
             published,
             besluiten,
+            accepts_from,
         })
+    }
+
+    /// De cel-bronnen die de wetten van deze cel aanwijzen (tier 3).
+    ///
+    /// `pub(crate)`: dit is geen weg naar een andere cel — de cel heeft er geen
+    /// — maar de afspraak die de wereld uitvoert als de engine tijdens een
+    /// besluit om zo'n waarde vraagt.
+    pub(crate) fn accepts_from(&self) -> impl Iterator<Item = &AcceptedSource> {
+        self.accepts_from.values()
     }
 
     /// Leg één executogram vast in een eigen kroniekstroom.
@@ -399,16 +425,43 @@ impl Cell {
         let mut service = service.borrow_mut();
         self.register_own_facts(&mut service, op_moment)?;
 
-        let result = service.evaluate_law_output(
-            regulation,
-            output,
-            engine_parameters(parameters, params),
-            &op_moment.format("%Y-%m-%d").to_string(),
-        )?;
+        let result = service
+            .evaluate_law_output(
+                regulation,
+                output,
+                engine_parameters(parameters, params),
+                &op_moment.format("%Y-%m-%d").to_string(),
+            )
+            .map_err(|error| self.explain_reach(definition, error))?;
 
         Ok(LexostatusOutcome::Established(
             definition.project(result.outputs),
         ))
+    }
+
+    /// Vertaal "onbekende regeling" naar "die naam is een cel" waar dat zo is.
+    ///
+    /// De reduce-engine heeft geen cel-tier, dus een `source.regulation` die een
+    /// cel aanwijst is voor haar een regeling die ze niet kent — en dat is
+    /// letterlijk waar, maar het verbergt wat er gebeurde. De cel weet wél dat
+    /// die naam een peer is (haar configuratie zegt het), dus ze kan de melding
+    /// geven die de lezer nodig heeft: hier reikt een reductie buiten haar cel,
+    /// en dat kan niet.
+    fn explain_reach(
+        &self,
+        definition: &LexostatusDefinition,
+        error: regelrecht_engine::EngineError,
+    ) -> SimulatorError {
+        if let regelrecht_engine::EngineError::LawNotFound(name) = &error {
+            if self.accepts_from.keys().any(|(cell, _)| cell == name) {
+                return SimulatorError::ReductionReachesOutsideCell {
+                    cell: self.id.clone(),
+                    lexostatus: definition.name.clone(),
+                    peer: name.clone(),
+                };
+            }
+        }
+        error.into()
     }
 
     /// Zet de eigen feiten zoals ze op dit moment waren klaar als databron.
@@ -431,6 +484,37 @@ impl Cell {
             }
             service.register_dict_source(&stream.stream, &stream.key, stream.records)?;
         }
+        Ok(())
+    }
+
+    /// Geef de besluit-engine de cel-tier, voor de duur van dit ene besluit.
+    ///
+    /// De resolver komt van buiten en wordt hier alleen doorgegeven: de cel
+    /// bouwt hem niet en kan hem niet bevragen. Wat ze wél bepaalt, is *voor
+    /// welke cel-ids* hij bereikbaar is — precies de bronnen die haar eigen
+    /// wetten noemen en die haar configuratie heeft uitgewerkt. Een cel-id
+    /// daarbuiten blijft voor de engine een onbekende regeling en dus een fout,
+    /// en dat is invariant I3 als capability in plaats van als afspraak.
+    ///
+    /// Zonder gedeclareerde bronnen gebeurt er niets: dan is er geen cel-tier en
+    /// gedraagt de besluit-engine zich als de reduce-engine.
+    fn grant_cell_tier(
+        &self,
+        service: &mut LawExecutionService,
+        resolver: Option<Rc<dyn CellResolver>>,
+    ) -> Result<()> {
+        let Some(resolver) = resolver else {
+            return Ok(());
+        };
+        let ids: BTreeSet<&str> = self
+            .accepts_from
+            .values()
+            .map(|source| source.cell.as_str())
+            .collect();
+        if ids.is_empty() {
+            return Ok(());
+        }
+        service.set_cell_resolver(ids, resolver)?;
         Ok(())
     }
 
@@ -517,13 +601,60 @@ impl Cell {
     /// Een input die op dit moment niet op te halen is, is een fout en geen
     /// "niets vastgesteld": een besluit dat een feit mist, hoort niet met een gat
     /// verder te rekenen en al helemaal niet vast te leggen.
+    ///
+    /// `accepted` zijn de waarden die de cel van een andere cel *accepteert*:
+    /// zij vraagt ze niet zelf op (ze houdt geen veiligheidscontext en geen
+    /// transport), ze krijgt ze aangereikt voor precies de inputs die haar
+    /// definitie met `accept_from` aanwijst — zie [`Self::acceptance_requests`].
+    /// `resolver` is dezelfde weg, maar voor de verwijzingen die *de wet* legt
+    /// (tier 3): de besluit-engine krijgt hem voor de duur van dit ene besluit,
+    /// en de reduce-engine nooit.
     pub(crate) fn decide(
         &mut self,
         besluit: &str,
         params: &BTreeMap<String, Value>,
         op_moment: NaiveDate,
+        accepted: &BTreeMap<String, DecretogramInput>,
+        resolver: Option<Rc<dyn CellResolver>>,
     ) -> Result<Decretogram> {
-        let definition = self
+        let definition = self.definition(besluit)?;
+
+        definition.check_params(&self.id, params)?;
+        // Vóór het ophalen en het rekenen: een zaak waarvan het kenmerk niet
+        // eenduidig is, hoort er helemaal niet te komen — en dan hoeft de engine
+        // er ook niet voor te draaien.
+        let zaakkenmerk = definition.zaakkenmerk(&self.id, params)?;
+
+        let inputs = self.collect_inputs(&definition, params, accepted, op_moment)?;
+        let decretogram = self.execute(&definition, zaakkenmerk, inputs, resolver, op_moment)?;
+
+        let event = decretogram.event()?;
+        self.record_own(BESCHIKKINGEN, event)?;
+
+        Ok(decretogram)
+    }
+
+    /// Wat dit besluit bij een andere cel moet ophalen voordat het kan rekenen.
+    ///
+    /// De cel stelt de vragen samen en stelt ze niet: ze kan geen andere cel
+    /// bereiken. Wie dat wel kan — in deze opstelling [`crate::World::decide`] —
+    /// haalt de antwoorden op en geeft ze aan [`Self::decide`] terug. Dat die
+    /// twee stappen buiten de cel bij elkaar komen, is geen omweg maar de vorm
+    /// van RFC-022 §2.
+    pub(crate) fn acceptance_requests(
+        &self,
+        besluit: &str,
+        params: &BTreeMap<String, Value>,
+    ) -> Result<Vec<AcceptanceRequest>> {
+        let definition = self.definition(besluit)?;
+        definition.check_params(&self.id, params)?;
+        Ok(definition.acceptance_requests(params))
+    }
+
+    /// Eén besluit-definitie van deze cel, of een nette fout die opsomt wat de
+    /// cel wél kan besluiten.
+    fn definition(&self, besluit: &str) -> Result<BesluitDefinition> {
+        Ok(self
             .besluiten
             .get(besluit)
             .ok_or_else(|| SimulatorError::UnknownBesluit {
@@ -536,21 +667,7 @@ impl Cell {
                     .collect::<Vec<_>>()
                     .join(", "),
             })?
-            .clone();
-
-        definition.check_params(&self.id, params)?;
-        // Vóór het ophalen en het rekenen: een zaak waarvan het kenmerk niet
-        // eenduidig is, hoort er helemaal niet te komen — en dan hoeft de engine
-        // er ook niet voor te draaien.
-        let zaakkenmerk = definition.zaakkenmerk(&self.id, params)?;
-
-        let inputs = self.collect_inputs(&definition, params, op_moment)?;
-        let decretogram = self.execute(&definition, zaakkenmerk, inputs, op_moment)?;
-
-        let event = decretogram.event()?;
-        self.record_own(BESCHIKKINGEN, event)?;
-
-        Ok(decretogram)
+            .clone())
     }
 
     /// Verzamel de inputs van een besluit, elk met de herkomst erbij.
@@ -563,11 +680,32 @@ impl Cell {
         &self,
         definition: &BesluitDefinition,
         params: &BTreeMap<String, Value>,
+        accepted: &BTreeMap<String, DecretogramInput>,
         op_moment: NaiveDate,
     ) -> Result<BTreeMap<String, DecretogramInput>> {
         let mut collected: BTreeMap<String, DecretogramInput> = BTreeMap::new();
         for (input, origin) in &definition.inputs {
             let gathered = match origin {
+                BesluitInput::AcceptFrom {
+                    cell, lexostatus, ..
+                } => {
+                    // Onbereikbaar langs `World::decide`, dat elk verzoek uit
+                    // `acceptance_requests` inwilligt voordat het hier komt. Een
+                    // ontbrekend antwoord mag hier nooit stil een gat worden: dan
+                    // zou de engine op `null` rekenen en zou er een besluit
+                    // liggen dat een feit mist.
+                    accepted.get(input).cloned().ok_or_else(|| {
+                        SimulatorError::BesluitInputMissing {
+                            cell: self.id.clone(),
+                            besluit: definition.name.clone(),
+                            input: input.clone(),
+                            reason: format!(
+                                "lexostatus '{lexostatus}' van cel '{cell}' is voor dit \
+                                 besluit niet opgehaald"
+                            ),
+                        }
+                    })?
+                }
                 BesluitInput::Param { param } => {
                     // Onbereikbaar: `validate` bindt elke `param` aan een
                     // gedocumenteerde parameter, en `check_params` eist dat elke
@@ -670,6 +808,7 @@ impl Cell {
         definition: &BesluitDefinition,
         zaakkenmerk: String,
         inputs: BTreeMap<String, DecretogramInput>,
+        resolver: Option<Rc<dyn CellResolver>>,
         op_moment: NaiveDate,
     ) -> Result<Decretogram> {
         // Onbereikbaar: `validate` weigert een besluit over een regeling die de
@@ -685,6 +824,7 @@ impl Cell {
 
         let mut service = service.borrow_mut();
         self.register_own_facts(&mut service, op_moment)?;
+        self.grant_cell_tier(&mut service, resolver)?;
 
         let engine_params: BTreeMap<String, Value> = inputs
             .iter()
@@ -855,6 +995,95 @@ fn build_service(documents: &[String]) -> Result<Option<LawExecutionService>> {
     Ok(Some(service))
 }
 
+/// Controleer de cel-bronnen van een configuratie en zet ze op sleutel.
+///
+/// Drie weigeringen, alle drie bij het optuigen en niet pas bij het eerste
+/// besluit:
+///
+/// - een bron die **geen van de eigen wetten noemt**. Dan zou de cel een peer
+///   mogen bevragen zonder dat haar recht daar ooit om vraagt, en dat is precies
+///   het vraaggraf dat invariant I3 uitsluit;
+/// - een cel-id dat **een eigen regeling overschaduwt**. De engine weigert dat
+///   ook (RFC-022 §4.2), maar pas bij het registreren van de resolver: een vraag
+///   voor de cel zou anders door de gelijknamige regeling beantwoord worden;
+/// - **twee afspraken over dezelfde `(cel, uitkomst)`**, want dan beslist de
+///   volgorde in het bestand welke lexostatus gevraagd wordt.
+fn check_accepted_sources(
+    config: &CellConfig,
+    service: Option<&LawExecutionService>,
+) -> Result<BTreeMap<(String, String), AcceptedSource>> {
+    let asked = service
+        .map(|service| cell_sources_in_laws(service, &config.laws))
+        .unwrap_or_default();
+
+    let mut sources: BTreeMap<(String, String), AcceptedSource> = BTreeMap::new();
+    for source in &config.accepts_from {
+        if config.laws.iter().any(|law| law == &source.cell) {
+            return Err(SimulatorError::CellShadowsRegulation {
+                cell: config.id.clone(),
+                peer: source.cell.clone(),
+            });
+        }
+        let key = (source.cell.clone(), source.output.clone());
+        if !asked.contains(&key) {
+            return Err(SimulatorError::UnclaimedCellSource {
+                cell: config.id.clone(),
+                peer: source.cell.clone(),
+                output: source.output.clone(),
+                asked: asked
+                    .iter()
+                    .map(|(cell, output)| format!("{cell}.{output}"))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            });
+        }
+        if sources.insert(key, source.clone()).is_some() {
+            return Err(SimulatorError::DuplicateCellSource {
+                cell: config.id.clone(),
+                peer: source.cell.clone(),
+                output: source.output.clone(),
+            });
+        }
+    }
+    Ok(sources)
+}
+
+/// De `(cel, uitkomst)`-paren die de wetten van deze cel bij een **andere cel**
+/// halen: elke `source.regulation` die geen regeling is die de cel zelf laadt.
+///
+/// Dat is dezelfde lezing als de engine hanteert (RFC-022 §4.2): een
+/// `source.regulation` wijst een producent aan, en of dat een regeling of een
+/// organisatie is, blijkt uit wat er geladen is. De uitkomstnaam is
+/// `source.output`, of — als de wet die niet noemt — de naam van de input zelf,
+/// precies wat de engine aan een resolver doorgeeft.
+fn cell_sources_in_laws(
+    service: &LawExecutionService,
+    own_laws: &[String],
+) -> BTreeSet<(String, String)> {
+    let mut sources = BTreeSet::new();
+    for law in service.resolver().all_law_versions() {
+        for article in &law.articles {
+            let Some(execution) = article.get_execution_spec() else {
+                continue;
+            };
+            for input in execution.input.iter().flatten() {
+                let Some(source) = input.source.as_ref() else {
+                    continue;
+                };
+                let Some(regulation) = source.regulation.as_ref() else {
+                    continue;
+                };
+                if own_laws.iter().any(|law| law == regulation) {
+                    continue;
+                }
+                let output = source.output.clone().unwrap_or_else(|| input.name.clone());
+                sources.insert((regulation.clone(), output));
+            }
+        }
+    }
+    sources
+}
+
 /// De namen die een regeling als parameter of input declareert, over alle
 /// geladen versies heen.
 ///
@@ -915,6 +1144,13 @@ mod tests {
     /// Geen fixtures: deze tests tuigen een cel rechtstreeks op, buiten een
     /// wereld om, dus er is niets dat een stroom extra velden aanreikt.
     fn no_fixtures() -> BTreeMap<String, BTreeSet<String>> {
+        BTreeMap::new()
+    }
+
+    /// Geen geaccepteerde waarden: deze besluiten vragen niemand iets. Buiten
+    /// een wereld om is er ook niemand die een vraag over de grens kan zetten —
+    /// een cel kan dat zelf niet, en dat is het punt.
+    fn no_accepted() -> BTreeMap<String, DecretogramInput> {
         BTreeMap::new()
     }
 
@@ -1350,6 +1586,95 @@ lexostatus_definitions:
         );
     }
 
+    /// Een cel die één testregeling laadt, met de meegegeven `accepts_from`.
+    ///
+    /// De regeling staat in `fixtures/regulation/` en niet in het corpus: ze
+    /// bestaat om een eigenschap van de opstelling te tonen (een
+    /// `source.regulation` die een cel aanwijst), en dat is geen recht.
+    fn toets_cel(accepts_from: &str) -> Result<Cell> {
+        let config = config(&format!(
+            r"
+id: toeslagen
+laws:
+  - test_partnerschapstoets
+{accepts_from}
+"
+        ));
+        Cell::from_config(&config, &regulation_root(), &no_fixtures())
+    }
+
+    #[test]
+    fn een_cel_bron_die_de_wet_noemt_wordt_geaccepteerd() {
+        toets_cel(
+            "accepts_from:
+  - cell: brp
+    output: partnerschap
+    lexostatus: partnerschap
+    field: partnerschap_type",
+        )
+        .unwrap_or_else(|e| panic!("deze afspraak hoort bij wat de wet vraagt: {e}"));
+    }
+
+    /// Een cel bevraagt alleen de cellen die haar eigen wetten noemen (I3). Een
+    /// afspraak daarbuiten zet een vraaggraf open waar het recht niet om vraagt.
+    #[test]
+    fn een_cel_bron_die_geen_wet_noemt_wordt_geweigerd() {
+        let err = toets_cel(
+            "accepts_from:
+  - cell: kadaster
+    output: eigendom
+    lexostatus: eigendom
+    field: is_eigenaar",
+        )
+        .expect_err("een bron die geen wet aanwijst hoort te falen");
+        let SimulatorError::UnclaimedCellSource { asked, .. } = &err else {
+            panic!("verwachtte UnclaimedCellSource, kreeg {err}");
+        };
+        assert!(
+            asked.contains("brp.partnerschap"),
+            "de melding hoort te zeggen waar de wetten wél om vragen, kreeg: {asked}"
+        );
+    }
+
+    #[test]
+    fn twee_afspraken_over_dezelfde_bron_worden_geweigerd() {
+        let err = toets_cel(
+            "accepts_from:
+  - cell: brp
+    output: partnerschap
+    lexostatus: partnerschap
+    field: partnerschap_type
+  - cell: brp
+    output: partnerschap
+    lexostatus: laatste_huwelijk
+    field: partnerschap_type",
+        )
+        .expect_err("twee afspraken over dezelfde bron horen te falen");
+        assert!(
+            matches!(err, SimulatorError::DuplicateCellSource { .. }),
+            "verwachtte DuplicateCellSource, kreeg {err}"
+        );
+    }
+
+    /// Een cel-id dat net zo heet als een eigen regeling zou een vraag voor de
+    /// andere organisatie door die regeling laten beantwoorden, zonder spoor. De
+    /// engine weigert dat ook; hier valt het bij het optuigen.
+    #[test]
+    fn een_cel_bron_die_een_eigen_regeling_overschaduwt_wordt_geweigerd() {
+        let err = toets_cel(
+            "accepts_from:
+  - cell: test_partnerschapstoets
+    output: partnerschap
+    lexostatus: partnerschap
+    field: partnerschap_type",
+        )
+        .expect_err("een cel-id dat een eigen regeling overschaduwt hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::CellShadowsRegulation { .. }),
+            "verwachtte CellShadowsRegulation, kreeg {err}"
+        );
+    }
+
     #[test]
     fn een_output_die_de_stroom_niet_kent_wordt_geweigerd() {
         let err = Cell::from_config(
@@ -1538,7 +1863,13 @@ besluit_definitions:
     fn een_besluit_legt_precies_een_decretogram_vast() {
         let mut cell = besluitende_toeslagen(VASTSTELLING);
         let gram = cell
-            .decide("zorgtoeslag_vaststelling", &bsn(), moment())
+            .decide(
+                "zorgtoeslag_vaststelling",
+                &bsn(),
+                moment(),
+                &no_accepted(),
+                None,
+            )
             .unwrap_or_else(|e| panic!("het besluit moet genomen kunnen worden: {e}"));
 
         assert_eq!(
@@ -1578,7 +1909,13 @@ besluit_definitions:
     fn het_decretogram_draagt_zijn_inputs_met_herkomst() {
         let mut cell = besluitende_toeslagen(VASTSTELLING);
         let gram = cell
-            .decide("zorgtoeslag_vaststelling", &bsn(), moment())
+            .decide(
+                "zorgtoeslag_vaststelling",
+                &bsn(),
+                moment(),
+                &no_accepted(),
+                None,
+            )
             .unwrap_or_else(|e| panic!("het besluit moet genomen kunnen worden: {e}"));
 
         let uit_de_kroniek = gram
@@ -1616,7 +1953,13 @@ besluit_definitions:
     fn een_besluit_zonder_zijn_feiten_faalt_en_legt_niets_vast() {
         let mut cell = besluitende_toeslagen(VASTSTELLING);
         let err = cell
-            .decide("zorgtoeslag_vaststelling", &bsn(), date("2024-01-01"))
+            .decide(
+                "zorgtoeslag_vaststelling",
+                &bsn(),
+                date("2024-01-01"),
+                &no_accepted(),
+                None,
+            )
             .expect_err("vóór de levering is er geen feit om op te besluiten");
         assert!(
             matches!(err, SimulatorError::BesluitInputMissing { .. }),
@@ -1640,8 +1983,14 @@ besluit_definitions:
     fn twee_besluiten_op_een_dag_leveren_het_laatstgenomen_besluit() {
         let mut cell = besluitende_toeslagen(VASTSTELLING);
         for _ in 0..2 {
-            cell.decide("zorgtoeslag_vaststelling", &bsn(), moment())
-                .unwrap_or_else(|e| panic!("het besluit moet genomen kunnen worden: {e}"));
+            cell.decide(
+                "zorgtoeslag_vaststelling",
+                &bsn(),
+                moment(),
+                &no_accepted(),
+                None,
+            )
+            .unwrap_or_else(|e| panic!("het besluit moet genomen kunnen worden: {e}"));
         }
 
         assert_eq!(
@@ -1673,7 +2022,13 @@ besluit_definitions:
     #[test]
     fn een_onbekend_besluit_noemt_wat_de_cel_wel_kent() {
         let err = besluitende_toeslagen(VASTSTELLING)
-            .decide("zorgtoeslag_terugvordering", &bsn(), moment())
+            .decide(
+                "zorgtoeslag_terugvordering",
+                &bsn(),
+                moment(),
+                &no_accepted(),
+                None,
+            )
             .expect_err("een besluit dat niet gedefinieerd is hoort te falen");
         let SimulatorError::UnknownBesluit { defined, .. } = &err else {
             panic!("verwachtte UnknownBesluit, kreeg {err}");
@@ -1769,8 +2124,14 @@ chronicles:
     #[test]
     fn de_eigen_besluiten_gaan_niet_als_databron_naar_de_engine() {
         let mut cell = besluitende_toeslagen(VASTSTELLING);
-        cell.decide("zorgtoeslag_vaststelling", &bsn(), moment())
-            .unwrap_or_else(|e| panic!("het besluit moet genomen kunnen worden: {e}"));
+        cell.decide(
+            "zorgtoeslag_vaststelling",
+            &bsn(),
+            moment(),
+            &no_accepted(),
+            None,
+        )
+        .unwrap_or_else(|e| panic!("het besluit moet genomen kunnen worden: {e}"));
 
         let Some(service) = &cell.service else {
             panic!("deze cel laadt wetten en heeft dus een engine");

--- a/packages/simulator/src/corpus.rs
+++ b/packages/simulator/src/corpus.rs
@@ -27,6 +27,23 @@ pub fn regulation_root() -> PathBuf {
         })
 }
 
+/// Waar de testregelingen van deze crate staan.
+///
+/// Een tweede wortel náást het corpus, met opzet klein: een scenario dat een
+/// eigenschap van de *opstelling* moet aantonen heeft soms een regeling nodig die
+/// in het corpus niet thuishoort. Tier 3 is daar het voorbeeld van — een wet met
+/// een `source.regulation` die een organisatie aanwijst in plaats van een
+/// regeling — en zo'n wet hoort niet in het echte corpus te gaan staan omdat een
+/// testopstelling haar nodig heeft.
+///
+/// Het corpus gaat vóór: een naam die daar bestaat, wordt daar geladen, dus een
+/// fixture kan geen echte regeling overschaduwen.
+fn fixture_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("fixtures")
+        .join("regulation")
+}
+
 /// Alleen de `$id` uit een regelingdocument; de rest laat de engine parseren.
 #[derive(Deserialize)]
 struct RegulationId {
@@ -36,10 +53,31 @@ struct RegulationId {
 
 /// Lees alle versies van één regeling als YAML-teksten, op pad gesorteerd.
 ///
-/// Faalt als de map niet bestaat, leeg is, of een document bevat waarvan de
-/// `$id` niet met de mapnaam overeenkomt — dan zou de cel iets anders laden dan
-/// ze denkt te laden, en dat is geen fout om stil te slikken.
+/// Zoekt eerst in het corpus en daarna in de testregelingen van deze crate
+/// ([`fixture_root`]). Faalt als geen van beide de map heeft, als ze leeg is, of
+/// als er een document in staat waarvan de `$id` niet met de mapnaam
+/// overeenkomt — dan zou de cel iets anders laden dan ze denkt te laden, en dat
+/// is geen fout om stil te slikken.
 pub(crate) fn regulation_versions(root: &Path, regulation: &str) -> Result<Vec<String>> {
+    let found = versions_under(root, regulation)?;
+    if !found.is_empty() {
+        return Ok(found);
+    }
+
+    let fixtures = fixture_root();
+    let found = versions_under(&fixtures, regulation)?;
+    if !found.is_empty() {
+        return Ok(found);
+    }
+
+    Err(SimulatorError::RegulationNotFound {
+        regulation: regulation.to_string(),
+        root: root.to_path_buf(),
+    })
+}
+
+/// Alle versies van één regeling onder één wortel; leeg als ze er niet staat.
+fn versions_under(root: &Path, regulation: &str) -> Result<Vec<String>> {
     let mut documents: Vec<(PathBuf, String)> = Vec::new();
 
     for entry in WalkDir::new(root)
@@ -77,13 +115,6 @@ pub(crate) fn regulation_versions(root: &Path, regulation: &str) -> Result<Vec<S
             }
             documents.push((path, text));
         }
-    }
-
-    if documents.is_empty() {
-        return Err(SimulatorError::RegulationNotFound {
-            regulation: regulation.to_string(),
-            root: root.to_path_buf(),
-        });
     }
 
     documents.sort_by(|(a, _), (b, _)| a.cmp(b));

--- a/packages/simulator/src/error.rs
+++ b/packages/simulator/src/error.rs
@@ -834,6 +834,33 @@ pub enum SimulatorError {
         peer: String,
     },
 
+    /// Een wet van deze cel wijst een producent aan die de cel niet laadt en ook
+    /// niet als cel-bron declareert.
+    ///
+    /// De engine zegt hier "regeling niet gevonden", en dat is letterlijk waar en
+    /// tegelijk het verkeerde spoor: de naam staat in de wet, dus wie dit leest
+    /// zoekt een ontbrekend corpusbestand terwijl er een afspraak mist. Welke van
+    /// de twee het is, weet de cel niet — een `source.regulation` zegt niet of ze
+    /// een regeling of een organisatie aanwijst (RFC-022 §4.2) — dus de melding
+    /// noemt beide uitwegen en kiest er niet één.
+    ///
+    /// Dit valt niet bij het optuigen: een besluit-definitie mag zo'n input zelf
+    /// aanleveren, en dan komt de verwijzing nooit aan bod.
+    #[error(
+        "cel '{cell}': besluit '{besluit}' voert een regeling uit die '{name}' aanwijst, \
+         maar deze cel laadt geen regeling met die naam en declareert '{name}' ook niet \
+         in `accepts_from`; laad de regeling, of leg in `accepts_from` vast welke \
+         lexostatus bij die cel gevraagd moet worden"
+    )]
+    UndeclaredCellSource {
+        /// De cel die wilde besluiten.
+        cell: String,
+        /// Het besluit dat de waarde nodig had.
+        besluit: String,
+        /// De naam uit `source.regulation` die nergens op uitkomt.
+        name: String,
+    },
+
     /// Een besluit kon een waarde niet van een andere cel accepteren.
     ///
     /// Eigen variant naast [`SimulatorError::BesluitInputMissing`], want de reden

--- a/packages/simulator/src/error.rs
+++ b/packages/simulator/src/error.rs
@@ -722,6 +722,145 @@ pub enum SimulatorError {
         known: String,
     },
 
+    /// Een besluit-definitie accepteert een input van de eigen cel.
+    ///
+    /// Voor eigen feiten is er een kroniek of een eigen wet. Zou dit mogen, dan
+    /// zou een cel zichzelf over de grens bevragen en als cross-cel-contact in
+    /// het vraaggraf komen — zie [`SimulatorError::TransportToSelf`], dezelfde
+    /// weigering een stap eerder.
+    #[error(
+        "cel '{cell}': besluit '{besluit}' accepteert input '{input}' van de eigen cel; \
+         voor eigen feiten is er een kroniek of een eigen wet"
+    )]
+    AcceptFromSelf {
+        /// De cel waarin de definitie staat.
+        cell: String,
+        /// De besluit-definitie.
+        besluit: String,
+        /// De input die zichzelf zou bevragen.
+        input: String,
+    },
+
+    /// Een cel declareert een cel-bron die geen van haar wetten aanwijst.
+    ///
+    /// Een cel bevraagt alleen de cellen die haar eigen wetten via
+    /// `source.regulation` noemen (invariant I3). Een afspraak daarbuiten zou
+    /// een vraaggraf openzetten waar het recht niet om vraagt, en dat hoort niet
+    /// pas tijdens een besluit te blijken.
+    #[error(
+        "cel '{cell}': `accepts_from` noemt '{peer}.{output}', maar geen van de eigen \
+         wetten vraagt daarom (wel: {asked})"
+    )]
+    UnclaimedCellSource {
+        /// De cel waarin de afspraak staat.
+        cell: String,
+        /// De gedeclareerde bron-cel.
+        peer: String,
+        /// De gedeclareerde uitkomst.
+        output: String,
+        /// Komma-gescheiden lijst van cel-bronnen die de wetten wél noemen.
+        asked: String,
+    },
+
+    /// Twee afspraken over dezelfde cel-bron en uitkomst.
+    #[error("cel '{cell}': `accepts_from` noemt '{peer}.{output}' twee keer")]
+    DuplicateCellSource {
+        /// De cel waarin de afspraak staat.
+        cell: String,
+        /// De bron-cel die dubbel staat.
+        peer: String,
+        /// De uitkomst die dubbel staat.
+        output: String,
+    },
+
+    /// Een gedeclareerde cel-bron heet net zo als een eigen regeling.
+    ///
+    /// Dan zou een vraag die voor de andere organisatie bedoeld is door de
+    /// gelijknamige regeling beantwoord worden, zonder spoor van de omleiding.
+    /// De engine weigert dat ook (RFC-022 §4.2); hier valt het bij het optuigen,
+    /// zodat de cel niet eerst hoeft te besluiten om het te merken.
+    #[error(
+        "cel '{cell}': `accepts_from` noemt cel '{peer}', maar die naam is ook een \
+         regeling die deze cel zelf laadt"
+    )]
+    CellShadowsRegulation {
+        /// De cel waarin de afspraak staat.
+        cell: String,
+        /// Het cel-id dat een eigen regeling overschaduwt.
+        peer: String,
+    },
+
+    /// Een cel wil accepteren van een cel die in deze wereld niet bestaat.
+    ///
+    /// Een cel kent geen andere cel, dus bij het optuigen van de cel valt dit
+    /// niet op; de wereld kent ze wel allemaal en toetst het daarom hier. Zonder
+    /// deze weigering zou een typfout in een peer-naam pas tijdens het besluit
+    /// opduiken, en dan als "transport kent geen cel" — een melding die naar het
+    /// transport wijst terwijl het bestand fout is.
+    #[error(
+        "cel '{cell}' wil {what} accepteren van cel '{peer}', maar die kent dit scenario \
+         niet (wel: {known})"
+    )]
+    UnknownAcceptedCell {
+        /// De cel die wil accepteren.
+        cell: String,
+        /// De peer die niet bestaat.
+        peer: String,
+        /// Wat er geaccepteerd zou worden, in woorden.
+        what: String,
+        /// Komma-gescheiden lijst van cellen die de wereld wél kent.
+        known: String,
+    },
+
+    /// Een reductie heeft een waarde van een andere cel nodig.
+    ///
+    /// Dit is de andere kant van de twee engine-configuraties (RFC-022 §4.2): de
+    /// reduce-engine heeft geen `CellResolver`, dus een `source.regulation` die
+    /// een cel aanwijst is voor haar een onbekende regeling. De cel reikt niet
+    /// buiten zichzelf om te kunnen antwoorden, en dat is geen gebrek maar het
+    /// hele punt — accepteren van een ander is iets wat je bij een **besluit**
+    /// doet, met herkomst in het decretogram, niet stilletjes tijdens een vraag.
+    #[error(
+        "cel '{cell}': lexostatus '{lexostatus}' heeft een waarde van cel '{peer}' nodig, \
+         maar een reductie reikt niet buiten de eigen cel; van een ander accepteren doet \
+         een cel in een besluit"
+    )]
+    ReductionReachesOutsideCell {
+        /// De cel waaraan gevraagd werd.
+        cell: String,
+        /// De lexostatus die niet te reduceren was.
+        lexostatus: String,
+        /// De cel waarvan de wet een waarde nodig had.
+        peer: String,
+    },
+
+    /// Een besluit kon een waarde niet van een andere cel accepteren.
+    ///
+    /// Eigen variant naast [`SimulatorError::BesluitInputMissing`], want de reden
+    /// ligt buiten deze cel: de bron-cel stelde niets vast, of ze publiceert de
+    /// gevraagde uitkomst niet. Het eerste is haar goed recht en geen defect —
+    /// wat er niet mag gebeuren, is doorrekenen met een gat. Het besluit valt dus
+    /// om en er wordt niets vastgelegd.
+    ///
+    /// De melding zegt wat de acceptatiecriteria vragen: welke input, van welke
+    /// cel, en waarom het niet lukte.
+    #[error(
+        "cel '{cell}': besluit '{besluit}' kon input '{input}' niet accepteren van cel \
+         '{peer}': {reason}"
+    )]
+    AcceptedInputMissing {
+        /// De cel die wilde besluiten.
+        cell: String,
+        /// Het besluit dat de input nodig had.
+        besluit: String,
+        /// De input die ontbrak.
+        input: String,
+        /// De bevraagde cel.
+        peer: String,
+        /// Waarom de waarde niet aankwam, met de lexostatus en het moment erin.
+        reason: String,
+    },
+
     /// Een cel bevraagt zichzelf via het transport.
     ///
     /// Voor de eigen feiten is er een reductie; het transport is er voor peers.

--- a/packages/simulator/src/lib.rs
+++ b/packages/simulator/src/lib.rs
@@ -29,6 +29,15 @@
 //! decretogram, dan is het antwoord "niets vastgesteld" en nooit een
 //! herberekening onder een inmiddels andere wetsversie.
 //!
+//! Een besluit mag **accepteren**: heeft het een waarde nodig die een andere
+//! organisatie vaststelt, dan wordt die opgehaald in plaats van nagerekend, en ze
+//! landt met haar herkomst in het decretogram — bron-cel, lexostatus, moment en
+//! ondertekening (invariant I5). Twee wegen, één mechanisme: `accept_from` in de
+//! besluit-definitie, of een `source.regulation` in de wet die een cel aanwijst
+//! (tier 3 van RFC-022 §4.2). Beide lopen langs de veiligheidscontext en het
+//! transport; de reduce-engine kan geen van beide, en dat is een ontbrekende
+//! capability en geen afspraak.
+//!
 //! ```no_run
 //! use regelrecht_simulator::{regulation_root, Scenario};
 //! use std::path::Path;
@@ -43,6 +52,7 @@
 
 #![deny(missing_docs)]
 
+mod accept;
 pub mod cell;
 mod corpus;
 pub mod error;
@@ -57,16 +67,17 @@ mod values;
 pub mod world;
 
 pub use cell::{
-    BesluitDefinition, BesluitInput, Cell, CellConfig, ChronicleEvent, ChronicleStore,
-    ChronicleStream, Decretogram, DecretogramInput, DocumentedParameter, InputOrigin, Intake,
-    Lexostatus, LexostatusDefinition, LexostatusOutcome, ParameterType, Reduction, BESCHIKKINGEN,
+    AcceptanceRequest, AcceptedSource, BesluitDefinition, BesluitInput, Cell, CellConfig,
+    ChronicleEvent, ChronicleStore, ChronicleStream, Decretogram, DecretogramInput,
+    DocumentedParameter, InputOrigin, Intake, Lexostatus, LexostatusDefinition, LexostatusOutcome,
+    ParameterType, Reduction, BESCHIKKINGEN,
 };
 pub use corpus::regulation_root;
 pub use error::{Result, SimulatorError, Subject};
 pub use scenario::{
-    Decision, DecisionOutcome, ExpectationFailure, Query, QueryOutcome, Scenario, ScenarioRun,
-    TransportOutcome, TransportQuery,
+    check_provenance, Decision, DecisionOutcome, ExpectationFailure, Query, QueryOutcome, Scenario,
+    ScenarioRun, TransportOutcome, TransportQuery,
 };
 pub use security::{Identity, SecurityContext, Signature, SignedAnswer};
 pub use transport::{CellTransport, InProcessTransport};
-pub use world::{Clock, Fixture, Recording, World};
+pub use world::{Clock, DecisionRecord, Fixture, Recording, World};

--- a/packages/simulator/src/scenario.rs
+++ b/packages/simulator/src/scenario.rs
@@ -52,14 +52,13 @@ pub struct Scenario {
     pub queries: Vec<Query>,
     /// De vragen die een cel aan een andere cel stelt, over de celgrens.
     ///
-    /// **Test-only stap, en dat is tijdelijk.** In de opstelling die we bouwen
-    /// stelt een cel zo'n vraag uitsluitend vanuit haar besluit-pad: ze heeft een
-    /// input nodig die een andere organisatie vaststelt. Dat pad bestaat inmiddels
-    /// ([`Self::decide`]), maar het accepteren van een waarde van een andere cel
-    /// nog niet: een besluit haalt zijn inputs uit de eigen kronieken en uit zijn
-    /// parameters. Tot dat er is, is deze stap de enige manier om het verkeer te
-    /// laten zien en erop te asserteren; daarna verhuist de aanroep naar het
-    /// besluit-pad en is ze hoogstens nog een sonde.
+    /// **Een sonde, geen onderdeel van de opstelling.** In de opstelling stelt een
+    /// cel zo'n vraag uitsluitend vanuit haar besluit-pad: ze heeft een input
+    /// nodig die een andere organisatie vaststelt, en dan *accepteert* ze die
+    /// (`accept_from`, of een `source.regulation` in haar wet — zie
+    /// [`Self::decide`]). Wat deze stap overhoudt is de mogelijkheid om één vraag
+    /// los te stellen en op haar antwoord te asserteren, zonder er een besluit
+    /// omheen te bouwen: handig om de naad zelf te beproeven, en verder niets.
     #[serde(default)]
     pub query_via_transport: Vec<TransportQuery>,
 }
@@ -123,6 +122,23 @@ pub struct Decision {
     /// erna iets te vinden hebben.
     #[serde(default)]
     pub expect: BTreeMap<String, Value>,
+    /// Waarden die dit besluit van een andere cel moet hebben **geaccepteerd**,
+    /// op naam, met de cel die haar vaststelde.
+    ///
+    /// Dit is invariant I5 als verwachting in het bestand: niet "de uitkomst
+    /// klopt" maar "deze waarde komt van die organisatie en is hier niet
+    /// nagerekend". Werkt voor beide wegen — een input met `accept_from` en een
+    /// waarde die de wet via `source.regulation` bij een cel haalde.
+    #[serde(default)]
+    pub expect_accepted: BTreeMap<String, String>,
+    /// Waarden die dit besluit **zelf** moet hebben vastgesteld: uit een eigen
+    /// kroniek, uit een parameter of uit een eigen wet.
+    ///
+    /// Het tegenbewijs bij [`Self::expect_accepted`], en zonder dat tegenbewijs
+    /// bewijst die niets: een opstelling waarin *alles* als geaccepteerd geldt,
+    /// haalt dezelfde assertie even makkelijk.
+    #[serde(default)]
+    pub expect_computed: Vec<String>,
 }
 
 /// Eén vraag van een cel aan een andere cel, over de celgrens.
@@ -169,6 +185,14 @@ pub enum ExpectationFailure {
         /// De waarden die de cel toch opleverde.
         values: BTreeMap<String, Value>,
     },
+    /// Een waarde in een decretogram kwam ergens anders vandaan dan verwacht —
+    /// of nergens herleidbaar vandaan (invariant I5).
+    Provenance {
+        /// De waarde waarover het gaat.
+        value: String,
+        /// Wat er over haar herkomst mis is.
+        reason: String,
+    },
 }
 
 /// Het resultaat van één vraag.
@@ -192,8 +216,8 @@ pub struct TransportOutcome {
     /// Het bewijsstuk van de veiligheidscontext: wie vroeg, ondertekend, met
     /// welke parameters, en wat de peer antwoordde.
     ///
-    /// Dit is wat het observatielog vastlegt, en straks wat een decretogram als
-    /// geaccepteerde waarde draagt.
+    /// Dit is wat het observatielog vastlegt, en wat een decretogram als
+    /// geaccepteerde waarde draagt zodra een besluit zo'n waarde accepteert.
     pub signed: SignedAnswer,
     /// De verwachtingen die niet uitkwamen; leeg is goed.
     pub failures: Vec<ExpectationFailure>,
@@ -206,6 +230,12 @@ pub struct DecisionOutcome {
     pub description: Option<String>,
     /// Het vastgelegde decretogram.
     pub decretogram: Decretogram,
+    /// Elk contact over een celgrens dat dit besluit nodig had, in volgorde.
+    ///
+    /// Dit is wat het observatielog van een besluit te zien krijgt. Het log komt
+    /// niets halen — het staat buiten de band en is passief — dus de runner geeft
+    /// het door, net als bij een vraag over de celgrens.
+    pub crossings: Vec<SignedAnswer>,
     /// De verwachtingen die niet uitkwamen; leeg is goed.
     pub failures: Vec<ExpectationFailure>,
 }
@@ -289,6 +319,20 @@ impl ScenarioRun {
                     "        input {name} = {} ({})",
                     input.value,
                     input.origin.describe()
+                );
+            }
+            // Wat er voor dit besluit over een celgrens ging. Een input met
+            // `accept_from` staat hierboven al met haar herkomst; deze regels
+            // zijn de enige plek waar een waarde die de *wet* bij een andere cel
+            // haalde (tier 3) in het verslag zichtbaar is.
+            for crossing in &decision.crossings {
+                let _ = writeln!(
+                    out,
+                    "        vroeg {}.{} op {} (over de celgrens, {})",
+                    crossing.answer.cell,
+                    crossing.answer.name,
+                    crossing.answer.op_moment,
+                    crossing.signature,
                 );
             }
             write_failures(&mut out, &decision.failures);
@@ -400,6 +444,9 @@ fn write_failures(out: &mut String, failures: &[ExpectationFailure]) {
                 out,
                 "        verwachtte 'niets vastgesteld', maar de cel gaf {values:?}"
             ),
+            ExpectationFailure::Provenance { value, reason } => {
+                writeln!(out, "        herkomst van '{value}': {reason}")
+            }
         };
     }
 }
@@ -533,17 +580,25 @@ impl Scenario {
                 world.advance(decision.op_moment)?;
             }
 
-            let decretogram = world.decide(
+            let record = world.decide(
                 &decision.cell,
                 &decision.besluit,
                 &decision.params,
                 decision.op_moment,
             )?;
-            let failures = check_values(&decision.expect, &decretogram.outputs);
+            let decretogram = record.decretogram;
+
+            let mut failures = check_values(&decision.expect, &decretogram.outputs);
+            // De gate draait bij élk besluit, ook als het scenario er niets over
+            // zegt: een invariant die je moet aanzetten, is een invariant die
+            // iemand vergeet.
+            failures.extend(check_provenance(&decretogram));
+            failures.extend(check_expected_origins(decision, &decretogram));
 
             decisions.push(DecisionOutcome {
                 description: decision.description.clone(),
                 decretogram,
+                crossings: record.crossings,
                 failures,
             });
         }
@@ -588,6 +643,158 @@ impl Scenario {
             outcomes.push(TransportOutcome { signed, failures });
         }
         Ok(outcomes)
+    }
+}
+
+/// **Invariant I5** — narekenen versus accepteren, als gate over elk besluit.
+///
+/// De invariant zegt: is een waarde door een andere organisatie vastgesteld, dan
+/// hoort ze geaccepteerd te zijn en niet hier herberekend. Dat is alleen te
+/// controleren als elke waarde in een decretogram zegt waar ze vandaan komt, en
+/// dus is dít wat de gate eist:
+///
+/// - **elke input is de waarde waarop gerekend is.** De herkomst staat bij de
+///   input, dus als het receipt met een andere waarde rekende, hoort de herkomst
+///   bij iets wat het besluit niet gebruikt heeft — en dan zegt het gram iets
+///   anders dan er gebeurd is.
+/// - **elke uitkomst komt uit deze uitvoering.** Een uitkomst die niet in het
+///   receipt staat, is er langs een andere weg in gezet en is dus niet berekend
+///   op de inputs die het gram noemt.
+/// - **een geaccepteerde waarde wijst naar een ánder.** Een gram dat zegt een
+///   waarde van zichzelf geaccepteerd te hebben, verbergt een eigen berekening
+///   achter het woord "accepteren".
+/// - **een geaccepteerde waarde is niet óók een eigen uitkomst.** Staat dezelfde
+///   naam bij de uitkomsten van het gram, dan is ze hier alsnog uitgerekend, en
+///   dan is de acceptatie versiering — precies het geval dat I5 uitsluit.
+///
+/// Hij draait bij elk besluit in elk scenario. Een scenario kan er met
+/// [`Decision::expect_accepted`] een concrete verwachting bovenop leggen; deze
+/// gate is wat er zonder die verwachting nog steeds geldt.
+pub fn check_provenance(gram: &Decretogram) -> Vec<ExpectationFailure> {
+    let mut failures = Vec::new();
+
+    for (name, input) in &gram.inputs {
+        match gram.receipt.execution.parameters.get(name) {
+            Some(value) if *value == input.value => {}
+            Some(value) => failures.push(ExpectationFailure::Provenance {
+                value: name.clone(),
+                reason: format!(
+                    "het gram legt {} vast met herkomst {}, maar de uitvoering rekende \
+                     met {value}",
+                    input.value,
+                    input.origin.describe()
+                ),
+            }),
+            None => failures.push(ExpectationFailure::Provenance {
+                value: name.clone(),
+                reason: format!(
+                    "staat als input in het gram ({}), maar de uitvoering kreeg haar niet",
+                    input.origin.describe()
+                ),
+            }),
+        }
+    }
+
+    for name in gram.outputs.keys() {
+        if !gram.receipt.results.outputs.contains_key(name) {
+            failures.push(ExpectationFailure::Provenance {
+                value: name.clone(),
+                reason: format!(
+                    "staat als uitkomst in het gram, maar het receipt van regeling \
+                     '{}' kent haar niet",
+                    gram.regulation
+                ),
+            });
+        }
+    }
+
+    for (name, cell) in gram.accepted_values() {
+        if cell == gram.cell {
+            failures.push(ExpectationFailure::Provenance {
+                value: name.to_string(),
+                reason: format!(
+                    "zegt geaccepteerd te zijn van cel '{cell}', maar dat is de cel die \
+                     besloot; dan is er narekenen als accepteren opgeschreven"
+                ),
+            });
+        }
+        if gram.outputs.contains_key(name) {
+            failures.push(ExpectationFailure::Provenance {
+                value: name.to_string(),
+                reason: format!(
+                    "is geaccepteerd van cel '{cell}' én staat als eigen uitkomst in het \
+                     gram; accepteren en narekenen tegelijk kan niet"
+                ),
+            });
+        }
+    }
+
+    failures
+}
+
+/// Reken een besluit af op de herkomst die het scenario verwacht.
+///
+/// Twee kanten, en ze horen bij elkaar: `expect_accepted` zegt dat een waarde
+/// van een bepaalde cel komt, `expect_computed` dat een waarde hier is
+/// vastgesteld. Alleen de eerste zou bewijzen dat de opstelling waarden kán
+/// accepteren, niet dat ze het onderscheid máákt.
+fn check_expected_origins(decision: &Decision, gram: &Decretogram) -> Vec<ExpectationFailure> {
+    let accepted = gram.accepted_values();
+    let mut failures = Vec::new();
+
+    for (value, expected) in &decision.expect_accepted {
+        match accepted.get(value.as_str()) {
+            Some(cell) if cell == expected => {}
+            Some(cell) => failures.push(ExpectationFailure::Provenance {
+                value: value.clone(),
+                reason: format!("verwachtte geaccepteerd van cel '{expected}', kreeg '{cell}'"),
+            }),
+            None => failures.push(ExpectationFailure::Provenance {
+                value: value.clone(),
+                reason: format!(
+                    "verwachtte geaccepteerd van cel '{expected}', maar deze waarde is \
+                     niet geaccepteerd{}",
+                    describe_origin(gram, value)
+                ),
+            }),
+        }
+    }
+
+    for value in &decision.expect_computed {
+        if let Some(cell) = accepted.get(value.as_str()) {
+            failures.push(ExpectationFailure::Provenance {
+                value: value.clone(),
+                reason: format!(
+                    "verwachtte een eigen vaststelling, maar deze waarde is geaccepteerd \
+                     van cel '{cell}'"
+                ),
+            });
+            continue;
+        }
+        if !gram.inputs.contains_key(value) && !gram.outputs.contains_key(value) {
+            failures.push(ExpectationFailure::Provenance {
+                value: value.clone(),
+                reason: "komt in dit gram niet voor, dus er valt niets over na te rekenen"
+                    .to_string(),
+            });
+        }
+    }
+
+    failures
+}
+
+/// Wat het gram wél over de herkomst van deze waarde zegt, voor in een melding.
+///
+/// Leeg als de naam er helemaal niet in voorkomt: dan is "deze waarde is niet
+/// geaccepteerd" al het hele verhaal, en een lege haak erachter suggereert dat
+/// er iets weggelaten is.
+fn describe_origin(gram: &Decretogram, value: &str) -> String {
+    match gram.inputs.get(value) {
+        Some(input) => format!(" ({})", input.origin.describe()),
+        None if gram.outputs.contains_key(value) => {
+            format!(" (eigen uitkomst van regeling '{}')", gram.regulation)
+        }
+        None => String::new(),
     }
 }
 

--- a/packages/simulator/src/world.rs
+++ b/packages/simulator/src/world.rs
@@ -22,14 +22,24 @@
 //! omdat een actie van een actor nog niet bestaat. De wereld houdt zelf geen
 //! register van wat er besloten is; het decretogram ligt in de kroniek van de
 //! cel die besloot.
+//!
+//! Daar komt één ding bij dat alleen de wereld kan: **accepteren**. Een besluit
+//! dat een waarde van een andere organisatie nodig heeft, zegt dat — en de wereld
+//! haalt hem op langs de veiligheidscontext van de besluitende cel en het
+//! transport, want zij kent de peers en de cel niet. Wat over de grens ging komt
+//! als [`DecisionRecord::crossings`] mee terug, zodat het meetinstrument het kan
+//! zien zonder dat een cel het kent.
 
+use crate::accept::CellBridge;
 use crate::cell::{Cell, CellConfig, ChronicleEvent, Decretogram, Intake, Lexostatus};
 use crate::error::{Result, SimulatorError, Subject};
+use crate::security::{Identity, SignedAnswer};
 use chrono::NaiveDate;
-use regelrecht_engine::Value;
+use regelrecht_engine::{CellResolver, Value};
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::path::Path;
+use std::rc::Rc;
 
 /// De logische klok van een wereld, zoals het wereldbestand haar opgeeft.
 #[derive(Debug, Clone, Copy, Deserialize)]
@@ -103,6 +113,23 @@ impl Recording {
 enum Trigger {
     /// Er wordt een executogram vastgelegd.
     Record(Recording),
+}
+
+/// Wat één besluit opleverde: het gram, en wat ervoor over de celgrens ging.
+///
+/// De twee horen bij elkaar en komen daarom samen naar buiten. Het gram draagt
+/// de geaccepteerde waarden met hun herkomst — dat is wat de cel vastlegt — en
+/// de contacten zijn het bewijs dat er precies die vragen gesteld zijn en geen
+/// andere. Het observatielog is test-only en passief (zie
+/// [`crate::observation`]), dus het kan dit niet zelf komen halen: wie besluit,
+/// geeft het door, anders is het log stil incompleet in plaats van rood.
+#[derive(Debug, Clone)]
+pub struct DecisionRecord {
+    /// Het vastgelegde besluit.
+    pub decretogram: Decretogram,
+    /// Elk contact over een celgrens dat dit besluit nodig had, in volgorde.
+    /// Leeg als het besluit alles zelf wist.
+    pub crossings: Vec<SignedAnswer>,
 }
 
 /// Eén gesimuleerde wereld: cellen, een klok, en wat er nog moet gebeuren.
@@ -186,6 +213,8 @@ impl World {
                 })?;
             cell.check_recording(&target.chronicle, &target.event(fixture.at))?;
         }
+
+        check_peers_exist(configs, &cells)?;
 
         let mut pending: Vec<(NaiveDate, Trigger)> = fixtures
             .iter()
@@ -285,13 +314,21 @@ impl World {
     /// `op_moment` mag niet ná de klok liggen, om dezelfde reden als bij
     /// [`World::reduce`]: een besluit "op" een moment dat nog niet gebeurd is,
     /// zou een gram in de toekomst leggen.
+    ///
+    /// Dit is ook de enige plek waar een besluit de **celgrens over** kan. De
+    /// cel zegt wat ze van een ander nodig heeft; de wereld — die de peers kent
+    /// en de identiteit van de besluitende cel draagt — haalt het op langs de
+    /// veiligheidscontext en het transport, en geeft het met herkomst terug. Wat
+    /// erover de grens ging komt als [`DecisionRecord::crossings`] mee naar
+    /// buiten: het observatielog staat buiten de band en kan het niet zelf komen
+    /// halen.
     pub fn decide(
         &mut self,
         cell: &str,
         besluit: &str,
         params: &BTreeMap<String, Value>,
         op_moment: NaiveDate,
-    ) -> Result<Decretogram> {
+    ) -> Result<DecisionRecord> {
         if op_moment > self.clock {
             return Err(SimulatorError::MomentAfterClock {
                 cell: cell.to_string(),
@@ -301,12 +338,62 @@ impl World {
                 clock: self.clock.to_string(),
             });
         }
-        self.cells
-            .get_mut(cell)
-            .ok_or_else(|| SimulatorError::UnknownCell {
+
+        // De besluitende cel gaat uit de map, en de rest gaat naar de brug. Twee
+        // vliegen: de brug kan de peers bezitten (een geregistreerde resolver
+        // moet de uitvoering overleven, dus lenen kan niet), en de besluitende
+        // cel is tijdens haar eigen besluit onbereikbaar voor het transport —
+        // een cel die zichzelf over de grens bevraagt is hier geen afspraak maar
+        // een lege plek.
+        let Some(mut deciding) = self.cells.remove(cell) else {
+            return Err(SimulatorError::UnknownCell {
                 cell: cell.to_string(),
-            })?
-            .decide(besluit, params, op_moment)
+            });
+        };
+        let bridge = Rc::new(CellBridge::new(
+            Identity::for_cell(cell),
+            besluit,
+            deciding.accepts_from().cloned().collect::<Vec<_>>(),
+            std::mem::take(&mut self.cells),
+        ));
+
+        let outcome = Self::accept_and_decide(&bridge, &mut deciding, besluit, params, op_moment);
+
+        // Ook als het besluit omviel: de wereld krijgt haar cellen terug zoals ze
+        // waren. Een mislukt besluit legt niets vast, maar het mag al helemaal
+        // geen cel laten verdwijnen.
+        self.cells = bridge.release();
+        self.cells.insert(cell.to_string(), deciding);
+
+        // Bij een fout gaan de contacten mee weg. Dat kan, omdat er dan geen
+        // besluit is om ze bij te leggen en de fout zelf al zegt bij wie het
+        // misging; het log meet een run die doorgaat, en een omgevallen besluit
+        // laat de run niet doorgaan.
+        Ok(DecisionRecord {
+            decretogram: outcome?,
+            crossings: bridge.crossings(),
+        })
+    }
+
+    /// Haal op wat het besluit van anderen nodig heeft, en laat de cel besluiten.
+    ///
+    /// De volgorde is de hele bewijslast van invariant I5: eerst vragen, dan
+    /// rekenen. Wat een ander vaststelt, komt binnen als waarde met herkomst en
+    /// gaat als parameter de engine in; de logica van die ander draait hier
+    /// niet. En wat de *wet* bij een andere cel haalt (tier 3), loopt langs
+    /// dezelfde brug, die de besluit-engine voor de duur van dit besluit krijgt.
+    fn accept_and_decide(
+        bridge: &Rc<CellBridge>,
+        deciding: &mut Cell,
+        besluit: &str,
+        params: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Result<Decretogram> {
+        let requests = deciding.acceptance_requests(besluit, params)?;
+        let accepted = bridge.accept_all(&requests, op_moment)?;
+        let shared: Rc<CellBridge> = Rc::clone(bridge);
+        let resolver: Rc<dyn CellResolver> = shared;
+        deciding.decide(besluit, params, op_moment, &accepted, Some(resolver))
     }
 
     /// Laat alles afgaan wat op of vóór `tot` valt, in datumvolgorde.
@@ -358,6 +445,54 @@ impl World {
     pub fn pending_triggers(&self) -> usize {
         self.pending.len()
     }
+}
+
+/// Bestaat elke cel waarvan er in deze wereld geaccepteerd wordt?
+///
+/// Twee soorten afspraak wijzen een peer aan: `accept_from` in een
+/// besluit-definitie en `accepts_from` op de cel zelf (tier 3). Geen van beide
+/// is bij het optuigen van de cel te controleren — een cel kent geen andere cel
+/// — dus het valt hier, bij de enige die ze allemaal kent.
+fn check_peers_exist(configs: &[CellConfig], cells: &BTreeMap<String, Cell>) -> Result<()> {
+    let known = || {
+        cells
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    for config in configs {
+        let peers = config
+            .besluit_definitions
+            .iter()
+            .flat_map(|definition| {
+                definition.inputs.iter().filter_map(move |(input, origin)| {
+                    let cell = origin.accepts_from()?;
+                    Some((
+                        cell,
+                        format!("input '{input}' van besluit '{}'", definition.name),
+                    ))
+                })
+            })
+            .chain(config.accepts_from.iter().map(|source| {
+                (
+                    source.cell.as_str(),
+                    format!("uitkomst '{}' van haar wetten", source.output),
+                )
+            }));
+
+        for (peer, what) in peers {
+            if !cells.contains_key(peer) {
+                return Err(SimulatorError::UnknownAcceptedCell {
+                    cell: config.id.clone(),
+                    peer: peer.to_string(),
+                    what,
+                    known: known(),
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/packages/simulator/src/world.rs
+++ b/packages/simulator/src/world.rs
@@ -365,10 +365,13 @@ impl World {
         self.cells = bridge.release();
         self.cells.insert(cell.to_string(), deciding);
 
-        // Bij een fout gaan de contacten mee weg. Dat kan, omdat er dan geen
-        // besluit is om ze bij te leggen en de fout zelf al zegt bij wie het
-        // misging; het log meet een run die doorgaat, en een omgevallen besluit
-        // laat de run niet doorgaan.
+        // Bij een fout gaan de contacten mee weg. Dat kan zolang een omgevallen
+        // besluit de run afbreekt — de scenario-runner geeft de fout door en stopt
+        // — en de fout zelf al zegt bij wie het misging. Wordt hier ooit een
+        // aanroeper op gezet die na een mislukt besluit doorgaat (een HTTP-laag
+        // die er een foutantwoord van maakt), dan mist het log precies de vragen
+        // van de besluiten die niet lukten, en dat is de gevaarlijke kant op: dan
+        // horen de contacten met de fout mee naar buiten.
         Ok(DecisionRecord {
             decretogram: outcome?,
             crossings: bridge.crossings(),

--- a/packages/simulator/tests/accepteren.rs
+++ b/packages/simulator/tests/accepteren.rs
@@ -132,6 +132,21 @@ fn niets_vastgesteld_bij_de_bron_laat_het_besluit_omvallen_zonder_gram() {
         "een omgevallen besluit hoort niets vast te leggen, maar er lag: {:?}",
         terugkijk.outcome
     );
+
+    // En de wereld is heel. Een besluit haalt de besluitende cel uit de map en
+    // geeft de rest aan de brug; valt het onderweg om, dan horen ze allemaal terug
+    // te staan. Zou er één blijven liggen, dan zou een mislukt besluit een cel
+    // laten verdwijnen — en dat zou pas bij de volgende vraag blijken, als een
+    // onbegrijpelijke "onbekende cel".
+    let bron = world
+        .reduce(
+            "belastingdienst",
+            "toetsingsinkomen",
+            &bsn(),
+            date("2024-02-01"),
+        )
+        .unwrap_or_else(|e| panic!("de bron-cel hoort er nog te staan: {e}"));
+    assert_eq!(bron.cell, "belastingdienst");
 }
 
 /// **Een geaccepteerde waarde wordt niet onthouden.**
@@ -210,6 +225,113 @@ fn een_verkeerde_herkomstverwachting_wordt_rood() {
         run.report().contains("herkomst van 'toetsingsinkomen'"),
         "het verslag hoort te zeggen wat er over de herkomst mis is:\n{}",
         run.report()
+    );
+}
+
+/// **Een tier-3-verwijzing zonder afspraak zegt dat de afspraak mist.**
+///
+/// Alleen gedeclareerde cel-ids bereiken de resolver, dus een wet die een cel
+/// noemt die niet in `accepts_from` staat, komt bij de engine uit als een
+/// regeling die niemand kent. Dat is letterlijk waar en het verkeerde spoor: wie
+/// het leest gaat een corpusbestand zoeken dat er niet hoort te zijn, terwijl de
+/// cel een afspraak mist. De melding hoort te zeggen welke van de twee het kan
+/// zijn, en de naam te noemen.
+#[test]
+fn een_tier_3_verwijzing_zonder_afspraak_wijst_naar_de_afspraak() {
+    let path = tier_drie();
+    let yaml = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    // Het hele `accepts_from`-blok eruit, tot aan de volgende sleutel van de cel.
+    let start = yaml
+        .find("    accepts_from:")
+        .unwrap_or_else(|| panic!("{} hoort een accepts_from-blok te hebben", path.display()));
+    let end = yaml
+        .find("    besluit_definitions:")
+        .unwrap_or_else(|| panic!("{} hoort besluit_definitions te hebben", path.display()));
+    assert!(start < end, "het blok hoort vóór de besluiten te staan");
+    let zonder_afspraak = format!("{}{}", &yaml[..start], &yaml[end..]);
+
+    let scenario =
+        Scenario::from_yaml(&zonder_afspraak).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    let mut world = scenario
+        .world(&regulation_root())
+        .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    world
+        .advance(date("2024-06-01"))
+        .unwrap_or_else(|e| panic!("de klok moet vooruit kunnen: {e}"));
+
+    let err = world
+        .decide(
+            "toeslagen",
+            "partnerschapstoets",
+            &bsn(),
+            date("2024-06-01"),
+        )
+        .expect_err("zonder afspraak bereikt de engine de cel niet");
+
+    assert!(
+        matches!(
+            &err,
+            SimulatorError::UndeclaredCellSource { name, .. } if name == "brp"
+        ),
+        "verwachtte UndeclaredCellSource over 'brp', kreeg {err}"
+    );
+    let melding = err.to_string();
+    assert!(
+        melding.contains("accepts_from") && melding.contains("laadt geen regeling"),
+        "de melding hoort beide uitwegen te noemen, kreeg: {melding}"
+    );
+}
+
+/// **Een besluit dat niet kan doorgaan, valt een andere organisatie niet lastig.**
+///
+/// De orde is niet vrij: eerst vaststellen dat er een zaak is om over te
+/// besluiten, dan pas vragen. Een zaakkenmerk dat niet eenduidig in te vullen is,
+/// levert geen besluit op — en dan hoort er ook geen ondertekende vraag de
+/// celgrens over te gaan. Die vraag is bij de bevraagde organisatie een
+/// gebeurtenis: ze ziet wie er iets over wie kwam opvragen, en dat hoort niet te
+/// gebeuren voor een besluit dat toch al niet genomen kan worden.
+///
+/// De test meet de orde en niet de melding: bij dit moment had de bron nog niets
+/// vastgesteld, dus als er eerst gevraagd wordt, valt het besluit om over de
+/// ontbrekende input in plaats van over het kenmerk.
+#[test]
+fn een_besluit_zonder_eenduidig_zaakkenmerk_vraagt_de_bron_niets() {
+    let path = accepteren();
+    let yaml = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("{}: {e}", path.display()))
+        // Twee verwijzingen, dus een scheidingsteken dat in geen waarde mag
+        // voorkomen — en hieronder komt het er wel in.
+        .replace(
+            "        zaakkenmerk: zorgtoeslag/{bsn}\n        params:\n          - name: bsn\n            type: string\n",
+            "        zaakkenmerk: zorgtoeslag/{bsn}/{jaar}\n        params:\n          - name: bsn\n            type: string\n          - name: jaar\n            type: string\n",
+        );
+
+    let scenario = Scenario::from_yaml(&yaml).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    let mut world = scenario
+        .world(&regulation_root())
+        .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    // Vóór de aanslag van de belastingdienst (2024-03-01): had het besluit hier
+    // wél gevraagd, dan was dat de fout geworden die we terugkrijgen.
+    world
+        .advance(date("2024-02-01"))
+        .unwrap_or_else(|e| panic!("de klok moet vooruit kunnen: {e}"));
+
+    let mut params = bsn();
+    params.insert("jaar".to_string(), Value::String("20/24".to_string()));
+
+    let err = world
+        .decide(
+            "toeslagen",
+            "zorgtoeslag_vaststelling",
+            &params,
+            date("2024-02-01"),
+        )
+        .expect_err("een kenmerk dat niet eenduidig is hoort het besluit te weigeren");
+
+    assert!(
+        matches!(err, SimulatorError::ZaakkenmerkSeparatorInValue { .. }),
+        "het besluit hoort te vallen op het kenmerk en niet op een input die het \
+         daarna alsnog is gaan ophalen, kreeg {err}"
     );
 }
 

--- a/packages/simulator/tests/accepteren.rs
+++ b/packages/simulator/tests/accepteren.rs
@@ -1,0 +1,240 @@
+//! Accepteren in plaats van narekenen, en wat er níet mag gebeuren.
+//!
+//! De scenariobestanden dragen zelf hun verwachting, dus wat hier staat zijn de
+//! asserties die geen scenario kán dragen: een run die omvalt, een gram dat er
+//! juist niet is, en een verwachting die fout is en dus rood hoort te worden.
+//! Alle drie zijn eigenschappen van de opstelling en niet van een wereld.
+
+use regelrecht_engine::Value;
+use regelrecht_simulator::{regulation_root, Scenario, SimulatorError};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Het tier-3-scenario: `toeslagen` voert een regeling uit die `brp` aanwijst.
+fn tier_drie() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("scenarios")
+        .join("toeslagen_accepteert_via_de_wet.yaml")
+}
+
+/// Het accepteer-scenario: `toeslagen` accepteert een waarde van de
+/// belastingdienst en rekent dezelfde waarde daarnaast zelf na.
+fn accepteren() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("scenarios")
+        .join("toeslagen_accepteert_toetsingsinkomen.yaml")
+}
+
+fn scenario(path: &Path) -> Scenario {
+    Scenario::load(path).unwrap_or_else(|e| panic!("{}: {e}", path.display()))
+}
+
+fn bsn() -> BTreeMap<String, Value> {
+    BTreeMap::from([("bsn".to_string(), Value::String("999993653".to_string()))])
+}
+
+fn date(text: &str) -> chrono::NaiveDate {
+    chrono::NaiveDate::parse_from_str(text, "%Y-%m-%d")
+        .unwrap_or_else(|e| panic!("testdatum '{text}' moet leesbaar zijn: {e}"))
+}
+
+/// **De cel reikt niet buiten zichzelf vanuit een reductie.**
+///
+/// Dezelfde regeling, dezelfde cel, dezelfde parameters — alleen langs de andere
+/// ingang. `Cell::decide` krijgt een resolver en komt bij `brp` uit;
+/// `Cell::reduce` krijgt er geen, dus de `source.regulation` naar die cel is voor
+/// die engine onoplosbaar. Dat is geen afspraak maar een ontbrekende capability:
+/// er is geen vlag om aan te zetten en geen pad omheen.
+#[test]
+fn een_reductie_komt_niet_bij_de_cel_tier() {
+    let path = tier_drie();
+    let scenario = scenario(&path);
+    let world = scenario
+        .world(&regulation_root())
+        .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+
+    let err = world
+        .reduce("toeslagen", "partnerschap_nu", &bsn(), date("2024-01-01"))
+        .expect_err("een reductie hoort niet buiten haar cel te reiken");
+
+    assert!(
+        matches!(
+            &err,
+            SimulatorError::ReductionReachesOutsideCell { peer, .. } if peer == "brp"
+        ),
+        "verwachtte ReductionReachesOutsideCell over 'brp', kreeg {err}"
+    );
+    // De melding hoort de lezer te vertellen wat er aan de hand is en niet alleen
+    // dat er een naam onbekend was: voor de reduce-engine is `brp` een regeling
+    // die ze niet kent, en die letterlijke waarheid verbergt het geval.
+    let melding = err.to_string();
+    assert!(
+        melding.contains("reikt niet buiten de eigen cel") && melding.contains("besluit"),
+        "de melding hoort te zeggen waarom dit niet kan, kreeg: {melding}"
+    );
+}
+
+/// **Stelt de bron niets vast, dan valt het besluit om — en legt niets vast.**
+///
+/// Het moment ligt vóór de aanslag van de belastingdienst, dus die cel had toen
+/// niets vastgesteld. Dat is haar goed recht en geen defect. Wat er niet mag
+/// gebeuren is doorrekenen met een gat: er komt geen gram, en de melding zegt
+/// welke input van welke cel ontbrak.
+#[test]
+fn niets_vastgesteld_bij_de_bron_laat_het_besluit_omvallen_zonder_gram() {
+    let path = accepteren();
+    let scenario = scenario(&path);
+    let mut world = scenario
+        .world(&regulation_root())
+        .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    // De aanslag van de belastingdienst stamt van 2024-03-01; hier besluit de
+    // cel een maand eerder, met de wetsversie die dan al geldt.
+    world
+        .advance(date("2024-02-01"))
+        .unwrap_or_else(|e| panic!("de klok moet vooruit kunnen: {e}"));
+
+    let err = world
+        .decide(
+            "toeslagen",
+            "zorgtoeslag_vaststelling",
+            &bsn(),
+            date("2024-02-01"),
+        )
+        .expect_err("zonder feit bij de bron hoort het besluit om te vallen");
+
+    let melding = err.to_string();
+    for deel in [
+        "toetsingsinkomen",
+        "belastingdienst",
+        "zorgtoeslag_vaststelling",
+    ] {
+        assert!(
+            melding.contains(deel),
+            "de melding hoort '{deel}' te noemen, kreeg: {melding}"
+        );
+    }
+
+    // En er ligt niets. Een half besluit is erger dan geen besluit: wie het later
+    // terugleest, kan niet zien dat er een feit ontbrak.
+    let terugkijk = world
+        .reduce(
+            "toeslagen",
+            "zorgtoeslagbeschikking",
+            &BTreeMap::from([(
+                "zaakkenmerk".to_string(),
+                Value::String("zorgtoeslag/999993653".to_string()),
+            )]),
+            date("2024-02-01"),
+        )
+        .unwrap_or_else(|e| panic!("de reductie hoort te slagen: {e}"));
+    assert!(
+        terugkijk.not_established().is_some(),
+        "een omgevallen besluit hoort niets vast te leggen, maar er lag: {:?}",
+        terugkijk.outcome
+    );
+}
+
+/// **Een geaccepteerde waarde wordt niet onthouden.**
+///
+/// Er is geen schaduwboekhouding: de waarde ging het decretogram in en nergens
+/// anders — niet in een kroniek, niet in het databronregister. Een tweede besluit
+/// gaat daarom opnieuw naar de bron, en dat is precies wat het vraaggraf laat
+/// zien: twee besluiten, twee contacten.
+#[test]
+fn een_nieuw_besluit_haalt_de_waarde_opnieuw_op() {
+    let path = tier_drie();
+    let scenario = scenario(&path);
+    let mut world = scenario
+        .world(&regulation_root())
+        .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    world
+        .advance(date("2024-06-01"))
+        .unwrap_or_else(|e| panic!("de klok moet vooruit kunnen: {e}"));
+
+    for ronde in 1..=2 {
+        let record = world
+            .decide(
+                "toeslagen",
+                "partnerschapstoets",
+                &bsn(),
+                date("2024-06-01"),
+            )
+            .unwrap_or_else(|e| panic!("besluit {ronde} hoort te slagen: {e}"));
+        assert_eq!(
+            record.crossings.len(),
+            1,
+            "besluit {ronde} hoort de bron opnieuw te vragen, niet te onthouden"
+        );
+        assert_eq!(record.crossings[0].answer.cell, "brp");
+        assert_eq!(
+            record.decretogram.accepted_values().get("partnerschap"),
+            Some(&"brp"),
+            "en de waarde hoort met haar bron in het gram te staan"
+        );
+    }
+}
+
+/// **De invarianten-gate bijt.**
+///
+/// Een scenario dat zegt dat een waarde geaccepteerd is terwijl de cel haar zelf
+/// vaststelde, hoort rood te worden. Zonder deze test bewijst een groene
+/// `expect_accepted` alleen dat er een veld gelezen is.
+#[test]
+fn een_verkeerde_herkomstverwachting_wordt_rood() {
+    let path = accepteren();
+    let yaml = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("{}: {e}", path.display()))
+        // Het tweede besluit rekent het toetsingsinkomen zelf na. Wie beweert dat
+        // het geaccepteerd is, hoort dat niet groen te krijgen.
+        .replace(
+            "    expect_computed:\n      - toetsingsinkomen",
+            "    expect_accepted:\n      toetsingsinkomen: belastingdienst",
+        );
+    assert!(
+        yaml.matches("expect_accepted").count() == 2,
+        "de vervanging hoort precies het tweede besluit te raken"
+    );
+
+    let scenario = Scenario::from_yaml(&yaml).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    let run = scenario
+        .run(&regulation_root())
+        .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+
+    assert!(
+        !run.passed(),
+        "een waarde uit de eigen kroniek is niet geaccepteerd, en dat hoort te \
+         blijken:\n{}",
+        run.report()
+    );
+    assert!(
+        run.report().contains("herkomst van 'toetsingsinkomen'"),
+        "het verslag hoort te zeggen wat er over de herkomst mis is:\n{}",
+        run.report()
+    );
+}
+
+/// **Een peer die niet bestaat, blijkt bij het optuigen.**
+///
+/// Een cel kent geen andere cel, dus zij kan dit niet weten; de wereld kent ze
+/// allemaal. Zonder deze toets zou een typfout pas tijdens een besluit opduiken,
+/// als een melding over het transport in plaats van over het bestand.
+#[test]
+fn accepteren_van_een_onbekende_cel_wordt_bij_het_optuigen_geweigerd() {
+    let path = accepteren();
+    let yaml = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("{}: {e}", path.display()))
+        .replace(
+            "accept_from: belastingdienst",
+            "accept_from: belastingdienstt",
+        );
+
+    let scenario = Scenario::from_yaml(&yaml).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    let err = scenario
+        .world(&regulation_root())
+        .expect_err("een peer die niet bestaat hoort te falen");
+
+    assert!(
+        matches!(err, SimulatorError::UnknownAcceptedCell { .. }),
+        "verwachtte UnknownAcceptedCell, kreeg {err}"
+    );
+}

--- a/packages/simulator/tests/observation_log.rs
+++ b/packages/simulator/tests/observation_log.rs
@@ -20,6 +20,13 @@ fn scenario_path() -> PathBuf {
         .join("transport_toeslagen_brp.yaml")
 }
 
+/// Het scenario waarin een besluit accepteert, met het narekenende besluit ernaast.
+fn accepteren_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("scenarios")
+        .join("toeslagen_accepteert_toetsingsinkomen.yaml")
+}
+
 /// Alle Rust-bestanden onder `src/`, met hun pad relatief aan de crate.
 fn source_files() -> Vec<(String, String)> {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
@@ -122,6 +129,73 @@ fn een_vraag_over_de_celgrens_levert_exact_een_regel_in_het_log() {
         log.report().contains(SIMULATED_SIGNATURE_PREFIX),
         "het verslag hoort te laten zien dat er ondertekend is, en hoe:\n{}",
         log.report()
+    );
+}
+
+/// Een besluit dat accepteert, staat met precies die ene vraag in het log — en
+/// een besluit dat narekent staat er niet in.
+///
+/// Dit is de reden dat het log ook van het besluit-pad zijn bewijsstukken
+/// aangereikt krijgt. Zou dat niet gebeuren, dan was het log stil incompleet
+/// terwijl er wél verkeer over de grens ging, en dat is de gevaarlijke kant op:
+/// het vraaggraf zou dan schoner lijken dan het is.
+#[test]
+fn een_besluit_dat_accepteert_staat_met_die_ene_vraag_in_het_log() {
+    let path = accepteren_path();
+    let scenario = Scenario::load(&path).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    let run = scenario
+        .run(&regulation_root())
+        .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    assert!(run.passed(), "{}", run.report());
+
+    let mut log = ObservationLog::new();
+    for decision in &run.decisions {
+        for crossing in &decision.crossings {
+            log.record(crossing);
+        }
+    }
+
+    assert_eq!(
+        log.len(),
+        1,
+        "twee besluiten, waarvan één accepteert: dat is precies één vraag over de \
+         grens:\n{}",
+        log.report()
+    );
+
+    let entry = &log.entries()[0];
+    assert_eq!(entry.asked_by.cell(), "toeslagen", "de vrager");
+    assert_eq!(entry.answer.cell, "belastingdienst", "de bevraagde cel");
+    assert_eq!(entry.answer.name, "toetsingsinkomen", "de lexostatus");
+    assert_eq!(
+        entry.params.get("bsn"),
+        Some(&Value::String("999993653".to_string())),
+        "de parameters waarmee gevraagd is"
+    );
+
+    // En wat er níet in het log staat: een uitvoering van de logica van de ander.
+    // De bevraagde cel is een bron-cel zonder wetten, en de besluitende cel laadt
+    // haar regelingen niet — ze accepteerde een vaststelling en deed die niet over.
+    let accepterend = &run.decisions[0].decretogram;
+    assert_eq!(
+        accepterend.accepted_values().get("toetsingsinkomen"),
+        Some(&"belastingdienst"),
+        "het gram hoort de bron van de geaccepteerde waarde te dragen"
+    );
+    assert_eq!(
+        accepterend.regulation, "wet_op_de_zorgtoeslag",
+        "het besluit voerde uitsluitend de eigen regeling uit"
+    );
+
+    let narekenend = &run.decisions[1];
+    assert!(
+        narekenend.crossings.is_empty(),
+        "een besluit dat op eigen feiten rekent, hoort niemand iets te vragen:\n{}",
+        run.report()
+    );
+    assert!(
+        narekenend.decretogram.accepted_values().is_empty(),
+        "en het hoort niets als geaccepteerd op te schrijven"
     );
 }
 


### PR DESCRIPTION
## Wat

Een besluit-definitie kan nu een input **accepteren** van een andere cel in
plaats van hem na te rekenen. Stelt een andere organisatie een feit vast — met
haar eigen bevoegd gezag — dan vraagt de besluitende cel dat op, legt vast bij
wie ze het ophaalde en op welk moment, en rekent daarmee verder. Dat is stap 4
van de RFC-009-beslisboom en invariant I5 uit de chronolexografie-opstelling.

Twee wegen, één mechanisme, beide langs de veiligheidscontext van de
besluitende cel en het transport:

| wie zegt het | waar | wat je schrijft |
|---|---|---|
| de besluit-definitie | `inputs` van het besluit | `accept_from` + `lexostatus` + `field` (+ `params`) |
| de wet (tier 3, RFC-022 §4.2) | `source.regulation` die een cel-id noemt | `accepts_from` op de cel: welke lexostatus bij welke uitkomst hoort |

Dat de tweede vorm een afspraak in de celconfiguratie nodig heeft, is geen
omissie: de wet noemt een cel-id en een uitkomstnaam, maar welke *gepubliceerde
lexostatus* daarbij hoort is een afspraak tussen twee organisaties en geen
recht. Diezelfde lijst is wat de besluit-engine haar cel-tier geeft — alleen
gedeclareerde cel-ids bereiken de resolver — dus een cel die er niet in staat,
kan niet per ongeluk bevraagd worden.

## Waarom zo

- **De cel haalt zelf niets op, ook niet op het besluit-pad.** Ze zegt wat ze
  nodig heeft (`Cell::acceptance_requests`) en krijgt het aangereikt. Het
  ophalen gebeurt in de nieuwe module `accept.rs`, buiten `src/cell/`, want een
  cel houdt geen veiligheidscontext en geen transport (RFC-022 §2). De
  grep-poort die dat op `src/cell/` afdwingt, blijft dus ongewijzigd staan.
- **Geen schaduwboekhouding.** De opgehaalde waarde gaat als parameter de
  engine in en met bron, lexostatus, moment en ondertekening het decretogram
  in; niet in een kroniek en niet in het databronregister. Een volgend besluit
  vraagt opnieuw bij de bron, en daar is een test voor.
- **Doorrekenen met een gat kan niet.** Antwoordt de bron "niets vastgesteld",
  dan valt het besluit om met een melding die zegt welke input van welke cel
  ontbrak, en er wordt niets vastgelegd.
- **De reduce-engine krijgt nog steeds geen resolver**, en dat is nu zichtbaar
  in plaats van beloofd: dezelfde lexostatus over dezelfde regeling faalt in
  `reduce` met *een reductie reikt niet buiten de eigen cel*.

## Wat er verder bij hoort

- `World::decide` geeft de contacten die over de celgrens gingen mee terug, zodat
  het test-only observatielog volledig blijft nu er ook vanuit een besluit
  verkeer is. Zou dat ontbreken, dan was het log stil incompleet in plaats van
  rood — de gevaarlijke kant op.
- De scenario-runner rekent **elk** besluit af op de herkomst van zijn waarden
  (per waarde `computed`/`accepted` met bron); een scenario kan er met
  `expect_accepted` / `expect_computed` een concrete verwachting bovenop leggen.
  Een test bewijst dat die gate bijt.
- Drie scenario's: accepteren náást narekenen in één wereld — met twee
  verschillende cijfers, dus twee verschillende bedragen, want zonder dat
  tegenbewijs bewijst het eerste niets — en tier 3 via een kleine testregeling
  in `packages/simulator/fixtures/regulation/`. Die staat met opzet niet in het
  corpus: geen echte wet hoort verbouwd te worden omdat een testopstelling iets
  wil laten zien. De loader zoekt daar pas als het corpus de naam niet kent, dus
  een fixture kan nooit een echte regeling overschaduwen.

## Buiten scope

Echte handtekeningen (de ondertekening blijft de herkenbare placeholder),
onbetrouwbaar gedrag tussen cellen (offline, verouderd, tegenstrijdig) en de
RFC-009-modi als configuratie.

## Checks

`just format`, `just lint`, `just build-check`, `just test-no-docker` (42 suites
groen) en de pre-commit-hooks over de gewijzigde bestanden. De nieuwe
testregeling is los langs `script/validate.sh` gehaald: OK op schema v0.5.8.