### PR TITLE
feat: autonomie-invarianten als falende scenario-gate in de simulator

### DIFF
--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -744,7 +744,7 @@ Elke melding is geschreven voor iemand die het scenario niet kent: welke
 invariant, welke actoren, welk moment. Bijvoorbeeld:
 
 ```text
-[FOUT] invarianten: 1 contact(en) over een celgrens
+[FOUT] invarianten: 1 contact(en) over een celgrens, 1 tak(ken) in het vraaggraf
      I3 (definities): cel 'toeslagen' vroeg 'belastingdienst.toetsingsinkomen' op
      2024-06-01, maar haar eigen wetten en besluit-definities vragen daar niet om
      (haar definities vragen: toeslagen -> brp.partnerschap); een cel bevraagt
@@ -1065,6 +1065,16 @@ zie [Accepteren in plaats van narekenen](#accepteren-in-plaats-van-narekenen-i5)
 Wat deze stap overhoudt, is één vraag los kunnen stellen en op haar antwoord
 asserteren zonder er een besluit omheen te bouwen: handig om de naad zelf te
 beproeven, en verder niets.
+
+Wat een sonde **niet** overslaat, is invariant I3. De gate houdt haar aan dezelfde
+definities als een besluit, dus de vragende cel heeft een reden nodig om te vragen:
+een eigen wet die de peer via `source.regulation` aanwijst, plus de
+`accepts_from`-afspraak die zegt onder welke gepubliceerde naam de waarde daar te
+halen is. Zonder die twee faalt het scenario, ook als de tak in `query_graph`
+staat. Dat is met opzet — een sonde die buiten I3 viel, zou in elk scenario een weg
+om de invariant heen openzetten — maar het betekent dat een nieuwe sonde niet
+alleen een identiteit vraagt. Zie
+[De vijf invarianten](#de-vijf-invarianten-en-de-gate-eronder).
 
 De stappen lopen in deze volgorde: eerst de besluiten, dan de vragen van een
 consument, dan die over een celgrens. Dat past bij wat ze zijn — een besluit is

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -22,6 +22,14 @@ van de vragende cel naar het **transport**, en dat is de enige weg. Zie
 **observatielog**, een test-only instrument dat met opzet buiten de band staat:
 [Het observatielog](#het-observatielog-buiten-de-band).
 
+Het eigenlijke product zijn de **invarianten**. Een scenario declareert het
+toegestane vraaggraf, de run levert het feitelijke, en de gate berekent er zelf uit
+de celconfiguraties bij wat het recht van elke cel eigenlijk vraagt — elk verschil
+laat het scenario falen. Zie
+[De vijf invarianten](#de-vijf-invarianten-en-de-gate-eronder), inclusief de
+vermelding die er altijd bij hoort: I1 tot en met I5 en het observatielog komen
+**niet** uit RFC-022.
+
 ## De drie chronolexogrammen, en waar ze hier zitten
 
 De paper onderscheidt drie soorten chronolexogram (RFC-022 §1.1–§1.2). Deze
@@ -671,9 +679,148 @@ de runner zet ze in het log. Was dat vergeten, dan was het log stil incompleet
 geworden in plaats van rood — de gevaarlijke kant op, want het vraaggraf zou
 schoner lijken dan het is.
 
-De invarianten-gate die het gedeclareerde vraaggraf met het feitelijke vergelijkt
-(I3) staat er nog niet. Dit is het instrument waar die op gaat rusten, en daar
-hoort die volledigheidseis dan ook thuis.
+De invarianten-gate rust hierop, en hij sluit één kant van die volledigheidseis
+echt: een decretogram dat zegt een waarde van een andere cel geaccepteerd te
+hebben zonder dat er een contact met die cel is vastgelegd, laat het scenario
+falen (I2). De andere kant — een contact dat nergens wordt aangereikt — is niet te
+meten door wie alleen de aangereikte contacten ziet, en blijft dus structureel.
+Zie de sectie hieronder.
+
+## De vijf invarianten, en de gate eronder
+
+**I1 tot en met I5 en het observatielog komen niet uit RFC-022.** Dat hoort hier te
+staan voordat er één invariant genoemd wordt, want de verleiding is groot om ze als
+RFC-inhoud te lezen: ze staan in de taal van de RFC en ze gaan over wat de RFC
+beweert. De RFC beweert autonomie; ze zegt nergens hoe je die meet. Dit is
+toegevoegd meetgereedschap — van ons, falsifieerbaar, en te wijzigen zonder dat er
+een RFC aan te pas komt.
+
+| | wat de invariant zegt | hoe hij gehandhaafd wordt |
+|---|---|---|
+| **I1** | geen gedeelde state: een cel bezit haar kroniekstore privé | het **typesysteem**: geen `pub fn store()`, geen publiek veld, geen constructie die een andere cel erbij laat |
+| **I2** | volledig waarneembaar: elk cross-cel-contact loopt langs veiligheidscontext → transport → log | structureel (één weg over de grens) plus een gate-toets: een geaccepteerde waarde zónder vastgelegd contact faalt |
+| **I3** | een cel bevraagt alleen de cellen die haar eigen wetten of besluit-definities noemen | een **capability** (alleen gedeclareerde cel-ids bereiken de resolver) plus de gate, die het feitelijke gedrag toetst |
+| **I4** | synthese gebeurt nooit in een cel | de reduce-engine heeft geen cel-resolver, plus de gate: combineren buiten een besluit faalt, en wat een besluit haalde moet in zijn gram staan |
+| **I5** | narekenen versus accepteren | `check_provenance` over elk decretogram, plus `expect_accepted`/`expect_computed` per besluit — zie [Accepteren in plaats van narekenen](#accepteren-in-plaats-van-narekenen-i5) |
+
+De gate leeft in [`src/invariant.rs`](src/invariant.rs) en draait bij **elke** run,
+ook bij een scenario dat er niets over zegt. Een invariant die je moet aanzetten,
+is een invariant die iemand vergeet.
+
+### Het vraaggraf: gedeclareerd, feitelijk, toegestaan
+
+Drie grafen, en het verschil tussen de derde en de eerste is de hele pointe.
+
+- **gedeclareerd** — `query_graph` in het wereldbestand: welke cel welke andere
+  cel mag bevragen, en op welke lexostatus. De lexostatus hoort erbij; "A mag B
+  bevragen" is een blanco machtiging, en wat een cel publiceert zijn losse,
+  gedocumenteerde namen (RFC-022 §4.1).
+- **feitelijk** — afgeleid uit wat er werkelijk over de grenzen ging: de
+  bewijsstukken die de veiligheidscontext afgaf, dezelfde regels die het
+  observatielog bewaart.
+- **toegestaan** — *berekend* uit de celconfiguraties: de `accept_from`-inputs van
+  de besluit-definities van een cel, plus haar `accepts_from`-afspraken, waarmee
+  een `source.regulation` uit een van haar eigen wetten bij een lexostatus van een
+  peer uitkomt.
+
+Wat de gate daarmee doet:
+
+1. **feitelijk versus gedeclareerd, beide kanten op.** Een vraag die niet
+   gedeclareerd is faalt, en een gedeclareerde vraag die uitbleef faalt óók. Die
+   tweede is de belangrijkste: een niet-gedeclareerde vraag valt op, een vraag die
+   stilletjes wegvalt niet. Zonder die kant blijft een scenario waarin het besluit
+   verdwijnt groen terwijl het niets meer aantoont.
+2. **feitelijk versus toegestaan (I3).** Een gestelde vraag buiten de definities
+   faalt — **ook als het scenario haar declareert.** Zou een declaratie hier
+   volstaan, dan was elke schending met één regel YAML te legaliseren en hield I3
+   niets tegen dan slordigheid.
+3. **gedeclareerd versus toegestaan.** Een declaratie waar geen definitie om
+   vraagt, faalt op zichzelf, ook als de vraag nooit gesteld wordt. Een toegestaan
+   graf dat ruimer is dan het recht van de cellen vraagt, vertelt een lezer iets
+   anders dan er waar is — en zodra iemand er een vraag bij schrijft, ziet die
+   vraag er gedeclareerd en dus in orde uit.
+
+Elke melding is geschreven voor iemand die het scenario niet kent: welke
+invariant, welke actoren, welk moment. Bijvoorbeeld:
+
+```text
+[FOUT] invarianten: 1 contact(en) over een celgrens
+     I3 (definities): cel 'toeslagen' vroeg 'belastingdienst.toetsingsinkomen' op
+     2024-06-01, maar haar eigen wetten en besluit-definities vragen daar niet om
+     (haar definities vragen: toeslagen -> brp.partnerschap); een cel bevraagt
+     alleen de cellen die haar definities noemen, ook als het scenario de vraag
+     toestaat
+```
+
+De gate meldt zich ook als hij niets vond. Een gate die alleen bij een fout iets
+zegt, is niet te onderscheiden van een gate die niet gedraaid heeft.
+
+### I4: combineren mag, onzichtbaar combineren niet
+
+I4 zegt niet dat een cel nooit twee organisaties mag bevragen. Het zegt dat het
+combineren zichtbaar moet zijn. Twee toetsen, twee kanten van dezelfde naad:
+
+- **een cel die buiten een besluit-pad meer dan één cel bevraagt, faalt.** Buiten
+  een besluit is er geen gram, dus het totaalbeeld zou daar ontstaan zonder dat
+  iemand het kan terugzien.
+- **wat een besluit over de grens haalde, moet in zijn decretogram staan.** Een
+  contact zonder bijbehorende geaccepteerde waarde is combineren dat het gram niet
+  laat zien. En omgekeerd: een geaccepteerde waarde zonder contact betekent dat het
+  contact nergens vastligt of dat de waarde ergens anders vandaan kwam — dat is de
+  I2-toets uit de tabel hierboven.
+
+Combineren bij een **consument** blijft legitiem (RFC-022 §4.1) en is voor de gate
+onzichtbaar, omdat een consument geen celgrens overgaat: hij stelt twee gewone
+vragen. Dat is geen gat maar het onderscheid zelf.
+
+### De negatieve fixtures
+
+Een gate die nooit rood wordt, is niet van een ontbrekende gate te onderscheiden.
+In [`scenarios/negatief/`](scenarios/negatief/) staan daarom scenariobestanden die
+met opzet één invariant schenden en die **moeten** falen:
+
+| bestand | schending |
+|---|---|
+| `niet_gedeclareerde_call.yaml` | een besluit vraagt over de grens; het scenario declareert die vraag niet |
+| `gedeclareerde_call_bleef_uit.yaml` | de declaratie is in orde, maar de vraag wordt nooit gesteld |
+| `cel_bevraagt_cel_buiten_haar_definities.yaml` | een cel bevraagt een cel die haar definities niet noemen — en het scenario declareert die vraag wél (I3) |
+| `declaratie_buiten_de_definities.yaml` | het vraaggraf staat een vraag toe waar geen enkele definitie om vraagt |
+| `reductie_combineert_twee_cellen.yaml` | een cel legt buiten een besluit-pad twee celantwoorden bij elkaar (I4) |
+
+Ze vallen buiten de gewone scenariosuite, want die verwacht van elk bestand dat het
+groen is. [`tests/invarianten.rs`](tests/invarianten.rs) draait ze en rekent ze af
+op twee dingen: dát ze falen, en waaróp. Dat tweede is het eigenlijke werk — een
+fixture die om de verkeerde reden rood staat, bewijst niets over de invariant die
+hij zegt te meten. Diezelfde test dwingt af dat elk bestand in die map een regel in
+de tabel heeft en omgekeerd, zodat een fixture die niemand draait geen bestand is
+dat stil niets doet.
+
+De achterdeur waarlangs de twee gedrags-fixtures hun schending uitdrukken is
+`query_via_transport`, de sonde over de naad. In de opstelling zelf kan een cel dit
+niet: `Cell::reduce` krijgt nooit een cel-resolver, en over haar grens komt ze
+alleen vanuit een besluit. Dat de schendingen alleen via de sonde te schrijven zijn,
+is dus goed nieuws — maar een gate die de sonde zou overslaan, zou dat goede nieuws
+niet kunnen aantonen, en zou bovendien in elk scenario een weg om I3 heen
+openzetten. Daarom wordt de sonde aan dezelfde definities gehouden als een besluit.
+
+Twee toetsen zijn niet als fixture te schrijven, omdat de opstelling ze onmogelijk
+maakt: een gram dat accepteert zonder contact, en een contact dat het gram niet laat
+zien. `tests/invarianten.rs` meet ze door echte artefacten verkeerd aan elkaar te
+knopen — het gram van het ene besluit naast de contacten van het andere — in plaats
+van een wereld te bouwen waarin het kan.
+
+### Wat de gate niet doet
+
+- **Hij kan een contact dat nergens wordt aangereikt niet zien.** Volledigheid van
+  het meetinstrument is structureel, niet afgedwongen; zie
+  [Het observatielog](#het-observatielog-buiten-de-band).
+- **De contacten van een omgevallen besluit verdwijnen.** `World::decide` geeft bij
+  een fout de contacten niet mee, en een omgevallen besluit breekt de run af. Dat
+  is te verdedigen zolang die twee samen opgaan, en het staat als voorwaarde in
+  `world.rs` — maar de vragen van een besluit dat niet lukte, staan niet in het
+  graf.
+- **Hij zegt niets over prestaties en draait niet over het hele corpus.** Dat zijn
+  twee aparte vragen; deze gate is een eigenschap van een run.
 
 ## De tijdlijn
 
@@ -733,8 +880,9 @@ bereikt geen stille regel in het bestand is.
 ## Het wereldbestand
 
 Een wereld is één YAML-bestand: `clock` (de tijdlijn), `cells` (wie er zijn),
-`settings` (casusdata die geen wet is), `fixtures` (de startstand), `decide`
-(welke cel wanneer waarover besluit) en twee soorten vraag: `queries` (een
+`settings` (casusdata die geen wet is), `fixtures` (de startstand), `query_graph`
+(het toegestane vraaggraf), `decide` (welke cel wanneer waarover besluit) en twee
+soorten vraag: `queries` (een
 consument bevraagt een cel) en `query_via_transport` (een cel bevraagt een andere
 cel). Elk draagt zijn eigen verwachting. De assertie hoort bij het bestand, niet
 bij Rust: een nieuw testgeval is een nieuw bestand.
@@ -857,6 +1005,12 @@ fixtures:                                       # de startstand van de wereld
         bsn: '999993653'
         partnerschap_type: GEEN
 
+query_graph:                                    # het toegestane vraaggraf
+  - doc: waarom deze vraag mag                  # optioneel
+    from: toeslagen                             # de cel die mag vragen
+    to: belastingdienst                         # de cel aan wie
+    lexostatus: toetsingsinkomen                # en waarover
+
 decide:                                         # besluiten, elk op een moment
   - description: vrije omschrijving             # optioneel
     cell: toeslagen                             # de cel die besluit
@@ -923,6 +1077,10 @@ landt.
 Een `decide` mag zonder `expect`, anders dan een vraag: hij legt iets vast, en
 bewijst daarmee ook zonder verwachting iets — namelijk dat de vragen erna iets te
 vinden hebben.
+
+`query_graph` mag weg, en dan zegt het bestand iets: **er gaat niets over een
+celgrens.** Zie [De vijf invarianten](#de-vijf-invarianten-en-de-gate-eronder) voor
+wat ermee gebeurt.
 
 Onbekende velden worden geweigerd, zodat een typfout niet stil verdwijnt. Elke
 vraag heeft minstens één verwachting: een vraag zonder `expect` en zonder
@@ -1072,11 +1230,11 @@ nog open. Zo ook **echte ondertekening** en de RFC-009-modi als configuratie: de
 ondertekening in een geaccepteerde waarde is de placeholder uit
 [Ondertekening is gesimuleerd](#ondertekening-is-gesimuleerd).
 
-Aan de kant van de celgrens ontbreken verder de **invarianten-gate** die het
-gedeclareerde vraaggraf uit het scenario vergelijkt met het feitelijke uit het
-observatielog (I3) — de herkomstgate van I5 draait wel, bij elk besluit — en
-**autorisatie**: de veiligheidscontext kent identiteit en ondertekening, en beslist
-nog niets over wat mag.
+Aan de kant van de celgrens ontbreekt verder **autorisatie**: de
+veiligheidscontext kent identiteit en ondertekening, en beslist nog niets over wat
+mag. De invarianten-gate draait wel — zie
+[De vijf invarianten](#de-vijf-invarianten-en-de-gate-eronder) voor wat hij toetst
+en, even belangrijk, wat hij niet kan zien.
 
 Ook een **HTTP-transport** is er niet; dat is het punt van de trait. Komt het er,
 dan is dat een tweede implementatie naast `InProcessTransport` en geen wijziging in

--- a/packages/simulator/fixtures/regulation/test_dubbele_celbron/2024-01-01.yaml
+++ b/packages/simulator/fixtures/regulation/test_dubbele_celbron/2024-01-01.yaml
@@ -1,0 +1,90 @@
+---
+$schema: >-
+  https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.8/schema/v0.5.8/schema.json
+$id: test_dubbele_celbron
+name: Testregeling met twee celbronnen
+regulatory_layer: WET
+bwb_id: BWBR9999902
+publication_date: '2024-01-01'
+valid_from: '2024-01-01'
+url: https://example.com/test_dubbele_celbron
+competent_authority: Dienst Toeslagen
+
+# Een testregeling, met opzet **niet** in het corpus: ze bestaat om een
+# eigenschap van de opstelling aan te tonen en niet om recht weer te geven. Zie
+# `test_partnerschapstoets` voor dezelfde afweging; een echte wet hoort niet
+# verbouwd te worden omdat een testopstelling iets wil laten zien.
+#
+# Wat deze regeling toevoegt is precies één ding: ze wijst **twee** andere
+# organisaties aan (`brp` en `belastingdienst`, elk als `source.regulation` die
+# geen regeling is maar een cel-id). Daarmee is er een cel te bouwen wier eigen
+# recht twee peers vraagt — en dat is wat een scenario nodig heeft om te laten
+# zien dat het *combineren* van die twee buiten een besluit-pad een schending van
+# invariant I4 is, en niet gewoon een cel die buiten haar definities reikt. Zonder
+# twee toegestane bronnen zouden die twee fouten in één fixture door elkaar lopen.
+#
+# De twee artikelen zijn met opzet onafhankelijk: er is hier niets te rekenen dat
+# de invariant scherper maakt, en een gezamenlijke uitkomst zou alleen de vraag
+# opwerpen of de engine hem goed uitrekent.
+articles:
+  - number: '1'
+    url: https://example.com/test_dubbele_celbron#Artikel1
+    text: >-
+      De eerste uitkomst is waar indien de relatievorm van de betrokkene een
+      huwelijk is, zoals de basisregistratie personen die vaststelt.
+    machine_readable:
+      execution:
+        produces:
+          legal_character: BESCHIKKING
+        parameters:
+          - name: bsn
+            type: string
+            required: true
+        input:
+          - name: partnerschap_type
+            type: string
+            source:
+              regulation: brp
+              output: partnerschap
+              parameters:
+                bsn: $bsn
+        output:
+          - name: is_gehuwd
+            type: boolean
+        actions:
+          - output: is_gehuwd
+            value:
+              operation: EQUALS
+              subject: $partnerschap_type
+              value: HUWELIJK
+
+  - number: '2'
+    url: https://example.com/test_dubbele_celbron#Artikel2
+    text: >-
+      De tweede uitkomst is waar indien de inkomensklasse van de betrokkene laag
+      is, zoals de belastingdienst die vaststelt.
+    machine_readable:
+      execution:
+        produces:
+          legal_character: BESCHIKKING
+        parameters:
+          - name: bsn
+            type: string
+            required: true
+        input:
+          - name: inkomensklasse
+            type: string
+            source:
+              regulation: belastingdienst
+              output: inkomensklasse
+              parameters:
+                bsn: $bsn
+        output:
+          - name: inkomen_is_laag
+            type: boolean
+        actions:
+          - output: inkomen_is_laag
+            value:
+              operation: EQUALS
+              subject: $inkomensklasse
+              value: LAAG

--- a/packages/simulator/scenarios/negatief/cel_bevraagt_cel_buiten_haar_definities.yaml
+++ b/packages/simulator/scenarios/negatief/cel_bevraagt_cel_buiten_haar_definities.yaml
@@ -1,0 +1,125 @@
+---
+name: een cel bevraagt een cel die haar eigen definities niet noemen
+description: >-
+  **Negatieve fixture: dit scenario hoort te falen** — op invariant I3. Hij staat
+  in `scenarios/negatief/` en wordt door `tests/invarianten.rs` gedraaid, dat
+  controleert dát hij faalt en waarop.
+
+  Wat er mis is: `toeslagen` bevraagt `belastingdienst`, en niets in haar eigen
+  recht vraagt daarom. Haar wet wijst `brp` aan en verder niemand, en geen van
+  haar besluit-definities accepteert iets van de belastingdienst.
+
+  En het scenario **declareert die vraag wel**. Dat is met opzet, want het is de
+  hele pointe van I3: het toegestane vraaggraf is niet wat een scenario mag
+  beweren, het is wat uit de `accept_from`-inputs en de `accepts_from`-afspraken
+  van de cellen volgt. Een declaratie is geen vrijbrief; zou ze dat zijn, dan
+  hield I3 niets tegen dan slordigheid, en was elke schending met één regel YAML
+  te legaliseren. Daarom komt er hier een tweede melding bij: de declaratie zelf
+  loopt uit de pas met de definities.
+
+  De weg waarlangs de vraag gesteld wordt is `query_via_transport`. Dat is de
+  sonde over de naad, en in de opstelling zelf de enige manier waarop een cel
+  buiten een besluit over haar grens komt — dus de enige manier waarop een
+  scenariobestand deze schending kan uitdrukken. Vandaar dat de gate de sonde aan
+  dezelfde definities houdt als een besluit: een uitzondering daar zou in elk
+  scenario een weg om I3 heen openzetten.
+
+clock:
+  start: 2024-01-01
+
+cells:
+  # De cel die haar recht wél aanwijst, en die hier niets gevraagd wordt. Ze
+  # staat erin omdat `accepts_from` van `toeslagen` naar haar verwijst: een
+  # afspraak met een cel die de wereld niet kent, wordt bij het optuigen
+  # geweigerd.
+  - id: brp
+    laws: []
+
+    chronicles:
+      - stream: relaties
+        key: bsn
+        events:
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: brp
+            grondslag: eigen registratie
+            op_moment: 2023-03-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: HUWELIJK
+
+    lexostatus_definitions:
+      - name: partnerschap
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - partnerschap_type
+        reduction:
+          chronicle: relaties
+          key: bsn
+          latest: true
+
+  # De cel die bevraagd wordt zonder dat iemands recht daarom vroeg. Zij merkt
+  # niets: een cel kan niet zien of een vraag bij het recht van de vrager past, en
+  # dat is precies waarom deze invariant aan de kant van de vrager gemeten wordt.
+  - id: belastingdienst
+    laws: []
+
+    chronicles:
+      - stream: aanslagen
+        key: bsn
+        events:
+          - name: aanslag_vastgesteld
+            intake: eigen_besluit
+            recording_actor: belastingdienst
+            grondslag: Wet inkomstenbelasting 2001, hoofdstuk 2
+            op_moment: 2024-03-01
+            fields:
+              bsn: '999993653'
+              toetsingsinkomen: 81000
+
+    lexostatus_definitions:
+      - name: toetsingsinkomen
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - toetsingsinkomen
+        reduction:
+          chronicle: aanslagen
+          key: bsn
+          latest: true
+
+  - id: toeslagen
+    laws:
+      - test_partnerschapstoets
+
+    # Wat haar recht vraagt: `brp`, en niemand anders.
+    accepts_from:
+      - cell: brp
+        output: partnerschap
+        lexostatus: partnerschap
+        field: partnerschap_type
+
+query_graph:
+  - doc: >-
+      Het scenario staat deze vraag toe. Dat verandert niets: de definities van
+      `toeslagen` vragen niet om de belastingdienst.
+    from: toeslagen
+    to: belastingdienst
+    lexostatus: toetsingsinkomen
+
+query_via_transport:
+  - description: >-
+      De vraag die niet mag. Ze lukt technisch prima — de belastingdienst
+      antwoordt netjes — en dat is het punt: alleen het vraaggraf laat zien dat
+      hier iets gebeurde waar het recht van deze cel niet om vraagt.
+    from: toeslagen
+    cell: belastingdienst
+    lexostatus: toetsingsinkomen
+    params:
+      bsn: '999993653'
+    op_moment: 2024-06-01
+    expect:
+      toetsingsinkomen: 81000

--- a/packages/simulator/scenarios/negatief/declaratie_buiten_de_definities.yaml
+++ b/packages/simulator/scenarios/negatief/declaratie_buiten_de_definities.yaml
@@ -1,0 +1,116 @@
+---
+name: het vraaggraf staat een vraag toe waar geen enkele definitie om vraagt
+description: >-
+  **Negatieve fixture: dit scenario hoort te falen.** Hij staat in
+  `scenarios/negatief/` en wordt door `tests/invarianten.rs` gedraaid, dat
+  controleert dát hij faalt en waarop.
+
+  Wat er mis is: het vraaggraf declareert dat `toeslagen` bij `belastingdienst`
+  een toetsingsinkomen mag opvragen, en niets in haar recht vraagt daarom — geen
+  `accept_from` in een besluit-definitie, geen `accepts_from`-afspraak bij haar
+  wetten. Er wordt in deze run ook nooit zo'n vraag gesteld, en daarom is dit iets
+  anders dan `cel_bevraagt_cel_buiten_haar_definities.yaml`: daar faalt het
+  *gedrag*, hier faalt de **declaratie** op zichzelf.
+
+  Dat dit een eigen fout is en niet alleen een ongebruikte regel, is het punt. Een
+  toegestaan vraaggraf dat ruimer is dan de definities vragen, vertelt een lezer
+  iets anders over de opstelling dan er waar is — en zodra iemand er een vraag bij
+  schrijft, is die vraag "gedeclareerd" en lijkt alles in orde. De gate berekent
+  het toegestane graf daarom zelf uit de celconfiguraties en vergelijkt de
+  declaratie ermee.
+
+  Er komt een tweede melding bij: de gedeclareerde tak is ook niet gesteld. Die
+  hoort erbij — een declaratie die niets meet is óók een fout — maar de melding
+  waar deze fixture over gaat, is die over declaratie en definitie die uit de pas
+  lopen.
+
+clock:
+  start: 2024-01-01
+
+cells:
+  - id: brp
+    laws: []
+
+    chronicles:
+      - stream: relaties
+        key: bsn
+        events:
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: brp
+            grondslag: eigen registratie
+            op_moment: 2023-03-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: HUWELIJK
+
+    lexostatus_definitions:
+      - name: partnerschap
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - partnerschap_type
+        reduction:
+          chronicle: relaties
+          key: bsn
+          latest: true
+
+  - id: belastingdienst
+    laws: []
+
+    chronicles:
+      - stream: aanslagen
+        key: bsn
+        events:
+          - name: aanslag_vastgesteld
+            intake: eigen_besluit
+            recording_actor: belastingdienst
+            grondslag: Wet inkomstenbelasting 2001, hoofdstuk 2
+            op_moment: 2024-03-01
+            fields:
+              bsn: '999993653'
+              toetsingsinkomen: 81000
+
+    lexostatus_definitions:
+      - name: toetsingsinkomen
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - toetsingsinkomen
+        reduction:
+          chronicle: aanslagen
+          key: bsn
+          latest: true
+
+  - id: toeslagen
+    laws:
+      - test_partnerschapstoets
+
+    accepts_from:
+      - cell: brp
+        output: partnerschap
+        lexostatus: partnerschap
+        field: partnerschap_type
+
+query_graph:
+  - doc: >-
+      Deze tak komt uit de lucht vallen: geen wet en geen besluit van `toeslagen`
+      vraagt om de belastingdienst.
+    from: toeslagen
+    to: belastingdienst
+    lexostatus: toetsingsinkomen
+
+queries:
+  - description: >-
+      Een gewone vraag van een consument aan de bron-cel. Die gaat niet over een
+      celgrens en staat dus ook niet in het vraaggraf; ze staat hier zodat dit
+      bestand iets meet en de fout in de declaratie zit en niet in de leegte.
+    cell: belastingdienst
+    lexostatus: toetsingsinkomen
+    params:
+      bsn: '999993653'
+    op_moment: 2024-06-01
+    expect:
+      toetsingsinkomen: 81000

--- a/packages/simulator/scenarios/negatief/gedeclareerde_call_bleef_uit.yaml
+++ b/packages/simulator/scenarios/negatief/gedeclareerde_call_bleef_uit.yaml
@@ -1,0 +1,107 @@
+---
+name: het scenario declareert een vraag die in de run nooit gesteld wordt
+description: >-
+  **Negatieve fixture: dit scenario hoort te falen.** Zie
+  `niet_gedeclareerde_call.yaml` voor waarom deze bestanden apart staan.
+
+  Wat er mis is: het vraaggraf declareert dat `toeslagen` de relatievorm bij `brp`
+  mag opvragen, en die declaratie is in orde — haar eigen wet vraagt daarom, dus
+  declaratie en definitie lopen hier niet uit de pas. Alleen wordt het besluit dat
+  die vraag zou stellen nooit genomen: er staat geen `decide` in dit bestand. De
+  vraag blijft dus uit.
+
+  Dat dít faalt is de minder voor de hand liggende helft van de vergelijking, en
+  de belangrijkste. Een niet-gedeclareerde vraag valt op; een vraag die stilletjes
+  wegvalt niet. Zou de gate alleen de eerste kant meten, dan zou een scenario
+  waarin het besluit verdwijnt — verplaatst, uitgecommentarieerd, kapot — groen
+  blijven terwijl het niets meer aantoont. Het is de gevaarlijkste vorm van
+  groen: hij lijkt op bewijs.
+
+clock:
+  start: 2024-01-01
+
+cells:
+  - id: brp
+    laws: []
+
+    chronicles:
+      - stream: relaties
+        key: bsn
+        events:
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: brp
+            grondslag: eigen registratie
+            op_moment: 2023-03-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: HUWELIJK
+
+    lexostatus_definitions:
+      - name: partnerschap
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - partnerschap_type
+        reduction:
+          chronicle: relaties
+          key: bsn
+          latest: true
+
+  - id: toeslagen
+    laws:
+      - test_partnerschapstoets
+
+    accepts_from:
+      - cell: brp
+        output: partnerschap
+        lexostatus: partnerschap
+        field: partnerschap_type
+
+    besluit_definitions:
+      - name: partnerschapstoets
+        regulation: test_partnerschapstoets
+        output: is_gehuwd
+        zaakkenmerk: partnerschapstoets/{bsn}
+        params:
+          - name: bsn
+            type: string
+        inputs:
+          bsn:
+            param: bsn
+
+    lexostatus_definitions:
+      - name: partnerschapsbeschikking
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - is_gehuwd
+        reduction:
+          chronicle: beschikkingen
+          key: zaakkenmerk
+          latest: true
+
+query_graph:
+  - doc: >-
+      Deze tak is toegestaan en past bij de definities van `toeslagen` — ze wordt
+      alleen nooit gebruikt, want het besluit dat haar zou stellen ontbreekt.
+    from: toeslagen
+    to: brp
+    lexostatus: partnerschap
+
+# Hier hoorde het besluit te staan dat de vraag stelt. Het ontbreekt, en dat is
+# de schending.
+
+queries:
+  - description: >-
+      Zonder besluit ligt er geen decretogram, dus de cel heeft over deze zaak
+      niets vastgesteld. Dat is een geldig antwoord en geen fout; de fout zit in
+      het vraaggraf.
+    cell: toeslagen
+    lexostatus: partnerschapsbeschikking
+    params:
+      zaakkenmerk: partnerschapstoets/999993653
+    op_moment: 2024-06-01
+    expect_not_established: true

--- a/packages/simulator/scenarios/negatief/niet_gedeclareerde_call.yaml
+++ b/packages/simulator/scenarios/negatief/niet_gedeclareerde_call.yaml
@@ -1,0 +1,105 @@
+---
+name: een besluit vraagt over een celgrens zonder dat het scenario dat declareert
+description: >-
+  **Negatieve fixture: dit scenario hoort te falen.** Hij staat in
+  `scenarios/negatief/` en wordt door `tests/invarianten.rs` gedraaid, dat
+  controleert dát hij faalt en waarop — niet door de gewone scenariosuite, die
+  van elk bestand verwacht dat het groen is.
+
+  Wat er mis is: het besluit van `toeslagen` haalt de relatievorm bij `brp`, want
+  haar eigen wet vraagt daarom. Dat mág, maar dit bestand declareert geen enkel
+  vraaggraf, en dan is de bewering van het scenario "er gaat niets over een
+  celgrens". De gate hoort dat verschil te melden met de vraag erin — welke cel,
+  welke cel, welke lexostatus, welk moment — en niet met een telling.
+
+  Waarom de afwezigheid van `query_graph` een bewering is en geen omissie: was
+  een leeg graf "geen mening", dan zou elk scenario dat de declaratie vergeet
+  stilzwijgend elk verkeer toestaan, en dan meet de gate alleen nog bij wie eraan
+  dacht.
+
+clock:
+  start: 2024-01-01
+
+cells:
+  - id: brp
+    laws: []
+
+    chronicles:
+      - stream: relaties
+        key: bsn
+        events:
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: brp
+            grondslag: eigen registratie
+            op_moment: 2023-03-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: HUWELIJK
+
+    lexostatus_definitions:
+      - name: partnerschap
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - partnerschap_type
+        reduction:
+          chronicle: relaties
+          key: bsn
+          latest: true
+
+  - id: toeslagen
+    laws:
+      - test_partnerschapstoets
+
+    accepts_from:
+      - cell: brp
+        output: partnerschap
+        lexostatus: partnerschap
+        field: partnerschap_type
+
+    besluit_definitions:
+      - name: partnerschapstoets
+        regulation: test_partnerschapstoets
+        output: is_gehuwd
+        zaakkenmerk: partnerschapstoets/{bsn}
+        params:
+          - name: bsn
+            type: string
+        inputs:
+          bsn:
+            param: bsn
+
+    lexostatus_definitions:
+      - name: partnerschapsbeschikking
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - is_gehuwd
+        reduction:
+          chronicle: beschikkingen
+          key: zaakkenmerk
+          latest: true
+
+# Hier hoort een `query_graph` te staan met de tak toeslagen -> brp.partnerschap.
+# Hij staat er niet, en dat is de schending.
+
+decide:
+  - cell: toeslagen
+    besluit: partnerschapstoets
+    params:
+      bsn: '999993653'
+    op_moment: 2024-06-01
+    expect:
+      is_gehuwd: true
+
+queries:
+  - cell: toeslagen
+    lexostatus: partnerschapsbeschikking
+    params:
+      zaakkenmerk: partnerschapstoets/999993653
+    op_moment: 2024-06-01
+    expect:
+      is_gehuwd: true

--- a/packages/simulator/scenarios/negatief/reductie_combineert_twee_cellen.yaml
+++ b/packages/simulator/scenarios/negatief/reductie_combineert_twee_cellen.yaml
@@ -1,0 +1,139 @@
+---
+name: een cel combineert buiten een besluit-pad antwoorden van twee cellen
+description: >-
+  **Negatieve fixture: dit scenario hoort te falen** — op invariant I4. Hij staat
+  in `scenarios/negatief/` en wordt door `tests/invarianten.rs` gedraaid, dat
+  controleert dát hij faalt en waarop.
+
+  Wat er mis is: `toeslagen` haalt een relatievorm bij `brp` en een inkomensklasse
+  bij `belastingdienst`, en er is geen besluit waar die twee samenkomen. Dan
+  bestaat het totaalbeeld tóch ergens — in die cel, op dat moment — en dat is
+  precies wat deze opstelling zegt dat nergens gebeurt.
+
+  Let op wat hier **niet** mis is, want dat is het verschil dat I4 maakt. Beide
+  vragen zijn toegestaan: de wet van `toeslagen` wijst beide cellen aan, beide
+  afspraken staan in `accepts_from`, en beide takken staan in het vraaggraf. Elke
+  vraag afzonderlijk is dus in orde. Wat niet mag is ze bij elkaar leggen op een
+  plek waar niemand het kan terugzien. In een besluit mág dat wel, en dan staat het
+  in het decretogram met bron, moment en ondertekening per waarde — combineren is
+  niet verboden, onzichtbaar combineren is dat.
+
+  De achterdeur waarlangs dit hier gebeurt is `query_via_transport`, de sonde over
+  de naad. In de opstelling zelf kan een cel dit niet: `Cell::reduce` krijgt nooit
+  een cel-resolver, dus een reductie die buiten haar eigen kronieken reikt is een
+  ontbrekende capability en geen afspraak. Dat de schending alleen via de sonde uit
+  te drukken is, is dus goed nieuws — maar een gate die hem niet zou zien, zou dat
+  goede nieuws niet kunnen aantonen.
+
+clock:
+  start: 2024-01-01
+
+cells:
+  - id: brp
+    laws: []
+
+    chronicles:
+      - stream: relaties
+        key: bsn
+        events:
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: brp
+            grondslag: eigen registratie
+            op_moment: 2023-03-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: HUWELIJK
+
+    lexostatus_definitions:
+      - name: partnerschap
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - partnerschap_type
+        reduction:
+          chronicle: relaties
+          key: bsn
+          latest: true
+
+  - id: belastingdienst
+    laws: []
+
+    chronicles:
+      - stream: aanslagen
+        key: bsn
+        events:
+          - name: aanslag_vastgesteld
+            intake: eigen_besluit
+            recording_actor: belastingdienst
+            grondslag: Wet inkomstenbelasting 2001, hoofdstuk 2
+            op_moment: 2024-03-01
+            fields:
+              bsn: '999993653'
+              inkomensklasse: LAAG
+
+    lexostatus_definitions:
+      - name: inkomensklasse
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - inkomensklasse
+        reduction:
+          chronicle: aanslagen
+          key: bsn
+          latest: true
+
+  # De combinerende cel. Haar wet is een testregeling die twee organisaties
+  # aanwijst, en beide afspraken staan hieronder: het toegestane vraaggraf van
+  # deze cel bevat dus beide takken. Daarmee is dit bestand een fixture over I4 en
+  # niet over I3 — zonder die twee afspraken zouden de twee schendingen door
+  # elkaar lopen en zou de test niet kunnen zeggen welke hij meet.
+  - id: toeslagen
+    laws:
+      - test_dubbele_celbron
+
+    accepts_from:
+      - cell: brp
+        output: partnerschap
+        lexostatus: partnerschap
+        field: partnerschap_type
+
+      - cell: belastingdienst
+        output: inkomensklasse
+        lexostatus: inkomensklasse
+        field: inkomensklasse
+
+query_graph:
+  - from: toeslagen
+    to: brp
+    lexostatus: partnerschap
+
+  - from: toeslagen
+    to: belastingdienst
+    lexostatus: inkomensklasse
+
+query_via_transport:
+  - description: de eerste bron
+    from: toeslagen
+    cell: brp
+    lexostatus: partnerschap
+    params:
+      bsn: '999993653'
+    op_moment: 2024-06-01
+    expect:
+      partnerschap_type: HUWELIJK
+
+  - description: >-
+      En de tweede. Op dit moment kent `toeslagen` de antwoorden van twee
+      organisaties zonder dat er een besluit is dat ze bij elkaar brengt; het
+      moment in de faalmelding is dít moment.
+    from: toeslagen
+    cell: belastingdienst
+    lexostatus: inkomensklasse
+    params:
+      bsn: '999993653'
+    op_moment: 2024-07-01
+    expect:
+      inkomensklasse: LAAG

--- a/packages/simulator/scenarios/toeslagen_accepteert_toetsingsinkomen.yaml
+++ b/packages/simulator/scenarios/toeslagen_accepteert_toetsingsinkomen.yaml
@@ -168,6 +168,18 @@ cells:
           key: zaakkenmerk
           latest: true
 
+# Het toegestane vraaggraf. Eén tak, en die hoort bij het eerste besluit: het
+# tweede rekent op eigen feiten en vraagt niemand iets. Beide kanten worden
+# afgerekend, dus dit bestand bewijst óók dat er niet méér over de grens ging —
+# en dat het nagerekende besluit werkelijk niemand bevroeg.
+query_graph:
+  - doc: >-
+      `toeslagen` mag het toetsingsinkomen opvragen bij de cel die het
+      vaststelde; haar besluit-definitie zegt dat met `accept_from`.
+    from: toeslagen
+    to: belastingdienst
+    lexostatus: toetsingsinkomen
+
 decide:
   - description: >-
       Accepteren. Het toetsingsinkomen komt van de belastingdienst, en het gram

--- a/packages/simulator/scenarios/toeslagen_accepteert_via_de_wet.yaml
+++ b/packages/simulator/scenarios/toeslagen_accepteert_via_de_wet.yaml
@@ -128,6 +128,19 @@ cells:
           parameters:
             bsn: $bsn
 
+# Het toegestane vraaggraf. De tak komt hier niet uit een besluit-definitie maar
+# uit de wet: `test_partnerschapstoets` vraagt om `partnerschap` bij `brp`, en
+# `accepts_from` hierboven wijst de lexostatus aan. De gate berekent dat zelf uit
+# de celconfiguratie, dus een declaratie die hier iets anders zou zeggen dan de
+# definities vragen, faalt ook als ze precies de gestelde vraag beschrijft.
+query_graph:
+  - doc: >-
+      `toeslagen` mag bij `brp` de lexostatus `partnerschap` opvragen; de wet
+      die ze uitvoert vraagt daarom.
+    from: toeslagen
+    to: brp
+    lexostatus: partnerschap
+
 decide:
   - description: >-
       Het besluit leunt op een feit van `brp`, en het gram zegt dat ook: de

--- a/packages/simulator/scenarios/transport_toeslagen_brp.yaml
+++ b/packages/simulator/scenarios/transport_toeslagen_brp.yaml
@@ -58,12 +58,38 @@ cells:
           key: bsn
           latest: true
 
-  # De vragende cel. Ze publiceert hier zelf niets en legt niets vast: in deze
-  # ronde is ze alleen vrager, want het besluit-pad dat een opgehaalde waarde
-  # zou accepteren bestaat nog niet. Wat ze wél heeft, is een identiteit — en
-  # dat is alles wat er nodig is om een vraag te ondertekenen.
+  # De vragende cel. Ze publiceert hier zelf niets en legt niets vast: in dit
+  # scenario is ze alleen vrager, en wat ze nodig heeft om een vraag over de
+  # grens te zetten is een identiteit.
+  #
+  # Wat ze óók nodig heeft, is een *reden*. Invariant I3 zegt dat een cel alleen
+  # de cellen bevraagt die haar eigen wetten of besluit-definities noemen, en de
+  # gate rekent de sonde hieronder daar net zo hard op af als een besluit — zou
+  # hij dat niet doen, dan lag er in elk scenario een weg omheen. Die reden
+  # staat hier: haar wet vraagt via `source.regulation` om `partnerschap` bij de
+  # cel `brp`, en `accepts_from` legt vast onder welke gepubliceerde naam dat
+  # daar te halen is. Dat is geen recht maar een afspraak tussen twee
+  # organisaties, en daarom staat het in de celconfiguratie en niet in de wet.
   - id: toeslagen
-    laws: []
+    laws:
+      - test_partnerschapstoets
+
+    accepts_from:
+      - cell: brp
+        output: partnerschap
+        lexostatus: partnerschap
+        field: partnerschap_type
+
+# Het toegestane vraaggraf van dit scenario: precies één tak. Wat er straks over
+# de grens gaat wordt hiermee vergeleken, beide kanten op — een vraag die hier
+# niet staat is een fout, en deze tak zonder vraag ook.
+query_graph:
+  - doc: >-
+      `toeslagen` mag bij `brp` de lexostatus `partnerschap` opvragen; haar
+      eigen wet vraagt daarom.
+    from: toeslagen
+    to: brp
+    lexostatus: partnerschap
 
 query_via_transport:
   - description: >-

--- a/packages/simulator/src/cell/besluit.rs
+++ b/packages/simulator/src/cell/besluit.rs
@@ -470,8 +470,20 @@ impl BesluitInput {
     /// Voor wie de afspraken van buiten wil nalopen — de wereld toetst ermee of
     /// de peer bestaat — zonder de vorm van de variant na te bouwen.
     pub fn accepts_from(&self) -> Option<&str> {
+        Some(self.accepted_query()?.0)
+    }
+
+    /// De cel én de lexostatus die deze input bij een ander opvraagt.
+    ///
+    /// Eén tak van het toegestane vraaggraf, zoals de besluit-definitie hem
+    /// aanwijst (invariant I3). De lexostatus hoort erbij: wat een cel
+    /// publiceert zijn losse, gedocumenteerde namen (RFC-022 §4.1), dus "deze
+    /// cel mag die cel bevragen" is als afspraak te grof.
+    pub fn accepted_query(&self) -> Option<(&str, &str)> {
         match self {
-            Self::AcceptFrom { cell, .. } => Some(cell),
+            Self::AcceptFrom {
+                cell, lexostatus, ..
+            } => Some((cell, lexostatus)),
             Self::FromChronicle { .. } | Self::Param { .. } => None,
         }
     }

--- a/packages/simulator/src/error.rs
+++ b/packages/simulator/src/error.rs
@@ -880,6 +880,56 @@ pub enum SimulatorError {
         lexostatus: String,
     },
 
+    /// Het gedeclareerde vraaggraf noemt een cel die het scenario niet heeft.
+    ///
+    /// Bij het lezen en niet pas na een run: zo'n tak wordt nooit gesteld en zou
+    /// anders als "gedeclareerde vraag die uitbleef" naar buiten komen — een
+    /// melding die de lezer naar de run stuurt terwijl er een typfout in het
+    /// bestand staat.
+    #[error(
+        "scenario '{scenario}': het vraaggraf declareert '{edge}', maar cel '{cell}' bestaat \
+         in dit scenario niet (wel: {known})"
+    )]
+    QueryGraphUnknownCell {
+        /// Het scenario waarin de declaratie staat.
+        scenario: String,
+        /// De gedeclareerde tak.
+        edge: String,
+        /// De cel die niet bestaat.
+        cell: String,
+        /// Komma-gescheiden lijst van cellen die het scenario wél kent.
+        known: String,
+    },
+
+    /// Een tak van het vraaggraf laat een cel zichzelf bevragen.
+    ///
+    /// Dezelfde weigering als [`SimulatorError::TransportToSelf`], een stap
+    /// eerder: zo'n tak kan nooit uitkomen, want de veiligheidscontext laat een
+    /// vraag aan de eigen cel niet over de grens.
+    #[error(
+        "scenario '{scenario}': het vraaggraf declareert '{edge}', maar een cel bevraagt \
+         zichzelf niet over een celgrens; voor eigen feiten is er een reductie"
+    )]
+    QueryGraphToSelf {
+        /// Het scenario waarin de declaratie staat.
+        scenario: String,
+        /// De gedeclareerde tak.
+        edge: String,
+    },
+
+    /// Dezelfde tak staat twee keer in het vraaggraf.
+    ///
+    /// Een graf is een verzameling, dus de tweede regel voegt niets toe. Stil
+    /// samenvoegen zou betekenen dat er een regel in het bestand staat die niets
+    /// doet, en dat is precies wat een wereldbestand niet hoort te hebben.
+    #[error("scenario '{scenario}': het vraaggraf declareert '{edge}' twee keer")]
+    DuplicateQueryGraphEdge {
+        /// Het scenario waarin de declaratie staat.
+        scenario: String,
+        /// De dubbele tak.
+        edge: String,
+    },
+
     /// Een vraag richt zich tot een cel die het scenario niet kent.
     #[error("scenario kent geen cel '{cell}'")]
     UnknownCell {

--- a/packages/simulator/src/invariant.rs
+++ b/packages/simulator/src/invariant.rs
@@ -561,10 +561,13 @@ fn check_visibility(
 /// Het eerste moment waarop deze tak gevraagd werd.
 ///
 /// Een tak kan meer dan één keer gesteld zijn; de melding noemt het eerste
-/// voorval, want dat is het moment waarop de schending begon. Zonder contact
-/// valt er niets te noemen — dat kan niet gebeuren voor een tak die uit de
-/// contacten is afgeleid, en dan is de eerste dag van de jaartelling een
-/// zichtbaar onzinnige uitkomst in plaats van een stille aanname.
+/// voorval, want dat is het moment waarop de schending begon.
+///
+/// Zonder contact valt er niets te noemen, en dat kan bij beide aanroepers niet
+/// gebeuren: die geven alleen takken mee die uit `entries` zijn afgeleid. Blijft
+/// er toch niets over, dan komt `NaiveDate::default()` eruit — 1 januari 1970,
+/// een datum die in een wereld die op een `clock.start` begint niet te verwarren
+/// is met een moment uit de run.
 fn first_moment(entries: &[&SignedAnswer], edge: &QueryEdge) -> NaiveDate {
     entries
         .iter()

--- a/packages/simulator/src/invariant.rs
+++ b/packages/simulator/src/invariant.rs
@@ -1,0 +1,845 @@
+//! De invarianten-gate: het gedeclareerde vraaggraf naast het feitelijke.
+//!
+//! Een scenario declareert welke cel welke andere cel mag bevragen en op welke
+//! lexostatus. Een run levert wat er werkelijk over de celgrenzen ging. Elk
+//! verschil tussen die twee is een falend scenario — een niet-gedeclareerde
+//! vraag net zo goed als een gedeclareerde vraag die uitbleef. Dat tweede is
+//! geen bijzaak: een scenario waarin de vraag stilletjes wegvalt, meet niets
+//! meer en zou zonder die kant van de vergelijking groen blijven.
+//!
+//! Wat deze gate toetst, en aan wat:
+//!
+//! | invariant | de toets | waaraan |
+//! |---|---|---|
+//! | **I2** | elke waarde die een gram geaccepteerd noemt, heeft een vastgelegd contact | het gram tegen de contacten |
+//! | **I3** | het feitelijke graf is precies het gedeclareerde graf | declaratie tegen contacten |
+//! | **I3** | elke gestelde vraag past binnen de definities van de vragende cel | contacten tegen de celconfiguratie |
+//! | **I3** | elke gedeclareerde vraag past binnen die definities | declaratie tegen de celconfiguratie |
+//! | **I4** | een cel combineert niet buiten een besluit-pad | contacten per vragende cel |
+//! | **I4** | wat een besluit over de grens haalde, staat in zijn decretogram | de contacten tegen het gram |
+//!
+//! I1 staat er niet bij en dat is geen vergeten regel: "een cel bezit haar
+//! kroniekstore privé" is afgedwongen door het typesysteem — er is geen
+//! `pub fn store()` — en een gate die dat naloopt zou een compileerfout
+//! nameten. I5 staat er ook niet bij: die draait als
+//! [`crate::check_provenance`] over elk decretogram.
+//!
+//! **I1 tot en met I5 en het meetinstrument waarop deze gate rust, komen niet
+//! uit RFC-022.** Die RFC beweert autonomie maar zegt nergens hoe je die meet;
+//! dit is toegevoegd meetgereedschap, en het hoort niet als RFC-inhoud gelezen
+//! te worden.
+//!
+//! ## Waarom het toegestane graf berekend wordt en niet geloofd
+//!
+//! Een cel bevraagt alleen cellen die haar eigen wetten of besluit-definities
+//! noemen (I3). Dat is uit de configuratie te *berekenen*: de `accept_from`-
+//! inputs van haar besluiten, en de afspraken in `accepts_from` waarmee ze de
+//! `source.regulation`-verwijzingen van haar wetten bij een peer uit laat komen.
+//! [`defined_graph`] doet dat, en dus kan een declaratie ernaast liggen: een
+//! scenario dat een vraag toestaat die geen definitie van de vragende cel vraagt,
+//! declareert iets wat die cel niet hoort te doen, en dat is een fout in het
+//! bestand en niet in de run.
+//!
+//! Daarom ook de regel die op het eerste gezicht dubbelop lijkt: een gestelde
+//! vraag die buiten de definities valt, is een fout **ook als het scenario haar
+//! declareert**. Zonder die regel zou elke declaratie een vrijbrief zijn en zou
+//! I3 niets meer tegenhouden dan slordigheid.
+//!
+//! ## Waarop de gate rust, en wat dat kost
+//!
+//! De gate leest de bewijsstukken van de veiligheidscontext ([`SignedAnswer`]) —
+//! exact de regels die het meetinstrument bewaart, niet een tweede boekhouding
+//! ernaast. Dat het instrument zelf hier niet geïmporteerd wordt, is met opzet:
+//! het staat buiten de band en geen productiepad mag ernaar verwijzen. Dat de
+//! twee hetzelfde zien is daarom een assertie en geen aanname — zie
+//! `tests/invarianten.rs`, dat het graf uit het instrument haalt en met het graf
+//! van de gate vergelijkt.
+//!
+//! Wat de gate niet kan zien, hoort er expliciet bij te staan: een contact dat
+//! nergens wordt aangereikt. Volledigheid is structureel — de
+//! veiligheidscontext is de enige weg over een grens en `World::decide` geeft
+//! elk contact mee — en niet door deze gate afgedwongen. Eén kant is wél
+//! gedicht, en dat is de kant die in de praktijk misgaat: een gram dat zegt te
+//! hebben geaccepteerd zonder dat er een contact bij staat, valt op (I2).
+
+use crate::cell::{BesluitInput, CellConfig, Decretogram};
+use crate::security::SignedAnswer;
+use chrono::NaiveDate;
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+/// Eén tak van een vraaggraf: welke cel bevraagt welke andere cel, en waarover.
+///
+/// De lexostatus hoort erbij en is geen detail. "Cel A mag cel B bevragen" is
+/// een blanco machtiging; wat een cel publiceert zijn losse, gedocumenteerde
+/// namen (RFC-022 §4.1), en het graf hoort op diezelfde korrel te staan.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct QueryEdge {
+    /// De vragende cel.
+    pub from: String,
+    /// De bevraagde cel.
+    pub to: String,
+    /// De gepubliceerde lexostatus die gevraagd wordt.
+    pub lexostatus: String,
+}
+
+impl fmt::Display for QueryEdge {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} -> {}.{}", self.from, self.to, self.lexostatus)
+    }
+}
+
+impl QueryEdge {
+    /// De tak die dit bewijsstuk beschrijft.
+    ///
+    /// Dit is de hele afleiding van het feitelijke graf: wie vroeg staat in het
+    /// bewijsstuk, en aan wie en waarover staat in het antwoord. Er wordt niets
+    /// bij bedacht.
+    pub fn of(answer: &SignedAnswer) -> Self {
+        Self {
+            from: answer.asked_by.cell().to_string(),
+            to: answer.answer.cell.clone(),
+            lexostatus: answer.answer.name.clone(),
+        }
+    }
+}
+
+/// Eén tak zoals een wereldbestand hem declareert.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeclaredQuery {
+    /// Vrije toelichting: waarom deze vraag mag. Verschijnt nergens in een
+    /// antwoord.
+    #[serde(default)]
+    pub doc: Option<String>,
+    /// De cel die mag vragen.
+    pub from: String,
+    /// De cel aan wie ze mag vragen.
+    pub to: String,
+    /// De lexostatus die ze daar mag vragen.
+    pub lexostatus: String,
+}
+
+impl DeclaredQuery {
+    /// Deze declaratie als tak.
+    pub fn edge(&self) -> QueryEdge {
+        QueryEdge {
+            from: self.from.clone(),
+            to: self.to.clone(),
+            lexostatus: self.lexostatus.clone(),
+        }
+    }
+}
+
+/// Wat er in één run over de celgrenzen ging, met de plek waar het vandaan kwam.
+///
+/// De herkomst hoort erbij, want I4 hangt eraan: een contact vanuit een besluit
+/// mag combineren — het gram laat het zien — en een contact daarbuiten niet.
+/// Zonder dat onderscheid zou de gate een besluit dat twee organisaties bevraagt
+/// niet van een cel kunnen onderscheiden die stilletjes hetzelfde doet.
+#[derive(Debug, Default)]
+pub struct Traffic<'a> {
+    /// Per besluit: het gram, en de contacten die dat besluit nodig had.
+    pub decisions: Vec<DecisionTraffic<'a>>,
+    /// Contacten die niet bij een besluit horen: de sonde
+    /// `query_via_transport`, waarmee een scenario één vraag los over de naad
+    /// zet. In de opstelling zelf komt een cel alleen vanuit een besluit over
+    /// haar grens, dus dit is de enige weg waarlangs een scenario een
+    /// I3- of I4-schending kan uitdrukken — en daarom wordt de sonde aan
+    /// dezelfde definities gehouden als een besluit.
+    pub probes: Vec<&'a SignedAnswer>,
+}
+
+/// De contacten van één besluit, met het gram dat eruit kwam.
+#[derive(Debug)]
+pub struct DecisionTraffic<'a> {
+    /// Het vastgelegde besluit.
+    pub decretogram: &'a Decretogram,
+    /// Wat dit besluit over een celgrens haalde, in volgorde.
+    pub crossings: &'a [SignedAnswer],
+}
+
+impl<'a> Traffic<'a> {
+    /// Elk contact van deze run, in de volgorde waarin het plaatsvond.
+    ///
+    /// Dezelfde volgorde als een run ze aflegt: eerst de besluiten, dan de
+    /// sondes. Dat is ook de volgorde waarin het meetinstrument ze krijgt, dus
+    /// de gate en het instrument lezen dezelfde rij.
+    pub fn entries(&self) -> Vec<&'a SignedAnswer> {
+        self.decisions
+            .iter()
+            .flat_map(|decision| decision.crossings.iter())
+            .chain(self.probes.iter().copied())
+            .collect()
+    }
+}
+
+/// Eén invariant die niet gehaald werd.
+///
+/// Elke variant draagt wat een lezer nodig heeft die het scenario niet kent:
+/// welke invariant, welke actoren, en welk moment. Dat laatste is geen luxe —
+/// twee cellen kunnen dezelfde vraag op twee momenten stellen, en dan is
+/// "welke call het betrof" zonder moment geen antwoord.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InvariantFailure {
+    /// Er ging een vraag over een celgrens die het scenario niet declareert.
+    UndeclaredCall {
+        /// De vraag die gesteld werd.
+        edge: QueryEdge,
+        /// Het moment waarop ze gesteld werd.
+        op_moment: NaiveDate,
+        /// Wat het scenario wél declareert.
+        declared: String,
+    },
+    /// Het scenario declareert een vraag die in deze run niet gesteld is.
+    CallDidNotHappen {
+        /// De gedeclareerde vraag.
+        edge: QueryEdge,
+        /// Wat er wél gevraagd is.
+        observed: String,
+    },
+    /// Een cel bevroeg een cel die haar eigen definities niet noemen (I3).
+    CallOutsideDefinitions {
+        /// De vraag die gesteld werd.
+        edge: QueryEdge,
+        /// Het moment waarop ze gesteld werd.
+        op_moment: NaiveDate,
+        /// Wat de definities van de vragende cel wél toestaan.
+        defined: String,
+    },
+    /// Het scenario declareert een vraag waar de definities niet om vragen.
+    DeclarationOutsideDefinitions {
+        /// De gedeclareerde vraag.
+        edge: QueryEdge,
+        /// Wat de definities van de vragende cel wél toestaan.
+        defined: String,
+    },
+    /// Een cel combineerde antwoorden van meer dan één cel buiten een
+    /// besluit-pad (I4).
+    SynthesisOutsideBesluit {
+        /// De cel die combineerde.
+        cell: String,
+        /// De cellen die ze bevroeg.
+        peers: String,
+        /// Het moment waarop de tweede bron erbij kwam.
+        op_moment: NaiveDate,
+    },
+    /// Een besluit haalde iets over de grens dat zijn decretogram niet laat
+    /// zien (I4).
+    CrossingNotInDecretogram {
+        /// De vraag die het besluit stelde.
+        edge: QueryEdge,
+        /// Het moment waarop ze gesteld werd.
+        op_moment: NaiveDate,
+        /// De zaak waarover besloten werd.
+        zaakkenmerk: String,
+        /// Wat het gram wél als geaccepteerd opschrijft.
+        accepted: String,
+    },
+    /// Een gram noemt een waarde geaccepteerd zonder dat er een contact met die
+    /// cel is vastgelegd (I2).
+    AcceptedWithoutCrossing {
+        /// De waarde die geaccepteerd zou zijn.
+        value: String,
+        /// De cel die haar vastgesteld zou hebben.
+        peer: String,
+        /// De zaak waarover besloten werd.
+        zaakkenmerk: String,
+        /// De contacten die er wél zijn.
+        observed: String,
+    },
+}
+
+impl InvariantFailure {
+    /// Welke invariant hier niet gehaald werd.
+    ///
+    /// Als tekst en niet als eigen enum: het nummer is wat een lezer zoekt, en
+    /// een tweede opsomming naast de README zou ernaast gaan lopen.
+    pub fn invariant(&self) -> &'static str {
+        match self {
+            Self::AcceptedWithoutCrossing { .. } => "I2",
+            Self::UndeclaredCall { .. }
+            | Self::CallDidNotHappen { .. }
+            | Self::CallOutsideDefinitions { .. }
+            | Self::DeclarationOutsideDefinitions { .. } => "I3",
+            Self::SynthesisOutsideBesluit { .. } | Self::CrossingNotInDecretogram { .. } => "I4",
+        }
+    }
+
+    /// De melding, leesbaar voor wie dit scenario niet kent.
+    pub fn describe(&self) -> String {
+        let invariant = self.invariant();
+        match self {
+            Self::UndeclaredCall {
+                edge,
+                op_moment,
+                declared,
+            } => format!(
+                "{invariant} (vraaggraf): cel '{}' vroeg '{}.{}' op {op_moment}, maar dit \
+                 scenario declareert die vraag niet ({declared})",
+                edge.from, edge.to, edge.lexostatus
+            ),
+            Self::CallDidNotHappen { edge, observed } => format!(
+                "{invariant} (vraaggraf): dit scenario declareert dat cel '{}' '{}.{}' mag \
+                 vragen, maar die vraag is in deze run niet gesteld ({observed})",
+                edge.from, edge.to, edge.lexostatus
+            ),
+            Self::CallOutsideDefinitions {
+                edge,
+                op_moment,
+                defined,
+            } => format!(
+                "{invariant} (definities): cel '{}' vroeg '{}.{}' op {op_moment}, maar haar \
+                 eigen wetten en besluit-definities vragen daar niet om ({defined}); \
+                 een cel bevraagt alleen de cellen die haar definities noemen, ook als \
+                 het scenario de vraag toestaat",
+                edge.from, edge.to, edge.lexostatus
+            ),
+            Self::DeclarationOutsideDefinitions { edge, defined } => format!(
+                "{invariant} (declaratie): dit scenario declareert dat cel '{}' '{}.{}' mag \
+                 vragen, maar geen `accept_from` of `accepts_from` van die cel vraagt daarom \
+                 ({defined}); declaratie en definitie lopen uit de pas",
+                edge.from, edge.to, edge.lexostatus
+            ),
+            Self::SynthesisOutsideBesluit {
+                cell,
+                peers,
+                op_moment,
+            } => format!(
+                "{invariant}: cel '{cell}' bevroeg buiten een besluit-pad meer dan één cel \
+                 ({peers}); de tweede kwam erbij op {op_moment}. Combineren over cellen heen \
+                 hoort in een besluit, zichtbaar in het decretogram, of bij een consument — \
+                 nooit onzichtbaar in een cel"
+            ),
+            Self::CrossingNotInDecretogram {
+                edge,
+                op_moment,
+                zaakkenmerk,
+                accepted,
+            } => format!(
+                "{invariant}: cel '{}' vroeg voor zaak '{zaakkenmerk}' op {op_moment} \
+                 '{}.{}', maar het decretogram laat geen waarde van cel '{}' zien \
+                 ({accepted}); dan combineert de cel onzichtbaar",
+                edge.from, edge.to, edge.lexostatus, edge.to
+            ),
+            Self::AcceptedWithoutCrossing {
+                value,
+                peer,
+                zaakkenmerk,
+                observed,
+            } => format!(
+                "{invariant}: het decretogram van zaak '{zaakkenmerk}' noemt waarde \
+                 '{value}' geaccepteerd van cel '{peer}', maar er is geen contact met die \
+                 cel vastgelegd ({observed})"
+            ),
+        }
+    }
+}
+
+/// Het **feitelijke** vraaggraf: de takken die de bewijsstukken beschrijven.
+///
+/// Neemt wat het meetinstrument bewaart — een rij [`SignedAnswer`]s — en leidt
+/// daar het graf uit af. Dezelfde vraag twee keer is één tak: een graf zegt wie
+/// wie mag bevragen en niet hoe vaak.
+pub fn observed_graph<'a>(
+    entries: impl IntoIterator<Item = &'a SignedAnswer>,
+) -> BTreeSet<QueryEdge> {
+    entries.into_iter().map(QueryEdge::of).collect()
+}
+
+/// Het **toegestane** vraaggraf, berekend uit de celconfiguraties.
+///
+/// Twee soorten afspraak wijzen een peer aan, en ze staan hier op één hoop
+/// omdat I3 ze niet onderscheidt:
+///
+/// - een `accept_from`-input van een besluit-definitie: de cel zegt zelf dat
+///   deze waarde van een andere organisatie komt;
+/// - een `accepts_from`-afspraak van de cel: daarmee komt een
+///   `source.regulation` uit een van haar eigen wetten bij een lexostatus van
+///   een peer uit (tier 3 van RFC-022 §4.2).
+///
+/// Dat de tweede lijst er staat in plaats van de wet zelf, is geen omweg: de wet
+/// noemt een cel-id en een uitkomstnaam, en welke gepubliceerde lexostatus daar
+/// bij hoort is een afspraak tussen twee organisaties en geen recht. De
+/// afspraken zijn bovendien al aan de wetten gebonden — een `accepts_from` die
+/// geen van de eigen wetten opvraagt, wordt bij het optuigen van de cel
+/// geweigerd — dus wat hier uit komt is precies wat het recht van die cel vraagt.
+pub fn defined_graph(cells: &[CellConfig]) -> BTreeSet<QueryEdge> {
+    let mut edges = BTreeSet::new();
+    for config in cells {
+        let from_besluiten = config
+            .besluit_definitions
+            .iter()
+            .flat_map(|definition| definition.inputs.values())
+            .filter_map(BesluitInput::accepted_query);
+        let from_laws = config
+            .accepts_from
+            .iter()
+            .map(|source| (source.cell.as_str(), source.lexostatus.as_str()));
+
+        for (to, lexostatus) in from_besluiten.chain(from_laws) {
+            edges.insert(QueryEdge {
+                from: config.id.clone(),
+                to: to.to_string(),
+                lexostatus: lexostatus.to_string(),
+            });
+        }
+    }
+    edges
+}
+
+/// Draai de gate over één run.
+///
+/// Hij draait bij élke run, ook als het scenario geen vraaggraf declareert:
+/// dan is het toegestane graf leeg en is elk contact over een celgrens
+/// niet-gedeclareerd. Een invariant die je moet aanzetten, is een invariant die
+/// iemand vergeet.
+pub fn check_invariants(
+    declared: &[DeclaredQuery],
+    cells: &[CellConfig],
+    traffic: &Traffic<'_>,
+) -> Vec<InvariantFailure> {
+    let entries = traffic.entries();
+    let observed = observed_graph(entries.iter().copied());
+    let declared_edges: BTreeSet<QueryEdge> = declared.iter().map(DeclaredQuery::edge).collect();
+    let defined = defined_graph(cells);
+
+    let mut failures = Vec::new();
+    failures.extend(compare_graphs(&declared_edges, &observed, &entries));
+    failures.extend(check_definitions(
+        &declared_edges,
+        &observed,
+        &defined,
+        &entries,
+    ));
+    failures.extend(check_synthesis(traffic));
+    failures.extend(check_visibility(traffic, &observed));
+    failures
+}
+
+/// Het gedeclareerde graf naast het feitelijke, beide kanten op (I3).
+fn compare_graphs(
+    declared: &BTreeSet<QueryEdge>,
+    observed: &BTreeSet<QueryEdge>,
+    entries: &[&SignedAnswer],
+) -> Vec<InvariantFailure> {
+    let mut failures = Vec::new();
+    for edge in observed.difference(declared) {
+        failures.push(InvariantFailure::UndeclaredCall {
+            edge: edge.clone(),
+            op_moment: first_moment(entries, edge),
+            declared: listing("gedeclareerd", declared),
+        });
+    }
+    for edge in declared.difference(observed) {
+        failures.push(InvariantFailure::CallDidNotHappen {
+            edge: edge.clone(),
+            observed: listing("wel gesteld", observed),
+        });
+    }
+    failures
+}
+
+/// Elke gestelde en elke gedeclareerde vraag tegen de definities (I3).
+///
+/// Een gestelde vraag daarbuiten is een fout ook als het scenario haar
+/// declareert; anders zou een declaratie een vrijbrief zijn.
+fn check_definitions(
+    declared: &BTreeSet<QueryEdge>,
+    observed: &BTreeSet<QueryEdge>,
+    defined: &BTreeSet<QueryEdge>,
+    entries: &[&SignedAnswer],
+) -> Vec<InvariantFailure> {
+    let mut failures = Vec::new();
+    for edge in observed.difference(defined) {
+        failures.push(InvariantFailure::CallOutsideDefinitions {
+            edge: edge.clone(),
+            op_moment: first_moment(entries, edge),
+            defined: defined_for(defined, &edge.from),
+        });
+    }
+    for edge in declared.difference(defined) {
+        failures.push(InvariantFailure::DeclarationOutsideDefinitions {
+            edge: edge.clone(),
+            defined: defined_for(defined, &edge.from),
+        });
+    }
+    failures
+}
+
+/// Combineert een cel buiten een besluit-pad over cellen heen? (I4)
+///
+/// Binnen een besluit mag het: daar staat het in het decretogram, en dat is
+/// precies het verschil tussen combineren en *onzichtbaar* combineren. Buiten
+/// een besluit is er geen gram, dus twee bronnen bij één vrager is synthese in
+/// een cel.
+fn check_synthesis(traffic: &Traffic<'_>) -> Vec<InvariantFailure> {
+    let mut seen: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    let mut failures = Vec::new();
+
+    for signed in &traffic.probes {
+        let asker = signed.asked_by.cell();
+        let peers = seen.entry(asker).or_default();
+        let is_new = peers.insert(signed.answer.cell.as_str());
+        // Het moment waarop de tweede bron erbij kwam, en niet het laatste
+        // contact: dat is het moment waarop de cel meer dan één cel kende, en
+        // daarmee het moment dat in de melding thuishoort.
+        if is_new && peers.len() == 2 {
+            failures.push(InvariantFailure::SynthesisOutsideBesluit {
+                cell: asker.to_string(),
+                peers: peers.iter().copied().collect::<Vec<_>>().join(", "),
+                op_moment: signed.answer.op_moment,
+            });
+        }
+    }
+    failures
+}
+
+/// Staat wat een besluit over de grens haalde in zijn gram, en omgekeerd?
+///
+/// Twee kanten van dezelfde naad:
+///
+/// - een contact zonder geaccepteerde waarde van die cel is combineren zonder
+///   dat het gram het laat zien (I4);
+/// - een geaccepteerde waarde zonder contact met die cel betekent dat het
+///   contact nergens is vastgelegd, of dat de waarde ergens anders vandaan
+///   kwam. Beide zijn een gat in wat de opstelling meet (I2).
+fn check_visibility(
+    traffic: &Traffic<'_>,
+    observed: &BTreeSet<QueryEdge>,
+) -> Vec<InvariantFailure> {
+    let mut failures = Vec::new();
+    for decision in &traffic.decisions {
+        let gram = decision.decretogram;
+        let accepted = gram.accepted_values();
+        let peers: BTreeSet<&str> = accepted.values().copied().collect();
+        let asked: BTreeSet<&str> = decision
+            .crossings
+            .iter()
+            .map(|signed| signed.answer.cell.as_str())
+            .collect();
+
+        for signed in decision.crossings {
+            if peers.contains(signed.answer.cell.as_str()) {
+                continue;
+            }
+            failures.push(InvariantFailure::CrossingNotInDecretogram {
+                edge: QueryEdge::of(signed),
+                op_moment: signed.answer.op_moment,
+                zaakkenmerk: gram.zaakkenmerk.clone(),
+                accepted: if accepted.is_empty() {
+                    "het gram noemt geen enkele geaccepteerde waarde".to_string()
+                } else {
+                    format!(
+                        "geaccepteerd: {}",
+                        accepted
+                            .iter()
+                            .map(|(value, cell)| format!("{value} van {cell}"))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                },
+            });
+        }
+
+        for (value, peer) in &accepted {
+            if asked.contains(peer) {
+                continue;
+            }
+            failures.push(InvariantFailure::AcceptedWithoutCrossing {
+                value: (*value).to_string(),
+                peer: (*peer).to_string(),
+                zaakkenmerk: gram.zaakkenmerk.clone(),
+                observed: listing("vastgelegd", observed),
+            });
+        }
+    }
+    failures
+}
+
+/// Het eerste moment waarop deze tak gevraagd werd.
+///
+/// Een tak kan meer dan één keer gesteld zijn; de melding noemt het eerste
+/// voorval, want dat is het moment waarop de schending begon. Zonder contact
+/// valt er niets te noemen — dat kan niet gebeuren voor een tak die uit de
+/// contacten is afgeleid, en dan is de eerste dag van de jaartelling een
+/// zichtbaar onzinnige uitkomst in plaats van een stille aanname.
+fn first_moment(entries: &[&SignedAnswer], edge: &QueryEdge) -> NaiveDate {
+    entries
+        .iter()
+        .find(|signed| QueryEdge::of(signed) == *edge)
+        .map_or_else(NaiveDate::default, |signed| signed.answer.op_moment)
+}
+
+/// Wat de definities van één vragende cel toestaan, voor in een melding.
+fn defined_for(defined: &BTreeSet<QueryEdge>, from: &str) -> String {
+    let own: BTreeSet<QueryEdge> = defined
+        .iter()
+        .filter(|edge| edge.from == from)
+        .cloned()
+        .collect();
+    if own.is_empty() {
+        return "haar definities noemen geen enkele andere cel".to_string();
+    }
+    listing("haar definities vragen", &own)
+}
+
+/// Een opsomming van takken voor een melding, of de mededeling dat er geen zijn.
+fn listing(label: &str, edges: &BTreeSet<QueryEdge>) -> String {
+    if edges.is_empty() {
+        return format!("{label}: geen enkele vraag over een celgrens");
+    }
+    format!(
+        "{label}: {}",
+        edges
+            .iter()
+            .map(QueryEdge::to_string)
+            .collect::<Vec<_>>()
+            .join("; ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cell::LexostatusOutcome;
+    use crate::security::{Identity, SecurityContext};
+    use crate::transport::CellTransport;
+    use crate::Lexostatus;
+    use crate::Result;
+    use regelrecht_engine::Value;
+    use std::collections::BTreeMap;
+
+    /// Een transport dat elke vraag met een leeg feit beantwoordt.
+    ///
+    /// Genoeg voor deze tests: ze gaan over de takken van het graf, niet over
+    /// wat een cel antwoordt. Een echte cel erbij halen zou een corpus vragen
+    /// en de assertie niet scherper maken.
+    struct AnyPeer;
+
+    impl CellTransport for AnyPeer {
+        fn query(
+            &self,
+            cell: &str,
+            lexostatus: &str,
+            _params: &BTreeMap<String, Value>,
+            op_moment: NaiveDate,
+        ) -> Result<Lexostatus> {
+            Ok(Lexostatus {
+                cell: cell.to_string(),
+                name: lexostatus.to_string(),
+                op_moment,
+                outcome: LexostatusOutcome::Established(BTreeMap::new()),
+            })
+        }
+    }
+
+    fn moment(day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(2024, 6, day)
+            .unwrap_or_else(|| panic!("2024-06-{day} moet een geldige datum zijn"))
+    }
+
+    /// Eén bewijsstuk zoals de veiligheidscontext het aflevert.
+    fn crossing(from: &str, to: &str, lexostatus: &str, day: u32) -> SignedAnswer {
+        let transport = AnyPeer;
+        SecurityContext::new(Identity::for_cell(from), &transport)
+            .query(to, lexostatus, &BTreeMap::new(), moment(day))
+            .unwrap_or_else(|e| panic!("de sonde hoort door te gaan: {e}"))
+    }
+
+    fn edge(from: &str, to: &str, lexostatus: &str) -> QueryEdge {
+        QueryEdge {
+            from: from.to_string(),
+            to: to.to_string(),
+            lexostatus: lexostatus.to_string(),
+        }
+    }
+
+    fn declared(from: &str, to: &str, lexostatus: &str) -> DeclaredQuery {
+        DeclaredQuery {
+            doc: None,
+            from: from.to_string(),
+            to: to.to_string(),
+            lexostatus: lexostatus.to_string(),
+        }
+    }
+
+    /// Een cel die met een `accept_from` één peer mag bevragen.
+    fn cell_with_accept_from() -> CellConfig {
+        serde_yaml_ng::from_str(
+            r"
+id: toeslagen
+laws: []
+besluit_definitions:
+  - name: toekenning
+    regulation: wet_op_de_zorgtoeslag
+    output: heeft_recht_op_zorgtoeslag
+    zaakkenmerk: 'zorgtoeslag/{bsn}'
+    params:
+      - name: bsn
+        type: string
+    inputs:
+      toetsingsinkomen:
+        accept_from: belastingdienst
+        lexostatus: toetsingsinkomen
+        field: toetsingsinkomen
+        params:
+          bsn: $bsn
+",
+        )
+        .unwrap_or_else(|e| panic!("testconfig moet parsen: {e}"))
+    }
+
+    /// Een cel die met een `accepts_from`-afspraak één peer mag bevragen.
+    fn cell_with_accepts_from() -> CellConfig {
+        serde_yaml_ng::from_str(
+            r"
+id: toeslagen
+laws:
+  - test_partnerschapstoets
+accepts_from:
+  - cell: brp
+    output: partnerschap
+    lexostatus: partnerschap
+    field: partnerschap_type
+",
+        )
+        .unwrap_or_else(|e| panic!("testconfig moet parsen: {e}"))
+    }
+
+    #[test]
+    fn het_toegestane_graf_komt_uit_een_accept_from_input() {
+        assert_eq!(
+            defined_graph(&[cell_with_accept_from()]),
+            BTreeSet::from([edge("toeslagen", "belastingdienst", "toetsingsinkomen")]),
+            "een `accept_from`-input is een tak van het toegestane graf"
+        );
+    }
+
+    #[test]
+    fn het_toegestane_graf_komt_ook_uit_de_afspraken_bij_de_wetten() {
+        assert_eq!(
+            defined_graph(&[cell_with_accepts_from()]),
+            BTreeSet::from([edge("toeslagen", "brp", "partnerschap")]),
+            "een `accepts_from`-afspraak hoort er net zo goed in: daarmee komt een \
+             `source.regulation` van een eigen wet bij een peer uit"
+        );
+    }
+
+    #[test]
+    fn een_niet_gedeclareerde_vraag_faalt_en_noemt_welke() {
+        let signed = crossing("toeslagen", "brp", "partnerschap", 1);
+        let traffic = Traffic {
+            decisions: Vec::new(),
+            probes: vec![&signed],
+        };
+        let failures = check_invariants(&[], &[cell_with_accepts_from()], &traffic);
+
+        let melding = failures
+            .iter()
+            .find(|failure| matches!(failure, InvariantFailure::UndeclaredCall { .. }))
+            .map(InvariantFailure::describe)
+            .unwrap_or_else(|| {
+                panic!("verwachtte een niet-gedeclareerde vraag, kreeg {failures:?}")
+            });
+        assert!(
+            melding.contains("toeslagen") && melding.contains("brp.partnerschap"),
+            "de melding hoort te zeggen welke vraag het betrof, kreeg: {melding}"
+        );
+        assert!(
+            melding.contains("2024-06-01"),
+            "en op welk moment, kreeg: {melding}"
+        );
+    }
+
+    #[test]
+    fn een_gedeclareerde_vraag_die_uitbleef_faalt_ook() {
+        let traffic = Traffic::default();
+        let failures = check_invariants(
+            &[declared("toeslagen", "brp", "partnerschap")],
+            &[cell_with_accepts_from()],
+            &traffic,
+        );
+        assert!(
+            failures
+                .iter()
+                .any(|failure| matches!(failure, InvariantFailure::CallDidNotHappen { .. })),
+            "een declaratie die niets meet hoort te falen, kreeg {failures:?}"
+        );
+    }
+
+    #[test]
+    fn een_gedeclareerde_vraag_buiten_de_definities_faalt_ook_als_ze_gesteld_wordt() {
+        // De vraag staat in het toegestane graf van het scenario, en dat is met
+        // opzet: I3 gaat over wat de definities van de cel vragen, en een
+        // declaratie is geen vrijbrief.
+        let signed = crossing("toeslagen", "kiesraad", "zetels", 2);
+        let traffic = Traffic {
+            decisions: Vec::new(),
+            probes: vec![&signed],
+        };
+        let failures = check_invariants(
+            &[declared("toeslagen", "kiesraad", "zetels")],
+            &[cell_with_accepts_from()],
+            &traffic,
+        );
+
+        assert!(
+            !failures
+                .iter()
+                .any(|failure| matches!(failure, InvariantFailure::UndeclaredCall { .. })),
+            "de vraag ís gedeclareerd, dus dáárover hoort niets te komen: {failures:?}"
+        );
+        let melding = failures
+            .iter()
+            .find(|failure| matches!(failure, InvariantFailure::CallOutsideDefinitions { .. }))
+            .map(InvariantFailure::describe)
+            .unwrap_or_else(|| panic!("verwachtte een vraag buiten de definities: {failures:?}"));
+        assert!(
+            melding.contains("kiesraad") && melding.contains("2024-06-02"),
+            "de melding hoort de actoren en het moment te noemen, kreeg: {melding}"
+        );
+    }
+
+    #[test]
+    fn twee_bronnen_bij_een_vrager_buiten_een_besluit_is_synthese() {
+        let eerste = crossing("toeslagen", "brp", "partnerschap", 1);
+        let tweede = crossing("toeslagen", "belastingdienst", "toetsingsinkomen", 3);
+        let traffic = Traffic {
+            decisions: Vec::new(),
+            probes: vec![&eerste, &tweede],
+        };
+        let failures = check_synthesis(&traffic);
+
+        let melding = failures
+            .first()
+            .map(InvariantFailure::describe)
+            .unwrap_or_else(|| panic!("twee bronnen bij één vrager hoort te falen"));
+        assert_eq!(
+            failures.len(),
+            1,
+            "één melding per vrager, niet één per bron"
+        );
+        assert!(
+            melding.starts_with("I4")
+                && melding.contains("brp")
+                && melding.contains("belastingdienst")
+                && melding.contains("2024-06-03"),
+            "de melding hoort I4, beide bronnen en het moment te noemen, kreeg: {melding}"
+        );
+    }
+
+    #[test]
+    fn een_vrager_met_een_bron_is_geen_synthese() {
+        let signed = crossing("toeslagen", "brp", "partnerschap", 1);
+        let traffic = Traffic {
+            decisions: Vec::new(),
+            probes: vec![&signed],
+        };
+        assert!(
+            check_synthesis(&traffic).is_empty(),
+            "één bron is niet combineren"
+        );
+    }
+}

--- a/packages/simulator/src/lib.rs
+++ b/packages/simulator/src/lib.rs
@@ -45,6 +45,14 @@
 //! is daarna een **reductie** over die vastleggingen (`sum: bedrag`) en geen
 //! saldo dat ernaast wordt bijgehouden.
 //!
+//! Het eigenlijke product zijn de **invarianten**. Een scenario declareert het
+//! toegestane vraaggraf; [`invariant::check_invariants`] legt daar het
+//! feitelijke graf naast, berekent uit de celconfiguraties wat het recht van
+//! elke cel eigenlijk vraagt, en laat elk verschil het scenario laten falen. Zie
+//! de moduledocs van [`invariant`] voor wat er per invariant getoetst wordt —
+//! en voor de vermelding die er altijd bij hoort: I1 tot en met I5 en het
+//! meetinstrument eronder komen **niet** uit RFC-022.
+//!
 //! ```no_run
 //! use regelrecht_simulator::{regulation_root, Scenario};
 //! use std::path::Path;
@@ -63,6 +71,7 @@ mod accept;
 pub mod cell;
 mod corpus;
 pub mod error;
+pub mod invariant;
 // Meetinstrument, geen onderdeel van de opstelling: zie de moduledocs. Met opzet
 // geen re-export hieronder — wie hem gebruikt, noemt hem bij zijn volle naam, en
 // geen ander bestand in `src/` mag dat doen.
@@ -82,6 +91,10 @@ pub use cell::{
 };
 pub use corpus::regulation_root;
 pub use error::{Result, SimulatorError, Subject};
+pub use invariant::{
+    check_invariants, defined_graph, observed_graph, DecisionTraffic, DeclaredQuery,
+    InvariantFailure, QueryEdge, Traffic,
+};
 pub use scenario::{
     check_provenance, Decision, DecisionOutcome, ExpectationFailure, Query, QueryOutcome, Scenario,
     ScenarioRun, TransportOutcome, TransportQuery,

--- a/packages/simulator/src/observation.rs
+++ b/packages/simulator/src/observation.rs
@@ -39,9 +39,22 @@
 //! Zodra een cel zelf kan besluiten, verhuist de vraag naar dat pad — en dan moet
 //! het vastleggen mee. Gebeurt dat niet, dan is het log stil incompleet in plaats
 //! van rood, en dat is de gevaarlijke kant op. Volledigheid is daarom een
-//! eigenschap van de invarianten-gate die het gedeclareerde vraaggraf met het
-//! feitelijke vergelijkt (I3), en niet van deze module: die gate hoort te falen
-//! als een cel een peer bevraagt zonder dat het log het weet.
+//! eigenschap van de invarianten-gate ([`crate::invariant`]) en niet van deze
+//! module.
+//!
+//! Die gate bestaat, en hij sluit één kant echt: een decretogram dat zegt een
+//! waarde van een andere cel geaccepteerd te hebben zonder dat er een contact met
+//! die cel is vastgelegd, laat het scenario falen (I2). De andere kant — een
+//! contact dat nergens wordt aangereikt — is niet te meten door wie alleen de
+//! aangereikte contacten ziet; die blijft structureel, want de
+//! veiligheidscontext is de enige weg over een grens en `World::decide` geeft
+//! elk contact mee. Dat hoort expliciet te staan in plaats van als afgedekt te
+//! gelden.
+//!
+//! De gate importeert deze module niet, en dat is geen omweg maar dezelfde regel
+//! als hierboven: geen productiepad verwijst hiernaar. Hij leest dezelfde
+//! bewijsstukken, en dat de twee daardoor hetzelfde graf zien is een assertie in
+//! `tests/invarianten.rs` en geen aanname.
 
 use crate::{LexostatusOutcome, SignedAnswer};
 use std::fmt::Write as _;

--- a/packages/simulator/src/scenario.rs
+++ b/packages/simulator/src/scenario.rs
@@ -7,6 +7,9 @@
 
 use crate::cell::{CellConfig, Decretogram, Lexostatus, LexostatusOutcome};
 use crate::error::{Result, SimulatorError};
+use crate::invariant::{
+    check_invariants, observed_graph, DecisionTraffic, DeclaredQuery, InvariantFailure, Traffic,
+};
 use crate::security::{Identity, SecurityContext, SignedAnswer};
 use crate::transport::InProcessTransport;
 use crate::values::equivalent;
@@ -14,7 +17,7 @@ use crate::world::{Clock, Fixture, World};
 use chrono::NaiveDate;
 use regelrecht_engine::Value;
 use serde::Deserialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 use std::path::Path;
 
@@ -68,6 +71,25 @@ pub struct Scenario {
     /// omheen te bouwen: handig om de naad zelf te beproeven, en verder niets.
     #[serde(default)]
     pub query_via_transport: Vec<TransportQuery>,
+    /// Het **toegestane vraaggraf**: welke cel welke andere cel mag bevragen, en
+    /// op welke lexostatus.
+    ///
+    /// De runner legt hier het feitelijke graf naast — afgeleid uit wat er over
+    /// de celgrenzen ging — en laat elk verschil het scenario laten falen: een
+    /// vraag die hier niet staat net zo goed als een vraag die hier wél staat en
+    /// niet gesteld werd (invariant I3).
+    ///
+    /// Weglaten mag en betekent iets: **geen enkele vraag over een celgrens**.
+    /// Dat is met opzet de default, want een gate die je moet aanzetten is een
+    /// gate die iemand vergeet — een scenario dat stilletjes over een grens
+    /// reikt, hoort rood te worden en niet te zwijgen.
+    ///
+    /// Wat hier staat is een declaratie en geen vrijbrief: de gate berekent uit
+    /// de `accept_from`-inputs en de `accepts_from`-afspraken van elke cel wat
+    /// haar eigen recht vraagt, en een declaratie die daarbuiten valt faalt ook
+    /// als de vraag netjes gesteld wordt.
+    #[serde(default)]
+    pub query_graph: Vec<DeclaredQuery>,
 }
 
 /// Eén vraag van een consument aan één cel.
@@ -264,10 +286,17 @@ pub struct ScenarioRun {
     pub outcomes: Vec<QueryOutcome>,
     /// De uitkomsten van de vragen over een celgrens, in scenariovolgorde.
     pub transport_outcomes: Vec<TransportOutcome>,
+    /// De invarianten die deze run niet haalde; leeg is goed.
+    ///
+    /// Apart van de verwachtingen per vraag, en dat is geen ordening maar een
+    /// verschil in soort: een verwachting is wat dít scenario beweert, een
+    /// invariant is wat elk scenario moet halen. Ze staan dus niet bij één vraag
+    /// en niet bij één besluit — ze gaan over de run als geheel.
+    pub invariant_failures: Vec<InvariantFailure>,
 }
 
 impl ScenarioRun {
-    /// Kwamen alle verwachtingen uit?
+    /// Kwamen alle verwachtingen uit, en haalde de run haar invarianten?
     pub fn passed(&self) -> bool {
         self.decisions.iter().all(|o| o.failures.is_empty())
             && self.outcomes.iter().all(|o| o.failures.is_empty())
@@ -275,6 +304,38 @@ impl ScenarioRun {
                 .transport_outcomes
                 .iter()
                 .all(|o| o.failures.is_empty())
+            && self.invariant_failures.is_empty()
+    }
+
+    /// Wat er in deze run over de celgrenzen ging, met de plek waar het vandaan
+    /// kwam.
+    ///
+    /// Dit is wat de invarianten-gate leest, en het is ook exact wat een
+    /// meetinstrument aangereikt krijgt: dezelfde bewijsstukken, in dezelfde
+    /// volgorde. Publiek, zodat een test de twee tegen elkaar kan houden in
+    /// plaats van te moeten geloven dat ze hetzelfde zien.
+    pub fn traffic(&self) -> Traffic<'_> {
+        Traffic {
+            decisions: self
+                .decisions
+                .iter()
+                .map(|decision| DecisionTraffic {
+                    decretogram: &decision.decretogram,
+                    crossings: &decision.crossings,
+                })
+                .collect(),
+            probes: self
+                .transport_outcomes
+                .iter()
+                .map(|outcome| &outcome.signed)
+                .collect(),
+        }
+    }
+
+    /// Elk contact over een celgrens in deze run, in de volgorde waarin het
+    /// plaatsvond.
+    pub fn crossings(&self) -> Vec<&SignedAnswer> {
+        self.traffic().entries()
     }
 
     /// Heeft deze run iets vastgelegd? Een run zonder vragen bewijst niets.
@@ -401,6 +462,29 @@ impl ScenarioRun {
             write_failures(&mut out, &outcome.failures);
         }
 
+        // De invarianten-gate staat in het verslag ook als hij niets vond. Een
+        // gate die alleen bij een fout iets zegt, is niet te onderscheiden van
+        // een gate die niet gedraaid heeft — en dat is precies het soort stilte
+        // waar deze opstelling tegen bedoeld is.
+        let contacts = self.crossings();
+        let edges = observed_graph(contacts.iter().copied()).len();
+        let mark = if self.invariant_failures.is_empty() {
+            "ok"
+        } else {
+            "FOUT"
+        };
+        // Het aantal takken staat erbij en niet alleen het aantal contacten: het
+        // graf is waar de gate over gaat, en dezelfde vraag twee keer is één tak.
+        let _ = writeln!(
+            out,
+            "  [{mark}] invarianten: {} contact(en) over een celgrens, {edges} tak(ken) \
+             in het vraaggraf",
+            contacts.len(),
+        );
+        for failure in &self.invariant_failures {
+            let _ = writeln!(out, "        {}", failure.describe());
+        }
+
         let _ = writeln!(out, "  klok staat op {}", self.clock);
         // Een fixture waar de klok nooit aan toe komt, is een regel in het
         // bestand die niets doet. Dat mag, maar het hoort niet stil te zijn:
@@ -501,6 +585,51 @@ impl Scenario {
                 });
             }
         }
+        self.validate_query_graph()
+    }
+
+    /// Controleer het gedeclareerde vraaggraf op zichzelf.
+    ///
+    /// Bij het lezen en niet pas na een run, want elk van deze drie zou anders
+    /// als een falende invariant naar buiten komen terwijl er een schrijffout in
+    /// het bestand staat. Een tak naar een cel die niet bestaat, wordt nooit
+    /// gesteld en zou als "gedeclareerde vraag die uitbleef" verschijnen — een
+    /// melding die de lezer naar de run stuurt in plaats van naar de typfout.
+    fn validate_query_graph(&self) -> Result<()> {
+        let known = || {
+            self.cells
+                .iter()
+                .map(|cell| cell.id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let mut seen: BTreeSet<String> = BTreeSet::new();
+
+        for declared in &self.query_graph {
+            let edge = declared.edge();
+            for cell in [&declared.from, &declared.to] {
+                if !self.cells.iter().any(|config| &config.id == cell) {
+                    return Err(SimulatorError::QueryGraphUnknownCell {
+                        scenario: self.name.clone(),
+                        edge: edge.to_string(),
+                        cell: cell.clone(),
+                        known: known(),
+                    });
+                }
+            }
+            if declared.from == declared.to {
+                return Err(SimulatorError::QueryGraphToSelf {
+                    scenario: self.name.clone(),
+                    edge: edge.to_string(),
+                });
+            }
+            if !seen.insert(edge.to_string()) {
+                return Err(SimulatorError::DuplicateQueryGraphEdge {
+                    scenario: self.name.clone(),
+                    edge: edge.to_string(),
+                });
+            }
+        }
         Ok(())
     }
 
@@ -576,14 +705,23 @@ impl Scenario {
 
         let transport_outcomes = self.run_via_transport(&mut world)?;
 
-        Ok(ScenarioRun {
+        let mut run = ScenarioRun {
             name: self.name.clone(),
             clock: world.now(),
             pending_triggers: world.pending_triggers(),
             decisions,
             outcomes,
             transport_outcomes,
-        })
+            invariant_failures: Vec::new(),
+        };
+        // De gate draait als laatste en over de hele run: hij vergelijkt het
+        // gedeclareerde vraaggraf met wat er werkelijk over de grenzen ging, en
+        // dat laatste is pas compleet als alles gedraaid heeft. Hij draait bij
+        // élk scenario, ook bij eentje dat geen vraaggraf declareert — dan is
+        // het toegestane graf leeg, en dat is een even geldige bewering.
+        let failures = check_invariants(&self.query_graph, &self.cells, &run.traffic());
+        run.invariant_failures = failures;
+        Ok(run)
     }
 
     /// Laat de cellen hun besluiten nemen, elk op zijn eigen moment.
@@ -1045,6 +1183,7 @@ query_via_transport:
             decisions: Vec::new(),
             outcomes: Vec::new(),
             transport_outcomes: Vec::new(),
+            invariant_failures: Vec::new(),
         };
 
         assert!(
@@ -1081,6 +1220,7 @@ query_via_transport:
             decisions: Vec::new(),
             outcomes: vec![outcome("vóór de vastlegging"), outcome("erna, ongewijzigd")],
             transport_outcomes: Vec::new(),
+            invariant_failures: Vec::new(),
         };
 
         let report = run.report();

--- a/packages/simulator/src/scenario.rs
+++ b/packages/simulator/src/scenario.rs
@@ -8,7 +8,8 @@
 use crate::cell::{CellConfig, Decretogram, Lexostatus, LexostatusOutcome};
 use crate::error::{Result, SimulatorError};
 use crate::invariant::{
-    check_invariants, observed_graph, DecisionTraffic, DeclaredQuery, InvariantFailure, Traffic,
+    check_invariants, observed_graph, DecisionTraffic, DeclaredQuery, InvariantFailure, QueryEdge,
+    Traffic,
 };
 use crate::security::{Identity, SecurityContext, SignedAnswer};
 use crate::transport::InProcessTransport;
@@ -590,11 +591,17 @@ impl Scenario {
 
     /// Controleer het gedeclareerde vraaggraf op zichzelf.
     ///
-    /// Bij het lezen en niet pas na een run, want elk van deze drie zou anders
-    /// als een falende invariant naar buiten komen terwijl er een schrijffout in
-    /// het bestand staat. Een tak naar een cel die niet bestaat, wordt nooit
-    /// gesteld en zou als "gedeclareerde vraag die uitbleef" verschijnen — een
-    /// melding die de lezer naar de run stuurt in plaats van naar de typfout.
+    /// Bij het lezen en niet pas na een run, want een schrijffout in het bestand
+    /// hoort niet als uitslag van de gate naar buiten te komen. Een tak naar een
+    /// cel die niet bestaat wordt nooit gesteld en zou als "gedeclareerde vraag
+    /// die uitbleef" verschijnen — een melding die de lezer naar de run stuurt in
+    /// plaats van naar de typfout; een tak van een cel naar zichzelf net zo, want
+    /// de veiligheidscontext laat die vraag niet over een grens.
+    ///
+    /// De dubbele tak staat er om de omgekeerde reden: die zou de gate juist
+    /// *niets* laten zeggen. Een graf is een verzameling, dus de tweede regel
+    /// wordt stil opgeslokt, en dan staat er een regel in het bestand die niets
+    /// doet.
     fn validate_query_graph(&self) -> Result<()> {
         let known = || {
             self.cells
@@ -603,7 +610,10 @@ impl Scenario {
                 .collect::<Vec<_>>()
                 .join(", ")
         };
-        let mut seen: BTreeSet<String> = BTreeSet::new();
+        // Op de tak zelf en niet op haar tekst: de `Display`-vorm plakt cel en
+        // lexostatus met een punt aan elkaar, en dan zou een lexostatus met een
+        // punt erin twee verschillende takken als dubbel kunnen aanmerken.
+        let mut seen: BTreeSet<QueryEdge> = BTreeSet::new();
 
         for declared in &self.query_graph {
             let edge = declared.edge();
@@ -623,10 +633,11 @@ impl Scenario {
                     edge: edge.to_string(),
                 });
             }
-            if !seen.insert(edge.to_string()) {
+            let melding = edge.to_string();
+            if !seen.insert(edge) {
                 return Err(SimulatorError::DuplicateQueryGraphEdge {
                     scenario: self.name.clone(),
-                    edge: edge.to_string(),
+                    edge: melding,
                 });
             }
         }
@@ -1111,6 +1122,106 @@ query_via_transport:
         );
     }
 
+    /// Een wereld met twee cellen, waar een vraaggraf bij te schrijven is.
+    ///
+    /// De cellen zijn bron-cellen zonder kroniek: deze tests gaan over wat er bij
+    /// het *lezen* van het bestand geweigerd wordt, en komen nooit aan een run
+    /// toe.
+    fn met_vraaggraf(query_graph: &str) -> Result<Scenario> {
+        Scenario::from_yaml(&format!(
+            "
+name: twee cellen en een vraaggraf
+clock: {{ start: 2025-01-01 }}
+cells:
+  - id: toeslagen
+    laws: []
+  - id: brp
+    laws: []
+query_graph:
+{query_graph}"
+        ))
+    }
+
+    #[test]
+    fn een_vraaggraf_naar_een_onbekende_cel_wordt_geweigerd() {
+        let err = met_vraaggraf(
+            "  - from: toeslagen
+    to: kiesraad
+    lexostatus: zetels
+",
+        )
+        .expect_err(
+            "een tak naar een cel die het scenario niet heeft, zou na de run als \
+             'gedeclareerde vraag die uitbleef' verschijnen en de lezer naar de run sturen \
+             in plaats van naar de typfout",
+        );
+        assert!(
+            matches!(err, SimulatorError::QueryGraphUnknownCell { .. }),
+            "verwachtte QueryGraphUnknownCell, kreeg {err}"
+        );
+        let melding = err.to_string();
+        assert!(
+            melding.contains("kiesraad") && melding.contains("toeslagen, brp"),
+            "de melding hoort de onbekende cel te noemen en de cellen die er wél zijn, \
+             kreeg: {melding}"
+        );
+    }
+
+    #[test]
+    fn een_vraaggraf_waarin_een_cel_zichzelf_bevraagt_wordt_geweigerd() {
+        let err = met_vraaggraf(
+            "  - from: toeslagen
+    to: toeslagen
+    lexostatus: partnerschap
+",
+        )
+        .expect_err("een cel komt voor eigen feiten niet over een celgrens");
+        assert!(
+            matches!(err, SimulatorError::QueryGraphToSelf { .. }),
+            "verwachtte QueryGraphToSelf, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn dezelfde_tak_twee_keer_in_het_vraaggraf_wordt_geweigerd() {
+        let err = met_vraaggraf(
+            "  - from: toeslagen
+    to: brp
+    lexostatus: partnerschap
+  - doc: dezelfde tak, andere toelichting
+    from: toeslagen
+    to: brp
+    lexostatus: partnerschap
+",
+        )
+        .expect_err(
+            "een graf is een verzameling, dus de tweede regel wordt stil opgeslokt — \
+             en dan staat er een regel in het bestand die niets doet",
+        );
+        assert!(
+            matches!(err, SimulatorError::DuplicateQueryGraphEdge { .. }),
+            "verwachtte DuplicateQueryGraphEdge, kreeg {err}"
+        );
+    }
+
+    #[test]
+    fn twee_takken_naar_dezelfde_cel_op_verschillende_lexostatussen_mogen() {
+        assert!(
+            met_vraaggraf(
+                "  - from: toeslagen
+    to: brp
+    lexostatus: partnerschap
+  - from: toeslagen
+    to: brp
+    lexostatus: woonplaats
+",
+            )
+            .is_ok(),
+            "wat een cel publiceert zijn losse namen, dus twee lexostatussen bij één peer \
+             zijn twee takken en niet een dubbele"
+        );
+    }
+
     #[test]
     fn onbekend_veld_in_een_vraag_over_de_celgrens_wordt_geweigerd() {
         // `from` staat naast de gewone velden van een vraag, en die combinatie is
@@ -1195,6 +1306,31 @@ query_via_transport:
             !run(0).report().contains("gingen niet af"),
             "zonder wachtende vastleggingen hoort die regel weg te blijven; kreeg:\n{}",
             run(0).report()
+        );
+    }
+
+    /// Het verslag meldt de gate ook als hij niets vond.
+    ///
+    /// Dat staat in de moduledocs als eigenschap en is precies het soort regel dat
+    /// bij een opschoning weggehaald wordt zonder dat er iets rood wordt: een
+    /// verslag zonder die regel is niet te onderscheiden van een gate die niet
+    /// gedraaid heeft, en dat is de stilte waar deze opstelling tegen bedoeld is.
+    #[test]
+    fn het_verslag_meldt_de_invarianten_ook_als_er_niets_te_melden_was() {
+        let run = ScenarioRun {
+            name: "niets over een grens".to_string(),
+            clock: moment(),
+            pending_triggers: 0,
+            decisions: Vec::new(),
+            outcomes: Vec::new(),
+            transport_outcomes: Vec::new(),
+            invariant_failures: Vec::new(),
+        };
+
+        let verslag = run.report();
+        assert!(
+            verslag.contains("[ok] invarianten: 0 contact(en) over een celgrens"),
+            "een run zonder bevindingen hoort de gate alsnog te melden; kreeg:\n{verslag}"
         );
     }
 

--- a/packages/simulator/tests/invarianten.rs
+++ b/packages/simulator/tests/invarianten.rs
@@ -1,0 +1,336 @@
+//! De invarianten-gate, gemeten aan scenario's die hem moeten laten struikelen.
+//!
+//! Een gate die nooit rood wordt, is niet van een ontbrekende gate te
+//! onderscheiden. Daarom staat er naast de positieve suite een map met
+//! **negatieve fixtures**: scenariobestanden die met opzet één invariant
+//! schenden. Deze test draait ze en rekent ze af op twee dingen — dat ze falen,
+//! en waaróp ze falen. Dat tweede is het eigenlijke werk: een fixture die om de
+//! verkeerde reden rood staat, bewijst niets over de invariant die hij zegt te
+//! meten.
+//!
+//! Hier staat ook de assertie die de gate aan het meetinstrument bindt. De gate
+//! leest de bewijsstukken van de veiligheidscontext; het observatielog bewaart
+//! dezelfde bewijsstukken. Dat die twee hetzelfde graf opleveren is een
+//! eigenschap die iemand kan breken, dus hij wordt gemeten en niet aangenomen —
+//! het log hoort nergens in `src/` geïmporteerd te worden, dus de gate kan hem
+//! niet zelf uitlezen.
+
+use regelrecht_simulator::invariant::{check_invariants, observed_graph, DecisionTraffic, Traffic};
+use regelrecht_simulator::observation::ObservationLog;
+use regelrecht_simulator::{
+    defined_graph, regulation_root, InvariantFailure, QueryEdge, Scenario, ScenarioRun,
+};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// Of een faalmelding de melding is waar een fixture over gaat.
+type Expected = fn(&InvariantFailure) -> bool;
+
+/// Elke negatieve fixture, met de melding die hij moet opleveren.
+///
+/// De tabel staat in Rust en niet in de bestanden zelf, en dat is met opzet: een
+/// scenario dat zijn eigen falen verwacht, zou `passed()` van binnenuit kunnen
+/// omdraaien, en dan is "dit scenario is groen" geen uitspraak meer. Wat er wél
+/// afgedwongen wordt, is dat de tabel volledig is — zie
+/// [`elke_negatieve_fixture_staat_in_de_tabel`].
+const FIXTURES: [(&str, &str, Expected); 5] = [
+    ("niet_gedeclareerde_call.yaml", "I3", |failure| {
+        matches!(failure, InvariantFailure::UndeclaredCall { .. })
+    }),
+    ("gedeclareerde_call_bleef_uit.yaml", "I3", |failure| {
+        matches!(failure, InvariantFailure::CallDidNotHappen { .. })
+    }),
+    (
+        "cel_bevraagt_cel_buiten_haar_definities.yaml",
+        "I3",
+        |failure| matches!(failure, InvariantFailure::CallOutsideDefinitions { .. }),
+    ),
+    ("declaratie_buiten_de_definities.yaml", "I3", |failure| {
+        matches!(
+            failure,
+            InvariantFailure::DeclarationOutsideDefinitions { .. }
+        )
+    }),
+    ("reductie_combineert_twee_cellen.yaml", "I4", |failure| {
+        matches!(failure, InvariantFailure::SynthesisOutsideBesluit { .. })
+    }),
+];
+
+fn negatief_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("scenarios")
+        .join("negatief")
+}
+
+fn scenario_path(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("scenarios")
+        .join(name)
+}
+
+fn run(path: &Path) -> ScenarioRun {
+    let scenario = Scenario::load(path).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    scenario
+        .run(&regulation_root())
+        .unwrap_or_else(|e| panic!("{}: {e}", path.display()))
+}
+
+#[test]
+fn elke_negatieve_fixture_staat_in_de_tabel() {
+    let dir = negatief_dir();
+    let files: BTreeSet<String> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("kan {} niet lezen: {e}", dir.display()))
+        .filter_map(std::result::Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().to_string())
+        .filter(|name| name.ends_with(".yaml"))
+        .collect();
+    let tabel: BTreeSet<String> = FIXTURES
+        .iter()
+        .map(|(name, _, _)| (*name).to_string())
+        .collect();
+
+    // Beide kanten. Een fixture zonder tabelregel wordt nooit gedraaid en is dus
+    // een bestand dat niets doet; een tabelregel zonder fixture zou een test zijn
+    // die op niets afgaat en toch groen meldt.
+    assert_eq!(
+        files, tabel,
+        "elke negatieve fixture hoort in de tabel te staan en omgekeerd"
+    );
+}
+
+#[test]
+fn er_zijn_minstens_drie_negatieve_fixtures() {
+    assert!(
+        FIXTURES.len() >= 3,
+        "één gate en één tegenvoorbeeld is te weinig: elke soort schending hoort \
+         een eigen fixture te hebben"
+    );
+}
+
+#[test]
+fn elke_negatieve_fixture_faalt_op_de_invariant_die_hij_meet() {
+    for (name, invariant, expected) in FIXTURES {
+        let path = negatief_dir().join(name);
+        let run = run(&path);
+
+        assert!(
+            !run.passed(),
+            "{name}: deze fixture hoort te falen, maar de run is groen:\n{}",
+            run.report()
+        );
+        let failure = run
+            .invariant_failures
+            .iter()
+            .find(|failure| expected(failure))
+            .unwrap_or_else(|| {
+                panic!(
+                    "{name}: verwachtte de melding van {invariant} waar deze fixture over \
+                     gaat, kreeg:\n{}",
+                    run.report()
+                )
+            });
+        assert_eq!(
+            failure.invariant(),
+            invariant,
+            "{name}: de melding hoort bij {invariant} te horen"
+        );
+
+        // De melding hoort leesbaar te zijn voor wie dit scenario niet kent:
+        // welke invariant, welke actoren, en — waar dat betekenis heeft — welk
+        // moment. Het verslag van de run draagt haar, want dat is wat een mens
+        // bij een falende test onder ogen krijgt.
+        let melding = failure.describe();
+        assert!(
+            melding.starts_with(invariant),
+            "{name}: de melding hoort met de invariant te beginnen, kreeg: {melding}"
+        );
+        assert!(
+            melding.contains("cel") || melding.contains("scenario"),
+            "{name}: de melding hoort de actoren te noemen, kreeg: {melding}"
+        );
+        assert!(
+            run.report().contains(&melding),
+            "{name}: het verslag hoort de melding te dragen:\n{}",
+            run.report()
+        );
+    }
+}
+
+/// De negatieve fixtures falen op een invariant, niet op een gewone verwachting.
+///
+/// Zonder deze test zou een fixture waarin per ongeluk een bedrag niet uitkomt
+/// even rood zijn, en dan zou de suite groen blijven terwijl de gate niets deed.
+#[test]
+fn de_negatieve_fixtures_halen_hun_gewone_verwachtingen_wel() {
+    for (name, _, _) in FIXTURES {
+        let path = negatief_dir().join(name);
+        let run = run(&path);
+
+        let gewone_fouten: Vec<String> = run
+            .decisions
+            .iter()
+            .map(|outcome| outcome.failures.len())
+            .chain(run.outcomes.iter().map(|outcome| outcome.failures.len()))
+            .chain(
+                run.transport_outcomes
+                    .iter()
+                    .map(|outcome| outcome.failures.len()),
+            )
+            .filter(|count| *count > 0)
+            .map(|count| count.to_string())
+            .collect();
+
+        assert!(
+            gewone_fouten.is_empty(),
+            "{name}: deze fixture hoort uitsluitend op een invariant te falen, niet op \
+             een verwachting bij een vraag of een besluit:\n{}",
+            run.report()
+        );
+    }
+}
+
+/// Het graf dat de gate leest, is het graf dat het observatielog laat zien.
+///
+/// De gate kan het log niet zelf uitlezen — geen productiepad mag ernaar
+/// verwijzen — dus dat ze hetzelfde zien is een eigenschap die iemand kan breken.
+/// Hier wordt ze gemeten: de contacten van de run gaan in een echt log, het graf
+/// komt uit de entries van dat log, en dat moet gelijk zijn aan het graf dat de
+/// gate over dezelfde run afleidt.
+#[test]
+fn het_graf_van_de_gate_is_het_graf_van_het_observatielog() {
+    for name in [
+        "transport_toeslagen_brp.yaml",
+        "toeslagen_accepteert_toetsingsinkomen.yaml",
+        "toeslagen_accepteert_via_de_wet.yaml",
+    ] {
+        let path = scenario_path(name);
+        let run = run(&path);
+        assert!(run.passed(), "{name}:\n{}", run.report());
+
+        let mut log = ObservationLog::new();
+        for crossing in run.crossings() {
+            log.record(crossing);
+        }
+        assert!(
+            !log.is_empty(),
+            "{name}: dit scenario hoort verkeer over een celgrens te hebben, anders \
+             vergelijkt deze test twee lege verzamelingen"
+        );
+
+        assert_eq!(
+            observed_graph(log.entries()),
+            observed_graph(run.crossings()),
+            "{name}: de gate en het meetinstrument horen hetzelfde graf te zien"
+        );
+    }
+}
+
+/// Een geslaagd scenario declareert precies wat er gebeurde.
+///
+/// De positieve suite dekt dit al — de gate draait bij elke run — maar niet
+/// zichtbaar: daar staat alleen dat de run groen is. Hier staat waaróm dat iets
+/// betekent, en dat het toegestane graf uit de celconfiguraties volgt en niet uit
+/// de declaratie.
+#[test]
+fn het_gedeclareerde_graf_van_een_geslaagd_scenario_is_het_feitelijke() {
+    let path = scenario_path("toeslagen_accepteert_toetsingsinkomen.yaml");
+    let scenario = Scenario::load(&path).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    let run = scenario
+        .run(&regulation_root())
+        .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+
+    let verwacht = BTreeSet::from([QueryEdge {
+        from: "toeslagen".to_string(),
+        to: "belastingdienst".to_string(),
+        lexostatus: "toetsingsinkomen".to_string(),
+    }]);
+    assert_eq!(
+        observed_graph(run.crossings()),
+        verwacht,
+        "één besluit dat accepteert is één tak, en het besluit ernaast vraagt niemand \
+         iets:\n{}",
+        run.report()
+    );
+    assert_eq!(
+        defined_graph(&scenario.cells),
+        verwacht,
+        "en dat is ook wat de `accept_from`-input van haar besluit-definitie toestaat"
+    );
+}
+
+/// Een gram dat zegt te hebben geaccepteerd zonder vastgelegd contact, valt op.
+///
+/// Dit is de I2-kant van de naad, en hij is met opzet niet als fixture te
+/// schrijven: in de opstelling is het onmogelijk, want de enige weg naar een
+/// geaccepteerde waarde loopt langs de veiligheidscontext, die het bewijsstuk
+/// teruggeeft. Wat hier gebouwd wordt is dus geen wereld maar een meting: een
+/// echt decretogram, en de contacten weggelaten. Zou de gate dit laten passeren,
+/// dan zou een incompleet log niet van een volledig te onderscheiden zijn — en
+/// dat is precies de kant waar het gevaarlijk is.
+#[test]
+fn een_geaccepteerde_waarde_zonder_contact_faalt_op_i2() {
+    let path = scenario_path("toeslagen_accepteert_toetsingsinkomen.yaml");
+    let scenario = Scenario::load(&path).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    let run = run(&path);
+    let accepterend = &run.decisions[0];
+
+    let zonder_contact = Traffic {
+        decisions: vec![DecisionTraffic {
+            decretogram: &accepterend.decretogram,
+            crossings: &[],
+        }],
+        probes: Vec::new(),
+    };
+    let failures = check_invariants(&scenario.query_graph, &scenario.cells, &zonder_contact);
+
+    let melding = failures
+        .iter()
+        .find(|failure| matches!(failure, InvariantFailure::AcceptedWithoutCrossing { .. }))
+        .map(InvariantFailure::describe)
+        .unwrap_or_else(|| panic!("verwachtte een I2-melding, kreeg {failures:?}"));
+    assert!(
+        melding.starts_with("I2")
+            && melding.contains("belastingdienst")
+            && melding.contains("zorgtoeslag/999993653"),
+        "de melding hoort de bron en de zaak te noemen, kreeg: {melding}"
+    );
+}
+
+/// Een contact dat het decretogram niet laat zien, valt op (I4).
+///
+/// De andere kant van dezelfde naad, en ook deze is in de opstelling onmogelijk:
+/// wat een besluit accepteert, staat in zijn gram. De meting zet daarom het
+/// contact van het accepterende besluit naast het gram van het besluit dat
+/// nárekende — twee echte artefacten, verkeerd aan elkaar geknoopt. Zonder deze
+/// toets zou een cel die over de grens reikt en het niet vastlegt, alleen aan een
+/// declaratie op te merken zijn.
+#[test]
+fn een_contact_dat_het_gram_niet_laat_zien_faalt_op_i4() {
+    let path = scenario_path("toeslagen_accepteert_toetsingsinkomen.yaml");
+    let scenario = Scenario::load(&path).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    let run = run(&path);
+    let accepterend = &run.decisions[0];
+    let narekenend = &run.decisions[1];
+
+    let verkeerd_geknoopt = Traffic {
+        decisions: vec![DecisionTraffic {
+            decretogram: &narekenend.decretogram,
+            crossings: &accepterend.crossings,
+        }],
+        probes: Vec::new(),
+    };
+    let failures = check_invariants(&scenario.query_graph, &scenario.cells, &verkeerd_geknoopt);
+
+    let melding = failures
+        .iter()
+        .find(|failure| matches!(failure, InvariantFailure::CrossingNotInDecretogram { .. }))
+        .map(InvariantFailure::describe)
+        .unwrap_or_else(|| panic!("verwachtte een I4-melding, kreeg {failures:?}"));
+    assert!(
+        melding.starts_with("I4")
+            && melding.contains("belastingdienst")
+            && melding.contains("zorgtoeslag-eigen/999993653")
+            && melding.contains("2024-06-01"),
+        "de melding hoort de actoren, de zaak en het moment te noemen, kreeg: {melding}"
+    );
+}

--- a/packages/simulator/tests/invarianten.rs
+++ b/packages/simulator/tests/invarianten.rs
@@ -28,32 +28,57 @@ type Expected = fn(&InvariantFailure) -> bool;
 
 /// Elke negatieve fixture, met de melding die hij moet opleveren.
 ///
+/// Vier kolommen: het bestand, de invariant waar hij over gaat, welke melding dat
+/// is, en **hoeveel** meldingen het bestand in totaal oplevert. Die laatste staat
+/// erbij omdat "de bedoelde melding zit erbij" niet uitsluit dat er nog iets
+/// anders bij zit: een fixture die er een tweede schending bij krijgt, of een gate
+/// die te veel meldt, blijft dan groen. Waar een fixture meer dan één melding
+/// heeft, staat in zijn eigen `description` welke en waarom.
+///
 /// De tabel staat in Rust en niet in de bestanden zelf, en dat is met opzet: een
 /// scenario dat zijn eigen falen verwacht, zou `passed()` van binnenuit kunnen
 /// omdraaien, en dan is "dit scenario is groen" geen uitspraak meer. Wat er wél
 /// afgedwongen wordt, is dat de tabel volledig is — zie
 /// [`elke_negatieve_fixture_staat_in_de_tabel`].
-const FIXTURES: [(&str, &str, Expected); 5] = [
-    ("niet_gedeclareerde_call.yaml", "I3", |failure| {
-        matches!(failure, InvariantFailure::UndeclaredCall { .. })
-    }),
-    ("gedeclareerde_call_bleef_uit.yaml", "I3", |failure| {
-        matches!(failure, InvariantFailure::CallDidNotHappen { .. })
-    }),
+const FIXTURES: [(&str, &str, Expected, usize); 5] = [
+    (
+        "niet_gedeclareerde_call.yaml",
+        "I3",
+        |failure| matches!(failure, InvariantFailure::UndeclaredCall { .. }),
+        1,
+    ),
+    (
+        "gedeclareerde_call_bleef_uit.yaml",
+        "I3",
+        |failure| matches!(failure, InvariantFailure::CallDidNotHappen { .. }),
+        1,
+    ),
     (
         "cel_bevraagt_cel_buiten_haar_definities.yaml",
         "I3",
         |failure| matches!(failure, InvariantFailure::CallOutsideDefinitions { .. }),
+        // Plus de declaratie die uit de pas loopt met de definities: het bestand
+        // declareert de vraag die het niet mag stellen.
+        2,
     ),
-    ("declaratie_buiten_de_definities.yaml", "I3", |failure| {
-        matches!(
-            failure,
-            InvariantFailure::DeclarationOutsideDefinitions { .. }
-        )
-    }),
-    ("reductie_combineert_twee_cellen.yaml", "I4", |failure| {
-        matches!(failure, InvariantFailure::SynthesisOutsideBesluit { .. })
-    }),
+    (
+        "declaratie_buiten_de_definities.yaml",
+        "I3",
+        |failure| {
+            matches!(
+                failure,
+                InvariantFailure::DeclarationOutsideDefinitions { .. }
+            )
+        },
+        // Plus de gedeclareerde vraag die uitbleef: ze wordt hier nooit gesteld.
+        2,
+    ),
+    (
+        "reductie_combineert_twee_cellen.yaml",
+        "I4",
+        |failure| matches!(failure, InvariantFailure::SynthesisOutsideBesluit { .. }),
+        1,
+    ),
 ];
 
 fn negatief_dir() -> PathBuf {
@@ -86,7 +111,7 @@ fn elke_negatieve_fixture_staat_in_de_tabel() {
         .collect();
     let tabel: BTreeSet<String> = FIXTURES
         .iter()
-        .map(|(name, _, _)| (*name).to_string())
+        .map(|(name, ..)| (*name).to_string())
         .collect();
 
     // Beide kanten. Een fixture zonder tabelregel wordt nooit gedraaid en is dus
@@ -109,13 +134,22 @@ fn er_zijn_minstens_drie_negatieve_fixtures() {
 
 #[test]
 fn elke_negatieve_fixture_faalt_op_de_invariant_die_hij_meet() {
-    for (name, invariant, expected) in FIXTURES {
+    for (name, invariant, expected, meldingen) in FIXTURES {
         let path = negatief_dir().join(name);
         let run = run(&path);
 
         assert!(
             !run.passed(),
             "{name}: deze fixture hoort te falen, maar de run is groen:\n{}",
+            run.report()
+        );
+        // Precies de meldingen uit de tabel en geen meldingen erbij. Een fixture
+        // die er ongemerkt een tweede schending bij krijgt, meet niet meer wat hij
+        // zegt te meten — ook niet als de bedoelde melding er nog bij zit.
+        assert_eq!(
+            run.invariant_failures.len(),
+            meldingen,
+            "{name}: verwachtte precies {meldingen} melding(en):\n{}",
             run.report()
         );
         let failure = run
@@ -162,7 +196,7 @@ fn elke_negatieve_fixture_faalt_op_de_invariant_die_hij_meet() {
 /// even rood zijn, en dan zou de suite groen blijven terwijl de gate niets deed.
 #[test]
 fn de_negatieve_fixtures_halen_hun_gewone_verwachtingen_wel() {
-    for (name, _, _) in FIXTURES {
+    for (name, ..) in FIXTURES {
         let path = negatief_dir().join(name);
         let run = run(&path);
 

--- a/packages/simulator/tests/scenarios.rs
+++ b/packages/simulator/tests/scenarios.rs
@@ -3,6 +3,12 @@
 //! De assertie staat in het scenario, niet hier: deze test controleert alleen
 //! dat elk bestand draait en dat geen enkele verwachting mist. Een nieuw
 //! testgeval is dus een nieuw YAML-bestand, geen nieuwe Rust.
+//!
+//! Eén map doet niet mee: `scenarios/negatief/` houdt de bestanden die met opzet
+//! een invariant schenden en die dus **moeten** falen. Die worden door
+//! `tests/invarianten.rs` gedraaid, dat ze op hun faalmelding afrekent. Ze onder
+//! deze suite laten vallen zou betekenen dat de hele crate rood staat zodra de
+//! gate werkt.
 
 use regelrecht_simulator::{regulation_root, Scenario, ScenarioRun};
 use std::path::{Path, PathBuf};
@@ -13,7 +19,10 @@ fn scenario_files() -> Vec<PathBuf> {
         .unwrap_or_else(|e| panic!("kan {} niet lezen: {e}", dir.display()))
         .filter_map(Result::ok)
         .map(|entry| entry.path())
-        .filter(|path| path.extension().is_some_and(|ext| ext == "yaml"))
+        // Alleen de bestanden in de map zelf: `read_dir` daalt niet af, en de
+        // filter op bestand houdt `negatief/` er expliciet buiten in plaats van
+        // op een toevalligheid van de extensiecontrole te leunen.
+        .filter(|path| path.is_file() && path.extension().is_some_and(|ext| ext == "yaml"))
         .collect();
     files.sort();
     files


### PR DESCRIPTION
De simulator kon tot nu toe alleen *laten zien* wat er over een celgrens ging; er
was niets dat een scenario liet falen als dat iets anders was dan bedoeld. Deze PR
maakt daar een gate van.

## Wat erbij komt

Een scenario declareert het **toegestane vraaggraf**:

```yaml
query_graph:
  - doc: haar besluit-definitie vraagt daarom
    from: toeslagen
    to: belastingdienst
    lexostatus: toetsingsinkomen
```

De runner leidt het **feitelijke** graf af uit de bewijsstukken van de
veiligheidscontext en legt de twee naast elkaar. Elk verschil laat het scenario
falen, met de vraag erin (welke cel, welke cel, welke lexostatus, welk moment):
een niet-gedeclareerde vraag net zo goed als een gedeclareerde vraag die uitbleef.
Die tweede kant is de belangrijkste — een vraag die stilletjes wegvalt laat een
scenario groen dat niets meer aantoont.

Daarnaast berekent de gate het toegestane graf **zelf** uit de celconfiguraties:
de `accept_from`-inputs van de besluit-definities van een cel, plus haar
`accepts_from`-afspraken, waarmee een `source.regulation` uit een van haar eigen
wetten bij een lexostatus van een peer uitkomt. Daarmee worden drie invarianten
toetsbaar:

- **I3** — een gestelde vraag buiten die definities faalt, **ook als het scenario
  haar declareert**. Zou een declaratie volstaan, dan hield I3 niets tegen dan
  slordigheid en was elke schending met één regel YAML te legaliseren. En een
  declaratie waar geen definitie om vraagt, faalt op zichzelf: declaratie en
  definitie horen niet uit de pas te lopen.
- **I4** — een cel die buiten een besluit-pad meer dan één cel bevraagt, faalt.
  Combineren is niet verboden, onzichtbaar combineren is dat: in een besluit staat
  het in het decretogram, en bij een consument gaat er geen celgrens over. Daarom
  ook de tweede helft: wat een besluit over de grens haalde, moet in zijn
  decretogram staan.
- **I2** — de keerzijde daarvan: een gram dat zegt een waarde van een cel
  geaccepteerd te hebben zonder dat er een contact met die cel is vastgelegd,
  faalt. Dat dicht de enige kant van de volledigheidseis die te meten valt; de
  andere (een contact dat nergens wordt aangereikt) blijft structureel en staat als
  zodanig in de docs.

De gate draait bij **elke** run, ook bij een scenario zonder `query_graph` — dan
is het toegestane graf leeg, en dat is een even geldige bewering. Een gate die je
moet aanzetten is een gate die iemand vergeet. Het verslag van een run meldt de
gate ook als hij niets vond, zodat "stil" niet hetzelfde is als "niet gedraaid".

## Negatieve fixtures

In `scenarios/negatief/` staan vijf scenariobestanden die met opzet één invariant
schenden en die **moeten** falen; `tests/invarianten.rs` controleert dát ze falen
en waaróp. Dat tweede is het eigenlijke werk: een fixture die om de verkeerde
reden rood staat, bewijst niets over de invariant die hij zegt te meten. Dezelfde
test dwingt af dat elk bestand in die map een regel in de tabel heeft en
omgekeerd, zodat een fixture die niemand draait geen bestand is dat stil niets
doet.

De twee toetsen die de opstelling onmogelijk maakt — accepteren zonder contact, en
een contact dat het gram niet laat zien — worden gemeten door echte artefacten
verkeerd aan elkaar te knopen, in plaats van een wereld te bouwen waarin het kan.

De gate importeert het observatielog niet (geen productiepad mag dat) maar leest
dezelfde bewijsstukken. Dat de twee hetzelfde graf zien is daarom een assertie en
geen aanname.

## Verder

- `transport_toeslagen_brp.yaml` geeft de vragende cel nu een reden om te vragen:
  een wet die de peer aanwijst plus de bijbehorende afspraak. De sonde
  (`query_via_transport`) wordt aan dezelfde definities gehouden als een besluit —
  een uitzondering daar zou in elk scenario een weg om I3 heen openzetten.
- `test_dubbele_celbron` als testregeling: een cel wier eigen recht twee
  organisaties aanwijst, zodat de I4-fixture niet tegelijk I3 schendt.
- De crate-README beschrijft de vijf invarianten en hoe elk gehandhaafd wordt
  (typesysteem, capability, gate), inclusief een sectie over wat de gate **niet**
  doet. Er staat expliciet bij dat **I1 tot en met I5 en het observatielog niet uit
  RFC-022 komen**: de RFC beweert autonomie en zegt nergens hoe je die meet. Dit is
  toegevoegd meetgereedschap, en dat onderscheid hoort niet weg te vallen.

Buiten scope, met opzet: prestatie-eisen op het log, en een gate over de hele
corpus in CI.

## Gates

`cargo fmt --check`, workspace-clippy met `-Dwarnings`, de workspace-tests zonder
de container-gebonden crates (`test-no-docker`) en de pre-commit-hooks (yamllint +
schemavalidatie op de nieuwe testregeling) zijn lokaal groen. De branch is
gerebased op de huidige basisbranch, dus de verplichtingen-stapel zit eronder.

