### PR TITLE
fix(demo): werkend menu, een simulatie die op een telefoon te starten is

### DIFF
--- a/corpus/demo/demo-config.yaml
+++ b/corpus/demo/demo-config.yaml
@@ -22,20 +22,19 @@ profiles:
     portal_heading: Waar heb ik recht op? Wat zijn mijn plichten?
     portal_subtitle: >-
       Bekijk hier uw toeslagen, uitkeringen, aangiften, en andere regelingen van de overheid.
-    # DELEGATION staat aan: Merijn heeft ouderlijk gezag over twee kinderen
-    # (Burgerlijk Wetboek) en vertegenwoordigt twee ondernemingen
-    # (Machtigingenwet), waarvan één als vennoot met alleen leesrecht. Dat
-    # verschil in rechten komt uit de wet zelf en is precies wat de demo laat
-    # zien.
-    # CHANGE_WIZARD: één ingang voor 'er is iets veranderd' (inkomen, huur,
-    # adres, huishouden), naast de tegels die elk over één regeling gaan.
-    # HARMONIZE: uit een simulatierun één vereenvoudigde regeling afleiden en
-    # laten zien hoe dicht die bij de bestaande wetten blijft.
+    # Merijn is het startprofiel (`default_profile`), dus dit is wat iemand
+    # ziet die de demo opent. Alles staat daarom uit: het verhaal begint bij
+    # een burger met toeslagen, en wie een feature wil tonen zet hem tijdens de
+    # demo aan via Features in het menu. De vlaggen stonden hier eerder aan
+    # omdat de features net gebouwd waren, wat geen reden is om ze aan een
+    # presentator op te dringen.
+    # Claudia (ondernemer) houdt haar eigen vlaggen, dus de features blijven
+    # vindbaar zonder dat je iets hoeft om te zetten.
     feature_flags:
-      DELEGATION: true
+      DELEGATION: false
       AUTO_APPROVE_CLAIMS: false
-      CHANGE_WIZARD: true
-      HARMONIZE: true
+      CHANGE_WIZARD: false
+      HARMONIZE: false
     sidebar_laws: null
     disabled_laws:
       BELASTINGDIENST: [zorgverzekeringswet/bijdrage, zvw, zvw/werkgeversbijdrage]

--- a/frontend-demo/src/App.vue
+++ b/frontend-demo/src/App.vue
@@ -268,8 +268,11 @@ const openCases = computed(() => state.cases.filter((c) => c.status === 'IN_REVI
                 ></nldd-menu-item>
               </nldd-menu>
             </nldd-button>
-            <!-- Dezelfde keuze als menu, voor als de knop niet meer past. -->
-            <nldd-menu-group slot="overflow" text="Namens wie" @select="onDelegationSelect">
+            <!-- Dezelfde keuze als menu, voor als de knop niet meer past.
+                 `@select` per item: het overloopmenu toont een kloon en de
+                 toolbar dispatcht `select` op het originele item, dus een
+                 handler op de groep eromheen vuurt nooit. -->
+            <nldd-menu-group slot="overflow" text="Namens wie">
               <nldd-menu-item
                 v-for="d in delegations"
                 :key="`${d.subjectType}:${d.subjectId}`"
@@ -279,6 +282,7 @@ const openCases = computed(() => state.cases.filter((c) => c.status === 'IN_REVI
                 :details="delegationLabel(d)"
                 :icon="DELEGATION_ICONS[d.subjectType] ?? 'person'"
                 :selected="(activeDelegation ? `${activeDelegation.subjectType}:${activeDelegation.subjectId}` : `SELF:${profile?.bsn}`) === `${d.subjectType}:${d.subjectId}` || undefined"
+                @select="demo.setDelegation(d)"
               ></nldd-menu-item>
             </nldd-menu-group>
           </nldd-toolbar-item>
@@ -298,7 +302,7 @@ const openCases = computed(() => state.cases.filter((c) => c.status === 'IN_REVI
             </nldd-button>
             <!-- Idem voor het personage: zonder deze variant verdween de
                  profielkiezer onder 1130px zonder vervanging. -->
-            <nldd-menu-group slot="overflow" text="Demoprofiel" @select="onProfileSelect">
+            <nldd-menu-group slot="overflow" text="Demoprofiel">
               <nldd-menu-item
                 v-for="[key, p] in profileOptions"
                 :key="key"
@@ -307,6 +311,7 @@ const openCases = computed(() => state.cases.filter((c) => c.status === 'IN_REVI
                 :text="p.name"
                 :details="p.type"
                 :selected="profileKey === key || undefined"
+                @select="demo.setProfile(key)"
               ></nldd-menu-item>
             </nldd-menu-group>
           </nldd-toolbar-item>
@@ -316,70 +321,63 @@ const openCases = computed(() => state.cases.filter((c) => c.status === 'IN_REVI
                overloopknop: het demo-menu was dan onbereikbaar. Als vaste
                inhoud van `slot="overflow"` staat alles onder één knop, met de
                overgelopen tabbladen erboven. -->
-          <!-- Een streep tussen wat er overgelopen is (namens wie, profiel) en
-               de instellingen hieronder; zonder de streep lopen die twee in
-               één lijst door elkaar. -->
-          <nldd-menu-divider slot="overflow"></nldd-menu-divider>
-          <!-- De features aan en uit, midden in een demo. De POC kon dit
-               alleen via omgevingsvariabelen bij het starten; een
-               presentator moet het tijdens zijn verhaal kunnen omzetten.
-               In een uitklapper zoals Weergave, zodat het hoofdmenu kort
-               blijft; het aantal aanstaande features staat ernaast, want
-               dat is wat je wilt weten zonder open te klappen. -->
-          <nldd-menu-item slot="overflow" text="Features" icon="puzzle-piece" :details="featureSummary">
-            <nldd-menu accessible-label="Features">
-              <!-- Geen `details` op deze items: dat is een kort label rechts
-                   ("3 van 4 aan"), geen ondertitel. Een hele zin erin duwt het
-                   label op een smal scherm in een kolom van één woord breed,
-                   zodat "Wijziging doorgeven" over vier regels brak. -->
-              <nldd-menu-item
-                v-for="f in FEATURES"
-                :key="f.key"
-                type="checkbox"
-                :text="f.label"
-                :icon="f.icon"
-                :selected="features[f.key] || undefined"
-                @select="demo.toggleFeature(f.key)"
-              ></nldd-menu-item>
-              <!-- Handmatig beoordelen is dezelfde soort schakelaar als de rest
-                   en hoort dus hier, niet los in het hoofdmenu. Het is de
-                   tegenhanger van AUTO_APPROVE_CLAIMS, maar het staat in de
-                   demostaat en niet in de vlaggen, vandaar de losse regel. -->
-              <nldd-menu-divider></nldd-menu-divider>
-              <nldd-menu-item
-                type="checkbox"
-                text="Alle aanvragen handmatig beoordelen"
-                icon="checklist"
-                :selected="state.manualReview || undefined"
-                @select="toggleManualReview"
-              ></nldd-menu-item>
-              <template v-if="hasFeatureOverrides">
-                <nldd-menu-divider></nldd-menu-divider>
-                <nldd-menu-item
-                  text="Terug naar het profiel"
-                  icon="refresh"
-                  @select="demo.resetFeatures()"
-                ></nldd-menu-item>
-              </template>
-            </nldd-menu>
-          </nldd-menu-item>
-          <nldd-menu-divider slot="overflow"></nldd-menu-divider>
-          <nldd-menu-item slot="overflow" text="Weergave" icon="appearance">
-            <nldd-menu @select="onColorSchemeSelect">
-              <nldd-menu-item
-                v-for="[value, label, icon] in colorSchemeOptions"
-                :key="value"
-                type="radio"
-                :value="value"
-                :text="label"
-                :icon="icon"
-                :selected="colorScheme === value || undefined"
-              ></nldd-menu-item>
-            </nldd-menu>
-          </nldd-menu-item>
-          <nldd-menu-item slot="overflow" text="Volledig scherm" icon="square-arrow-up" @select="toggleFullscreen"></nldd-menu-item>
-          <nldd-menu-divider slot="overflow"></nldd-menu-divider>
-          <nldd-menu-item slot="overflow" text="Demo resetten…" icon="refresh" @select="askReset"></nldd-menu-item>
+          <!-- Alles plat in groepen, geen uitklappers. Een submenu werkt hier
+               niet: nldd-menu verplaatst een geopend submenu naar
+               document.body, en de toolbar luistert op het hoofdmenu om het
+               `select` van een kloon terug te mappen naar het origineel.
+               Buiten dat menu bubbelt het event er nooit heen, dus Features en
+               Weergave deden als uitklapper helemaal niets, op elke breedte.
+               Groepen mét een titel geven dezelfde ordening zonder die klik. -->
+          <nldd-menu-group slot="overflow" text="Features">
+            <!-- Geen `details` op deze items: dat is een kort label rechts,
+                 geen ondertitel. Een hele zin erin duwt het label op een smal
+                 scherm in een kolom van één woord breed, zodat "Wijziging
+                 doorgeven" over vier regels brak. -->
+            <nldd-menu-item
+              v-for="f in FEATURES"
+              :key="f.key"
+              type="checkbox"
+              :text="f.label"
+              :icon="f.icon"
+              :selected="features[f.key] || undefined"
+              @select="demo.toggleFeature(f.key)"
+            ></nldd-menu-item>
+            <!-- Handmatig beoordelen staat hier zonder streep ertussen: het is
+                 dezelfde soort schakelaar als de vlaggen erboven. Het gaat over
+                 aanvragen waar 'correcties direct goedkeuren' over correcties
+                 gaat, maar dat is geen ander soort instelling. Het verschil is
+                 alleen dat het in de demostaat zit en niet in de vlaggen, en
+                 dat is niets wat een presentator hoeft te zien. -->
+            <nldd-menu-item
+              type="checkbox"
+              text="Alle aanvragen handmatig beoordelen"
+              icon="checklist"
+              :selected="state.manualReview || undefined"
+              @select="toggleManualReview"
+            ></nldd-menu-item>
+            <nldd-menu-item
+              v-if="hasFeatureOverrides"
+              text="Terug naar het profiel"
+              icon="refresh"
+              @select="demo.resetFeatures()"
+            ></nldd-menu-item>
+          </nldd-menu-group>
+          <nldd-menu-group slot="overflow" text="Weergave">
+            <nldd-menu-item
+              v-for="[value, label, icon] in colorSchemeOptions"
+              :key="value"
+              type="radio"
+              :value="value"
+              :text="label"
+              :icon="icon"
+              :selected="colorScheme === value || undefined"
+              @select="setColorScheme(value)"
+            ></nldd-menu-item>
+          </nldd-menu-group>
+          <nldd-menu-group slot="overflow" text="Demo">
+            <nldd-menu-item text="Volledig scherm" icon="square-arrow-up" @select="toggleFullscreen"></nldd-menu-item>
+            <nldd-menu-item text="Demo resetten…" icon="refresh" @select="askReset"></nldd-menu-item>
+          </nldd-menu-group>
         </nldd-toolbar>
       </nldd-container>
 

--- a/frontend-demo/src/useNarrow.js
+++ b/frontend-demo/src/useNarrow.js
@@ -1,0 +1,25 @@
+import { onMounted, onUnmounted, ref } from 'vue';
+
+/**
+ * Is het venster smal genoeg om de weergave uit te dunnen?
+ *
+ * Eén drempel voor de hele demo, zodat het portaal, de simulatie en de
+ * werkbalk niet elk op een eigen breedte omklappen. 900px valt samen met het
+ * punt waarop `nldd-navigation-split-view` zijn zijpaneel niet meer naast de
+ * inhoud kwijt kan.
+ *
+ * Dit gaat bewust niet via een CSS-mediaquery: de delen die verdwijnen zitten
+ * in slots van `nldd-title`, en die component zet er in zijn shadow-DOM een
+ * eigen display op die een regel van buiten niet overstemt.
+ */
+export const NARROW_BREAKPOINT = 900;
+
+export function useNarrow(breakpoint = NARROW_BREAKPOINT) {
+  const narrow = ref(typeof window === 'undefined' ? false : window.innerWidth < breakpoint);
+  function onResize() {
+    narrow.value = window.innerWidth < breakpoint;
+  }
+  onMounted(() => window.addEventListener('resize', onResize));
+  onUnmounted(() => window.removeEventListener('resize', onResize));
+  return narrow;
+}

--- a/frontend-demo/src/views/PortaalView.vue
+++ b/frontend-demo/src/views/PortaalView.vue
@@ -8,6 +8,7 @@ import { fieldSpec, numericImpact } from '../data/format.js';
 import { loadFailures } from '../engine/useDemoEngine.js';
 import { PERMISSION_LABELS, delegationLabel } from '../data/delegation.js';
 import { useDemo } from '../store/demoStore.js';
+import { useNarrow } from '../useNarrow.js';
 
 // The citizen's (or entrepreneur's) portal: every regeling the persona can
 // discover, evaluated live, ordered by financial impact. This is where the
@@ -15,6 +16,9 @@ import { useDemo } from '../store/demoStore.js';
 // submits an application.
 
 const demo = useDemo();
+// Op een smal scherm blijft alleen de kop staan; zie de toelichting in de
+// template bij nldd-title.
+const narrow = useNarrow();
 const { profile, persona, portalLaws, corpus, state, activeDelegation, canSubmitClaims, features } = demo;
 
 // Impact per law (from the tiles' evaluations) drives the ordering.
@@ -128,17 +132,35 @@ const loadFailureText = computed(() => loadFailures.value.map((f) => `${f.id} ($
          de tekst boven de tegels op dezelfde marge staat. -->
     <nldd-simple-section width="1440px">
       <nldd-title slot="header" size="2">
-        <span slot="overline">Ingelogd als {{ persona?.name ?? profile?.name }}<template v-if="activeDelegation"> · namens {{ activeDelegation.subjectName }}</template> · demo, geen echte overheidsdienst</span>
+        <!-- Op een smal scherm blijft alleen de kop staan: vijf lagen tekst
+             vulden daar het scherm voordat de eerste tegel in beeld kwam. Wie
+             is ingelogd staat ook in de werkbalk. Namens wie er gehandeld
+             wordt blijft wél staan, want dat verandert de betekenis van alles
+             eronder.
+             Dit gaat met v-if en niet met een CSS-klasse: overline en subtitle
+             zijn slots van nldd-title, en de component zet daar in zijn
+             shadow-DOM een eigen display op die een regel van buiten niet
+             overstemt (gemeten: allebei bleven zichtbaar). -->
+        <span v-if="!narrow || activeDelegation" slot="overline">
+          <template v-if="narrow">Namens {{ activeDelegation.subjectName }}</template>
+          <template v-else>Ingelogd als {{ persona?.name ?? profile?.name }}<template v-if="activeDelegation"> · namens {{ activeDelegation.subjectName }}</template> · demo, geen echte overheidsdienst</template>
+        </span>
         <h1>{{ heading }}</h1>
-        <span slot="subtitle">{{ subtitle }}</span>
+        <span v-if="!narrow" slot="subtitle">{{ subtitle }}</span>
         <!-- De slot heet `end`, niet `actions`: nldd-title kent alleen
              overline, default, subtitle en end. Met `actions` viel het blok
              buiten de shadow-DOM en was het 0x0 — de persona-tags stonden er
              dus wel, maar zag niemand. `.title__end` is een flexrij die niet
              krimpt, dus de tags gaan er los in: een nldd-container ertussen
-             heeft geen eigen breedte en werd 0px breed. -->
-        <nldd-tag v-for="p in properties" :key="p" slot="end" size="sm" :text="p"></nldd-tag>
-        <nldd-tag v-if="profile?.kvk && !activeDelegation" slot="end" size="sm" icon="building" :text="`KVK ${profile.kvk}`"></nldd-tag>
+             heeft geen eigen breedte en werd 0px breed.
+             Op een smal scherm staan ze naast de kop en namen ze de helft van
+             de breedte, waardoor die over vier regels brak. Het zijn
+             eigenschappen van de persona, net als de beschrijving hierboven,
+             dus ze gaan daar samen weg. -->
+        <template v-if="!narrow">
+          <nldd-tag v-for="p in properties" :key="p" slot="end" size="sm" :text="p"></nldd-tag>
+          <nldd-tag v-if="profile?.kvk && !activeDelegation" slot="end" size="sm" icon="building" :text="`KVK ${profile.kvk}`"></nldd-tag>
+        </template>
       </nldd-title>
       <!-- Eén ingang voor 'er is iets veranderd', naast de tegels die elk over
            één regeling gaan. Onder de kop en niet ernaast: het is een actie op
@@ -147,7 +169,7 @@ const loadFailureText = computed(() => loadFailures.value.map((f) => `${f.id} ($
         <nldd-button size="sm" variant="secondary" start-icon="edit" text="Wijziging doorgeven" @click="wizardOpen = true"></nldd-button>
       </nldd-container>
       <!-- De beschrijving hoort bij de persona zelf; namens een ander zegt zij niets. -->
-      <nldd-rich-text v-if="persona?.description && !activeDelegation" spacing="tight"><p><em>{{ persona.description }}</em></p></nldd-rich-text>
+      <nldd-rich-text v-if="persona?.description && !activeDelegation && !narrow" spacing="tight"><p><em>{{ persona.description }}</em></p></nldd-rich-text>
       <!-- The persona line above sets `spacing="tight"`, which strips the space
            under it, so a banner placed straight after touched it (measured: 0px
            between them). The banners get their own container with a gap. -->

--- a/frontend-demo/src/views/SimulatieView.vue
+++ b/frontend-demo/src/views/SimulatieView.vue
@@ -11,6 +11,7 @@ import { BUSINESS_DIMENSIONS, CITIZEN_DIMENSIONS, breakdown, flattenResults, toC
 import { disposableIncomeBreakdown, summariseDisposableIncome } from '../simulation/income.js';
 import { describeModel, featuresFor, taxLawIds, trainBracketModel, trainingData } from '../simulation/harmonize.js';
 import { useDemo } from '../store/demoStore.js';
+import { useNarrow } from '../useNarrow.js';
 
 // Simulatie: a synthetic population of citizens or businesses, every portal
 // law evaluated for each of them by the same engine the portal uses, and the
@@ -90,6 +91,9 @@ watch(activeRun, () => {
 
 async function run() {
   if (!ready.value || running.value) return;
+  // Op een smal scherm bedekt de sheet het hoofdpaneel, dus de voortgang en de
+  // uitkomst zouden erachter verdwijnen.
+  splitView.value?.hidePrimarySidebarSheet?.();
   running.value = true;
   runError.value = null;
   signal.cancelled = false;
@@ -206,6 +210,13 @@ const harmonizeRelativeError = computed(() => {
 const harmonizeNetCost = computed(() => (harmonizeModel.value?.metrics?.meanAmount ?? 0) < 0);
 
 // ---- inspector ----------------------------------------------------------------
+// De instellingen staan op een smal scherm in een sheet; na het starten van
+// een run moet die dicht, anders bedekt hij de uitkomst waar het om gaat.
+// Op een breed scherm blijft het paneel gewoon staan (zie de split view in de
+// template), dus daar is de knop overbodig.
+const splitView = ref(null);
+const narrow = useNarrow();
+
 const inspector = ref(null); // { type: 'params', lawId } | { type: 'law', lawId }
 function editParameters(law) {
   inspector.value = { type: 'params', lawId: law.id };
@@ -361,20 +372,33 @@ function exportJson() {
 </script>
 
 <template>
-  <nldd-navigation-split-view>
-    <nldd-split-view-pane slot="sidebar" has-content>
-      <nldd-page sticky-header>
-        <nldd-container slot="header" padding="8">
-          <nldd-toolbar size="sm">
-            <nldd-toolbar-title slot="start" text="Simulatie" :supporting-text="`${lawSet.runnable.length} regelingen`"></nldd-toolbar-title>
-          </nldd-toolbar>
-        </nldd-container>
-        <nldd-container padding="12" gap="12">
+  <!-- Alleen op een smal scherm wordt het zijpaneel een sheet. Daar viel het
+       anders helemaal weg en was er geen enkele manier meer om een simulatie
+       te starten. Op een breed scherm blijft het staan, anders dan bij Wetten
+       en Scenario's: tijdens een demo stel je hier voortdurend parameters bij,
+       en dat zou telkens een extra klik kosten. -->
+  <nldd-navigation-split-view
+    ref="splitView"
+    :primary-sidebar-as-sheet="narrow || undefined"
+    primary-sidebar-accessible-label="Simulatie-instellingen"
+  >
+    <nldd-split-view-pane slot="sidebar" has-content background="tinted">
+      <!-- Kop, keuze en zoekveld horen in de header, zoals Wetten het doet: de
+           burger/ondernemer-keuze is de hoofdknop van dit paneel, want alles
+           eronder gaat over de gekozen soort.
+           `sticky-header` staat er bewust niet op. Een plakkende header zweeft
+           over de scroll-container (gemeten: 61px, en precies evenveel bij
+           Wetten), wat daar onzichtbaar blijft omdat een lijst begint waar hier
+           meteen een invoerveld staat. -->
+      <nldd-page background="inherit">
+        <nldd-container slot="header" padding="12" gap="8">
+          <nldd-top-title-bar text="Simulatie" :supporting-text="`${lawSet.runnable.length} regelingen`"></nldd-top-title-bar>
           <nldd-segmented-control width="full" :value="kind" @change="kind = $event.detail?.value ?? kind">
             <nldd-segmented-control-item value="burgers" text="Burgers" icon="person"></nldd-segmented-control-item>
             <nldd-segmented-control-item value="ondernemers" text="Ondernemers" icon="business-suitcase"></nldd-segmented-control-item>
           </nldd-segmented-control>
-
+        </nldd-container>
+        <nldd-container padding="12" gap="12">
           <nldd-form-field :label="kind === 'ondernemers' ? 'Aantal bedrijven' : 'Aantal personen'">
             <nldd-number-field :value="params.count" min="1" max="2000" step="10" width="full" @change="params.count = numberFrom($event) ?? params.count"></nldd-number-field>
           </nldd-form-field>
@@ -422,9 +446,17 @@ function exportJson() {
 
     <nldd-split-view-pane slot="main" has-content>
       <nldd-page sticky-header>
-        <nldd-container v-if="runs.length" slot="header" padding="8">
+        <!-- De koptekst staat er altijd, ook zonder run: hij draagt de knop
+             naar de instellingen, en die is op een smal scherm de enige
+             ingang naar het zijpaneel. Stond hij achter `runs.length`, dan
+             was er zonder simulatie geen enkele manier om er een te
+             starten. -->
+        <nldd-container slot="header" padding="8">
           <nldd-toolbar size="sm">
-            <nldd-toolbar-item slot="start">
+            <nldd-toolbar-item slot="start" v-if="narrow">
+              <nldd-button size="sm" variant="neutral-tinted" start-icon="settings" text="Instellingen" @click="splitView?.showPrimarySidebarSheet?.()"></nldd-button>
+            </nldd-toolbar-item>
+            <nldd-toolbar-item slot="start" v-if="runs.length">
               <nldd-tab-bar size="sm" @tabchange="onTab">
                 <nldd-tab-bar-item v-for="r in runs" :key="r.id" :data-run="r.id" :selected="activeTab === r.id || undefined" :text="r.label"></nldd-tab-bar-item>
                 <nldd-tab-bar-item v-if="runs.length > 1" data-run="vergelijking" :selected="activeTab === 'vergelijking' || undefined" text="Vergelijking" icon="arrow-left-right"></nldd-tab-bar-item>
@@ -460,9 +492,7 @@ function exportJson() {
           <nldd-inline-dialog
             icon="chart-x-y-axis-line"
             text="Nog geen simulatie"
-            :supporting-text="harmonizeEnabled
-              ? 'Kies links een populatie en druk op Simuleren. Elke persoon of elk bedrijf wordt door de engine door alle regelingen gehaald. Daarna verschijnt rechtsboven ook Harmonisatie, dat op die uitkomsten rekent.'
-              : 'Kies links een populatie en druk op Simuleren. Elke persoon of elk bedrijf wordt door de engine door alle regelingen gehaald.'"
+            :supporting-text="`${narrow ? 'Kies onder Instellingen' : 'Kies links'} een populatie en druk op Simuleren. Elke persoon of elk bedrijf wordt door de engine door alle regelingen gehaald.${harmonizeEnabled ? ' Daarna verschijnt rechtsboven ook Harmonisatie, dat op die uitkomsten rekent.' : ''}`"
           ></nldd-inline-dialog>
         </nldd-simple-section>
 


### PR DESCRIPTION
Vijf dingen die op een smal scherm misgingen, plus twee vragen over hoe het menu in elkaar zit.

## Uitklappers in het menu deden niets, op geen enkele breedte

Dit begon als "donkere modus werkt niet op smal" en bleek breder. `nldd-menu` verplaatst een geopend submenu naar `document.body`, terwijl `nldd-toolbar` op het hoofdmenu luistert om de klik van een kloon terug te koppelen naar het originele item. Buiten dat menu bereikt het `select`-event de toolbar nooit, dus zowel **Weergave** als **Features** deed helemaal niets, ook op een breed scherm.

Het menu is nu plat: vier groepen met een titel, elk item direct klikbaar.

```
Demoprofiel   Merijn · Claudia
Features      vier vlaggen + handmatig beoordelen
Weergave      Systeem · Licht · Donker
Demo          Volledig scherm · Demo resetten…
```

Nagemeten dat het kleurenschema en de featurevlaggen nu op 1600px én 500px aankomen.

## De simulatie was op een telefoon niet te starten

Het zijpaneel viel weg en de koptekst van het hoofdpaneel stond achter `v-if="runs.length"`, dus zonder simulatie was er geen enkele knop om er een te beginnen.

Het paneel is op smal nu een sheet met een knop linksboven, zoals bij Wetten en Scenario's, en sluit zichzelf zodra een run begint. Op een breed scherm blijft het gewoon staan, anders dan bij die twee: tijdens een demo stel je hier voortdurend parameters bij, en dat zou telkens een extra klik kosten.

`sticky-header` moest eraf. Een plakkende header zweeft 61px over de scroll-container, wat bij Wetten niet opvalt omdat daar een lijst begint waar hier meteen een invoerveld staat.

## De portaalkop kostte een heel telefoonscherm

Vijf lagen tekst voordat de eerste tegel in beeld kwam. Op smal blijft alleen de kop staan: die stelt de vraag waar de pagina antwoord op geeft. De regel "ingelogd als" staat ook al in de werkbalk; de ondertitel, de persona-beschrijving en de tags gaan weg.

De kop ging van vier regels naar twee (gemeten 130px naar 65px), en er passen nu twee tegels in beeld waar eerst nog geen halve paste. "Namens wie" blijft wél staan, want dat verandert de betekenis van alles eronder.

Dit gaat met `v-if` en niet met een mediaquery: `overline` en `subtitle` zijn slots van `nldd-title`, en die component zet er in zijn shadow-DOM een eigen `display` op die een regel van buiten niet overstemt (gemeten: allebei bleven zichtbaar). De drempel staat één keer in `useNarrow.js`, zodat het portaal en de simulatie op dezelfde breedte omklappen.

## Merijn begint kaal

Merijn is het startprofiel, dus dit is wat iemand ziet die de demo opent. Er stonden drie van de vier vlaggen aan omdat de features net gebouwd waren, wat geen reden is om een presentator een vol scherm te geven. Alles staat nu uit; wie een feature wil tonen zet hem tijdens de demo aan. Claudia houdt haar eigen vlaggen, dus de features blijven vindbaar zonder configuratie.

"Demo resetten" zet de vlaggen terug naar het profiel. Dat deed het al, via `defaultState()`.

## De streep die niets scheidde

Tussen "correcties direct goedkeuren" en "alle aanvragen handmatig beoordelen" stond een divider die een onderscheid suggereerde dat er niet is. Het eerste gaat over correcties (`AUTO_APPROVE_CLAIMS`, demoStore.js:536), het tweede over aanvragen (`state.manualReview`, demoStore.js:416), maar het is dezelfde soort schakelaar. Het enige echte verschil is dat de een in de vlaggen zit en de ander in de demostaat, en dat hoeft een presentator niet te zien. Streep weg.

## Getest

Playwright-probes: het kleurenschema en de featurevlaggen op 1600px en 500px, de simulatie op beide breedtes (knop alleen op smal, paneel direct open op breed), en de portaalkop nagemeten op 430px. Verder `npm test -w frontend-demo` (222 tests) en de slot-guard.

Geen extra CSS: een `@media`-regel bleek niet te werken tegen de shadow-DOM van `nldd-title` en is weer verwijderd, dus er blijft niets achter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDtS6g2dMUXHwNRYJMxtE3
