### PR TITLE
feat: wereld-API van de simulator: acties, instellingen, beeld en terugzetten

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -4231,6 +4231,7 @@ dependencies = [
  "regelrecht-engine",
  "rust_decimal",
  "serde",
+ "serde_json",
  "serde_yaml_ng",
  "thiserror 2.0.20",
  "walkdir",

--- a/packages/simulator/Cargo.toml
+++ b/packages/simulator/Cargo.toml
@@ -19,6 +19,12 @@ serde_yaml_ng.workspace = true
 thiserror.workspace = true
 walkdir.workspace = true
 
+[dev-dependencies]
+# Alleen voor de snapshot-fixture: het contract naar een frontend is JSON, dus de
+# test die het vastpint schrijft JSON. De crate zelf serialiseert niets naar JSON
+# — `Snapshot` is `Serialize` en laat de vorm aan de aanroeper.
+serde_json.workspace = true
+
 [[bin]]
 name = "run-scenario"
 path = "src/bin/run_scenario.rs"

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -1171,8 +1171,11 @@ levert nog steeds het beeld van toen, want de reductie filtert zelf op
 levering of een vervallen termijn die ertussen valt eerst landt.
 
 Een wereldbestand gebruikt in de praktijk `act` óf `decide`. Mengen kan, en dan
-gaan de acties voor; wie een moment kiest dat vóór de klok ligt, krijgt een fout
-("de klok loopt niet terug") en geen stilte.
+gaan de acties voor. Een `act` op een moment dat de klok al voorbij is, levert een
+fout ("de klok loopt niet terug") en geen stilte: een actie gebeurt op de stand
+van de klok en draagt haar moment niet mee het gram in, dus zou ze anders op een
+andere dag landen dan het bestand noemt. Een `decide` draagt zijn moment zelf en
+mag daarmee wél terugkijken; het gram krijgt dan de dag die er staat.
 
 Een `act` en een `decide` mogen zonder `expect`, anders dan een vraag: ze leggen
 iets vast, en bewijzen daarmee ook zonder verwachting iets — namelijk dat de
@@ -1270,6 +1273,13 @@ volgorde in Rust komt te staan. Het is met opzet geen tweede reductietaal: er ko
 geen waarde naar buiten, alleen ja of nee. Kan een actie nu niet, dan is dat een
 leesbare weigering die zegt wát er nog niet ligt, en het beeld van de wereld toont
 haar met diezelfde reden erbij.
+
+Die cel hoeft niet de actor te zijn: de wereld beantwoordt de vraag zelf, net zoals
+zij het beeld van alle kronieken maakt. Het is daarmee **geen contact over een
+celgrens** — het staat niet in het vraaggraf en niet in het observatielog, en er
+komt geen cel aan de kroniek van een ander. Moet de actor zélf weten dat er iets
+gebeurd is, dan hoort dat als levering in zijn eigen kroniek te liggen
+(`delivers_to`), en wijst de voorwaarde naar die kroniek.
 
 Een actie ontsnapt niet aan de invarianten. Lokt ze een besluit uit dat een waarde
 van een andere cel accepteert, dan gaat dat contact over een celgrens en hoort de

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -879,13 +879,39 @@ bereikt geen stille regel in het bestand is.
 
 ## Het wereldbestand
 
-Een wereld is één YAML-bestand: `clock` (de tijdlijn), `cells` (wie er zijn),
-`settings` (casusdata die geen wet is), `fixtures` (de startstand), `query_graph`
-(het toegestane vraaggraf), `decide` (welke cel wanneer waarover besluit) en twee
-soorten vraag: `queries` (een
-consument bevraagt een cel) en `query_via_transport` (een cel bevraagt een andere
-cel). Elk draagt zijn eigen verwachting. De assertie hoort bij het bestand, niet
+Een wereld is één YAML-bestand. Het valt in twee helften uiteen, en die scheiding
+is de kern van de opzet:
+
+**De wereld zelf** — wat er is, en wat er gedaan kan worden:
+
+| sleutel | wat |
+|---|---|
+| `clock` | waar de logische klok begint; verplicht |
+| `cells` | de organisaties, elk met `laws`, `chronicles`, `lexostatus_definitions`, `besluit_definitions` (met `obligations`) en `accepts_from` |
+| `settings` | casusdata die geen wet is, bijvoorbeeld een betalingsritme |
+| `fixtures` | de startstand: vastleggingen met een moment |
+| `actions` | wat een actor op de tijdlijn kan doen |
+| `deadlines` | termijnen die waarschuwen als een feit ontbreekt |
+
+**De stappen van een scenario** — wat er in déze run gebeurt, en wat dat moet
+opleveren:
+
+| sleutel | wat |
+|---|---|
+| `act` | een actor doet een actie, op een moment |
+| `decide` | een cel besluit rechtstreeks, op een moment |
+| `queries` | een consument bevraagt een cel |
+| `query_via_transport` | een cel bevraagt een andere cel (een sonde) |
+| `query_graph` | het toegestane vraaggraf: welke cel welke andere mag bevragen |
+| `expect_warnings` | de termijnen die deze run moet melden |
+
+Elke stap draagt zijn eigen verwachting. De assertie hoort bij het bestand, niet
 bij Rust: een nieuw testgeval is een nieuw bestand.
+
+De eerste helft is ook los te lezen — `WorldDefinition::load` — en dat is wat een
+web-laag doet: één wereldbestand, en per sessie een verse `World` eruit. Een
+scenariobestand draagt beide helften; de crate leest de eerste eruit met
+`Scenario::definition()`.
 
 ```yaml
 name: korte naam van het scenario
@@ -1005,6 +1031,63 @@ fixtures:                                       # de startstand van de wereld
         bsn: '999993653'
         partnerschap_type: GEEN
 
+actions:                                        # wat een actor kan doen
+  - id: burger.aanvraag                         # waarmee de actie aangeroepen wordt
+    actor: burger                               # de cel die haar doet
+    label: Aanvraag indienen                    # wat een lezer ziet; casusdata
+    doc: vrije toelichting                      # optioneel
+    records:                                    # óf `records`, óf `decides`
+      cell: burger                              # bij wie het gram landt
+      chronicle: aanvragen                      # in welke stroom
+      name: aanvraag_ingediend                  # hoe het gram heet
+      intake: aanvraag                          # waarlangs het binnenkomt
+      grondslag: Awir art. 15                   # optioneel
+      fields:                                   # het formulier van de actie
+        - name: bsn
+          type: string                          # string | number | boolean
+        - name: jaar
+          type: number
+      delivers_to:                              # optioneel: hetzelfde feit óók
+        cell: toeslagen                         # bij de ontvanger
+        chronicle: aanvragen
+        intake: aanvraag                        # standaard `levering`
+        name: aanvraag_ontvangen                # standaard dezelfde naam
+
+  - id: toeslagen.toekenning
+    actor: toeslagen
+    label: Beslis op de aanvraag
+    decides:                                    # start het besluit-pad van een cel
+      cell: toeslagen
+      besluit: zorgtoeslag_vaststelling         # het formulier is dat van dit
+                                                # besluit (zijn `params`)
+    available_when:                             # optioneel: pas als het verhaal
+      cell: toeslagen                           # zover is
+      chronicle: aanvragen
+      field: jaar
+      equals: 2024
+
+deadlines:                                      # termijnen die waarschuwen
+  - label: aanvraag ontvangen vóór 1 maart      # wat een lezer ziet; casusdata
+    at: 2024-03-01                              # de dag waarop de termijn verstrijkt
+    warn_if_missing:                            # het feit dat er dan hoort te liggen
+      cell: toeslagen
+      chronicle: aanvragen
+      name: aanvraag_ontvangen
+
+act:                                            # acties, elk op een moment
+  - description: vrije omschrijving             # optioneel
+    action: burger.aanvraag                     # de actie hierboven
+    values:                                     # het ingevulde formulier
+      bsn: '999993653'
+      jaar: 2024
+    op_moment: 2024-01-10                       # de klok gaat hier eerst naartoe
+    expect:                                     # optioneel, bij een `decides`-actie
+      heeft_recht_op_zorgtoeslag: true
+    expect_accepted:                            # optioneel: herkomst per waarde
+      toetsingsinkomen: belastingdienst
+    expect_computed:                            # en wat hier wél vastgesteld is
+      - is_verzekerde
+
 query_graph:                                    # het toegestane vraaggraf
   - doc: waarom deze vraag mag                  # optioneel
     from: toeslagen                             # de cel die mag vragen
@@ -1056,6 +1139,9 @@ query_via_transport:                            # vragen over een celgrens
     op_moment: 2024-01-01
     expect:                                     # zelfde verwachtingen als bij
       partnerschap_type: HUWELIJK               # een gewone vraag
+
+expect_warnings:                                # de termijnen die deze run miste
+  - aanvraag ontvangen vóór 1 maart             # leeg (of afwezig) = geen enkele
 ```
 
 `query_via_transport` is een **sonde, geen onderdeel van de opstelling**. In de
@@ -1076,17 +1162,21 @@ om de invariant heen openzetten — maar het betekent dat een nieuwe sonde niet
 alleen een identiteit vraagt. Zie
 [De vijf invarianten](#de-vijf-invarianten-en-de-gate-eronder).
 
-De stappen lopen in deze volgorde: eerst de besluiten, dan de vragen van een
-consument, dan die over een celgrens. Dat past bij wat ze zijn — een besluit is
-een gebeurtenis op de tijdlijn, een vraag kijkt erop terug — en het maakt niets
-onmogelijk: een vraag over een moment *vóór* een besluit levert nog steeds het
-beeld van toen, want de reductie filtert zelf op `op_moment`. De klok gaat vóór
-elke stap vooruit tot haar moment, zodat een levering die ertussen valt eerst
-landt.
+De stappen lopen in deze volgorde: eerst de acties, dan de besluiten, dan de
+vragen van een consument, dan die over een celgrens. Dat past bij wat ze zijn — een
+actie en een besluit zijn gebeurtenissen op de tijdlijn, een vraag kijkt erop
+terug — en het maakt niets onmogelijk: een vraag over een moment *vóór* een besluit
+levert nog steeds het beeld van toen, want de reductie filtert zelf op
+`op_moment`. De klok gaat vóór elke stap vooruit tot haar moment, zodat een
+levering of een vervallen termijn die ertussen valt eerst landt.
 
-Een `decide` mag zonder `expect`, anders dan een vraag: hij legt iets vast, en
-bewijst daarmee ook zonder verwachting iets — namelijk dat de vragen erna iets te
-vinden hebben.
+Een wereldbestand gebruikt in de praktijk `act` óf `decide`. Mengen kan, en dan
+gaan de acties voor; wie een moment kiest dat vóór de klok ligt, krijgt een fout
+("de klok loopt niet terug") en geen stilte.
+
+Een `act` en een `decide` mogen zonder `expect`, anders dan een vraag: ze leggen
+iets vast, en bewijzen daarmee ook zonder verwachting iets — namelijk dat de
+vragen erna iets te vinden hebben.
 
 `query_graph` mag weg, en dan zegt het bestand iets: **er gaat niets over een
 celgrens.** Zie [De vijf invarianten](#de-vijf-invarianten-en-de-gate-eronder) voor
@@ -1151,6 +1241,163 @@ Eenzelfde feit kan dus twee kanten op geschreven worden — als `events` in de
 celconfiguratie of als `fixture` met een `at` — en dat is geen dubbelop. Het
 eerste is wat de cel al bijhield toen de wereld begon, het tweede is wat er
 tijdens de run gebeurt.
+
+### Acties: wat een actor kan doen
+
+Een actie is de aansturing van de wereld, en ze is **data**. `World::act(id,
+waarden)` voert er één uit, op de stand van de klok — een actie draagt geen eigen
+moment, want dat is wat haar van een `fixture` onderscheidt: een startstand staat
+op een datum, een actor doet iets op het moment dat de wereld staat.
+
+Twee vormen, en precies één per actie:
+
+- **`records`** legt een executogram vast in een eigen kroniek van de actor. Het
+  formulier (`fields`) zegt wat de actor invult en van welk type; de waarden
+  worden de velden van het gram. Staat er `delivers_to`, dan landt hetzelfde feit
+  óók bij de ontvanger — als **tweede gram in zijn eigen kroniek**, op zijn eigen
+  naam, met zijn eigen kanaal. Dat is de eerlijke vorm van een aanvraag: de
+  aanvrager weet wat ze indiende, de ontvanger weet wat hem geleverd is, en geen
+  van beide leest de kroniek van de ander. Aan jezelf leveren wordt geweigerd —
+  dat zou hetzelfde gram twee keer in dezelfde kroniek zetten.
+- **`decides`** start het besluit-pad van een cel. Het formulier is dan **dat van
+  het besluit**: de `params` die de besluit-definitie al documenteert. Een tweede
+  lijst in de actie zou daarvan gaan afwijken.
+
+`available_when` is één simpele voorwaarde: *er ligt in kroniek X van cel Y een
+feit waarin veld Z de waarde W heeft.* Daarmee kan een actie wachten tot het
+verhaal zover is — beslissen pas als er een aanvraag ligt — zonder dat die
+volgorde in Rust komt te staan. Het is met opzet geen tweede reductietaal: er komt
+geen waarde naar buiten, alleen ja of nee. Kan een actie nu niet, dan is dat een
+leesbare weigering die zegt wát er nog niet ligt, en het beeld van de wereld toont
+haar met diezelfde reden erbij.
+
+Een actie ontsnapt niet aan de invarianten. Lokt ze een besluit uit dat een waarde
+van een andere cel accepteert, dan gaat dat contact over een celgrens en hoort de
+tak in `query_graph` te staan — precies zoals bij een `decide`. De gate leest álle
+besluiten van een run, of ze door een actie zijn uitgelokt of rechtstreeks genomen:
+zouden die twee uit elkaar vallen, dan zou een actie een weg om I3 heen openen.
+Zie [De vijf invarianten](#de-vijf-invarianten-en-de-gate-eronder).
+
+Alles wat een actie belooft, wordt bij het optuigen getoetst: bestaat de actor,
+bestaat de cel, houdt ze de stroom, kan die stroom haar sleutelveld uit het
+formulier krijgen, bestaat het besluit, en gaat de voorwaarde over een veld dat
+bestaat. Een actie die pas bij de eerste klik omvalt, is een typfout die op het
+verkeerde moment boven water komt. De stroom met decretogrammen
+(`beschikkingen`) is geen doel voor een actie: daar ontstaat een gram door te
+besluiten.
+
+### Termijnen: waarschuwen zonder te blokkeren
+
+Een `deadline` zegt wanneer een feit er hoort te liggen. Passeert de klok die dag
+en ligt het er niet, dan komt er een **waarschuwing** naast de wereld — en verder
+niets. De aanvraag kan alsnog binnenkomen, en ze landt gewoon.
+
+Dat is een standpunt en geen gemak. De wet zegt wat de termijn was, niet dat er
+daarna niets meer mag; wat er met een te late aanvraag gebeurt, is een besluit van
+het bestuursorgaan en geen eigenschap van de simulator. Een termijn die de actie
+tegenhoudt, zou de opstelling laten beweren dat een te late aanvraag niet bestaat.
+
+De waarschuwing valt op het moment dat de termijn passeert, en niet aan het eind
+van een run. Dat moet ook: een feit dat er een dag later wél ligt, lag er op de
+termijn niet, en een berekening achteraf zou nooit waarschuwen. `at` is daarom een
+vaste datum en geen sjabloon over `settings` — de termijnen staan bij het optuigen
+in de wachtrij, en een instelling die later wijzigt zou een termijn moeten
+verplaatsen die misschien al gepasseerd is.
+
+Een scenario rekent erop af met `expect_warnings`. Die lijst wordt **altijd**
+vergeleken, ook als hij niet in het bestand staat: dan is de verwachting "geen
+enkele". Een waarschuwing die niemand verwachtte, hoort een run te laten falen in
+plaats van stil in het verslag te belanden.
+
+### De wereld besturen
+
+Vijf ingangen, en samen zijn ze wat een web-laag nodig heeft:
+
+| aanroep | wat |
+|---|---|
+| `World::from_definition(&definition, corpus)` | tuig een wereld op uit een wereldbestand |
+| `World::act(id, waarden)` | voer een actie uit op de stand van de klok |
+| `World::advance(tot)` | zet de klok vooruit en laat de triggers onderweg afgaan |
+| `World::update_settings(wijzigingen)` | wijzig de instellingen |
+| `World::reset()` | terug naar de startstand |
+| `World::snapshot()` | het beeld van alles wat er staat |
+
+`act` en `advance` leveren `Events`: welke grammen erbij kwamen, welke besluiten
+genomen zijn en welke termijnen verstreken. Dat is geen tweede waarheid naast de
+kronieken — alles erin ligt óók in de cel waar het hoort — maar het verslag van
+één stap.
+
+`reset` is **opnieuw beginnen**, niet terugdraaien. Dat verschil is de hele reden
+dat het kan: een kroniek groeit en wijzigt nooit, dus "terug" bestaat niet; wat wél
+bestaat is een verse wereld uit hetzelfde bestand. Ook de instellingen gaan terug
+naar wat het bestand zegt — wie ze wijzigde, wijzigde de wereld en niet het
+bestand.
+
+### Instellingen komen vast te staan
+
+`update_settings` weigert een instelling te wijzigen die **al door een besluit
+gebruikt is**. Een besluit legt vast waarop besloten is; een ritme dat er achteraf
+onder vandaan geschoven wordt, laat het gram iets anders zeggen dan er gebeurd is,
+en dan is een decretogram niet meer terug te lezen. Wie het toch wil wijzigen,
+begint een nieuwe wereld.
+
+Wat "gebruikt" betekent, komt uit de besluit-definitie en niet uit het gram: het
+gram draagt het uitgerekende schema, en daaruit is niet meer te zien of het ritme
+uit een instelling kwam of letterlijk in de definitie stond. Welke instellingen
+vaststaan, staat in het beeld van de wereld (`locked_settings`) — zodat een lezer
+kan zien welke knop nog om kan zonder het te hoeven proberen.
+
+Verder is `update_settings` alles-of-niets, en het toetst de nieuwe stand met
+dezelfde controle als bij het optuigen: een instelling die geen ritme is, valt hier
+en niet bij het eerstvolgende besluit dat erop leunt.
+
+### Het beeld van de wereld
+
+`World::snapshot()` levert één doorsnede van alles wat er staat, en dat is het
+**contract naar een frontend** (`serde`-`Serialize`; `tests/fixtures/snapshot.json`
+is het vastgepinde voorbeeld):
+
+| sleutel | wat |
+|---|---|
+| `clock` | waar de logische klok staat |
+| `settings` + `locked_settings` | wat geldt, en wat vast staat en waardoor |
+| `cells` | per cel haar `laws`, wat ze publiceert, wat ze kan besluiten, en haar kronieken |
+| `cells[].chronicles[].grams` | elk gram met zijn soort (`lexogram`/`decretogram`/`executogram`), moment, kanaal, grondslag en velden |
+| `…grams[].fields[].origin` | de herkomst per waarde |
+| `actions` | elke actie met haar formulier, en of ze nu kan |
+| `crossings` | wat er over een celgrens ging |
+| `warnings` | de termijnen die verstreken zonder dat het feit er lag |
+
+Drie dingen om bij stil te staan:
+
+**Geen casusnamen.** Er staat geen naam in het contract die bij één casus hoort.
+Elk label komt uit het wereldbestand, dus een andere casus is een ander bestand en
+geen andere frontend.
+
+**Herkomst per waarde.** Bij een executogram is de herkomst de vastlegging zelf:
+langs welk kanaal, op welke grondslag. Bij een decretogram valt ze uiteen, en dat
+is het hele punt van invariant I5 — een input die van een andere cel
+**geaccepteerd** is, draagt bron, lexostatus, moment en ondertekening; een uitkomst
+draagt de regeling die haar berekende; een vast veld van het gram draagt dat het
+dat is. Een geaccepteerde waarde hoort niet op een berekende te lijken. Een gram
+dat een cel zelf vastlegde over haar eigen vaststelling — een bron-cel zonder
+engine — draagt geen receipt, en dan is de herkomst van elke waarde erin de
+vastlegging, want er heeft geen uitvoering gedraaid.
+
+**Het receipt gaat niet mee.** Een decretogram draagt het volledige RFC-013
+Execution Receipt, en dat draagt wandkloktijd. Een beeld dat per run verschilt is
+geen contract, dus het receipt blijft in de kroniek waar het hoort; wat een lezer
+eraan had, is de herkomst hierboven. Het `lexogram` in de lijst met gram-soorten
+komt in geen enkele kroniek voor: de wet is generiek en van niemand in bijzonder,
+en welk recht een cel laadt staat in `cells[].laws`. De variant staat er zodat een
+lezer één vocabulaire voor alle drie de grammen heeft.
+
+Het beeld is een **inspectiebeeld**, net zoals het observatielog een meetinstrument
+is. De wereld bezit de cellen en zij maakt het; een cel kan het niet opvragen en
+kan er dus niet de kroniek van een ander mee lezen. `crossings` is het materiaal
+van dat log, en een lezer hoort het als zodanig te labelen: wie deze lijst houdt,
+kent de unie van wat over de grenzen ging — precies het totaalbeeld waarvan geen
+enkele cel er een heeft.
 
 ### Kroniekstromen en tijd
 
@@ -1227,10 +1474,16 @@ een eigen verplichting, en dat is nog nergens uitgewerkt. Een verplichting kan o
 niet gewijzigd of ingetrokken worden: het schema staat in het gram, en een gram
 verandert niet.
 
-**Een besluit wordt nog niet door een actie uitgelokt.** Het scenario zegt in
-`decide` wie wanneer waarover besluit; er is nog geen `World::act` waarmee een
-actor (een aanvraag indienen, een opgave doen) een cel aan het werk zet. Dat is
-de reden dat `decide` een stap in het bestand is en geen gevolg van iets anders.
+**Een voorwaarde op een actie is één gelijkheid.** `available_when` kijkt naar één
+veld in één kroniek van één cel. Er is geen "en", geen "of", geen "ligt er iets"
+zonder waarde, en geen voorwaarde over een gram-naam. Wat er nu kan, is genoeg voor
+"het verhaal is zover"; een voorwaarde die meer nodig heeft, is een aanwijzing dat
+het wereldbestand een stap mist.
+
+**Een gemiste termijn heeft geen gevolg in de wereld.** Ze komt in de lijst met
+waarschuwingen en verder niets: geen gram, geen verval van een recht, geen
+herinnering die op een termijn afgaat. Wat een bestuursorgaan met een te late
+aanvraag doet, is een besluit en dus een besluit-definitie.
 
 **Onbetrouwbaar gedrag tussen cellen bestaat niet.** Een bron-cel is er altijd, ze
 antwoordt meteen, en haar antwoord is nooit verouderd of in tegenspraak met dat van

--- a/packages/simulator/scenarios/negatief/actie_lokt_niet_gedeclareerde_call_uit.yaml
+++ b/packages/simulator/scenarios/negatief/actie_lokt_niet_gedeclareerde_call_uit.yaml
@@ -1,0 +1,114 @@
+---
+name: een actie lokt een besluit uit dat over een celgrens vraagt zonder declaratie
+description: >-
+  **Negatieve fixture: dit scenario hoort te falen.** Hij staat in
+  `scenarios/negatief/` en wordt door `tests/invarianten.rs` gedraaid, dat
+  controleert dát hij faalt en waarop — niet door de gewone scenariosuite, die
+  van elk bestand verwacht dat het groen is.
+
+  Wat er mis is: hetzelfde als in `niet_gedeclareerde_call.yaml`, maar het besluit
+  wordt hier niet rechtstreeks genomen. Een **actie** start het besluit-pad, en
+  dat besluit haalt de relatievorm bij `brp` omdat haar eigen wet daarom vraagt.
+  Het bestand declareert geen enkel vraaggraf, en dan is de bewering "er gaat
+  niets over een celgrens".
+
+  Waarom dat een eigen fixture verdient: een actie is een tweede weg naar het
+  besluit-pad, en de gate leest de besluiten van een run. Zouden de besluiten die
+  een actie uitlokt daar niet in meekomen, dan zou een wereldbestand elke
+  celgrens over kunnen door de actie ervoor te zetten — en dan meet de gate
+  alleen nog de weg die niemand meer gebruikt.
+
+clock:
+  start: 2024-01-01
+
+cells:
+  - id: brp
+    laws: []
+
+    chronicles:
+      - stream: relaties
+        key: bsn
+        events:
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: brp
+            grondslag: eigen registratie
+            op_moment: 2023-03-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: HUWELIJK
+
+    lexostatus_definitions:
+      - name: partnerschap
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - partnerschap_type
+        reduction:
+          chronicle: relaties
+          key: bsn
+          latest: true
+
+  - id: toeslagen
+    laws:
+      - test_partnerschapstoets
+
+    accepts_from:
+      - cell: brp
+        output: partnerschap
+        lexostatus: partnerschap
+        field: partnerschap_type
+
+    besluit_definitions:
+      - name: partnerschapstoets
+        regulation: test_partnerschapstoets
+        output: is_gehuwd
+        zaakkenmerk: partnerschapstoets/{bsn}
+        params:
+          - name: bsn
+            type: string
+        inputs:
+          bsn:
+            param: bsn
+
+    lexostatus_definitions:
+      - name: partnerschapsbeschikking
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - is_gehuwd
+        reduction:
+          chronicle: beschikkingen
+          key: zaakkenmerk
+          latest: true
+
+actions:
+  - id: toeslagen.partnerschapstoets
+    actor: toeslagen
+    label: Beslis op de partnerschapstoets
+    decides:
+      cell: toeslagen
+      besluit: partnerschapstoets
+
+# Hier hoort een `query_graph` te staan met de tak toeslagen -> brp.partnerschap.
+# Hij staat er niet, en dat is de schending.
+
+act:
+  - description: de actie start het besluit-pad, en dat vraagt over de celgrens
+    action: toeslagen.partnerschapstoets
+    values:
+      bsn: '999993653'
+    op_moment: 2024-06-01
+    expect:
+      is_gehuwd: true
+
+queries:
+  - cell: toeslagen
+    lexostatus: partnerschapsbeschikking
+    params:
+      zaakkenmerk: partnerschapstoets/999993653
+    op_moment: 2024-06-01
+    expect:
+      is_gehuwd: true

--- a/packages/simulator/scenarios/termijn_gemist.yaml
+++ b/packages/simulator/scenarios/termijn_gemist.yaml
@@ -1,0 +1,136 @@
+---
+name: een gemiste termijn waarschuwt en blokkeert niets
+description: >-
+  Een termijn in het wereldbestand zegt wanneer een feit er hoort te liggen. Ligt
+  het er op dat moment niet, dan komt er een **waarschuwing** naast de wereld —
+  en verder niets. De aanvraag kan alsnog binnenkomen, en ze landt gewoon: de wet
+  zegt wat de termijn was, niet dat er daarna niets meer mag.
+
+  Waarom dat een standpunt is en geen gemak: een termijn die de actie blokkeert,
+  zou de opstelling laten beweren dat een te late aanvraag niet bestaat. Ze
+  bestaat wel, en wat er met de te late aanvraag gebeurt, is een besluit van het
+  bestuursorgaan en geen eigenschap van de simulator.
+
+  De tweede assertie is de tijdreductie eronder: op het moment van de termijn was
+  er níets vastgesteld, en dat blijft het antwoord op dat moment, ook nu de
+  aanvraag er ligt. Zou de waarschuwing pas aan het eind van de run uitgerekend
+  worden, dan zou ze nooit vallen — want dán ligt de aanvraag er.
+
+clock:
+  start: 2024-01-01
+
+cells:
+  # Twee bron-cellen. Geen wetten, geen engine: een termijn en een levering zijn
+  # geen berekening, en dit scenario hoort dat niet nodig te hebben.
+  - id: burger
+    laws: []
+    chronicles:
+      - stream: aanvragen
+        key: bsn
+
+    lexostatus_definitions:
+      - name: ingediende_aanvraag
+        doc: wat deze aanvrager zelf indiende
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - jaar
+        reduction:
+          chronicle: aanvragen
+          key: bsn
+          latest: true
+
+  - id: toeslagen
+    laws: []
+    chronicles:
+      - stream: aanvragen
+        key: bsn
+
+    lexostatus_definitions:
+      - name: ontvangen_aanvraag
+        doc: wat deze cel geleverd kreeg
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - jaar
+        reduction:
+          chronicle: aanvragen
+          key: bsn
+          latest: true
+
+actions:
+  - id: burger.aanvraag
+    actor: burger
+    label: Aanvraag indienen
+    records:
+      cell: burger
+      chronicle: aanvragen
+      name: aanvraag_ingediend
+      intake: aanvraag
+      grondslag: Awir art. 15
+      fields:
+        - name: bsn
+          type: string
+        - name: jaar
+          type: number
+      delivers_to:
+        cell: toeslagen
+        chronicle: aanvragen
+        name: aanvraag_ontvangen
+        intake: aanvraag
+
+deadlines:
+  - label: aanvraag ontvangen vóór 1 februari
+    at: 2024-02-01
+    warn_if_missing:
+      cell: toeslagen
+      chronicle: aanvragen
+      name: aanvraag_ontvangen
+
+act:
+  - description: >-
+      De aanvraag komt een maand ná de termijn binnen. Ze wordt vastgelegd en
+      geleverd; de weigering die er niet is, is het punt.
+    action: burger.aanvraag
+    values:
+      bsn: '999993653'
+      jaar: 2024
+    op_moment: 2024-03-01
+
+queries:
+  - description: >-
+      Op het moment van de termijn lag er niets, en dat blijft het antwoord op dat
+      moment — ook nu de klok een maand verder staat en de aanvraag er ligt.
+    cell: toeslagen
+    lexostatus: ontvangen_aanvraag
+    params:
+      bsn: '999993653'
+    op_moment: 2024-02-01
+    expect_not_established: true
+
+  - description: >-
+      En de te late aanvraag ligt er gewoon, met haar eigen moment. Een
+      waarschuwing houdt niets tegen.
+    cell: toeslagen
+    lexostatus: ontvangen_aanvraag
+    params:
+      bsn: '999993653'
+    op_moment: 2024-03-01
+    expect:
+      jaar: 2024
+
+  - description: >-
+      De aanvrager weet wat zij indiende, uit haar eigen kroniek. Ook bij een te
+      late aanvraag zijn het twee grammen en geen gedeelde staat.
+    cell: burger
+    lexostatus: ingediende_aanvraag
+    params:
+      bsn: '999993653'
+    op_moment: 2024-03-01
+    expect:
+      jaar: 2024
+
+expect_warnings:
+  - aanvraag ontvangen vóór 1 februari

--- a/packages/simulator/scenarios/toeslagen_volledig_verhaal.yaml
+++ b/packages/simulator/scenarios/toeslagen_volledig_verhaal.yaml
@@ -1,0 +1,451 @@
+---
+name: het volledige verhaal, gedreven door acties van actoren
+description: >-
+  Aanvraag → besluit → betalingen → tweede besluit, en niets ervan staat in Rust.
+  De stappen hieronder roepen alleen `act` aan: welke actor wat kan doen, welk
+  formulier daarbij hoort en wanneer een actie überhaupt kan, staat in `actions`
+  van dit bestand. Een andere casus is een ander wereldbestand.
+
+  Vier dingen die dit scenario moet vastpinnen:
+
+  1. **Een aanvraag is twee grammen.** De burger legt in haar eigen kroniek vast
+     wat zij indiende; `toeslagen` legt in de zijne vast wat hem geleverd is.
+     Niemand leest de kroniek van de ander, en beide kanten weten wat er gebeurde.
+  2. **Een actie kan wachten tot het verhaal zover is.** Beslissen kan pas als er
+     een aanvraag ligt, en vaststellen pas als er een toekenning ligt. Die
+     voorwaarde is data (`available_when`), geen volgorde in Rust.
+  3. **Geen schaduwboekhouding.** De belastingdienst corrigeert het
+     toetsingsinkomen ná de toekenning. Het tweede besluit gaat opnieuw naar de
+     bron en komt daardoor op een ánder bedrag uit — had `toeslagen` het eerste
+     antwoord ergens bewaard, dan zou hier hetzelfde bedrag staan.
+  4. **De tijd doet het werk.** Niemand betaalt iets; de klok laat de termijnen
+     van de toekenning vervallen en dan legt de betalende cel vast dat zij
+     betaalde.
+
+clock:
+  start: 2024-01-01
+
+settings:
+  # Beleid en geen wet: de besluit-definitie verwijst ernaar met `$betalingsritme`
+  # in plaats van een ritme voor te schrijven. Zodra het besluit genomen is, staat
+  # deze instelling vast — het gram legt vast waarop besloten is.
+  betalingsritme: kwartaal
+
+cells:
+  # De aanvrager. Een bron-cel: geen wetten, geen engine. Wat zij houdt is haar
+  # eigen journaal van wat zij indiende.
+  - id: burger
+    laws: []
+    chronicles:
+      - stream: aanvragen
+        key: bsn
+
+    lexostatus_definitions:
+      - name: ingediende_aanvraag
+        doc: wat deze aanvrager zelf indiende, en wanneer
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - jaar
+        reduction:
+          chronicle: aanvragen
+          key: bsn
+          latest: true
+
+  # De cel die het toetsingsinkomen vaststelt, en die later de verplichtingen
+  # nakomt. Twee aanslagen: de tweede corrigeert de eerste, en dat verschil is
+  # wat het tweede besluit zichtbaar maakt.
+  - id: belastingdienst
+    laws: []
+    chronicles:
+      - stream: aanslagen
+        key: bsn
+        events:
+          - name: aanslag_vastgesteld
+            intake: eigen_besluit
+            recording_actor: belastingdienst
+            grondslag: Wet inkomstenbelasting 2001, hoofdstuk 2
+            op_moment: 2024-03-01
+            fields:
+              bsn: '999993653'
+              toetsingsinkomen: 81000
+              competent_authority: Belastingdienst
+
+          - name: aanslag_herzien
+            intake: eigen_besluit
+            recording_actor: belastingdienst
+            grondslag: Wet inkomstenbelasting 2001, hoofdstuk 2
+            op_moment: 2024-12-01
+            fields:
+              bsn: '999993653'
+              toetsingsinkomen: 85000
+              competent_authority: Belastingdienst
+
+      - stream: betalingen
+        key: zaakkenmerk
+
+    lexostatus_definitions:
+      - name: toetsingsinkomen
+        doc: >-
+          Het vastgestelde toetsingsinkomen op het gevraagde moment, met het
+          bevoegd gezag erbij. Een consument die hierop leunt, hoort te kunnen
+          zien wiens vaststelling dit is.
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - toetsingsinkomen
+          - competent_authority
+        reduction:
+          chronicle: aanslagen
+          key: bsn
+          latest: true
+
+      - name: betaald_tot_nu_toe
+        doc: wat deze cel op deze zaak betaald heeft, opgeteld
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - bedrag
+        reduction:
+          chronicle: betalingen
+          key: zaakkenmerk
+          sum: bedrag
+
+  - id: toeslagen
+    laws:
+      - wet_op_de_zorgtoeslag
+      - algemene_wet_inkomensafhankelijke_regelingen
+      - regeling_standaardpremie
+
+    chronicles:
+      # De kroniek waarin de levering van de burger landt. Leeg opgetuigd: wat
+      # erin komt, komt van een actie.
+      - stream: aanvragen
+        key: bsn
+
+      - stream: relaties
+        key: bsn
+        events:
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: toeslagen
+            grondslag: melding uit de basisregistratie personen
+            op_moment: 2023-01-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: GEEN
+
+      - stream: inkomensleveringen
+        key: bsn
+        events:
+          - name: inkomenslevering
+            intake: levering
+            recording_actor: toeslagen
+            grondslag: jaarlijkse inkomenslevering
+            op_moment: 2023-11-15
+            fields:
+              bsn: '999993653'
+              is_verzekerde: true
+              vermogen: 0
+
+      # De besluitende cel houdt zelf ook een betalingsstroom: zij legt vast dat
+      # haar gemeld is dat er betaald is.
+      - stream: betalingen
+        key: zaakkenmerk
+
+    besluit_definitions:
+      - name: zorgtoeslag_toekenning
+        doc: >-
+          Het eerste besluit over de zaak: recht en hoogte, met een
+          betalingsverplichting eraan. Het toetsingsinkomen wordt geaccepteerd
+          van de cel die het vaststelde en hier niet nagerekend (invariant I5).
+        regulation: wet_op_de_zorgtoeslag
+        output: heeft_recht_op_zorgtoeslag
+        outputs:
+          - hoogte_zorgtoeslag
+        zaakkenmerk: zorgtoeslag/{bsn}
+        params:
+          - name: bsn
+            type: string
+        inputs:
+          bsn:
+            param: bsn
+          is_verzekerde:
+            from_chronicle: inkomensleveringen
+            field: is_verzekerde
+          toetsingsinkomen:
+            accept_from: belastingdienst
+            lexostatus: toetsingsinkomen
+            field: toetsingsinkomen
+            params:
+              bsn: $bsn
+        obligations:
+          - amount: $hoogte_zorgtoeslag
+            payer: belastingdienst
+            schedule: $betalingsritme
+
+      - name: zorgtoeslag_vaststelling
+        doc: >-
+          Het tweede besluit over dezelfde zaak. Hetzelfde zaakkenmerk, dus het
+          ligt in dezelfde kroniek van dezelfde cel — en het gaat opnieuw naar de
+          bron voor het toetsingsinkomen, want er is nergens een kopie van het
+          eerste antwoord.
+        regulation: wet_op_de_zorgtoeslag
+        output: heeft_recht_op_zorgtoeslag
+        outputs:
+          - hoogte_zorgtoeslag
+        zaakkenmerk: zorgtoeslag/{bsn}
+        params:
+          - name: bsn
+            type: string
+        inputs:
+          bsn:
+            param: bsn
+          is_verzekerde:
+            from_chronicle: inkomensleveringen
+            field: is_verzekerde
+          toetsingsinkomen:
+            accept_from: belastingdienst
+            lexostatus: toetsingsinkomen
+            field: toetsingsinkomen
+            params:
+              bsn: $bsn
+
+    lexostatus_definitions:
+      - name: ontvangen_aanvraag
+        doc: wat deze cel over deze persoon geleverd kreeg
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - jaar
+        reduction:
+          chronicle: aanvragen
+          key: bsn
+          latest: true
+
+      - name: zorgtoeslagbeschikking
+        doc: wat deze cel over deze zaak besloten heeft, op het gevraagde moment
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - heeft_recht_op_zorgtoeslag
+          - hoogte_zorgtoeslag
+        reduction:
+          chronicle: beschikkingen
+          key: zaakkenmerk
+          latest: true
+
+      - name: betaald_tot_nu_toe
+        doc: >-
+          Wat er op deze zaak betaald is, voor zover deze cel dat weet: een som
+          over haar eigen meldingen, en dus een reductie — geen saldo dat naast
+          de kroniek wordt bijgehouden.
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - bedrag
+        reduction:
+          chronicle: betalingen
+          key: zaakkenmerk
+          sum: bedrag
+
+actions:
+  - id: burger.aanvraag
+    actor: burger
+    label: Aanvraag zorgtoeslag indienen
+    doc: >-
+      De aanvrager legt vast wat zij indient, en levert hetzelfde feit aan de
+      uitvoerder. Twee grammen, elk in een eigen kroniek.
+    records:
+      cell: burger
+      chronicle: aanvragen
+      name: aanvraag_ingediend
+      intake: aanvraag
+      grondslag: Awir art. 15
+      fields:
+        - name: bsn
+          type: string
+        - name: jaar
+          type: number
+      delivers_to:
+        cell: toeslagen
+        chronicle: aanvragen
+        name: aanvraag_ontvangen
+        intake: aanvraag
+
+  - id: toeslagen.toekenning
+    actor: toeslagen
+    label: Beslis op de aanvraag
+    doc: Kan pas als er een aanvraag ligt.
+    decides:
+      cell: toeslagen
+      besluit: zorgtoeslag_toekenning
+    available_when:
+      cell: toeslagen
+      chronicle: aanvragen
+      field: jaar
+      equals: 2024
+
+  - id: toeslagen.vaststelling
+    actor: toeslagen
+    label: Stel de zorgtoeslag definitief vast
+    doc: Kan pas als er een toekenning ligt.
+    decides:
+      cell: toeslagen
+      besluit: zorgtoeslag_vaststelling
+    available_when:
+      cell: toeslagen
+      chronicle: beschikkingen
+      field: besluit
+      equals: zorgtoeslag_toekenning
+
+deadlines:
+  - label: aanvraag ontvangen vóór 1 maart
+    at: 2024-03-01
+    warn_if_missing:
+      cell: toeslagen
+      chronicle: aanvragen
+      name: aanvraag_ontvangen
+
+query_graph:
+  # Eén tak, twee keer gesteld: beide besluiten halen het toetsingsinkomen bij de
+  # cel die het vaststelde. Een graf zegt wie wie mag bevragen en niet hoe vaak.
+  # Wat er verder gebeurt — de aanvraag, de levering, de betalingen — blijft
+  # binnen een cel, en hoort hier dus niet te staan.
+  - doc: het toetsingsinkomen wordt geaccepteerd, niet nagerekend (I5)
+    from: toeslagen
+    to: belastingdienst
+    lexostatus: toetsingsinkomen
+
+act:
+  - description: >-
+      De aanvrager dient in. Ze legt het vast in haar eigen kroniek, en
+      `toeslagen` krijgt hetzelfde feit als levering in de zijne.
+    action: burger.aanvraag
+    values:
+      bsn: '999993653'
+      jaar: 2024
+    op_moment: 2024-01-10
+
+  - description: >-
+      De uitvoerder beslist. Het toetsingsinkomen komt van de belastingdienst
+      (81000, de aanslag van maart) en wordt hier niet nagerekend; de
+      verplichting die eruit volgt kent vier kwartaaltermijnen.
+    action: toeslagen.toekenning
+    values:
+      bsn: '999993653'
+    op_moment: 2024-04-01
+    expect:
+      heeft_recht_op_zorgtoeslag: true
+      hoogte_zorgtoeslag: 197178.01
+    expect_accepted:
+      toetsingsinkomen: belastingdienst
+    expect_computed:
+      - is_verzekerde
+      - heeft_recht_op_zorgtoeslag
+      - hoogte_zorgtoeslag
+
+  - description: >-
+      Het tweede besluit, ná de herziene aanslag en onder dezelfde wetsversie.
+      Het vraagt opnieuw bij de bron en komt daardoor op een ander bedrag uit.
+      Stond het eerste antwoord ergens in een kroniek van `toeslagen`, dan zou
+      hier hetzelfde bedrag staan.
+    action: toeslagen.vaststelling
+    values:
+      bsn: '999993653'
+    op_moment: 2024-12-15
+    expect:
+      heeft_recht_op_zorgtoeslag: true
+      hoogte_zorgtoeslag: 197102.85
+    expect_accepted:
+      toetsingsinkomen: belastingdienst
+
+queries:
+  - description: >-
+      De aanvrager weet wat zij indiende, uit haar eigen kroniek. Niemand heeft
+      haar dat geleverd en niemand leest het bij `toeslagen` op.
+    cell: burger
+    lexostatus: ingediende_aanvraag
+    params:
+      bsn: '999993653'
+    op_moment: 2024-01-10
+    expect:
+      jaar: 2024
+
+  - description: >-
+      En de uitvoerder weet wat hem geleverd is — een eigen gram, met een eigen
+      kanaal.
+    cell: toeslagen
+    lexostatus: ontvangen_aanvraag
+    params:
+      bsn: '999993653'
+    op_moment: 2024-01-10
+    expect:
+      jaar: 2024
+
+  - description: >-
+      Op het moment vóór de aanvraag had de uitvoerder niets: de vraag over toen
+      blijft dat antwoord geven, ook nu de klok jaren verder staat.
+    cell: toeslagen
+    lexostatus: ontvangen_aanvraag
+    params:
+      bsn: '999993653'
+    op_moment: 2024-01-05
+    expect_not_established: true
+
+  - description: >-
+      Halverwege het jaar zijn er twee kwartaaltermijnen verstreken (april en
+      juli). De betalende cel telt dat op over haar eigen betalingen; niemand
+      houdt een saldo bij.
+    cell: belastingdienst
+    lexostatus: betaald_tot_nu_toe
+    params:
+      zaakkenmerk: zorgtoeslag/999993653
+    op_moment: 2024-08-01
+    expect:
+      bedrag: 98588
+
+  - description: >-
+      Na het jaar zijn alle vier de termijnen verstreken, en dan is er precies het
+      toegekende bedrag van de eerste beschikking betaald — inclusief de rest die
+      op de laatste termijn landde.
+    cell: toeslagen
+    lexostatus: betaald_tot_nu_toe
+    params:
+      zaakkenmerk: zorgtoeslag/999993653
+    op_moment: 2025-02-01
+    expect:
+      bedrag: 197178.01
+
+  - description: >-
+      De zaak terugvragen levert het laatste besluit over dat zaakkenmerk: de
+      vaststelling, op het herziene inkomen.
+    cell: toeslagen
+    lexostatus: zorgtoeslagbeschikking
+    params:
+      zaakkenmerk: zorgtoeslag/999993653
+    op_moment: 2025-02-01
+    expect:
+      hoogte_zorgtoeslag: 197102.85
+
+  - description: >-
+      En de toekenning is niet verdwenen: de vraag over het moment vóór de
+      vaststelling levert het gram van toen. Een kroniek groeit, ze wijzigt niet.
+    cell: toeslagen
+    lexostatus: zorgtoeslagbeschikking
+    params:
+      zaakkenmerk: zorgtoeslag/999993653
+    op_moment: 2024-12-10
+    expect:
+      hoogte_zorgtoeslag: 197178.01
+
+# De termijn is gehaald: de aanvraag lag er op 1 maart. Een lege lijst is een
+# volwaardige verwachting — een waarschuwing die hier zou opduiken, maakt deze
+# run rood.
+expect_warnings: []

--- a/packages/simulator/src/cell/besluit.rs
+++ b/packages/simulator/src/cell/besluit.rs
@@ -96,6 +96,15 @@ const FIXED_FIELDS: [&str; 9] = [
     RECEIPT,
 ];
 
+/// De vaste velden van een decretogram, in de volgorde waarin ze hierboven staan.
+///
+/// Voor het beeld van de wereld: alleen wie deze namen kent, kan van elk veld van
+/// een decretogram zeggen of het een uitkomst van het besluit is of een vast veld
+/// van het gram zelf — en dus waar de waarde vandaan komt.
+pub(crate) fn fixed_fields() -> &'static [&'static str] {
+    &FIXED_FIELDS
+}
+
 /// Veld met het bedrag van één betalingstermijn.
 pub const BEDRAG: &str = "bedrag";
 /// Veld met het volgnummer van een termijn binnen één verplichting.
@@ -1060,6 +1069,20 @@ impl BesluitDefinition {
             obligation.schedule(cell, &self.name, settings)?;
         }
         Ok(())
+    }
+
+    /// De instellingen van het wereldbestand waarop dit besluit leunt.
+    ///
+    /// Vandaag is dat alleen het ritme van een verplichting (`schedule:
+    /// $naam`). Wat het oplevert, is wat vast komt te staan zodra dit besluit
+    /// genomen is: het gram legt vast waarop besloten is, dus een instelling die
+    /// er daarna onder vandaan geschoven wordt, laat het gram iets anders zeggen
+    /// dan er gebeurd is (zie [`crate::World::update_settings`]).
+    pub fn settings_used(&self) -> BTreeSet<&str> {
+        self.obligations
+            .iter()
+            .filter_map(|obligation| obligation.schedule.strip_prefix('$'))
+            .collect()
     }
 
     /// De cellen die een verplichting van dit besluit moeten dragen.

--- a/packages/simulator/src/cell/chronicle.rs
+++ b/packages/simulator/src/cell/chronicle.rs
@@ -28,7 +28,7 @@ use std::collections::{BTreeMap, BTreeSet};
 /// staat er een vastlegging in de kroniek waarvan niemand meer kan zeggen
 /// waarlangs ze binnenkwam. Een kanaal erbij is één regel — het is
 /// platformvocabulaire, geen casusdata.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Intake {
     /// Iemand vroeg iets aan bij deze cel.
@@ -94,6 +94,24 @@ pub struct ChronicleStore {
     streams: Vec<ChronicleStream>,
 }
 
+/// Eén stroom zoals ze erbij ligt, geleend voor het inspectiebeeld.
+///
+/// De tegenhanger van [`ReducedStream`]: die voegt samen wat de engine als
+/// databron wil, deze houdt elk gram zoals het vastgelegd is. Dat is wat een
+/// beeld van de wereld nodig heeft — wie kijkt, hoort de grammen te zien en niet
+/// een toestand die als vastlegging nooit bestaan heeft.
+///
+/// Geleend en niet in bezit: het inspectiebeeld maakt er zijn eigen doorsnede
+/// van (zie [`crate::Snapshot`]) en kan hier niets aan veranderen.
+pub(crate) struct ChronicleView<'a> {
+    /// Naam van de stroom.
+    pub(crate) stream: &'a str,
+    /// Het sleutelveld van de stroom.
+    pub(crate) key: &'a str,
+    /// De vastleggingen, in de volgorde waarin ze vastgelegd zijn.
+    pub(crate) events: &'a [ChronicleEvent],
+}
+
 /// Eén stroom, teruggebracht tot de feiten die op een moment bekend waren.
 pub(crate) struct ReducedStream {
     /// Naam van de stroom.
@@ -152,6 +170,45 @@ impl ChronicleStore {
             .iter()
             .map(|stream| (stream.stream.clone(), stream.key.clone()))
             .collect()
+    }
+
+    /// De namen van de stromen die deze cel houdt, voor een foutmelding.
+    pub(crate) fn stream_names(&self) -> Vec<&str> {
+        self.streams
+            .iter()
+            .map(|stream| stream.stream.as_str())
+            .collect()
+    }
+
+    /// Elke stroom zoals ze erbij ligt, geleend.
+    ///
+    /// Voor het inspectiebeeld van de wereld, en voor niets anders: een cel geeft
+    /// hiermee geen weg naar een andere cel prijs (zie [`ChronicleView`]).
+    pub(crate) fn view(&self) -> Vec<ChronicleView<'_>> {
+        self.streams
+            .iter()
+            .map(|stream| ChronicleView {
+                stream: &stream.stream,
+                key: &stream.key,
+                events: &stream.events,
+            })
+            .collect()
+    }
+
+    /// Ligt er in deze stroom op of vóór `op_moment` een gram met deze naam?
+    ///
+    /// Ja of nee, nooit een waarde: dit is wat een termijn moet weten om te
+    /// kunnen zeggen dat een feit ontbrak (zie [`crate::world::Deadline`]).
+    pub(crate) fn contains_named(&self, stream: &str, name: &str, op_moment: NaiveDate) -> bool {
+        self.streams
+            .iter()
+            .find(|candidate| candidate.stream == stream)
+            .is_some_and(|found| {
+                found
+                    .events
+                    .iter()
+                    .any(|event| event.op_moment <= op_moment && event.name == name)
+            })
     }
 
     /// Het sleutelveld van één stroom; `None` als de cel haar niet houdt.

--- a/packages/simulator/src/cell/config.rs
+++ b/packages/simulator/src/cell/config.rs
@@ -117,7 +117,12 @@ pub struct LexostatusDefinition {
 /// Dezelfde vorm voor beide, want het is dezelfde belofte: dit zijn de namen en
 /// typen die de aanroeper mag — en moet — meegeven, en alles daarbuiten wordt
 /// geweigerd.
-#[derive(Debug, Clone, Deserialize)]
+/// `Serialize` hoort erbij omdat een snapshot het **formulier** van een actie
+/// draagt (zie [`crate::Snapshot`]), en dat formulier is precies deze lijst: wat
+/// een actor moet invullen en van welk type. Twee vormen naast elkaar zouden
+/// betekenen dat het contract naar de frontend iets anders belooft dan de cel
+/// accepteert.
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DocumentedParameter {
     /// Parameternaam, waarnaar een reductie met `$naam` en een zaakkenmerk met
@@ -129,7 +134,7 @@ pub struct DocumentedParameter {
 }
 
 /// De typen die een lexostatus-parameter kan hebben.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ParameterType {
     /// Tekst, bijvoorbeeld een BSN.
@@ -364,9 +369,61 @@ pub(crate) struct CellSurface<'a> {
     /// geladen versies heen. Dit is wat een besluit aan de engine mag aanleveren.
     pub(crate) regulation_inputs: BTreeMap<String, BTreeSet<String>>,
     /// Per kroniekstroom de veldnamen die de cel van die stroom kent.
-    pub(crate) streams: BTreeMap<String, BTreeSet<String>>,
+    pub(crate) streams: StreamFields,
     /// Per kroniekstroom het sleutelveld waarop ze groepeert.
     pub(crate) stream_keys: BTreeMap<String, String>,
+}
+
+/// Per kroniekstroom de veldnamen die een cel van die stroom kent.
+///
+/// Eén type, want twee plekken dragen precies deze kennis: [`CellSurface`]
+/// tijdens het optuigen, en de cel zelf daarna (zie
+/// [`crate::cell::Cell::check_stream_field`]). De wereld toetst er haar acties en
+/// termijnen tegen, en dat hoort langs dezelfde weg te gaan als de definities van
+/// de cel — anders keurt de ene een veldnaam goed die de andere afwijst.
+pub(crate) type StreamFields = BTreeMap<String, BTreeSet<String>>;
+
+/// De velden die een cel van deze stroom kent, of de fout die zegt dat ze de
+/// stroom niet houdt.
+pub(crate) fn fields_of_stream<'a>(
+    streams: &'a StreamFields,
+    cell: &str,
+    subject: Subject,
+    name: &str,
+    stream: &str,
+) -> Result<&'a BTreeSet<String>> {
+    streams
+        .get(stream)
+        .ok_or_else(|| SimulatorError::UnknownStream {
+            cell: cell.to_string(),
+            subject,
+            name: name.to_string(),
+            stream: stream.to_string(),
+            known: listing(streams.keys()),
+        })
+}
+
+/// Kent deze stroom dit veld?
+pub(crate) fn check_stream_field(
+    streams: &StreamFields,
+    cell: &str,
+    subject: Subject,
+    name: &str,
+    stream: &str,
+    field: &str,
+) -> Result<()> {
+    let fields = fields_of_stream(streams, cell, subject, name, stream)?;
+    if contains_name(fields, field) {
+        return Ok(());
+    }
+    Err(SimulatorError::UnknownFilterField {
+        cell: cell.to_string(),
+        subject,
+        name: name.to_string(),
+        stream: stream.to_string(),
+        field: field.to_string(),
+        known: listing(fields),
+    })
 }
 
 impl CellSurface<'_> {
@@ -435,15 +492,7 @@ impl CellSurface<'_> {
         name: &str,
         stream: &str,
     ) -> Result<&BTreeSet<String>> {
-        self.streams
-            .get(stream)
-            .ok_or_else(|| SimulatorError::UnknownStream {
-                cell: cell.to_string(),
-                subject,
-                name: name.to_string(),
-                stream: stream.to_string(),
-                known: listing(self.streams.keys()),
-            })
+        fields_of_stream(&self.streams, cell, subject, name, stream)
     }
 
     /// Het sleutelveld van een stroom; `None` als de cel haar niet houdt.
@@ -460,18 +509,7 @@ impl CellSurface<'_> {
         stream: &str,
         field: &str,
     ) -> Result<()> {
-        let fields = self.fields_of_stream(cell, subject, name, stream)?;
-        if contains_name(fields, field) {
-            return Ok(());
-        }
-        Err(SimulatorError::UnknownFilterField {
-            cell: cell.to_string(),
-            subject,
-            name: name.to_string(),
-            stream: stream.to_string(),
-            field: field.to_string(),
-            known: listing(fields),
-        })
+        check_stream_field(&self.streams, cell, subject, name, stream, field)
     }
 }
 

--- a/packages/simulator/src/cell/mod.rs
+++ b/packages/simulator/src/cell/mod.rs
@@ -33,7 +33,16 @@ pub use besluit::{
     AcceptanceRequest, BesluitDefinition, BesluitInput, Decretogram, DecretogramInput, InputOrigin,
     ObligationDefinition, ObligationDue, Schedule, BESCHIKKINGEN, BETALINGEN, ZAAKKENMERK,
 };
+// De vaste velden van een decretogram, voor het beeld van de wereld: dat moet een
+// uitkomst van een besluit van een vast veld kunnen onderscheiden om de herkomst
+// van elke waarde te kunnen noemen. `pub(crate)`, want het is geen contract naar
+// buiten — wat een gram draagt, staat in [`Decretogram`].
+pub(crate) use besluit::{fixed_fields, INPUTS, RECEIPT, REGULATION};
+// Het formulier van een actie wordt tegen dezelfde toets gehouden als de
+// parameters van een lexostatus of een besluit: precies wat gedocumenteerd is,
+// niets erbij en niets van het verkeerde type.
 pub use chronicle::{ChronicleEvent, ChronicleStore, ChronicleStream, Intake};
+pub(crate) use config::check_documented_params;
 pub use config::{
     AcceptedSource, Aggregate, CellConfig, DocumentedParameter, LexostatusDefinition,
     ParameterType, Reduction,
@@ -42,6 +51,7 @@ pub use config::{
 use crate::corpus;
 use crate::error::{Result, SimulatorError, Subject};
 use crate::values::amount;
+use chronicle::ChronicleView;
 use chrono::NaiveDate;
 use config::{engine_parameters, CellSurface};
 use regelrecht_engine::article::CompetentAuthority;
@@ -55,7 +65,12 @@ use std::rc::Rc;
 
 /// Het antwoord van een cel: de rechtstoestand vanuit een gevraagd perspectief,
 /// op de feiten die in die cel bekend zijn.
-#[derive(Debug, Clone)]
+///
+/// `Serialize` hoort erbij omdat een antwoord over een celgrens in het beeld van
+/// de wereld komt te staan (zie [`crate::Snapshot`]) en daar precies zo hoort te
+/// verschijnen als de cel het gaf — inclusief "niets vastgesteld", dat een
+/// antwoord is en geen leeg antwoord.
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct Lexostatus {
     /// De cel die geantwoord heeft.
     pub cell: String,
@@ -73,7 +88,13 @@ pub struct Lexostatus {
 /// feit had, heeft niet gefaald en is niet stuk; ze heeft een antwoord dat een
 /// consument moet kunnen onderscheiden van een antwoord met waarden. Een lege
 /// map zou dat onderscheid verstoppen, want die lijkt op een antwoord.
-#[derive(Debug, Clone)]
+///
+/// Geserialiseerd blijven de twee daarom uit elkaar: `{"established": {…}}`
+/// tegenover `{"not_established": {"reason": "…"}}`. Een vorm waarin ze
+/// samenvallen — een lege map, een `null` — zou het onderscheid dat deze
+/// opstelling maakt precies bij de grens naar buiten weer weggooien.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum LexostatusOutcome {
     /// Er was een feit, en dit is wat de cel erover publiceert.
     ///
@@ -116,6 +137,12 @@ impl Lexostatus {
 pub struct Cell {
     /// Het cel-id, alleen voor foutmeldingen en herkomst in het antwoord.
     id: String,
+    /// De regelingen die deze cel laadt, bij `$id`.
+    ///
+    /// Niet om er iets mee te doen — daarvoor is er een engine — maar omdat het
+    /// beeld van de wereld hoort te laten zien welk recht waar geladen is. Een
+    /// cel met een lege lijst is een bron-cel, en dat is te zien.
+    laws: Vec<String>,
     /// Engine met uitsluitend de eigen wetten van deze cel geladen — of geen
     /// engine, bij een bron-cel (`laws: []`).
     ///
@@ -141,6 +168,15 @@ pub struct Cell {
     besluit_service: Option<RefCell<LawExecutionService>>,
     /// De eigen feiten. Privé, en dat is het punt.
     chronicles: ChronicleStore,
+    /// Per kroniekstroom de veldnamen die deze cel van die stroom kent, zoals bij
+    /// het optuigen vastgesteld.
+    ///
+    /// Dezelfde kennis waarmee de definities van de cel getoetst zijn, bewaard
+    /// zodat de wereld haar **acties** en **termijnen** er langs dezelfde weg
+    /// tegen kan toetsen (zie [`Self::check_stream_field`]). Zou de wereld een
+    /// eigen lijstje bijhouden, dan zou een veldnaam die de cel afwijst in een
+    /// actie stil goedgekeurd worden.
+    streams: config::StreamFields,
     /// De gepubliceerde lexostatussen, op naam.
     published: BTreeMap<String, LexostatusDefinition>,
     /// De besluiten die deze cel kan nemen, op naam.
@@ -284,14 +320,147 @@ impl Cell {
 
         Ok(Self {
             id: config.id.clone(),
+            laws: config.laws.clone(),
             service: service.map(RefCell::new),
             besluit_service: besluit_service.map(RefCell::new),
             chronicles,
+            streams: surface.streams,
             published,
             besluiten,
             accepts_from,
             foreign_sources,
         })
+    }
+
+    /// Het cel-id.
+    pub(crate) fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// De regelingen die deze cel laadt, bij `$id`.
+    pub(crate) fn laws(&self) -> &[String] {
+        &self.laws
+    }
+
+    /// De namen die deze cel publiceert, in alfabetische volgorde.
+    pub(crate) fn published_names(&self) -> Vec<&str> {
+        self.published.keys().map(String::as_str).collect()
+    }
+
+    /// De besluiten die deze cel kan nemen, in alfabetische volgorde.
+    pub(crate) fn besluit_names(&self) -> Vec<&str> {
+        self.besluiten.keys().map(String::as_str).collect()
+    }
+
+    /// Kent deze cel deze stroom, en kent die stroom dit veld?
+    ///
+    /// `pub(crate)`, en alleen om iets te kunnen **afkeuren**: de wereld toetst er
+    /// de voorwaarde van een actie mee bij het optuigen. Het antwoord zegt niets
+    /// over wat er in de stroom staat — alleen dat een veldnaam met die naam
+    /// erin kan voorkomen — en het loopt langs precies dezelfde toets als de
+    /// definities van de cel.
+    pub(crate) fn check_stream_field(
+        &self,
+        subject: Subject,
+        name: &str,
+        stream: &str,
+        field: &str,
+    ) -> Result<()> {
+        config::check_stream_field(&self.streams, &self.id, subject, name, stream, field)
+    }
+
+    /// Houdt deze cel deze stroom?
+    ///
+    /// Dezelfde weigering als [`Self::check_stream_field`], zonder een veld: een
+    /// termijn wijst een stroom en een gram-naam aan, en een naam is geen veld.
+    pub(crate) fn check_stream(&self, subject: Subject, name: &str, stream: &str) -> Result<()> {
+        config::fields_of_stream(&self.streams, &self.id, subject, name, stream).map(|_| ())
+    }
+
+    /// Ligt er op of vóór `op_moment` een feit in deze stroom met dit veld op
+    /// deze waarde?
+    ///
+    /// Ja of nee, nooit een waarde. Hiermee beantwoordt de wereld de vraag "is het
+    /// verhaal zover?" voor een actie die pas mag als er iets gebeurd is (zie
+    /// [`crate::world::Availability`]). Dat is geen reductie en geen synthese: er
+    /// komt geen feit naar buiten, en geen andere cel kan hier bij.
+    pub(crate) fn has_fact(
+        &self,
+        stream: &str,
+        field: &str,
+        value: &Value,
+        op_moment: NaiveDate,
+    ) -> bool {
+        !self
+            .chronicles
+            .recordings(stream, field, value, &BTreeMap::new(), op_moment)
+            .is_empty()
+    }
+
+    /// Ligt er op of vóór `op_moment` een gram met deze naam in deze stroom?
+    ///
+    /// Voor een termijn die waarschuwt als een feit ontbreekt: dat is een vraag
+    /// over de naam van het gram, niet over een veldwaarde.
+    pub(crate) fn has_recording_named(
+        &self,
+        stream: &str,
+        name: &str,
+        op_moment: NaiveDate,
+    ) -> bool {
+        self.chronicles.contains_named(stream, name, op_moment)
+    }
+
+    /// Kan deze cel op eigen naam een feit met deze velden in deze stroom leggen?
+    ///
+    /// De toets van [`Self::record`], vooruitgeschoven naar het optuigen: een
+    /// actie noemt haar formulier en haar stroom, en dan staat hier al vast of het
+    /// gram dat eruit komt ooit kan landen. Een actie die pas bij de eerste klik
+    /// omvalt, is een typfout die op het verkeerde moment boven water komt.
+    ///
+    /// Geeft de reden als tekst en niet als [`SimulatorError`]: *waarom* het niet
+    /// kan weet de cel, *welke actie* het was weet de wereld, en die twee horen in
+    /// één melding samen te komen (zie [`SimulatorError::ActionRecording`]).
+    pub(crate) fn check_recordable(
+        &self,
+        stream: &str,
+        fields: &BTreeSet<String>,
+    ) -> std::result::Result<(), String> {
+        if stream == BESCHIKKINGEN {
+            return Err(format!(
+                "'{BESCHIKKINGEN}' is voorbehouden aan het besluit-pad; daar ontstaat een \
+                 gram door te besluiten en niet door het vast te leggen"
+            ));
+        }
+        let Some(key) = self.chronicles.key_of(stream) else {
+            return Err(format!(
+                "die cel houdt geen stroom met die naam (wel: {})",
+                self.chronicles.stream_names().join(", ")
+            ));
+        };
+        if !fields.iter().any(|field| field.eq_ignore_ascii_case(key)) {
+            return Err(format!(
+                "die stroom groepeert op veld '{key}', en dat veld staat niet in het \
+                 formulier (wel: {})",
+                fields
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+        Ok(())
+    }
+
+    /// De kronieken zoals ze erbij liggen, geleend voor het beeld van de wereld.
+    ///
+    /// Dit is de enige weg naar de inhoud van een kroniek buiten een reductie om,
+    /// en hij bestaat voor precies één doel: de wereld toont wat waar ligt (zie
+    /// [`crate::Snapshot`]). Dat is een inspectiebeeld, zoals het observatielog
+    /// een meetinstrument is — en het is met opzet `pub(crate)`, want een cel die
+    /// het kon aanroepen zou de kroniek van een ander lezen, en dan is invariant
+    /// I1 een afspraak in plaats van een compileerfout.
+    pub(crate) fn inspect(&self) -> Vec<ChronicleView<'_>> {
+        self.chronicles.view()
     }
 
     /// De cel-bronnen die de wetten van deze cel aanwijzen (tier 3).
@@ -820,6 +989,17 @@ impl Cell {
         definition.check_params(&self.id, params)?;
         definition.zaakkenmerk(&self.id, params)?;
         Ok(definition.acceptance_requests(params))
+    }
+
+    /// Eén besluit-definitie van deze cel, of een nette fout die opsomt wat de
+    /// cel wél kan besluiten.
+    ///
+    /// `pub(crate)`: een actie die een besluit-pad start, moet bij het optuigen
+    /// kunnen vaststellen dat dat besluit bestaat, en moet het formulier ervan
+    /// kunnen tonen — de gedocumenteerde parameters van het besluit. Een tweede
+    /// lijst parameters in de actie zou uiteen gaan lopen met de eerste.
+    pub(crate) fn besluit_definition(&self, besluit: &str) -> Result<BesluitDefinition> {
+        self.definition(besluit)
     }
 
     /// Eén besluit-definitie van deze cel, of een nette fout die opsomt wat de

--- a/packages/simulator/src/error.rs
+++ b/packages/simulator/src/error.rs
@@ -20,6 +20,10 @@ pub enum Subject {
     Lexostatus,
     /// Een besluit-definitie: een wetsuitvoering die vastgelegd wordt.
     Besluit,
+    /// Een actie van een actor op de tijdlijn.
+    Actie,
+    /// Een termijn die waarschuwt als een feit ontbreekt.
+    Termijn,
 }
 
 impl fmt::Display for Subject {
@@ -27,6 +31,8 @@ impl fmt::Display for Subject {
         f.write_str(match self {
             Self::Lexostatus => "lexostatus",
             Self::Besluit => "besluit",
+            Self::Actie => "actie",
+            Self::Termijn => "termijn",
         })
     }
 }
@@ -1130,6 +1136,100 @@ pub enum SimulatorError {
         cell: String,
         /// De gevraagde lexostatus.
         lexostatus: String,
+    },
+
+    /// Er is een actie aangeroepen die het wereldbestand niet kent.
+    #[error("de wereld kent geen actie '{action}' (wel: {known})")]
+    UnknownAction {
+        /// De aangeroepen actie.
+        action: String,
+        /// Komma-gescheiden lijst van de acties die er wél zijn.
+        known: String,
+    },
+
+    /// Het wereldbestand declareert twee acties met hetzelfde id.
+    ///
+    /// De tweede zou de eerste stil schaduwen: een actie wordt op haar id
+    /// aangeroepen, dus dan zou er één zijn die niemand meer kan doen.
+    #[error("de wereld declareert actie '{action}' twee keer")]
+    DuplicateAction {
+        /// Het dubbele actie-id.
+        action: String,
+    },
+
+    /// Een actie kan op dit moment niet: het verhaal is nog niet zover.
+    ///
+    /// Geen vergissing van de aanroeper maar een stand van de wereld, en daarom
+    /// een leesbare weigering: wát er nog niet vastligt staat erin.
+    #[error("actie '{action}' kan nu niet: {reason}")]
+    ActionNotAvailable {
+        /// De actie die niet kan.
+        action: String,
+        /// Waarom niet, in woorden.
+        reason: String,
+    },
+
+    /// Een actie legt vast in een stroom die dat niet kan dragen.
+    ///
+    /// Blijkt bij het optuigen en niet bij de eerste aanroep: een actie noemt haar
+    /// formulier en haar stroom, dus of het gram dat eruit komt ooit kan landen,
+    /// staat dan al vast.
+    #[error(
+        "actie '{action}': cel '{cell}' kan geen feit vastleggen in kroniekstroom \
+         '{stream}': {reason}"
+    )]
+    ActionRecording {
+        /// De actie uit het wereldbestand.
+        action: String,
+        /// De cel waarin vastgelegd zou worden.
+        cell: String,
+        /// De stroom die het niet kan dragen.
+        stream: String,
+        /// Waarom niet, in de woorden van de cel.
+        reason: String,
+    },
+
+    /// Een actie levert een feit aan de cel die het zelf vastlegt.
+    ///
+    /// Dan zou hetzelfde gram twee keer in dezelfde kroniek landen. Een levering
+    /// gaat van de ene organisatie naar de andere; aan jezelf leveren wat je net
+    /// zelf vastlegde, is geen tweede feit.
+    #[error("actie '{action}' levert aan cel '{cell}', maar die legt het feit zelf al vast")]
+    DeliveryToSelf {
+        /// De actie uit het wereldbestand.
+        action: String,
+        /// De cel die beide kanten zou zijn.
+        cell: String,
+    },
+
+    /// Er is een instelling gewijzigd die het wereldbestand niet kent.
+    ///
+    /// Een instelling bijzetten die nergens gebruikt wordt, zou een knop zijn die
+    /// niets doet; een typfout in een naam zou er precies zo uitzien.
+    #[error("de wereld kent geen instelling '{setting}' (wel: {known})")]
+    UnknownWorldSetting {
+        /// De naam die gewijzigd zou worden.
+        setting: String,
+        /// Komma-gescheiden lijst van de instellingen die er wél zijn.
+        known: String,
+    },
+
+    /// Een instelling die al door een besluit gebruikt is, wordt gewijzigd.
+    ///
+    /// Een besluit legt vast waarop besloten is. Een instelling die eronder
+    /// vandaan geschoven wordt, laat het gram iets anders zeggen dan er gebeurd
+    /// is — en precies dat is wat een decretogram onmogelijk hoort te maken.
+    #[error(
+        "instelling '{setting}' is al gebruikt door besluit '{besluit}' van cel '{cell}' \
+         en staat daarmee vast; wie haar wil wijzigen, begint een nieuwe wereld"
+    )]
+    SettingInUse {
+        /// De instelling die vast staat.
+        setting: String,
+        /// De cel die het besluit nam.
+        cell: String,
+        /// Het besluit dat haar gebruikte.
+        besluit: String,
     },
 
     /// Het scenariobestand kon niet gelezen worden.

--- a/packages/simulator/src/lib.rs
+++ b/packages/simulator/src/lib.rs
@@ -45,6 +45,21 @@
 //! is daarna een **reductie** over die vastleggingen (`sum: bedrag`) en geen
 //! saldo dat ernaast wordt bijgehouden.
 //!
+//! Wie de wereld aan het werk zet, is een **actor**. Een [`ActionDefinition`] in
+//! het wereldbestand zegt wat hij kan doen — een feit vastleggen en het eventueel
+//! leveren aan een ander, of een besluit-pad starten — met welk formulier, en
+//! wanneer het kan. [`World::act`] voert er één uit op de stand van de klok, en
+//! daarmee is de aansturing casusdata: een andere casus is een ander
+//! wereldbestand en geen Rust. Een [`Deadline`] waarschuwt als een feit op tijd
+//! ontbreekt, en blokkeert nooit.
+//!
+//! Naar buiten geeft [`World::snapshot`] één beeld van alles wat er staat: de
+//! klok, de instellingen, per cel haar kronieken met elk gram en de herkomst van
+//! elke waarde, de acties die nu kunnen, wat er over een celgrens ging en de
+//! waarschuwingen. Dat is het contract voor een frontend, en het kent geen casus —
+//! elk label komt uit het wereldbestand. [`World::reset`] begint opnieuw uit
+//! datzelfde bestand.
+//!
 //! Het eigenlijke product zijn de **invarianten**. Een scenario declareert het
 //! toegestane vraaggraf; [`invariant::check_invariants`] legt daar het
 //! feitelijke graf naast, berekent uit de celconfiguraties wat het recht van
@@ -78,6 +93,7 @@ pub mod invariant;
 pub mod observation;
 pub mod scenario;
 pub mod security;
+pub mod snapshot;
 pub mod transport;
 mod values;
 pub mod world;
@@ -96,9 +112,17 @@ pub use invariant::{
     InvariantFailure, QueryEdge, Traffic,
 };
 pub use scenario::{
-    check_provenance, Decision, DecisionOutcome, ExpectationFailure, Query, QueryOutcome, Scenario,
-    ScenarioRun, TransportOutcome, TransportQuery,
+    check_provenance, Act, ActOutcome, Decision, DecisionOutcome, ExpectationFailure, Query,
+    QueryOutcome, Scenario, ScenarioRun, TransportOutcome, TransportQuery,
 };
 pub use security::{Identity, SecurityContext, Signature, SignedAnswer};
+pub use snapshot::{
+    ActionEffectSnapshot, ActionSnapshot, CellSnapshot, ChronicleSnapshot, CrossingSnapshot,
+    FieldOrigin, FieldSnapshot, GramKind, GramSnapshot, LockedSetting, Snapshot,
+};
 pub use transport::{CellTransport, InProcessTransport};
-pub use world::{Clock, DecisionRecord, Fixture, Recording, World};
+pub use world::{
+    ActionDefinition, ActionEffect, Availability, Clock, Deadline, DecidesAction, DecisionRecord,
+    Delivery, Events, ExpectedFact, Fixture, RecordedFact, Recording, RecordsAction, Warning,
+    World, WorldDefinition,
+};

--- a/packages/simulator/src/scenario.rs
+++ b/packages/simulator/src/scenario.rs
@@ -892,16 +892,20 @@ impl Scenario {
 
     /// Laat de actoren hun acties doen, elk op zijn eigen moment.
     ///
-    /// De klok gaat eerst vooruit tot dat moment, en dan doet de actor het: een
-    /// actie heeft geen eigen moment mee te geven, ze gebeurt op de stand van de
+    /// De klok gaat eerst naar dat moment, en dan doet de actor het: een actie
+    /// heeft geen eigen moment mee te geven, ze gebeurt op de stand van de
     /// wereld. Zo landt een levering of een vervallen termijn die ertussen valt
     /// eerst — en dat is wat een actie die op zo'n feit wacht, nodig heeft.
+    ///
+    /// De klok gaat er **altijd** naartoe, ook als hij er al voorbij is. Anders
+    /// dan een `decide`, die zijn moment zelf meegeeft, kan een actie het hare
+    /// niet dragen: zou de klok blijven staan, dan landt het gram op een andere
+    /// dag dan het bestand noemt, en dan liegt die regel zonder dat iemand het
+    /// merkt. Nu levert ze de fout die erbij hoort — de klok loopt niet terug.
     fn do_acts(&self, world: &mut World) -> Result<Vec<ActOutcome>> {
         let mut acts = Vec::with_capacity(self.act.len());
         for step in &self.act {
-            if step.op_moment > world.now() {
-                world.advance(step.op_moment)?;
-            }
+            world.advance(step.op_moment)?;
 
             let events = world.act(&step.action, &step.values)?;
 
@@ -1297,6 +1301,56 @@ queries:
         );
     }
 
+    /// Een actie op een moment dat de klok al voorbij is, hoort te falen.
+    ///
+    /// Een actie gebeurt op de stand van de klok; zij draagt haar moment niet mee
+    /// het gram in. Bleef de klok staan, dan zou de vastlegging op een andere dag
+    /// landen dan het bestand noemt — een regel die iets anders doet dan ze zegt,
+    /// en dat is precies de stilte waar deze opstelling tegen bedoeld is.
+    #[test]
+    fn een_actie_op_een_moment_voor_de_klok_wordt_geweigerd() {
+        let yaml = r"
+name: twee acties in de verkeerde volgorde
+clock: { start: 2024-01-01 }
+cells:
+  - id: burger
+    laws: []
+    chronicles:
+      - stream: aanvragen
+        key: bsn
+actions:
+  - id: burger.aanvraag
+    actor: burger
+    label: Aanvraag indienen
+    records:
+      cell: burger
+      chronicle: aanvragen
+      name: aanvraag_ingediend
+      intake: aanvraag
+      fields:
+        - name: bsn
+          type: string
+act:
+  - action: burger.aanvraag
+    values:
+      bsn: '999993653'
+    op_moment: 2024-06-01
+  - action: burger.aanvraag
+    values:
+      bsn: '999993654'
+    op_moment: 2024-03-01
+";
+        let scenario =
+            Scenario::from_yaml(yaml).unwrap_or_else(|e| panic!("het scenario moet lezen: {e}"));
+        let err = scenario
+            .run(&crate::regulation_root())
+            .expect_err("een actie vóór de klok hoort te falen en niet stil op te schuiven");
+        assert!(
+            matches!(err, SimulatorError::ClockRunsBackwards { .. }),
+            "verwachtte ClockRunsBackwards, kreeg {err}"
+        );
+    }
+
     #[test]
     fn een_wereld_zonder_klok_wordt_geweigerd() {
         let yaml = r"
@@ -1507,10 +1561,6 @@ query_via_transport:
             .unwrap_or_else(|| panic!("2024-06-01 moet een geldige datum zijn"))
     }
 
-    /// Een vastlegging waar de klok niet aan toe kwam, hoort in het verslag te
-    /// staan. Zij is geldig bevonden bij het optuigen en doet daarna niets; dat
-    /// stil laten betekent dat een regel in het wereldbestand niets bewijst
-    /// zonder dat iemand het merkt.
     /// Een leeg beeld, voor de tests die over het **verslag** gaan.
     ///
     /// Die bouwen met opzet geen wereld op: wat ze controleren is wat er in de
@@ -1545,6 +1595,10 @@ query_via_transport:
         }
     }
 
+    /// Een vastlegging waar de klok niet aan toe kwam, hoort in het verslag te
+    /// staan. Zij is geldig bevonden bij het optuigen en doet daarna niets; dat
+    /// stil laten betekent dat een regel in het wereldbestand niets bewijst
+    /// zonder dat iemand het merkt.
     #[test]
     fn het_verslag_meldt_vastleggingen_die_niet_afgingen() {
         let run = |pending_triggers| report_of(pending_triggers, Vec::new());

--- a/packages/simulator/src/scenario.rs
+++ b/packages/simulator/src/scenario.rs
@@ -12,9 +12,12 @@ use crate::invariant::{
     Traffic,
 };
 use crate::security::{Identity, SecurityContext, SignedAnswer};
+use crate::snapshot::Snapshot;
 use crate::transport::InProcessTransport;
 use crate::values::equivalent;
-use crate::world::{Clock, Fixture, World};
+use crate::world::{
+    ActionDefinition, Clock, Deadline, Events, Fixture, Warning, World, WorldDefinition,
+};
 use chrono::NaiveDate;
 use regelrecht_engine::Value;
 use serde::Deserialize;
@@ -48,11 +51,28 @@ pub struct Scenario {
     /// klok die datum passeert.
     #[serde(default)]
     pub fixtures: Vec<Fixture>,
-    /// De besluiten die in deze run genomen worden, elk op een moment.
+    /// Wat de actoren in deze wereld op de tijdlijn kunnen doen.
+    #[serde(default)]
+    pub actions: Vec<ActionDefinition>,
+    /// De termijnen die waarschuwen als een feit ontbreekt.
+    #[serde(default)]
+    pub deadlines: Vec<Deadline>,
+    /// De acties die in deze run gedaan worden, elk op een moment.
     ///
-    /// Dit is de aansturing van het besluit-pad zolang een cel nog geen actie
-    /// van een actor kent: het scenario zegt wie wanneer waarover besluit. Ze
-    /// gaan vóór de vragen, en dat is de volgorde die past bij wat ze zijn — een
+    /// Dit is het verhaal van de wereld zoals een actor het afspeelt: een aanvraag
+    /// indienen, een besluit nemen, een verantwoording insturen. Ze gaan vóór de
+    /// besluiten uit [`Self::decide`], want een actie is de aansturing die het
+    /// wereldbestand zelf kent en `decide` is de rechtstreekse.
+    #[serde(default)]
+    pub act: Vec<Act>,
+    /// De besluiten die in deze run rechtstreeks genomen worden, elk op een moment.
+    ///
+    /// De aansturing naast een actie: het scenario zegt wie wanneer waarover
+    /// besluit, zonder dat er een actie in het wereldbestand voor hoeft te staan.
+    /// Handig om een besluit-pad los te beproeven; het verhaal van een wereld
+    /// hoort langs [`Self::act`] te lopen.
+    ///
+    /// Ze gaan vóór de vragen, en dat is de volgorde die past bij wat ze zijn — een
     /// besluit is een gebeurtenis op de tijdlijn, een vraag kijkt erop terug. Wie
     /// een vraag over een moment *vóór* een besluit stelt, krijgt nog altijd het
     /// beeld van toen: de reductie filtert zelf op `op_moment`.
@@ -91,6 +111,50 @@ pub struct Scenario {
     /// als de vraag netjes gesteld wordt.
     #[serde(default)]
     pub query_graph: Vec<DeclaredQuery>,
+    /// De labels van de termijnen die deze run moet melden, in alfabetische
+    /// volgorde vergeleken.
+    ///
+    /// Een lege lijst is een volwaardige verwachting: ze zegt dat er geen enkele
+    /// termijn gemist is. Daarom wordt de lijst altijd afgerekend, ook als hij niet
+    /// in het bestand staat — een waarschuwing die niemand verwacht, hoort een run
+    /// te laten falen in plaats van stil in het verslag te belanden.
+    #[serde(default)]
+    pub expect_warnings: Vec<String>,
+}
+
+/// Eén actie die een actor in deze run doet.
+///
+/// De tegenhanger van een [`Decision`], en een stap hoger: niet "deze cel besluit
+/// hierover" maar "deze actor doet dit". Wat er dan gebeurt, staat in het
+/// wereldbestand en niet in deze stap — een actie legt een feit vast, levert het
+/// eventueel aan een ander, of start een besluit-pad.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Act {
+    /// Vrije omschrijving, verschijnt in het verslag.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// De actie uit het wereldbestand.
+    pub action: String,
+    /// Het ingevulde formulier van de actie.
+    #[serde(default)]
+    pub values: BTreeMap<String, Value>,
+    /// Het moment waarop de actor dit doet. De klok gaat er eerst naartoe.
+    pub op_moment: NaiveDate,
+    /// De verwachte uitkomsten, als deze actie een besluit start.
+    ///
+    /// Mag leeg blijven, net als bij een [`Decision`]: een actie legt iets vast,
+    /// dus ze bewijst ook zonder verwachting dat de vragen erna iets te vinden
+    /// hebben.
+    #[serde(default)]
+    pub expect: BTreeMap<String, Value>,
+    /// Waarden die het besluit van deze actie **geaccepteerd** moet hebben, op
+    /// naam, met de cel die haar vaststelde (invariant I5).
+    #[serde(default)]
+    pub expect_accepted: BTreeMap<String, String>,
+    /// Waarden die het besluit van deze actie **zelf** moet hebben vastgesteld.
+    #[serde(default)]
+    pub expect_computed: Vec<String>,
 }
 
 /// Eén vraag van een consument aan één cel.
@@ -223,6 +287,13 @@ pub enum ExpectationFailure {
         /// Wat er over haar herkomst mis is.
         reason: String,
     },
+    /// De run meldde andere gemiste termijnen dan het scenario verwachtte.
+    Warnings {
+        /// De labels die het scenario verwachtte.
+        expected: Vec<String>,
+        /// De labels die de run meldde.
+        actual: Vec<String>,
+    },
 }
 
 /// Het resultaat van één vraag.
@@ -270,6 +341,19 @@ pub struct DecisionOutcome {
     pub failures: Vec<ExpectationFailure>,
 }
 
+/// Het resultaat van één actie.
+#[derive(Debug, Clone)]
+pub struct ActOutcome {
+    /// De omschrijving uit het scenario, als die er stond.
+    pub description: Option<String>,
+    /// De actie die gedaan is.
+    pub action: String,
+    /// Wat er door deze actie gebeurde.
+    pub events: Events,
+    /// De verwachtingen die niet uitkwamen; leeg is goed.
+    pub failures: Vec<ExpectationFailure>,
+}
+
 /// Het resultaat van een hele run.
 #[derive(Debug, Clone)]
 pub struct ScenarioRun {
@@ -281,7 +365,9 @@ pub struct ScenarioRun {
     /// ligt. De runner loopt de tijd af tot de laatste vraag, dus een fixture
     /// verder in de toekomst gebeurt in deze run niet.
     pub pending_triggers: usize,
-    /// De besluiten die genomen zijn, in scenariovolgorde.
+    /// De acties die gedaan zijn, in scenariovolgorde.
+    pub acts: Vec<ActOutcome>,
+    /// De besluiten die rechtstreeks genomen zijn, in scenariovolgorde.
     pub decisions: Vec<DecisionOutcome>,
     /// De uitkomsten van de vragen van een consument, in scenariovolgorde.
     pub outcomes: Vec<QueryOutcome>,
@@ -294,12 +380,24 @@ pub struct ScenarioRun {
     /// invariant is wat elk scenario moet halen. Ze staan dus niet bij één vraag
     /// en niet bij één besluit — ze gaan over de run als geheel.
     pub invariant_failures: Vec<InvariantFailure>,
+    /// De termijnen die verstreken zonder dat het feit er lag, in volgorde.
+    pub warnings: Vec<Warning>,
+    /// Verwachtingen over de run als geheel die niet uitkwamen; leeg is goed.
+    pub failures: Vec<ExpectationFailure>,
+    /// Het beeld van de wereld na de run.
+    ///
+    /// Hoort bij de run omdat het de stand is die eruit volgde, en niet iets wat
+    /// er los naast staat: een test die het contract naar een frontend vastpint,
+    /// hoort dat te kunnen doen op de wereld die een scenario heeft afgespeeld.
+    pub snapshot: Snapshot,
 }
 
 impl ScenarioRun {
     /// Kwamen alle verwachtingen uit, en haalde de run haar invarianten?
     pub fn passed(&self) -> bool {
-        self.decisions.iter().all(|o| o.failures.is_empty())
+        self.failures.is_empty()
+            && self.acts.iter().all(|o| o.failures.is_empty())
+            && self.decisions.iter().all(|o| o.failures.is_empty())
             && self.outcomes.iter().all(|o| o.failures.is_empty())
             && self
                 .transport_outcomes
@@ -315,16 +413,27 @@ impl ScenarioRun {
     /// meetinstrument aangereikt krijgt: dezelfde bewijsstukken, in dezelfde
     /// volgorde. Publiek, zodat een test de twee tegen elkaar kan houden in
     /// plaats van te moeten geloven dat ze hetzelfde zien.
+    ///
+    /// **Elk** besluit van de run zit erin, of het door een actie is uitgelokt of
+    /// rechtstreeks genomen. Die twee horen hier niet uit elkaar te vallen: een
+    /// besluit dat via een actie over de celgrens reikt, doet dat langs dezelfde
+    /// weg als een besluit uit `decide`, en zou de gate anders ontglippen. In
+    /// runvolgorde: eerst de acties, dan de rechtstreekse besluiten, dan de sondes.
     pub fn traffic(&self) -> Traffic<'_> {
+        let from_acts = self
+            .acts
+            .iter()
+            .flat_map(|act| &act.events.decisions)
+            .map(|record| DecisionTraffic {
+                decretogram: &record.decretogram,
+                crossings: &record.crossings,
+            });
+        let direct = self.decisions.iter().map(|decision| DecisionTraffic {
+            decretogram: &decision.decretogram,
+            crossings: &decision.crossings,
+        });
         Traffic {
-            decisions: self
-                .decisions
-                .iter()
-                .map(|decision| DecisionTraffic {
-                    decretogram: &decision.decretogram,
-                    crossings: &decision.crossings,
-                })
-                .collect(),
+            decisions: from_acts.chain(direct).collect(),
             probes: self
                 .transport_outcomes
                 .iter()
@@ -351,6 +460,20 @@ impl ScenarioRun {
     /// Leesbaar verslag van de run, geschikt voor een terminal of een testfout.
     pub fn report(&self) -> String {
         let mut out = format!("scenario '{}':\n", self.name);
+        for act in &self.acts {
+            let mark = if act.failures.is_empty() {
+                "ok"
+            } else {
+                "FOUT"
+            };
+            let _ = writeln!(out, "  [{mark}] actie '{}'", act.action);
+            if let Some(description) = &act.description {
+                let _ = writeln!(out, "        {description}");
+            }
+            out.push_str(&act.events.describe());
+            write_failures(&mut out, &act.failures);
+        }
+
         for decision in &self.decisions {
             let mark = if decision.failures.is_empty() {
                 "ok"
@@ -485,6 +608,13 @@ impl ScenarioRun {
         for failure in &self.invariant_failures {
             let _ = writeln!(out, "        {}", failure.describe());
         }
+        // De waarschuwingen staan bij elkaar en niet bij de stap waar ze vielen:
+        // een gemiste termijn is geen gevolg van een actie maar van wat er níet
+        // gebeurde, en dat is aan het eind pas te overzien.
+        for warning in &self.warnings {
+            let _ = writeln!(out, "  waarschuwing: {}", warning.describe());
+        }
+        write_failures(&mut out, &self.failures);
 
         let _ = writeln!(out, "  klok staat op {}", self.clock);
         // Een fixture waar de klok nooit aan toe komt, is een regel in het
@@ -544,6 +674,12 @@ fn write_failures(out: &mut String, failures: &[ExpectationFailure]) {
             ExpectationFailure::Provenance { value, reason } => {
                 writeln!(out, "        herkomst van '{value}': {reason}")
             }
+            ExpectationFailure::Warnings { expected, actual } => writeln!(
+                out,
+                "        verwachtte gemiste termijnen [{}], kreeg [{}]",
+                expected.join(", "),
+                actual.join(", ")
+            ),
         };
     }
 }
@@ -661,16 +797,29 @@ impl Scenario {
         Self::from_yaml(&text)
     }
 
+    /// De wereld waarin dit scenario zich afspeelt, los van zijn stappen.
+    ///
+    /// Het scenariobestand draagt de velden van een wereldbestand plus de stappen
+    /// erop, en die twee zijn hier niet samengevoegd tot één serde-vorm: een
+    /// geflatten veld verdraagt geen `deny_unknown_fields`, en dan zou een typfout
+    /// in een scenario stil verdwijnen. De prijs is deze kopie; de winst is dat
+    /// een wereldbestand en een scenario dezelfde vorm hebben en dat een typfout
+    /// in geen van beide doorglipt.
+    pub fn definition(&self) -> WorldDefinition {
+        WorldDefinition {
+            clock: self.clock,
+            cells: self.cells.clone(),
+            settings: self.settings.clone(),
+            fixtures: self.fixtures.clone(),
+            actions: self.actions.clone(),
+            deadlines: self.deadlines.clone(),
+        }
+    }
+
     /// Tuig de wereld op: de cellen, de klok op haar startmoment en de
     /// startstand die op dat moment al gebeurd was.
     pub fn world(&self, regulation_root: &Path) -> Result<World> {
-        World::new(
-            &self.cells,
-            self.clock,
-            &self.fixtures,
-            &self.settings,
-            regulation_root,
-        )
+        World::from_definition(&self.definition(), regulation_root)
     }
 
     /// Tuig de wereld op, laat de tijd lopen en stel alle vragen.
@@ -689,6 +838,7 @@ impl Scenario {
     pub fn run(&self, regulation_root: &Path) -> Result<ScenarioRun> {
         let mut world = self.world(regulation_root)?;
 
+        let acts = self.do_acts(&mut world)?;
         let decisions = self.take_decisions(&mut world)?;
 
         let mut outcomes = Vec::with_capacity(self.queries.len());
@@ -715,15 +865,20 @@ impl Scenario {
         }
 
         let transport_outcomes = self.run_via_transport(&mut world)?;
+        let warnings = world.warnings().to_vec();
 
         let mut run = ScenarioRun {
             name: self.name.clone(),
             clock: world.now(),
             pending_triggers: world.pending_triggers(),
+            acts,
             decisions,
             outcomes,
             transport_outcomes,
             invariant_failures: Vec::new(),
+            failures: check_warnings(&self.expect_warnings, &warnings),
+            warnings,
+            snapshot: world.snapshot(),
         };
         // De gate draait als laatste en over de hele run: hij vergelijkt het
         // gedeclareerde vraaggraf met wat er werkelijk over de grenzen ging, en
@@ -733,6 +888,46 @@ impl Scenario {
         let failures = check_invariants(&self.query_graph, &self.cells, &run.traffic());
         run.invariant_failures = failures;
         Ok(run)
+    }
+
+    /// Laat de actoren hun acties doen, elk op zijn eigen moment.
+    ///
+    /// De klok gaat eerst vooruit tot dat moment, en dan doet de actor het: een
+    /// actie heeft geen eigen moment mee te geven, ze gebeurt op de stand van de
+    /// wereld. Zo landt een levering of een vervallen termijn die ertussen valt
+    /// eerst — en dat is wat een actie die op zo'n feit wacht, nodig heeft.
+    fn do_acts(&self, world: &mut World) -> Result<Vec<ActOutcome>> {
+        let mut acts = Vec::with_capacity(self.act.len());
+        for step in &self.act {
+            if step.op_moment > world.now() {
+                world.advance(step.op_moment)?;
+            }
+
+            let events = world.act(&step.action, &step.values)?;
+
+            // Een actie die een besluit start, wordt op datzelfde besluit
+            // afgerekend — verwachtingen én de herkomstgate van I5. Een actie die
+            // vastlegt, heeft geen besluit, en dan is er niets om op te rekenen.
+            let mut failures = Vec::new();
+            for record in &events.decisions {
+                let gram = &record.decretogram;
+                failures.extend(check_values(&step.expect, &gram.outputs));
+                failures.extend(check_provenance(gram));
+                failures.extend(check_origins(
+                    &step.expect_accepted,
+                    &step.expect_computed,
+                    gram,
+                ));
+            }
+
+            acts.push(ActOutcome {
+                description: step.description.clone(),
+                action: step.action.clone(),
+                events,
+                failures,
+            });
+        }
+        Ok(acts)
     }
 
     /// Laat de cellen hun besluiten nemen, elk op zijn eigen moment.
@@ -760,7 +955,11 @@ impl Scenario {
             // zegt: een invariant die je moet aanzetten, is een invariant die
             // iemand vergeet.
             failures.extend(check_provenance(&decretogram));
-            failures.extend(check_expected_origins(decision, &decretogram));
+            failures.extend(check_origins(
+                &decision.expect_accepted,
+                &decision.expect_computed,
+                &decretogram,
+            ));
 
             decisions.push(DecisionOutcome {
                 description: decision.description.clone(),
@@ -905,11 +1104,15 @@ pub fn check_provenance(gram: &Decretogram) -> Vec<ExpectationFailure> {
 /// van een bepaalde cel komt, `expect_computed` dat een waarde hier is
 /// vastgesteld. Alleen de eerste zou bewijzen dat de opstelling waarden kán
 /// accepteren, niet dat ze het onderscheid máákt.
-fn check_expected_origins(decision: &Decision, gram: &Decretogram) -> Vec<ExpectationFailure> {
+fn check_origins(
+    expect_accepted: &BTreeMap<String, String>,
+    expect_computed: &[String],
+    gram: &Decretogram,
+) -> Vec<ExpectationFailure> {
     let accepted = gram.accepted_values();
     let mut failures = Vec::new();
 
-    for (value, expected) in &decision.expect_accepted {
+    for (value, expected) in expect_accepted {
         match accepted.get(value.as_str()) {
             Some(cell) if cell == expected => {}
             Some(cell) => failures.push(ExpectationFailure::Provenance {
@@ -927,7 +1130,7 @@ fn check_expected_origins(decision: &Decision, gram: &Decretogram) -> Vec<Expect
         }
     }
 
-    for value in &decision.expect_computed {
+    for value in expect_computed {
         if let Some(cell) = accepted.get(value.as_str()) {
             failures.push(ExpectationFailure::Provenance {
                 value: value.clone(),
@@ -963,6 +1166,29 @@ fn describe_origin(gram: &Decretogram, value: &str) -> String {
         }
         None => String::new(),
     }
+}
+
+/// Reken de run af op de termijnen die ze miste.
+///
+/// Altijd, ook als het scenario er niets over zegt: dan is de verwachting "geen
+/// enkele". Een waarschuwing die niemand verwachtte hoort een run te laten falen —
+/// ze zegt dat er iets níet gebeurd is wat er hoorde te gebeuren, en dat is
+/// precies het soort stilte waar een scenario voor bestaat.
+fn check_warnings(expected: &[String], actual: &[Warning]) -> Vec<ExpectationFailure> {
+    let mut found: Vec<String> = actual
+        .iter()
+        .map(|warning| warning.label.clone())
+        .collect::<Vec<_>>();
+    found.sort();
+    let mut wanted = expected.to_vec();
+    wanted.sort();
+    if wanted == found {
+        return Vec::new();
+    }
+    vec![ExpectationFailure::Warnings {
+        expected: wanted,
+        actual: found,
+    }]
 }
 
 /// Vergelijk de verwachtingen van een vraag met wat de reductie opleverde.
@@ -1285,17 +1511,43 @@ query_via_transport:
     /// staan. Zij is geldig bevonden bij het optuigen en doet daarna niets; dat
     /// stil laten betekent dat een regel in het wereldbestand niets bewijst
     /// zonder dat iemand het merkt.
-    #[test]
-    fn het_verslag_meldt_vastleggingen_die_niet_afgingen() {
-        let run = |pending_triggers| ScenarioRun {
+    /// Een leeg beeld, voor de tests die over het **verslag** gaan.
+    ///
+    /// Die bouwen met opzet geen wereld op: wat ze controleren is wat er in de
+    /// tekst staat, en een wereld eronder zou daar niets aan toevoegen behalve
+    /// tijd.
+    fn empty_snapshot() -> Snapshot {
+        Snapshot {
+            clock: moment(),
+            settings: BTreeMap::new(),
+            locked_settings: BTreeMap::new(),
+            cells: Vec::new(),
+            actions: Vec::new(),
+            crossings: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Een resultaat zonder run eronder, voor de verslagtests.
+    fn report_of(pending_triggers: usize, outcomes: Vec<QueryOutcome>) -> ScenarioRun {
+        ScenarioRun {
             name: "tijd".to_string(),
             clock: moment(),
             pending_triggers,
+            acts: Vec::new(),
             decisions: Vec::new(),
-            outcomes: Vec::new(),
+            outcomes,
             transport_outcomes: Vec::new(),
             invariant_failures: Vec::new(),
-        };
+            warnings: Vec::new(),
+            failures: Vec::new(),
+            snapshot: empty_snapshot(),
+        }
+    }
+
+    #[test]
+    fn het_verslag_meldt_vastleggingen_die_niet_afgingen() {
+        let run = |pending_triggers| report_of(pending_triggers, Vec::new());
 
         assert!(
             run(2).report().contains("2 vastlegging(en) gingen niet af"),
@@ -1317,17 +1569,7 @@ query_via_transport:
     /// gedraaid heeft, en dat is de stilte waar deze opstelling tegen bedoeld is.
     #[test]
     fn het_verslag_meldt_de_invarianten_ook_als_er_niets_te_melden_was() {
-        let run = ScenarioRun {
-            name: "niets over een grens".to_string(),
-            clock: moment(),
-            pending_triggers: 0,
-            decisions: Vec::new(),
-            outcomes: Vec::new(),
-            transport_outcomes: Vec::new(),
-            invariant_failures: Vec::new(),
-        };
-
-        let verslag = run.report();
+        let verslag = report_of(0, Vec::new()).report();
         assert!(
             verslag.contains("[ok] invarianten: 0 contact(en) over een celgrens"),
             "een run zonder bevindingen hoort de gate alsnog te melden; kreeg:\n{verslag}"
@@ -1349,15 +1591,10 @@ query_via_transport:
             },
             failures: Vec::new(),
         };
-        let run = ScenarioRun {
-            name: "tijd".to_string(),
-            clock: moment,
-            pending_triggers: 0,
-            decisions: Vec::new(),
-            outcomes: vec![outcome("vóór de vastlegging"), outcome("erna, ongewijzigd")],
-            transport_outcomes: Vec::new(),
-            invariant_failures: Vec::new(),
-        };
+        let run = report_of(
+            0,
+            vec![outcome("vóór de vastlegging"), outcome("erna, ongewijzigd")],
+        );
 
         let report = run.report();
         assert!(

--- a/packages/simulator/src/snapshot.rs
+++ b/packages/simulator/src/snapshot.rs
@@ -1,0 +1,510 @@
+//! Het beeld van de wereld: één doorsnede van alles wat er staat.
+//!
+//! Dit is het contract naar buiten. Een frontend — of wat er ook aan de andere
+//! kant van een HTTP-laag zit — hoeft precies dit te kennen: waar de klok staat,
+//! welke instellingen gelden en welke daarvan al vastliggen, wat er per cel in
+//! welke kroniek ligt, welke acties er nu te doen zijn en met welk formulier, wat
+//! er over een celgrens ging, en welke termijnen verstreken zonder dat het feit
+//! er lag.
+//!
+//! **Geen casusnamen.** Er staat geen enkele naam in dit bestand die bij één
+//! casus hoort. Elk label komt uit het wereldbestand, en daarmee is een andere
+//! casus een ander bestand en geen andere frontend.
+//!
+//! **Een inspectiebeeld, geen weg naar een cel.** De wereld bezit de cellen en
+//! zij maakt dit beeld; een cel kan het niet opvragen en kan er dus ook niet de
+//! kroniek van een ander mee lezen. Dat is dezelfde keuze als bij het
+//! meetinstrument naast de opstelling: het beeld ziet veel, en juist daarom is er
+//! geen productiepad in een cel dat eraan kan komen. Het is passief — opvragen
+//! verandert niets — en het rekent niets uit: alles wat hier staat, ligt ergens in
+//! een cel, en niets bestaat alleen hier.
+//!
+//! **Het receipt gaat niet mee.** Een decretogram draagt het volledige RFC-013
+//! Execution Receipt, en dat draagt wandkloktijd. Een beeld dat per run verschilt
+//! is geen contract, dus het receipt blijft in de kroniek waar het hoort. Wat een
+//! lezer van het receipt nodig heeft — de herkomst van elke waarde waarop besloten
+//! is — staat er wel, per veld.
+
+use crate::cell::{
+    fixed_fields, Cell, ChronicleEvent, DocumentedParameter, Intake, Lexostatus, INPUTS, RECEIPT,
+    REGULATION,
+};
+use crate::security::SignedAnswer;
+use crate::world::{ActionDefinition, ActionEffect, Warning};
+use chrono::NaiveDate;
+use regelrecht_engine::Value;
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+/// Alles wat er nu in de wereld staat.
+#[derive(Debug, Clone, Serialize)]
+pub struct Snapshot {
+    /// Waar de logische klok staat.
+    pub clock: NaiveDate,
+    /// De instellingen van deze wereld.
+    pub settings: BTreeMap<String, Value>,
+    /// De instellingen die al door een besluit gebruikt zijn en daarmee vast
+    /// staan, met het besluit dat ze gebruikte.
+    ///
+    /// Zodat een lezer kan zien welke knop nog om kan en welke niet, zonder het te
+    /// hoeven proberen. Zie [`crate::World::update_settings`].
+    pub locked_settings: BTreeMap<String, LockedSetting>,
+    /// De cellen, met hun kronieken.
+    pub cells: Vec<CellSnapshot>,
+    /// Elke actie uit het wereldbestand, met haar formulier en of ze nu kan.
+    pub actions: Vec<ActionSnapshot>,
+    /// Elk contact dat over een celgrens ging, in volgorde.
+    ///
+    /// Dit is het materiaal van het observatielog — het meetinstrument dat buiten
+    /// de band staat. Het staat hier omdat een besluit zijn contacten aan de
+    /// wereld teruggeeft en een beeld van de wereld ze hoort te kunnen tonen. Een
+    /// lezer hoort het als meetinstrument te labelen en niet als onderdeel van de
+    /// opstelling: de houder van deze lijst kent de unie van wat over de grenzen
+    /// ging, en dat is precies het totaalbeeld waarvan geen enkele cel er een
+    /// heeft.
+    pub crossings: Vec<CrossingSnapshot>,
+    /// De termijnen die verstreken zonder dat het feit er lag.
+    pub warnings: Vec<Warning>,
+}
+
+/// Een instelling die vast staat, en waardoor.
+#[derive(Debug, Clone, Serialize)]
+pub struct LockedSetting {
+    /// De cel die het besluit nam.
+    pub cell: String,
+    /// Het besluit dat de instelling gebruikte.
+    pub besluit: String,
+}
+
+/// Eén cel, zoals ze erbij staat.
+#[derive(Debug, Clone, Serialize)]
+pub struct CellSnapshot {
+    /// Het cel-id.
+    pub id: String,
+    /// De regelingen die deze cel laadt, bij `$id`.
+    ///
+    /// Leeg is een **bron-cel**: ze legt vast en reduceert, en heeft geen engine.
+    /// Dat is te zien, en dat hoort ook: het is de toets dat het
+    /// lexostatus-contract engine-onafhankelijk is.
+    pub laws: Vec<String>,
+    /// De namen die deze cel publiceert.
+    pub lexostatussen: Vec<String>,
+    /// De besluiten die deze cel kan nemen.
+    pub besluiten: Vec<String>,
+    /// De kronieken van deze cel, met elk gram dat erin ligt.
+    pub chronicles: Vec<ChronicleSnapshot>,
+}
+
+/// Eén kroniekstroom met haar grammen.
+#[derive(Debug, Clone, Serialize)]
+pub struct ChronicleSnapshot {
+    /// Naam van de stroom.
+    pub stream: String,
+    /// Het veld waarop de stroom groepeert.
+    pub key: String,
+    /// De grammen, in de volgorde waarin ze vastgelegd zijn.
+    pub grams: Vec<GramSnapshot>,
+}
+
+/// De drie chronolexogrammen van RFC-022 §1.
+///
+/// Een kroniek draagt er twee: wat een cel overkwam
+/// ([`Self::Executogram`]) en wat ze zelf besloot ([`Self::Decretogram`]). Het
+/// **lexogram** is de wet zelf — generiek, compile-time, en van niemand in
+/// bijzonder — en die ligt dus in geen enkele kroniek; welk recht een cel laadt,
+/// staat in [`CellSnapshot::laws`]. De variant staat er zodat een lezer één
+/// vocabulaire voor alle drie heeft en het derde gram niet stil ontbreekt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GramKind {
+    /// Een regel: de wet, generiek en niet van een cel.
+    Lexogram,
+    /// Een besluit dat de cel zelf nam.
+    Decretogram,
+    /// Een feit dat de cel overkwam: een aanvraag, een levering, een betaling.
+    Executogram,
+}
+
+/// Eén gram in een kroniek.
+#[derive(Debug, Clone, Serialize)]
+pub struct GramSnapshot {
+    /// Welk van de drie grammen dit is.
+    pub kind: GramKind,
+    /// Wat er gebeurde, in de woorden van de cel.
+    pub name: String,
+    /// Het kanaal waarlangs het feit de cel bereikte.
+    pub intake: Intake,
+    /// Wie vastlegde: het cel-id.
+    pub recording_actor: String,
+    /// Op welke grondslag; mag leeg zijn.
+    pub grondslag: String,
+    /// Het moment waarop dit feit in deze cel feit werd.
+    pub op_moment: NaiveDate,
+    /// De velden, elk met de herkomst van hun waarde.
+    pub fields: BTreeMap<String, FieldSnapshot>,
+}
+
+/// Eén veld van een gram: de waarde, en waar ze vandaan komt.
+#[derive(Debug, Clone, Serialize)]
+pub struct FieldSnapshot {
+    /// De vastgelegde waarde.
+    pub value: Value,
+    /// Waar ze vandaan komt.
+    pub origin: FieldOrigin,
+}
+
+/// Waar de waarde van één veld vandaan komt.
+///
+/// Bij een executogram is dat altijd hetzelfde: de cel legde het vast, langs een
+/// kanaal en op een grondslag. Bij een decretogram valt het uiteen, en dat is het
+/// hele punt van invariant I5 — een waarde die van een ander **geaccepteerd** is,
+/// hoort niet op een berekende waarde te lijken.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "herkomst", rename_all = "snake_case")]
+pub enum FieldOrigin {
+    /// De cel legde dit feit zelf vast.
+    Recorded {
+        /// Het kanaal waarlangs het binnenkwam.
+        intake: Intake,
+        /// De grondslag van de vastlegging; mag leeg zijn.
+        grondslag: String,
+    },
+    /// Een input waarop het besluit rekende, met de herkomst die het gram
+    /// vastlegde: een eigen kroniek, een parameter, of geaccepteerd van een
+    /// andere cel — met bron, naam, moment en ondertekening.
+    ///
+    /// Doorgegeven zoals het gram het opschreef en niet naverteld: wat een lezer
+    /// hier ziet, is wat er in de kroniek staat.
+    BesluitInput {
+        /// De herkomst zoals het decretogram haar vastlegde.
+        recorded_origin: Value,
+    },
+    /// Een uitkomst die de regeling van dit besluit berekende.
+    Computed {
+        /// De uitgevoerde regeling, bij `$id`.
+        regulation: String,
+    },
+    /// Een vast veld van het decretogram zelf: het zaakkenmerk, de regeling, het
+    /// bevoegd gezag, het schema van de verplichtingen.
+    Besluit,
+}
+
+/// Eén actie, met haar formulier en of ze nu kan.
+#[derive(Debug, Clone, Serialize)]
+pub struct ActionSnapshot {
+    /// Waarmee de actie aangeroepen wordt.
+    pub id: String,
+    /// De cel die haar doet.
+    pub actor: String,
+    /// Wat een lezer ziet. Casusdata.
+    pub label: String,
+    /// Vrije toelichting uit het wereldbestand.
+    pub doc: Option<String>,
+    /// Wat de actie uitwerkt.
+    pub effect: ActionEffectSnapshot,
+    /// Het formulier: wat de actor invult, en van welk type.
+    pub form: Vec<DocumentedParameter>,
+    /// Kan de actie nu?
+    pub available: bool,
+    /// Waarom ze nu niet kan; `None` als ze kan.
+    ///
+    /// Een actie die niet kan blijft in de lijst staan, met de reden erbij. Wie
+    /// alleen de mogelijke acties toont, laat een keuze verdwijnen zonder te
+    /// zeggen waarom — en dan is niet te zien waar het verhaal staat.
+    pub unavailable_reason: Option<String>,
+}
+
+/// Wat een actie uitwerkt, zoals een lezer het ziet.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "soort", rename_all = "snake_case")]
+pub enum ActionEffectSnapshot {
+    /// De actor legt een feit vast, en levert het eventueel aan een ander.
+    Records {
+        /// De cel waarin het gram landt.
+        cell: String,
+        /// De kroniekstroom.
+        chronicle: String,
+        /// Hoe het gram heet.
+        name: String,
+        /// De cel die hetzelfde feit als levering krijgt, als die er is.
+        delivers_to: Option<String>,
+    },
+    /// De actor start het besluit-pad van een cel.
+    Decides {
+        /// De cel die besluit.
+        cell: String,
+        /// De besluit-definitie.
+        besluit: String,
+    },
+}
+
+/// Eén contact over een celgrens, zoals het meetinstrument het ziet.
+#[derive(Debug, Clone, Serialize)]
+pub struct CrossingSnapshot {
+    /// De identiteit die vroeg en ondertekende.
+    pub asked_by: String,
+    /// De (gesimuleerde) ondertekening. Dat ze gesimuleerd is, staat in de
+    /// waarde: wie dat weglaat, leest later een placeholder als bewijs.
+    pub signature: String,
+    /// De parameters waarmee gevraagd is.
+    pub params: BTreeMap<String, Value>,
+    /// Het antwoord van de bevraagde cel, zoals zij het gaf.
+    pub answer: Lexostatus,
+}
+
+/// Eén actie met wat de wereld erover weet.
+///
+/// Het formulier en de beschikbaarheid staan niet in de actie zelf: het eerste
+/// kan van een besluit-definitie komen, het tweede hangt van de stand van de klok
+/// af. Beide weet alleen de wereld, en ze horen bij elkaar in het beeld.
+pub(crate) struct ActionState<'a> {
+    /// De actie uit het wereldbestand.
+    pub(crate) action: &'a ActionDefinition,
+    /// Wat de actor invult, en van welk type.
+    pub(crate) form: Vec<DocumentedParameter>,
+    /// Waarom ze nu niet kan; `None` als ze kan.
+    pub(crate) unavailable: Option<String>,
+}
+
+/// Alles wat de wereld aan het beeld meegeeft, geleend.
+///
+/// Eén parameter en geen zeven: wat hier binnenkomt is de stand van één wereld,
+/// en die hoort als één ding door te komen.
+pub(crate) struct WorldView<'a> {
+    /// Waar de logische klok staat.
+    pub(crate) clock: NaiveDate,
+    /// De instellingen die nu gelden.
+    pub(crate) settings: &'a BTreeMap<String, Value>,
+    /// De instellingen die vast staan, met cel en besluit dat ze gebruikte.
+    pub(crate) used_settings: &'a BTreeMap<String, (String, String)>,
+    /// De cellen van deze wereld.
+    pub(crate) cells: &'a BTreeMap<String, Cell>,
+    /// De acties, met hun formulier en beschikbaarheid.
+    pub(crate) actions: Vec<ActionState<'a>>,
+    /// Wat er over een celgrens ging, in volgorde.
+    pub(crate) crossings: &'a [SignedAnswer],
+    /// De termijnen die verstreken zonder dat het feit er lag.
+    pub(crate) warnings: &'a [Warning],
+}
+
+/// Bouw het beeld van de wereld.
+///
+/// `pub(crate)`: de weg hiernaartoe is [`crate::World::snapshot`]. Dit is geen
+/// tweede ingang naar de cellen — de aanroeper moet ze al bezitten om ze hier te
+/// kunnen lenen.
+pub(crate) fn build(view: &WorldView<'_>) -> Snapshot {
+    Snapshot {
+        clock: view.clock,
+        settings: view.settings.clone(),
+        locked_settings: view
+            .used_settings
+            .iter()
+            .map(|(setting, (cell, besluit))| {
+                (
+                    setting.clone(),
+                    LockedSetting {
+                        cell: cell.clone(),
+                        besluit: besluit.clone(),
+                    },
+                )
+            })
+            .collect(),
+        cells: view.cells.values().map(cell_snapshot).collect(),
+        actions: view.actions.iter().map(action_snapshot).collect(),
+        crossings: view.crossings.iter().map(crossing_snapshot).collect(),
+        warnings: view.warnings.to_vec(),
+    }
+}
+
+/// Eén cel, met haar kronieken.
+fn cell_snapshot(cell: &Cell) -> CellSnapshot {
+    CellSnapshot {
+        id: cell.id().to_string(),
+        laws: cell.laws().to_vec(),
+        lexostatussen: cell
+            .published_names()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        besluiten: cell
+            .besluit_names()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        chronicles: cell
+            .inspect()
+            .into_iter()
+            .map(|view| ChronicleSnapshot {
+                stream: view.stream.to_string(),
+                key: view.key.to_string(),
+                grams: view.events.iter().map(gram_snapshot).collect(),
+            })
+            .collect(),
+    }
+}
+
+/// Eén gram, met de herkomst van elke waarde erbij.
+fn gram_snapshot(event: &ChronicleEvent) -> GramSnapshot {
+    // Een decretogram ontstaat langs precies één weg — de cel besluit zelf — en
+    // draagt dat in zijn kanaal. Daarmee is het kanaal ook wat de twee soorten
+    // gram uit elkaar houdt, en niet een tweede veld dat ermee uit de pas kan
+    // lopen.
+    let kind = match event.intake {
+        Intake::EigenBesluit => GramKind::Decretogram,
+        Intake::Aanvraag | Intake::Levering | Intake::Betaling => GramKind::Executogram,
+    };
+
+    // Een gram dat langs het besluit-pad ontstond, draagt zijn receipt. Een cel
+    // zonder engine kan óók een eigen vaststelling in haar kroniek leggen — een
+    // bron-cel die opschrijft wat zij vaststelde — en dat gram draagt geen inputs,
+    // geen regeling en geen receipt. Het is even goed een decretogram, maar de
+    // herkomst van elke waarde erin is de vastlegging zelf en niet een uitvoering
+    // die nooit gedraaid heeft.
+    let from_besluit_path = kind == GramKind::Decretogram && event.fields.contains_key(RECEIPT);
+    let recorded = || FieldOrigin::Recorded {
+        intake: event.intake,
+        grondslag: event.grondslag.clone(),
+    };
+    let regulation = event
+        .fields
+        .get(REGULATION)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+
+    let mut fields: BTreeMap<String, FieldSnapshot> = event
+        .fields
+        .iter()
+        .filter(|(name, _)| !(from_besluit_path && omitted(name)))
+        .map(|(name, value)| {
+            let origin = match from_besluit_path {
+                false => recorded(),
+                true if fixed_fields().contains(&name.as_str()) => FieldOrigin::Besluit,
+                true => FieldOrigin::Computed {
+                    regulation: regulation.clone(),
+                },
+            };
+            (
+                name.clone(),
+                FieldSnapshot {
+                    value: value.clone(),
+                    origin,
+                },
+            )
+        })
+        .collect();
+
+    // De inputs van een besluit staan in het gram in één veld bij elkaar. Ze
+    // komen hier los te staan, elk met haar eigen herkomst, want dat is wat een
+    // lezer per waarde wil zien — en het veld waarin ze samen zaten, verdwijnt
+    // daarmee (zie [`omitted`]). Ze gaan er ná de eigen velden in: zou een input
+    // en een uitkomst dezelfde naam dragen, dan is de rijkere herkomst de juiste.
+    if from_besluit_path {
+        for (name, input) in besluit_inputs(&event.fields) {
+            fields.insert(
+                name,
+                FieldSnapshot {
+                    value: input.value.unwrap_or(Value::Null),
+                    origin: FieldOrigin::BesluitInput {
+                        recorded_origin: input.origin,
+                    },
+                },
+            );
+        }
+    }
+
+    GramSnapshot {
+        kind,
+        name: event.name.clone(),
+        intake: event.intake,
+        recording_actor: event.recording_actor.clone(),
+        grondslag: event.grondslag.clone(),
+        op_moment: event.op_moment,
+        fields,
+    }
+}
+
+/// Blijft dit veld van een gram uit het besluit-pad buiten het beeld?
+///
+/// Twee velden, elk om een eigen reden: het **receipt** draagt wandkloktijd en zou
+/// het beeld per run laten verschillen, en het veld met de **inputs** gaat uit
+/// elkaar in losse velden met hun herkomst — het twee keer meesturen zou dezelfde
+/// waarden twee keer in beeld brengen.
+fn omitted(name: &str) -> bool {
+    name == RECEIPT || name == INPUTS
+}
+
+/// Eén input van een besluit, zoals het gram haar draagt.
+struct RecordedInput {
+    /// De waarde waarop gerekend is.
+    value: Option<Value>,
+    /// De herkomst, zoals het gram haar opschreef.
+    origin: Value,
+}
+
+/// De inputs van een decretogram, uit het veld dat ze draagt.
+///
+/// Uit het gram gelezen en niet uit een tweede bron: wat hier uitkomt is precies
+/// wat er in de kroniek staat. Een gram zonder dit veld — of met iets anders erin
+/// dan verwacht — levert een lege lijst op, en dan staan de uitkomsten er nog
+/// steeds; een beeld hoort niet om te vallen omdat een herkomst niet te lezen was.
+fn besluit_inputs(fields: &BTreeMap<String, Value>) -> BTreeMap<String, RecordedInput> {
+    let Some(Value::Object(inputs)) = fields.get(INPUTS) else {
+        return BTreeMap::new();
+    };
+    inputs
+        .iter()
+        .filter_map(|(name, entry)| {
+            let Value::Object(parts) = entry else {
+                return None;
+            };
+            Some((
+                name.clone(),
+                RecordedInput {
+                    value: parts.get("value").cloned(),
+                    origin: parts.get("origin").cloned().unwrap_or(Value::Null),
+                },
+            ))
+        })
+        .collect()
+}
+
+/// Eén actie, met haar formulier en of ze nu kan.
+fn action_snapshot(state: &ActionState<'_>) -> ActionSnapshot {
+    let action = state.action;
+    let effect = match &action.effect {
+        ActionEffect::Records(records) => ActionEffectSnapshot::Records {
+            cell: records.cell.clone(),
+            chronicle: records.chronicle.clone(),
+            name: records.name.clone(),
+            delivers_to: records
+                .delivers_to
+                .as_ref()
+                .map(|delivery| delivery.cell.clone()),
+        },
+        ActionEffect::Decides(decides) => ActionEffectSnapshot::Decides {
+            cell: decides.cell.clone(),
+            besluit: decides.besluit.clone(),
+        },
+    };
+    ActionSnapshot {
+        id: action.id.clone(),
+        actor: action.actor.clone(),
+        label: action.label.clone(),
+        doc: action.doc.clone(),
+        effect,
+        form: state.form.clone(),
+        available: state.unavailable.is_none(),
+        unavailable_reason: state.unavailable.clone(),
+    }
+}
+
+/// Eén contact over een celgrens.
+fn crossing_snapshot(signed: &SignedAnswer) -> CrossingSnapshot {
+    CrossingSnapshot {
+        asked_by: signed.asked_by.to_string(),
+        signature: signed.signature.to_string(),
+        params: signed.params.clone(),
+        answer: signed.answer.clone(),
+    }
+}

--- a/packages/simulator/src/world.rs
+++ b/packages/simulator/src/world.rs
@@ -21,10 +21,21 @@
 //!
 //! De wereld is ook de enige die een cel kan laten **besluiten**
 //! ([`World::decide`]). Dat is geen trigger op de klok maar een aansturing van
-//! buiten: in deze opstelling zegt het scenario wie wanneer waarover besluit,
-//! omdat een actie van een actor nog niet bestaat. De wereld houdt zelf geen
-//! register van wat er besloten is; het decretogram ligt in de kroniek van de
-//! cel die besloot.
+//! buiten. De wereld houdt zelf geen register van wat er besloten is; het
+//! decretogram ligt in de kroniek van de cel die besloot.
+//!
+//! Die aansturing komt uit het wereldbestand: een [`ActionDefinition`] is wat een
+//! **actor** op de tijdlijn kan doen — een feit vastleggen (en het eventueel
+//! leveren aan een ander), of een besluit-pad starten. [`World::act`] voert er
+//! één uit, op de stand van de klok, met de waarden uit haar formulier.
+//! Daarmee is de aansturing casusdata: een andere casus is een ander
+//! wereldbestand en geen Rust.
+//!
+//! Naar buiten geeft [`World::snapshot`] één beeld van alles wat er staat — de
+//! klok, de instellingen, per cel haar kronieken met elk gram, de acties die nu
+//! kunnen, wat er over een celgrens ging en de waarschuwingen. Dat beeld is het
+//! contract voor een frontend; het kent geen casus, want elk label komt uit het
+//! wereldbestand.
 //!
 //! Daar komt één ding bij dat alleen de wereld kan: **accepteren**. Een besluit
 //! dat een waarde van een andere organisatie nodig heeft, zegt dat — en de wereld
@@ -35,16 +46,18 @@
 
 use crate::accept::CellBridge;
 use crate::cell::{
-    Cell, CellConfig, ChronicleEvent, Decretogram, Intake, Lexostatus, ObligationDue, BETALINGEN,
-    ZAAKKENMERK,
+    check_documented_params, BesluitDefinition, Cell, CellConfig, ChronicleEvent, Decretogram,
+    DocumentedParameter, Intake, Lexostatus, ObligationDue, BETALINGEN, ZAAKKENMERK,
 };
 use crate::error::{Result, SimulatorError, Subject};
 use crate::security::{Identity, SignedAnswer};
+use crate::snapshot::{ActionState, Snapshot, WorldView};
 use chrono::NaiveDate;
 use regelrecht_engine::{CellResolver, Value};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
-use std::path::Path;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 /// De logische klok van een wereld, zoals het wereldbestand haar opgeeft.
@@ -111,6 +124,332 @@ impl Recording {
     }
 }
 
+/// Wat een actor op de tijdlijn kan doen.
+///
+/// Dit is de aansturing van de wereld, en ze is **casusdata**. Een actie noemt
+/// wie haar doet, hoe ze heet voor een lezer, wat ze uitwerkt (een feit
+/// vastleggen of een besluit-pad starten) en wanneer ze überhaupt kan. Wat er
+/// niet in staat is even belangrijk: geen Rust, geen casusnaam in een type, en
+/// geen eigen tijdstip — een actie gebeurt op de stand van de klok, want dat is
+/// wat een actor doet.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(try_from = "ActionFields")]
+pub struct ActionDefinition {
+    /// Waarmee de actie aangeroepen wordt; uniek in de wereld.
+    pub id: String,
+    /// De cel die de actie doet.
+    ///
+    /// Een actor is een cel: een burger, een partij en een betaalsysteem zijn in
+    /// deze opstelling organisaties met een eigen kroniek (RFC-022 §1.3 — wie
+    /// vastlegt, is de celbeheerder). Een actor buiten de cellen om zou een feit
+    /// achterlaten dat niemand in zijn eigen journaal heeft.
+    pub actor: String,
+    /// Wat een lezer van deze actie ziet. Casusdata; de frontend verzint niets.
+    pub label: String,
+    /// Vrije toelichting; verschijnt in het beeld van de wereld naast het label.
+    pub doc: Option<String>,
+    /// Wat de actie uitwerkt.
+    pub effect: ActionEffect,
+    /// Wanneer deze actie kan; altijd, als het er niet staat.
+    pub available_when: Option<Availability>,
+}
+
+/// De twee dingen die een actie kan uitwerken.
+///
+/// Precies één van de twee, en dat is geen beperking maar de scheiding die deze
+/// opstelling maakt: een feit vastleggen is iets wat een cel *overkomt*, een
+/// besluit nemen is iets wat ze *doet*. Eén actie die beide zou doen, zou die
+/// twee in één gram laten vallen.
+#[derive(Debug, Clone)]
+pub enum ActionEffect {
+    /// De actor legt een executogram vast in een eigen kroniek.
+    Records(RecordsAction),
+    /// De actor start het besluit-pad van een cel.
+    ///
+    /// Het formulier is dan niet dat van de actie maar dat van het besluit: de
+    /// gedocumenteerde parameters die de besluit-definitie al noemt. Een tweede
+    /// lijst ernaast zou ervan gaan afwijken.
+    Decides(DecidesAction),
+}
+
+/// Het YAML-oppervlak van een actie: alle velden van beide vormen, los.
+///
+/// Dezelfde keuze als bij [`crate::Reduction`] en [`crate::BesluitInput`]: de
+/// vorm valt hieronder en niet in serde, zodat er in de foutmelding staat wat er
+/// mis is in plaats van "data did not match any variant" — en zodat een typfout
+/// in een veldnaam alsnog geweigerd wordt.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ActionFields {
+    /// Zie [`ActionDefinition::id`].
+    id: String,
+    /// Zie [`ActionDefinition::actor`].
+    actor: String,
+    /// Zie [`ActionDefinition::label`].
+    label: String,
+    /// Zie [`ActionDefinition::doc`].
+    #[serde(default)]
+    doc: Option<String>,
+    /// Zie [`ActionEffect::Records`].
+    #[serde(default)]
+    records: Option<RecordsAction>,
+    /// Zie [`ActionEffect::Decides`].
+    #[serde(default)]
+    decides: Option<DecidesAction>,
+    /// Zie [`ActionDefinition::available_when`].
+    #[serde(default)]
+    available_when: Option<Availability>,
+}
+
+impl TryFrom<ActionFields> for ActionDefinition {
+    type Error = String;
+
+    fn try_from(fields: ActionFields) -> std::result::Result<Self, Self::Error> {
+        let effect = match (fields.records, fields.decides) {
+            (Some(_), Some(_)) => {
+                return Err(format!(
+                    "actie '{}' noemt zowel `records` als `decides`; een actie legt een \
+                     feit vast (`records`) óf start een besluit (`decides`)",
+                    fields.id
+                ))
+            }
+            (Some(records), None) => ActionEffect::Records(records),
+            (None, Some(decides)) => ActionEffect::Decides(decides),
+            (None, None) => {
+                return Err(format!(
+                    "actie '{}' noemt geen `records` en geen `decides`, en werkt dus niets \
+                     uit",
+                    fields.id
+                ))
+            }
+        };
+        Ok(Self {
+            id: fields.id,
+            actor: fields.actor,
+            label: fields.label,
+            doc: fields.doc,
+            effect,
+            available_when: fields.available_when,
+        })
+    }
+}
+
+/// Een actie die een feit vastlegt, en het eventueel ook levert.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RecordsAction {
+    /// De cel waarin het gram landt. Doorgaans de actor zelf.
+    pub cell: String,
+    /// De kroniekstroom binnen die cel.
+    pub chronicle: String,
+    /// Wat er gebeurde, in de woorden van de casus.
+    pub name: String,
+    /// Het kanaal waarlangs het feit de cel bereikte.
+    pub intake: Intake,
+    /// Op welke grondslag dit feit vastgelegd wordt; mag leeg.
+    #[serde(default)]
+    pub grondslag: String,
+    /// Het formulier: wat de actor invult, en van welk type.
+    ///
+    /// Dezelfde vorm als de gedocumenteerde parameters van een lexostatus of een
+    /// besluit, en om dezelfde reden: wie een waarde aanlevert die er niet in
+    /// staat, of van het verkeerde type, wordt geweigerd.
+    #[serde(default)]
+    pub fields: Vec<DocumentedParameter>,
+    /// Bij wie hetzelfde feit óók landt, als levering.
+    #[serde(default)]
+    pub delivers_to: Option<Delivery>,
+}
+
+/// De ontvangende kant van een feit dat een actor vastlegt.
+///
+/// Dit is de eerlijke vorm van een aanvraag: de aanvrager weet wat zij indiende,
+/// de ontvanger weet wat hem geleverd is. Twee grammen, elk in de eigen kroniek
+/// van de cel die het overkwam — en niet één gram dat twee cellen delen.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Delivery {
+    /// De ontvangende cel.
+    pub cell: String,
+    /// De kroniekstroom waarin de levering landt.
+    pub chronicle: String,
+    /// Het kanaal waarlangs het feit bij de ontvanger binnenkomt.
+    ///
+    /// Standaard een levering; een aanvraag die bij het bestuursorgaan binnenkomt
+    /// mag `aanvraag` zeggen, en dan staat dat in de kroniek van de ontvanger.
+    #[serde(default = "levering")]
+    pub intake: Intake,
+    /// Hoe het gram bij de ontvanger heet; standaard dezelfde naam als bij de
+    /// actor.
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+/// Het standaardkanaal van een levering.
+fn levering() -> Intake {
+    Intake::Levering
+}
+
+/// Een actie die het besluit-pad van een cel start.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DecidesAction {
+    /// De cel die besluit.
+    pub cell: String,
+    /// De besluit-definitie die uitgevoerd wordt.
+    pub besluit: String,
+}
+
+/// Wanneer een actie kan: één simpele voorwaarde over een kroniek.
+///
+/// Leest als: *er ligt in kroniek `chronicle` van cel `cell` een feit waarin
+/// veld `field` de waarde `equals` heeft.* Daarmee kan een actie wachten tot het
+/// verhaal zover is — beslissen kan pas als er een aanvraag ligt — zonder dat de
+/// volgorde in Rust vastgelegd wordt.
+///
+/// Met opzet klein. Dit is geen tweede reductietaal: er komt geen waarde naar
+/// buiten, alleen ja of nee, en de vraag gaat over de wereld en niet over een
+/// cel die een andere cel bevraagt.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Availability {
+    /// De cel wiens kroniek nagekeken wordt.
+    pub cell: String,
+    /// De kroniekstroom.
+    pub chronicle: String,
+    /// Het veld waarop gekeken wordt.
+    pub field: String,
+    /// De waarde die dat veld moet hebben.
+    pub equals: Value,
+}
+
+impl Availability {
+    /// Leesbare voorwaarde, voor het beeld van de wereld en voor een weigering.
+    fn describe(&self) -> String {
+        format!(
+            "in kroniek '{}' van cel '{}' ligt nog geen feit met {} = {}",
+            self.chronicle, self.cell, self.field, self.equals
+        )
+    }
+}
+
+/// Een termijn die waarschuwt als een feit op tijd ontbreekt.
+///
+/// Nooit blokkerend, en dat is een standpunt en geen gemak: de wet zegt wat de
+/// termijn was, niet dat het bestuursorgaan daarna niets meer mag. Een aanvraag
+/// na de deadline is dus geen fout maar een waarschuwing naast de wereld, en het
+/// besluit kan alsnog genomen worden.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Deadline {
+    /// Wat een lezer van deze termijn ziet. Casusdata.
+    pub label: String,
+    /// De dag waarop de termijn verstrijkt.
+    ///
+    /// Een datum en geen sjabloon over `settings`: de termijnen worden bij het
+    /// optuigen op hun plek in de wachtrij gezet, en een instelling die daarna
+    /// wijzigt zou een termijn moeten verplaatsen die misschien al gepasseerd is.
+    pub at: NaiveDate,
+    /// Het feit dat er dan hoort te liggen.
+    pub warn_if_missing: ExpectedFact,
+}
+
+/// Het feit waarvan een termijn het ontbreken meldt.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExpectedFact {
+    /// De cel wiens kroniek nagekeken wordt.
+    pub cell: String,
+    /// De kroniekstroom.
+    pub chronicle: String,
+    /// De naam van het gram dat er hoort te liggen.
+    pub name: String,
+}
+
+/// Eén gemiste termijn, zoals de wereld haar meldt.
+#[derive(Debug, Clone, Serialize)]
+pub struct Warning {
+    /// Het label van de termijn uit het wereldbestand.
+    pub label: String,
+    /// De dag waarop de termijn verstreek.
+    pub at: NaiveDate,
+    /// De cel waar het feit hoorde te liggen.
+    pub cell: String,
+    /// De kroniekstroom waarin het hoorde te liggen.
+    pub chronicle: String,
+    /// De naam van het gram dat ontbrak.
+    pub name: String,
+}
+
+impl Warning {
+    /// Leesbare waarschuwing, voor een verslag.
+    pub fn describe(&self) -> String {
+        format!(
+            "{} ({}): cel '{}' had op dat moment geen '{}' in kroniek '{}'",
+            self.label, self.at, self.cell, self.name, self.chronicle
+        )
+    }
+}
+
+/// Eén feit dat tijdens een stap vastgelegd is.
+#[derive(Debug, Clone)]
+pub struct RecordedFact {
+    /// De cel waarin het gram landde.
+    pub cell: String,
+    /// De kroniekstroom.
+    pub chronicle: String,
+    /// Het gram zelf.
+    pub event: ChronicleEvent,
+}
+
+/// Wat er gebeurde tijdens één stap in de wereld.
+///
+/// Een stap is [`World::act`] of [`World::advance`], en wat er uit komt is wat een
+/// lezer — of een latere web-laag — wil weten: welke grammen erbij kwamen, welke
+/// besluiten genomen zijn en welke termijnen verstreken. Het is geen tweede
+/// waarheid naast de kronieken: alles hierin ligt óók in de cel waar het hoort,
+/// en [`World::snapshot`] is de stand.
+#[derive(Debug, Clone, Default)]
+pub struct Events {
+    /// De feiten die vastgelegd zijn, in volgorde.
+    pub recordings: Vec<RecordedFact>,
+    /// De besluiten die genomen zijn, met wat er voor elk over een celgrens ging.
+    pub decisions: Vec<DecisionRecord>,
+    /// De termijnen die onderweg verstreken zonder dat het feit er lag.
+    pub warnings: Vec<Warning>,
+}
+
+impl Events {
+    /// Gebeurde er niets?
+    pub fn is_empty(&self) -> bool {
+        self.recordings.is_empty() && self.decisions.is_empty() && self.warnings.is_empty()
+    }
+
+    /// Leesbaar verslag van deze stap, één regel per gebeurtenis.
+    pub fn describe(&self) -> String {
+        let mut out = String::new();
+        for fact in &self.recordings {
+            let _ = writeln!(
+                out,
+                "        {}.{}: {} op {}",
+                fact.cell, fact.chronicle, fact.event.name, fact.event.op_moment
+            );
+        }
+        for decision in &self.decisions {
+            let gram = &decision.decretogram;
+            let _ = writeln!(
+                out,
+                "        {} besluit '{}' op {} -> zaakkenmerk '{}'",
+                gram.cell, gram.besluit, gram.op_moment, gram.zaakkenmerk
+            );
+        }
+        for warning in &self.warnings {
+            let _ = writeln!(out, "        waarschuwing: {}", warning.describe());
+        }
+        out
+    }
+}
+
 /// Wat er gebeurt als de klok een moment passeert.
 ///
 /// De lus die ze afloopt is generiek, dus een soort erbij is een variant erbij
@@ -126,6 +465,12 @@ enum Trigger {
     /// oplegt. Dat is meteen de reden dat [`World::pending`] gesorteerd moet
     /// blijven bij het bijzetten.
     Obligation(ObligationDue),
+    /// Een termijn verstrijkt; ontbreekt het feit, dan komt er een waarschuwing.
+    ///
+    /// De plaats in het wereldbestand, want een waarschuwing hoort te vallen op
+    /// het moment dat de termijn passeert en niet aan het eind van de run: een
+    /// feit dat er een dag later wél ligt, lag er op de termijn niet.
+    Deadline(usize),
 }
 
 /// Wat één besluit opleverde: het gram, en wat ervoor over de celgrens ging.
@@ -145,6 +490,52 @@ pub struct DecisionRecord {
     pub crossings: Vec<SignedAnswer>,
 }
 
+/// Het hele wereldbestand, los van de stappen die een scenario erop zet.
+///
+/// Dit is wat een wereld **is**: een klok, de cellen, de instellingen, de
+/// startstand, de acties die een actor kan doen en de termijnen die kunnen
+/// verstrijken. Eén type, want [`World::reset`] moet er opnieuw uit kunnen
+/// opbouwen, en een web-laag moet er een verse wereld per sessie uit kunnen
+/// maken. Zou de wereld alleen haar cellen bewaren, dan was "terug naar de
+/// startstand" niet te doen zonder het bestand opnieuw te lezen.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorldDefinition {
+    /// De logische klok. Verplicht en expliciet: een run mag niet van de
+    /// wandklok afhangen.
+    pub clock: Clock,
+    /// De cellen in deze wereld.
+    pub cells: Vec<CellConfig>,
+    /// De instellingen: casusdata die geen wet is.
+    #[serde(default)]
+    pub settings: BTreeMap<String, Value>,
+    /// De startstand: vastleggingen met een moment.
+    #[serde(default)]
+    pub fixtures: Vec<Fixture>,
+    /// Wat de actoren op de tijdlijn kunnen doen.
+    #[serde(default)]
+    pub actions: Vec<ActionDefinition>,
+    /// De termijnen die waarschuwen als een feit ontbreekt.
+    #[serde(default)]
+    pub deadlines: Vec<Deadline>,
+}
+
+impl WorldDefinition {
+    /// Lees een wereldbestand uit YAML.
+    pub fn from_yaml(yaml: &str) -> Result<Self> {
+        Ok(serde_yaml_ng::from_str(yaml)?)
+    }
+
+    /// Lees een wereldbestand van schijf.
+    pub fn load(path: &Path) -> Result<Self> {
+        let text = std::fs::read_to_string(path).map_err(|source| SimulatorError::FileRead {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Self::from_yaml(&text)
+    }
+}
+
 /// Eén gesimuleerde wereld: cellen, een klok, en wat er nog moet gebeuren.
 ///
 /// De wereld bezit de cellen en is de enige die hun vastleg-pad kan aanroepen.
@@ -152,6 +543,16 @@ pub struct DecisionRecord {
 /// een moment ná de klok is een fout en geen voorspelling.
 #[derive(Debug)]
 pub struct World {
+    /// Het wereldbestand waaruit deze wereld is opgetuigd.
+    ///
+    /// Bewaard en niet weggegooid, want [`World::reset`] bouwt er opnieuw uit op,
+    /// en [`World::act`] leest er de actie uit die aangeroepen wordt. Dit is geen
+    /// tweede waarheid naast de cellen: er staat niets in wat er tijdens de run
+    /// gebeurd is.
+    definition: WorldDefinition,
+    /// Waar het corpus staat, zodat [`World::reset`] de cellen opnieuw kan
+    /// opbouwen.
+    regulation_root: PathBuf,
     /// De cellen, op id.
     cells: BTreeMap<String, Cell>,
     /// De instellingen van deze wereld: casusdata die geen wet is.
@@ -160,9 +561,28 @@ pub struct World {
     /// in een besluit-definitie vast te staan alsof de wet het voorschrijft.
     /// Daarom staan ze hier, bij de wereld, en niet in een cel: een cel leest ze
     /// niet, ze krijgt ze aangereikt bij het besluit dat erop leunt.
+    ///
+    /// Apart van [`Self::definition`], want [`World::update_settings`] mag ze
+    /// wijzigen en de startstand hoort daar niet mee te schuiven.
     settings: BTreeMap<String, Value>,
+    /// De instellingen die al door een besluit gebruikt zijn, met dat besluit.
+    ///
+    /// Wat hierin staat, staat vast: zie [`World::update_settings`]. Het is geen
+    /// schaduwboekhouding van de besluiten — het gram zelf ligt in de kroniek van
+    /// de cel die besloot — maar de enige manier om te weten waar een instelling
+    /// inmiddels onder ligt.
+    used_settings: BTreeMap<String, (String, String)>,
     /// Waar de logische klok staat.
     clock: NaiveDate,
+    /// Elk contact dat over een celgrens ging, in volgorde.
+    ///
+    /// Materiaal voor het meetinstrument, en niets meer: de cellen kunnen er niet
+    /// bij, geen beslissing leunt erop, en wie hem weglaat verandert geen enkele
+    /// uitkomst. Hij staat hier omdat een besluit ze aan de wereld teruggeeft en
+    /// een beeld van de wereld ze hoort te kunnen tonen.
+    crossings: Vec<SignedAnswer>,
+    /// De termijnen die verstreken zonder dat het feit er lag.
+    warnings: Vec<Warning>,
     /// Wat er nog moet gebeuren, oplopend op datum. Bij een gelijke datum
     /// beslist de volgorde waarin de triggers zijn opgegeven; de sortering is
     /// stabiel, dus dat is een vastgelegde eigenschap en geen toeval.
@@ -192,28 +612,47 @@ impl World {
     /// reden: of een instelling bestaat en of de betalende cel een
     /// betalingsstroom houdt, is niet iets om op de eerste vervaldatum achter te
     /// komen. Zie [`check_obligations`].
-    pub fn new(
-        configs: &[CellConfig],
-        clock: Clock,
-        fixtures: &[Fixture],
-        settings: &BTreeMap<String, Value>,
-        regulation_root: &Path,
-    ) -> Result<Self> {
-        // Per cel, per stroom: de veldnamen die een `fixture` erin zet. Een
-        // stroom mag leeg opgetuigd worden en haar inhoud pas via `fixtures`
-        // krijgen (zie `scenarios/toeslagen_tijdlijn.yaml`); zonder dit zou
+    pub fn from_definition(definition: &WorldDefinition, regulation_root: &Path) -> Result<Self> {
+        let configs = &definition.cells;
+        let fixtures = &definition.fixtures;
+
+        // Per cel, per stroom: de veldnamen die er van buiten de celconfiguratie
+        // in komen — uit een `fixture` of uit het formulier van een actie. Een
+        // stroom mag leeg opgetuigd worden en haar inhoud pas zo krijgen (zie
+        // `scenarios/toeslagen_tijdlijn.yaml`); zonder dit zou
         // `Cell::from_config` zo'n stroom als veldloos zien en een
         // kroniekfilter daarop onterecht als typfout afkeuren.
         let mut fixture_fields: BTreeMap<String, BTreeMap<String, BTreeSet<String>>> =
             BTreeMap::new();
+        let mut add = |cell: &str, chronicle: &str, fields: Vec<String>| {
+            fixture_fields
+                .entry(cell.to_string())
+                .or_default()
+                .entry(chronicle.to_string())
+                .or_default()
+                .extend(fields);
+        };
         for fixture in fixtures {
             let target = &fixture.record;
-            fixture_fields
-                .entry(target.cell.clone())
-                .or_default()
-                .entry(target.chronicle.clone())
-                .or_default()
-                .extend(target.fields.keys().cloned());
+            add(
+                &target.cell,
+                &target.chronicle,
+                target.fields.keys().cloned().collect(),
+            );
+        }
+        for action in &definition.actions {
+            let ActionEffect::Records(records) = &action.effect else {
+                continue;
+            };
+            let names: Vec<String> = records
+                .fields
+                .iter()
+                .map(|field| field.name.clone())
+                .collect();
+            add(&records.cell, &records.chronicle, names.clone());
+            if let Some(delivery) = &records.delivers_to {
+                add(&delivery.cell, &delivery.chronicle, names);
+            }
         }
 
         let mut cells: BTreeMap<String, Cell> = BTreeMap::new();
@@ -241,22 +680,48 @@ impl World {
         }
 
         check_peers_exist(configs, &cells)?;
-        check_obligations(configs, &cells, settings)?;
+        check_obligations(configs, &cells, &definition.settings)?;
+        check_actions(&definition.actions, &cells)?;
+        check_deadlines(&definition.deadlines, &cells)?;
 
         let mut pending: Vec<(NaiveDate, Trigger)> = fixtures
             .iter()
             .map(|fixture| (fixture.at, Trigger::Record(fixture.record.clone())))
+            .chain(
+                definition
+                    .deadlines
+                    .iter()
+                    .enumerate()
+                    .map(|(index, deadline)| (deadline.at, Trigger::Deadline(index))),
+            )
             .collect();
         pending.sort_by_key(|(at, _)| *at);
 
         let mut world = Self {
+            definition: definition.clone(),
+            regulation_root: regulation_root.to_path_buf(),
             cells,
-            settings: settings.clone(),
-            clock: clock.start,
+            settings: definition.settings.clone(),
+            used_settings: BTreeMap::new(),
+            clock: definition.clock.start,
+            crossings: Vec::new(),
+            warnings: Vec::new(),
             pending: pending.into(),
         };
-        world.fire_due(clock.start)?;
+        world.fire_due(definition.clock.start)?;
         Ok(world)
+    }
+
+    /// Tuig de wereld opnieuw op: terug naar de startstand.
+    ///
+    /// Een verse wereld uit hetzelfde bestand, en niet een wereld die haar
+    /// geschiedenis terugdraait. Dat verschil is de hele reden dat dit kan: een
+    /// kroniek groeit en wijzigt nooit, dus "terug" bestaat niet — wat wél bestaat
+    /// is opnieuw beginnen. Ook de instellingen gaan terug naar wat het bestand
+    /// zegt; wie ze wijzigde, wijzigde de wereld en niet het bestand.
+    pub fn reset(&mut self) -> Result<()> {
+        *self = Self::from_definition(&self.definition.clone(), &self.regulation_root)?;
+        Ok(())
     }
 
     /// Waar de logische klok staat.
@@ -282,16 +747,213 @@ impl World {
     /// eigen datum als `op_moment`, niet de eindstand. Achteruit loopt de klok
     /// niet: wie het beeld van een eerder moment wil, vraagt dat op met
     /// `op_moment` in [`World::reduce`].
-    pub fn advance(&mut self, tot: NaiveDate) -> Result<()> {
+    pub fn advance(&mut self, tot: NaiveDate) -> Result<Events> {
         if tot < self.clock {
             return Err(SimulatorError::ClockRunsBackwards {
                 clock: self.clock.to_string(),
                 to: tot.to_string(),
             });
         }
-        self.fire_due(tot)?;
+        let events = self.fire_due(tot)?;
         self.clock = tot;
+        Ok(events)
+    }
+
+    /// Voer één actie uit, op de stand van de klok.
+    ///
+    /// Een actie heeft geen eigen moment: ze gebeurt nu. Dat is wat haar van een
+    /// [`Fixture`] onderscheidt — een startstand staat op een datum, een actor
+    /// doet iets op het moment dat de wereld staat — en het is ook wat maakt dat
+    /// een actie geen gram in de toekomst kan leggen.
+    ///
+    /// `form_values` wordt tegen het formulier van de actie gehouden: precies de
+    /// velden die ze documenteert, van het type dat ze noemt. Bij een actie die
+    /// een besluit start, is dat formulier dat van het besluit zelf.
+    ///
+    /// Kan de actie nu niet ([`Availability`]), dan is dat een leesbare weigering
+    /// en geen stilte: er staat in wat er nog niet vastligt.
+    pub fn act(
+        &mut self,
+        action_id: &str,
+        form_values: &BTreeMap<String, Value>,
+    ) -> Result<Events> {
+        let action = self
+            .definition
+            .actions
+            .iter()
+            .find(|candidate| candidate.id == action_id)
+            .ok_or_else(|| SimulatorError::UnknownAction {
+                action: action_id.to_string(),
+                known: self
+                    .definition
+                    .actions
+                    .iter()
+                    .map(|candidate| candidate.id.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            })?
+            .clone();
+
+        if let Some(reason) = self.unavailable(&action) {
+            return Err(SimulatorError::ActionNotAvailable {
+                action: action.id.clone(),
+                reason,
+            });
+        }
+
+        check_documented_params(
+            &action.actor,
+            Subject::Actie,
+            &action.id,
+            &self.form(&action)?,
+            form_values,
+        )?;
+
+        match &action.effect {
+            ActionEffect::Records(records) => {
+                let mut events = Events::default();
+                for recording in recordings_of(&action, records, form_values) {
+                    events
+                        .recordings
+                        .push(self.apply_recording(&recording, self.clock)?);
+                }
+                Ok(events)
+            }
+            ActionEffect::Decides(decides) => {
+                let (record, mut events) = self.decide_and_settle(
+                    &decides.cell,
+                    &decides.besluit,
+                    form_values,
+                    self.clock,
+                )?;
+                events.decisions.push(record);
+                Ok(events)
+            }
+        }
+    }
+
+    /// Wijzig de instellingen van deze wereld.
+    ///
+    /// Een instelling die al door een besluit gebruikt is, staat vast. Dat is geen
+    /// voorzichtigheid maar wat een decretogram betekent: het gram legt vast
+    /// waarop besloten is, dus een ritme dat er achteraf onder vandaan geschoven
+    /// wordt, laat het gram iets anders zeggen dan er gebeurd is. Wie het toch wil
+    /// wijzigen, begint een nieuwe wereld ([`World::reset`]).
+    ///
+    /// Alles of niets: is er één wijziging die niet kan, dan gaat er geen enkele
+    /// door. Een half doorgevoerde wijziging zou een wereld achterlaten waarvan
+    /// niemand kan zeggen welke instellingen er nu gelden.
+    pub fn update_settings(&mut self, changes: &BTreeMap<String, Value>) -> Result<()> {
+        let mut updated = self.settings.clone();
+        for (setting, value) in changes {
+            if !self.settings.contains_key(setting) {
+                return Err(SimulatorError::UnknownWorldSetting {
+                    setting: setting.clone(),
+                    known: self
+                        .settings
+                        .keys()
+                        .map(String::as_str)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                });
+            }
+            if let Some((cell, besluit)) = self.used_settings.get(setting) {
+                return Err(SimulatorError::SettingInUse {
+                    setting: setting.clone(),
+                    cell: cell.clone(),
+                    besluit: besluit.clone(),
+                });
+            }
+            updated.insert(setting.clone(), value.clone());
+        }
+
+        // Dezelfde toets als bij het optuigen: een ritme dat niet bestaat hoort
+        // hier te vallen en niet bij het eerste besluit dat erop leunt.
+        check_obligations(&self.definition.cells, &self.cells, &updated)?;
+        self.settings = updated;
         Ok(())
+    }
+
+    /// Het beeld van de wereld: alles wat er nu staat, in één contract.
+    ///
+    /// Zie [`Snapshot`]. Het is een **inspectiebeeld**: de wereld toont wat waar
+    /// ligt, geen cel komt eraan, en er verandert niets door het op te vragen.
+    pub fn snapshot(&self) -> Snapshot {
+        crate::snapshot::build(&WorldView {
+            clock: self.clock,
+            settings: &self.settings,
+            used_settings: &self.used_settings,
+            cells: &self.cells,
+            actions: self.actions_now(),
+            crossings: &self.crossings,
+            warnings: &self.warnings,
+        })
+    }
+
+    /// De waarschuwingen die tot nu toe zijn ontstaan, in volgorde.
+    pub fn warnings(&self) -> &[Warning] {
+        &self.warnings
+    }
+
+    /// Elke actie uit het wereldbestand, met haar formulier en of ze nu kan.
+    ///
+    /// Alle acties en niet alleen de mogelijke: een actie die nog niet kan, met de
+    /// reden erbij, is wat een lezer nodig heeft om te zien waar het verhaal staat.
+    /// Wie alleen de mogelijke toont, laat een keuze verdwijnen zonder te zeggen
+    /// waarom.
+    fn actions_now(&self) -> Vec<ActionState<'_>> {
+        self.definition
+            .actions
+            .iter()
+            .map(|action| ActionState {
+                action,
+                // Onbereikbaar leeg: het optuigen heeft elke actie aan haar cel en
+                // haar besluit gebonden, dus het formulier is er.
+                form: self.form(action).unwrap_or_default(),
+                unavailable: self.unavailable(action),
+            })
+            .collect()
+    }
+
+    /// Het formulier van een actie: wat de actor invult, en van welk type.
+    ///
+    /// Bij een `records`-actie is dat wat de actie zelf noemt; bij een
+    /// `decides`-actie zijn het de gedocumenteerde parameters van het besluit. Die
+    /// tweede vorm heeft geen eigen lijst, en dat is met opzet: het besluit zegt al
+    /// wat het nodig heeft, en twee lijsten zouden gaan afwijken.
+    fn form(&self, action: &ActionDefinition) -> Result<Vec<DocumentedParameter>> {
+        match &action.effect {
+            ActionEffect::Records(records) => Ok(records.fields.clone()),
+            ActionEffect::Decides(decides) => Ok(self
+                .cell(&decides.cell)?
+                .besluit_definition(&decides.besluit)?
+                .params),
+        }
+    }
+
+    /// Waarom deze actie nu niet kan; `None` als ze kan.
+    fn unavailable(&self, action: &ActionDefinition) -> Option<String> {
+        let condition = action.available_when.as_ref()?;
+        // Onbereikbaar: het optuigen heeft de cel van de voorwaarde al gevonden.
+        let cell = self.cells.get(&condition.cell)?;
+        if cell.has_fact(
+            &condition.chronicle,
+            &condition.field,
+            &condition.equals,
+            self.clock,
+        ) {
+            return None;
+        }
+        Some(condition.describe())
+    }
+
+    /// Eén cel van deze wereld, of de fout die zegt dat ze er niet is.
+    fn cell(&self, cell: &str) -> Result<&Cell> {
+        self.cells
+            .get(cell)
+            .ok_or_else(|| SimulatorError::UnknownCell {
+                cell: cell.to_string(),
+            })
     }
 
     /// Vraag een gepubliceerde lexostatus aan één cel, op één moment.
@@ -305,6 +967,12 @@ impl World {
     /// De wereld combineert niets. Ze zoekt de cel op en geeft het antwoord
     /// door zoals de cel het gaf; synthese over cellen heen hoort bij een
     /// consument (RFC-022 §4.1).
+    ///
+    /// Eerst de cel, dan het moment. Die volgorde is geen smaak: een vraag aan een
+    /// cel die niet bestaat is een andere fout dan een vraag over een moment dat
+    /// nog niet geweest is, en wie het moment vooropzet, noemt de onbekende cel in
+    /// een melding over de klok — en stuurt de lezer naar de verkeerde regel in het
+    /// bestand.
     pub fn reduce(
         &self,
         cell: &str,
@@ -312,6 +980,7 @@ impl World {
         params: &BTreeMap<String, Value>,
         op_moment: NaiveDate,
     ) -> Result<Lexostatus> {
+        let found = self.cell(cell)?;
         if op_moment > self.clock {
             return Err(SimulatorError::MomentAfterClock {
                 cell: cell.to_string(),
@@ -321,12 +990,7 @@ impl World {
                 clock: self.clock.to_string(),
             });
         }
-        self.cells
-            .get(cell)
-            .ok_or_else(|| SimulatorError::UnknownCell {
-                cell: cell.to_string(),
-            })?
-            .reduce(lexostatus, params, op_moment)
+        found.reduce(lexostatus, params, op_moment)
     }
 
     /// Laat één cel een besluit nemen, op één moment.
@@ -357,6 +1021,30 @@ impl World {
         params: &BTreeMap<String, Value>,
         op_moment: NaiveDate,
     ) -> Result<DecisionRecord> {
+        self.decide_and_settle(cell, besluit, params, op_moment)
+            .map(|(record, _)| record)
+    }
+
+    /// Hetzelfde besluit, met wat de verplichtingen eruit meteen opleverden.
+    ///
+    /// Apart van [`Self::decide`], omdat die twee verschillende vragen
+    /// beantwoorden: een aanroeper die een besluit *neemt* wil het gram, en een
+    /// aanroeper die een **actie** uitvoert wil weten wat er in die ene stap
+    /// allemaal gebeurde — inclusief de eerste termijn, die op het moment van het
+    /// besluit al vervalt.
+    fn decide_and_settle(
+        &mut self,
+        cell: &str,
+        besluit: &str,
+        params: &BTreeMap<String, Value>,
+        op_moment: NaiveDate,
+    ) -> Result<(DecisionRecord, Events)> {
+        // Eerst de cel, dan het moment: zie [`Self::reduce`].
+        if !self.cells.contains_key(cell) {
+            return Err(SimulatorError::UnknownCell {
+                cell: cell.to_string(),
+            });
+        }
         if op_moment > self.clock {
             return Err(SimulatorError::MomentAfterClock {
                 cell: cell.to_string(),
@@ -373,6 +1061,7 @@ impl World {
         // cel is tijdens haar eigen besluit onbereikbaar voor het transport —
         // een cel die zichzelf over de grens bevraagt is hier geen afspraak maar
         // een lege plek.
+        // Onbereikbaar leeg: het bestaan van de cel is hierboven al vastgesteld.
         let Some(mut deciding) = self.cells.remove(cell) else {
             return Err(SimulatorError::UnknownCell {
                 cell: cell.to_string(),
@@ -422,12 +1111,44 @@ impl World {
         for due in &decretogram.obligations {
             self.plan(due.vervaldatum, Trigger::Obligation(due.clone()));
         }
-        self.fire_due(self.clock)?;
+        let events = self.fire_due(self.clock)?;
 
-        Ok(DecisionRecord {
-            decretogram,
-            crossings: bridge.crossings(),
-        })
+        // Welke instellingen dit besluit gebruikte, staan daarmee vast. Dat moet
+        // hier, bij het besluit dat gelukt is: een besluit dat omviel heeft niets
+        // vastgelegd en hoeft dus niets vast te zetten.
+        for setting in self.settings_of(cell, besluit) {
+            self.used_settings
+                .insert(setting, (cell.to_string(), besluit.to_string()));
+        }
+
+        let crossings = bridge.crossings();
+        self.crossings.extend(crossings.iter().cloned());
+
+        Ok((
+            DecisionRecord {
+                decretogram,
+                crossings,
+            },
+            events,
+        ))
+    }
+
+    /// De instellingen waarop dit besluit leunde, uit het wereldbestand.
+    ///
+    /// Uit de definitie en niet uit het gram: het gram draagt het uitgerekende
+    /// schema, en daaruit is niet meer te zien of het ritme uit een instelling
+    /// kwam of letterlijk in de definitie stond. Een besluit dat de cel niet kent
+    /// kwam hier nooit, dus een leeg antwoord is hier geen stilte.
+    fn settings_of(&self, cell: &str, besluit: &str) -> Vec<String> {
+        self.definition
+            .cells
+            .iter()
+            .filter(|config| config.id == cell)
+            .flat_map(|config| &config.besluit_definitions)
+            .filter(|definition| definition.name == besluit)
+            .flat_map(BesluitDefinition::settings_used)
+            .map(str::to_string)
+            .collect()
     }
 
     /// Haal op wat het besluit van anderen nodig heeft, en laat de cel besluiten.
@@ -479,23 +1200,67 @@ impl World {
     /// Eén voor één van de kop af, en niet een hele kop in één keer weggehaald:
     /// valt een trigger om, dan blijven de triggers ná hem gewoon staan in
     /// plaats van met de fout te verdwijnen.
-    fn fire_due(&mut self, tot: NaiveDate) -> Result<()> {
+    fn fire_due(&mut self, tot: NaiveDate) -> Result<Events> {
+        let mut events = Events::default();
         while let Some((at, trigger)) = self.next_due(tot) {
             self.clock = self.clock.max(at);
             match trigger {
                 Trigger::Record(recording) => {
-                    let event = recording.event(at);
-                    let cell = self.cells.get_mut(&recording.cell).ok_or_else(|| {
-                        SimulatorError::UnknownCell {
-                            cell: recording.cell.clone(),
-                        }
-                    })?;
-                    cell.record(&recording.chronicle, event)?;
+                    events
+                        .recordings
+                        .push(self.apply_recording(&recording, at)?);
                 }
-                Trigger::Obligation(due) => self.settle(&due)?,
+                Trigger::Obligation(due) => events.recordings.extend(self.settle(&due)?),
+                Trigger::Deadline(index) => events.warnings.extend(self.check_deadline(index, at)),
             }
         }
-        Ok(())
+        self.warnings.extend(events.warnings.iter().cloned());
+        Ok(events)
+    }
+
+    /// Leg één vastlegging vast, in de cel en de stroom die ze noemt.
+    ///
+    /// Eén plek voor de weg naar de kroniek, want twee dingen komen hier uit: een
+    /// [`Fixture`] die de klok passeert, en een [`ActionDefinition`] die een actor
+    /// nu doet. Zouden die uit elkaar lopen, dan zou een actie een gram kunnen
+    /// leggen dat een startstand niet mag leggen.
+    fn apply_recording(&mut self, recording: &Recording, at: NaiveDate) -> Result<RecordedFact> {
+        let event = recording.event(at);
+        let cell =
+            self.cells
+                .get_mut(&recording.cell)
+                .ok_or_else(|| SimulatorError::UnknownCell {
+                    cell: recording.cell.clone(),
+                })?;
+        cell.record(&recording.chronicle, event.clone())?;
+        Ok(RecordedFact {
+            cell: recording.cell.clone(),
+            chronicle: recording.chronicle.clone(),
+            event,
+        })
+    }
+
+    /// Verstrijkt hier een termijn zonder dat het feit er ligt?
+    ///
+    /// Levert een waarschuwing en nooit een fout: de wet zegt wat de termijn was,
+    /// niet dat er daarna niets meer mag (zie [`Deadline`]). Ligt het feit er wel,
+    /// dan gebeurt er niets — een gehaalde termijn is geen gebeurtenis.
+    fn check_deadline(&self, index: usize, at: NaiveDate) -> Option<Warning> {
+        // Onbereikbaar leeg: de trigger is bij het optuigen op zijn index gezet.
+        let deadline = self.definition.deadlines.get(index)?;
+        let expected = &deadline.warn_if_missing;
+        // Onbereikbaar leeg: het optuigen heeft de cel al gevonden.
+        let cell = self.cells.get(&expected.cell)?;
+        if cell.has_recording_named(&expected.chronicle, &expected.name, at) {
+            return None;
+        }
+        Some(Warning {
+            label: deadline.label.clone(),
+            at,
+            cell: expected.cell.clone(),
+            chronicle: expected.chronicle.clone(),
+            name: expected.name.clone(),
+        })
     }
 
     /// Laat een vervallen termijn nakomen, aan beide kanten.
@@ -510,7 +1275,7 @@ impl World {
     /// volgnummer is dezelfde termijn, en die wordt één keer nagekomen. Is de
     /// betaler de besluitende cel zelf, dan blijft het bij de betaling: een
     /// melding aan jezelf over wat je zelf deed is geen tweede feit.
-    fn settle(&mut self, due: &ObligationDue) -> Result<()> {
+    fn settle(&mut self, due: &ObligationDue) -> Result<Vec<RecordedFact>> {
         let payer = self
             .cells
             .get_mut(&due.payer)
@@ -518,16 +1283,29 @@ impl World {
                 cell: due.payer.clone(),
             })?;
         if !payer.pay_obligation(due)? {
-            return Ok(());
+            return Ok(Vec::new());
         }
+        let mut facts = vec![RecordedFact {
+            cell: due.payer.clone(),
+            chronicle: BETALINGEN.to_string(),
+            event: due.payment_event(),
+        }];
 
-        self.cells
+        if self
+            .cells
             .get_mut(&due.decided_by)
             .ok_or_else(|| SimulatorError::UnknownCell {
                 cell: due.decided_by.clone(),
             })?
-            .note_obligation_paid(due)?;
-        Ok(())
+            .note_obligation_paid(due)?
+        {
+            facts.push(RecordedFact {
+                cell: due.decided_by.clone(),
+                chronicle: BETALINGEN.to_string(),
+                event: due.delivery_event(),
+            });
+        }
+        Ok(facts)
     }
 
     /// De volgende trigger die op of vóór `tot` valt, van de kop van de lijst.
@@ -662,6 +1440,168 @@ fn check_obligations(
     Ok(())
 }
 
+/// De vastleggingen die één `records`-actie voortbrengt.
+///
+/// Eén of twee: het gram bij de actor, en — als de actie levert — hetzelfde feit
+/// bij de ontvanger. Twee grammen en niet één gedeeld gram, want een kroniek
+/// draagt wat een cel zélf overkwam (RFC-022 §1.3): de aanvrager weet wat ze
+/// indiende, de ontvanger weet wat hem geleverd is.
+fn recordings_of(
+    action: &ActionDefinition,
+    records: &RecordsAction,
+    values: &BTreeMap<String, Value>,
+) -> Vec<Recording> {
+    let own = Recording {
+        cell: records.cell.clone(),
+        chronicle: records.chronicle.clone(),
+        name: records.name.clone(),
+        intake: records.intake,
+        grondslag: records.grondslag.clone(),
+        fields: values.clone(),
+    };
+    let Some(delivery) = &records.delivers_to else {
+        return vec![own];
+    };
+    let delivered = Recording {
+        cell: delivery.cell.clone(),
+        chronicle: delivery.chronicle.clone(),
+        name: delivery
+            .name
+            .clone()
+            .unwrap_or_else(|| records.name.clone()),
+        intake: delivery.intake,
+        // De grondslag van de ontvanger is niet die van de actor: hij legt vast
+        // dat een ander hem iets leverde, en de actie waarlangs dat gebeurde is
+        // precies wat daarvan te zeggen valt.
+        grondslag: format!(
+            "levering door cel '{}' met actie '{}'",
+            action.actor, action.id
+        ),
+        fields: values.clone(),
+    };
+    vec![own, delivered]
+}
+
+/// Toets de acties tegen de wereld waarin ze staan.
+///
+/// Alles wat een actie belooft, blijkt hier en niet bij de eerste aanroep: bestaat
+/// de actor, bestaat de cel, kan de stroom het gram dragen, bestaat het besluit,
+/// en gaat de voorwaarde over een veld dat bestaat. Een wereldbestand met een
+/// typfout in een actie hoort niet te laden.
+fn check_actions(actions: &[ActionDefinition], cells: &BTreeMap<String, Cell>) -> Result<()> {
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for action in actions {
+        if !seen.insert(action.id.as_str()) {
+            return Err(SimulatorError::DuplicateAction {
+                action: action.id.clone(),
+            });
+        }
+        if !cells.contains_key(&action.actor) {
+            return Err(SimulatorError::UnknownCell {
+                cell: action.actor.clone(),
+            });
+        }
+
+        match &action.effect {
+            ActionEffect::Records(records) => {
+                let fields: BTreeSet<String> = records
+                    .fields
+                    .iter()
+                    .map(|field| field.name.clone())
+                    .collect();
+                check_recordable(
+                    &action.id,
+                    &records.cell,
+                    &records.chronicle,
+                    &fields,
+                    cells,
+                )?;
+                if let Some(delivery) = &records.delivers_to {
+                    if delivery.cell == records.cell {
+                        return Err(SimulatorError::DeliveryToSelf {
+                            action: action.id.clone(),
+                            cell: delivery.cell.clone(),
+                        });
+                    }
+                    check_recordable(
+                        &action.id,
+                        &delivery.cell,
+                        &delivery.chronicle,
+                        &fields,
+                        cells,
+                    )?;
+                }
+            }
+            ActionEffect::Decides(decides) => {
+                cells
+                    .get(&decides.cell)
+                    .ok_or_else(|| SimulatorError::UnknownCell {
+                        cell: decides.cell.clone(),
+                    })?
+                    .besluit_definition(&decides.besluit)?;
+            }
+        }
+
+        if let Some(condition) = &action.available_when {
+            cells
+                .get(&condition.cell)
+                .ok_or_else(|| SimulatorError::UnknownCell {
+                    cell: condition.cell.clone(),
+                })?
+                .check_stream_field(
+                    Subject::Actie,
+                    &action.id,
+                    &condition.chronicle,
+                    &condition.field,
+                )?;
+        }
+    }
+    Ok(())
+}
+
+/// Kan deze cel het gram van deze actie dragen?
+///
+/// De cel weet waarom niet; de wereld weet welke actie het was. Hier komen die
+/// twee in één melding samen.
+fn check_recordable(
+    action: &str,
+    cell: &str,
+    chronicle: &str,
+    fields: &BTreeSet<String>,
+    cells: &BTreeMap<String, Cell>,
+) -> Result<()> {
+    cells
+        .get(cell)
+        .ok_or_else(|| SimulatorError::UnknownCell {
+            cell: cell.to_string(),
+        })?
+        .check_recordable(chronicle, fields)
+        .map_err(|reason| SimulatorError::ActionRecording {
+            action: action.to_string(),
+            cell: cell.to_string(),
+            stream: chronicle.to_string(),
+            reason,
+        })
+}
+
+/// Toets de termijnen tegen de wereld waarin ze staan.
+///
+/// Een termijn die naar een cel of een stroom wijst die er niet is, waarschuwt
+/// altijd — over een feit dat nergens kon liggen. Dat hoort bij het optuigen te
+/// vallen, niet als een waarschuwing die niemand kan wegnemen.
+fn check_deadlines(deadlines: &[Deadline], cells: &BTreeMap<String, Cell>) -> Result<()> {
+    for deadline in deadlines {
+        let expected = &deadline.warn_if_missing;
+        let cell = cells
+            .get(&expected.cell)
+            .ok_or_else(|| SimulatorError::UnknownCell {
+                cell: expected.cell.clone(),
+            })?;
+        cell.check_stream(Subject::Termijn, &deadline.label, &expected.chronicle)?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -671,6 +1611,29 @@ mod tests {
     fn date(text: &str) -> NaiveDate {
         NaiveDate::parse_from_str(text, "%Y-%m-%d")
             .unwrap_or_else(|e| panic!("testdatum '{text}' moet leesbaar zijn: {e}"))
+    }
+
+    /// Een wereldbestand zonder acties en zonder termijnen.
+    ///
+    /// Die twee komen er per test bij die erover gaat; de tests hieronder gaan
+    /// over de klok, de triggers en de verplichtingen, en die hoeven niet elke
+    /// keer een leeg `actions:` op te schrijven.
+    fn definition(
+        cells: &[CellConfig],
+        clock_start: &str,
+        fixtures: &[Fixture],
+        settings: &BTreeMap<String, Value>,
+    ) -> WorldDefinition {
+        WorldDefinition {
+            clock: Clock {
+                start: date(clock_start),
+            },
+            cells: cells.to_vec(),
+            settings: settings.clone(),
+            fixtures: fixtures.to_vec(),
+            actions: Vec::new(),
+            deadlines: Vec::new(),
+        }
     }
 
     fn toeslagen() -> Vec<CellConfig> {
@@ -719,13 +1682,8 @@ lexostatus_definitions:
     }
 
     fn world(clock_start: &str, fixtures: &[Fixture]) -> World {
-        World::new(
-            &toeslagen(),
-            Clock {
-                start: date(clock_start),
-            },
-            fixtures,
-            &no_settings(),
+        World::from_definition(
+            &definition(&toeslagen(), clock_start, fixtures, &no_settings()),
             &regulation_root(),
         )
         .unwrap_or_else(|e| panic!("wereld moet op te tuigen zijn: {e}"))
@@ -954,13 +1912,13 @@ record:
 
     #[test]
     fn een_fixture_naar_een_onbekende_stroom_faalt_bij_het_optuigen() {
-        let err = World::new(
-            &toeslagen(),
-            Clock {
-                start: date("2024-01-01"),
-            },
-            &[fixture("2030-01-01", "betalingen", "GEEN")],
-            &no_settings(),
+        let err = World::from_definition(
+            &definition(
+                &toeslagen(),
+                "2024-01-01",
+                &[fixture("2030-01-01", "betalingen", "GEEN")],
+                &no_settings(),
+            ),
             &regulation_root(),
         )
         .expect_err("een stroom die de cel niet houdt hoort te falen");
@@ -1017,13 +1975,8 @@ besluit_definitions:
             },
         };
 
-        let err = World::new(
-            &[config],
-            Clock {
-                start: date("2024-01-01"),
-            },
-            &[verzonnen],
-            &no_settings(),
+        let err = World::from_definition(
+            &definition(&[config], "2024-01-01", &[verzonnen], &no_settings()),
             &regulation_root(),
         )
         .expect_err("een verzonnen decretogram hoort te falen");
@@ -1037,13 +1990,8 @@ besluit_definitions:
     fn een_fixture_naar_een_onbekende_cel_faalt_bij_het_optuigen() {
         let mut elders = fixture("2030-01-01", "relaties", "GEEN");
         elders.record.cell = "belastingdienst".to_string();
-        let err = World::new(
-            &toeslagen(),
-            Clock {
-                start: date("2024-01-01"),
-            },
-            &[elders],
-            &no_settings(),
+        let err = World::from_definition(
+            &definition(&toeslagen(), "2024-01-01", &[elders], &no_settings()),
             &regulation_root(),
         )
         .expect_err("een cel die de wereld niet kent hoort te falen");
@@ -1063,13 +2011,13 @@ besluit_definitions:
         for at in ["2023-01-01", "2030-01-01"] {
             let mut zonder_sleutel = fixture(at, "relaties", "GEEN");
             zonder_sleutel.record.fields.remove("bsn");
-            let err = World::new(
-                &toeslagen(),
-                Clock {
-                    start: date("2024-01-01"),
-                },
-                &[zonder_sleutel],
-                &no_settings(),
+            let err = World::from_definition(
+                &definition(
+                    &toeslagen(),
+                    "2024-01-01",
+                    &[zonder_sleutel],
+                    &no_settings(),
+                ),
                 &regulation_root(),
             )
             .expect_err("een vastlegging zonder sleutelveld hoort te falen");
@@ -1112,13 +2060,13 @@ lexostatus_definitions:
         )
         .unwrap_or_else(|e| panic!("testconfig moet parsen: {e}"));
 
-        let world = World::new(
-            &[config],
-            Clock {
-                start: date("2024-01-01"),
-            },
-            &[fixture("2023-01-01", "relaties", "HUWELIJK")],
-            &no_settings(),
+        let world = World::from_definition(
+            &definition(
+                &[config],
+                "2024-01-01",
+                &[fixture("2023-01-01", "relaties", "HUWELIJK")],
+                &no_settings(),
+            ),
             &regulation_root(),
         )
         .unwrap_or_else(|e| panic!("een wereld met dit kroniekfilter moet op te tuigen zijn: {e}"));
@@ -1239,13 +2187,13 @@ laws: []
         schedule: kwartaal";
 
     fn verplichting_wereld(schedule: &str, settings: &BTreeMap<String, Value>) -> Result<World> {
-        World::new(
-            &verplichting_configs(schedule, true),
-            Clock {
-                start: date("2024-01-01"),
-            },
-            &[],
-            settings,
+        World::from_definition(
+            &definition(
+                &verplichting_configs(schedule, true),
+                "2024-01-01",
+                &[],
+                settings,
+            ),
             &regulation_root(),
         )
     }
@@ -1398,13 +2346,8 @@ laws: []
         }];
         configs[0].besluit_definitions.push(tweede);
 
-        let mut world = World::new(
-            &configs,
-            Clock {
-                start: date("2024-01-01"),
-            },
-            &[],
-            &no_settings(),
+        let mut world = World::from_definition(
+            &definition(&configs, "2024-01-01", &[], &no_settings()),
             &regulation_root(),
         )
         .unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
@@ -1472,13 +2415,13 @@ laws: []
                 )]),
             },
         };
-        let mut world = World::new(
-            &verplichting_configs(KWARTAAL, true),
-            Clock {
-                start: date("2024-01-01"),
-            },
-            &[laat],
-            &no_settings(),
+        let mut world = World::from_definition(
+            &definition(
+                &verplichting_configs(KWARTAAL, true),
+                "2024-01-01",
+                &[laat],
+                &no_settings(),
+            ),
             &regulation_root(),
         )
         .unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
@@ -1554,13 +2497,13 @@ laws: []
     /// halverwege de tijdlijn. Dat hoort bij het optuigen te blijken.
     #[test]
     fn een_betaler_zonder_betalingsstroom_faalt_bij_het_optuigen() {
-        let err = World::new(
-            &verplichting_configs(KWARTAAL, false),
-            Clock {
-                start: date("2024-01-01"),
-            },
-            &[],
-            &no_settings(),
+        let err = World::from_definition(
+            &definition(
+                &verplichting_configs(KWARTAAL, false),
+                "2024-01-01",
+                &[],
+                &no_settings(),
+            ),
             &regulation_root(),
         )
         .expect_err("een betaler zonder betalingsstroom hoort te falen");
@@ -1611,6 +2554,561 @@ laws: []
         assert!(
             matches!(err, SimulatorError::ObligationBeforeDecision { .. }),
             "verwachtte ObligationBeforeDecision, kreeg {err}"
+        );
+    }
+
+    /// Een wereldbestand is los te lezen, en het weigert een typfout.
+    ///
+    /// Los, want een web-laag leest één wereldbestand en maakt er per sessie een
+    /// verse wereld uit; een scenario zet er alleen stappen bovenop. Weigert het
+    /// een typfout niet, dan valt een onbekend veld stil weg en doet een actie of
+    /// een termijn niets zonder dat iemand het merkt.
+    #[test]
+    fn een_wereldbestand_is_los_te_lezen_en_weigert_een_typfout() {
+        let yaml = |sleutel: &str| {
+            format!(
+                r"
+clock:
+  start: 2024-01-01
+cells:
+  - id: burger
+    laws: []
+    chronicles:
+      - stream: aanvragen
+        key: bsn
+{sleutel}:
+  - label: aanvraag ontvangen vóór 1 maart
+    at: 2024-03-01
+    warn_if_missing:
+      cell: burger
+      chronicle: aanvragen
+      name: aanvraag_ingediend
+"
+            )
+        };
+
+        let definition = WorldDefinition::from_yaml(&yaml("deadlines"))
+            .unwrap_or_else(|e| panic!("een wereldbestand moet los te lezen zijn: {e}"));
+        assert_eq!(definition.deadlines.len(), 1);
+        World::from_definition(&definition, &regulation_root())
+            .unwrap_or_else(|e| panic!("en op te tuigen: {e}"));
+
+        assert!(
+            WorldDefinition::from_yaml(&yaml("deadlnies")).is_err(),
+            "een typfout in een sleutel hoort te falen; anders doet de termijn niets"
+        );
+    }
+
+    /// Een termijn die naar een stroom wijst die de cel niet houdt, zou altijd
+    /// waarschuwen — over een feit dat nergens kon liggen. Dat hoort bij het
+    /// optuigen te vallen.
+    #[test]
+    fn een_termijn_naar_een_onbekende_stroom_faalt_bij_het_optuigen() {
+        let mut spec = definition(&actie_cellen(), "2024-01-01", &[], &no_settings());
+        spec.actions = vec![aanvraag_actie("")];
+        spec.deadlines = vec![Deadline {
+            label: "aanvraag op tijd".to_string(),
+            at: date("2024-03-01"),
+            warn_if_missing: ExpectedFact {
+                cell: "toeslagen".to_string(),
+                chronicle: "verantwoordingen".to_string(),
+                name: "verantwoording_ontvangen".to_string(),
+            },
+        }];
+        let err = World::from_definition(&spec, &regulation_root())
+            .expect_err("een stroom die de cel niet houdt hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownStream { .. }),
+            "verwachtte UnknownStream, kreeg {err}"
+        );
+    }
+
+    /// Een vraag aan een cel die niet bestaat, over een moment dat nog niet
+    /// geweest is.
+    ///
+    /// Twee dingen zijn er mis en er kan er maar één gemeld worden; het hoort de
+    /// cel te zijn. Andersom komt de onbekende cel in een melding over de klok te
+    /// staan — "cel 'belastingdienst' … ligt ná de klok" — en dan zoekt de lezer
+    /// een klokprobleem bij een cel die er niet is.
+    #[test]
+    fn een_onbekende_cel_gaat_voor_het_moment() {
+        let world = world("2024-01-01", &[]);
+        let err = world
+            .reduce(
+                "belastingdienst",
+                "toeslagpartnerschap",
+                &bsn(),
+                date("2024-06-01"),
+            )
+            .expect_err("een cel die de wereld niet kent hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownCell { .. }),
+            "verwachtte UnknownCell, kreeg {err}"
+        );
+    }
+
+    /// Twee bron-cellen en één actie: de aanvrager legt vast en levert.
+    ///
+    /// Bron-cellen, want een actie vraagt geen engine — en dan gaat deze
+    /// testgroep over wat een actie doet en niet over wat een wet uitrekent.
+    fn actie_cellen() -> Vec<CellConfig> {
+        let parse = |yaml: &str| -> CellConfig {
+            serde_yaml_ng::from_str(yaml)
+                .unwrap_or_else(|e| panic!("testconfig moet parsen: {e}\n{yaml}"))
+        };
+        vec![
+            parse(
+                r"
+id: burger
+laws: []
+chronicles:
+  - stream: aanvragen
+    key: bsn
+",
+            ),
+            parse(
+                r"
+id: toeslagen
+laws: []
+chronicles:
+  - stream: aanvragen
+    key: bsn
+lexostatus_definitions:
+  - name: ontvangen_aanvraag
+    inputs:
+      - name: bsn
+        type: string
+    outputs:
+      - jaar
+    reduction:
+      chronicle: aanvragen
+      key: bsn
+      latest: true
+",
+            ),
+        ]
+    }
+
+    /// De aanvraag-actie, met of zonder voorwaarde.
+    fn aanvraag_actie(available_when: &str) -> ActionDefinition {
+        let yaml = format!(
+            r"
+id: burger.aanvraag
+actor: burger
+label: Aanvraag indienen
+records:
+  cell: burger
+  chronicle: aanvragen
+  name: aanvraag_ingediend
+  intake: aanvraag
+  fields:
+    - name: bsn
+      type: string
+    - name: jaar
+      type: number
+  delivers_to:
+    cell: toeslagen
+    chronicle: aanvragen
+    name: aanvraag_ontvangen
+    intake: aanvraag
+{available_when}"
+        );
+        serde_yaml_ng::from_str(&yaml)
+            .unwrap_or_else(|e| panic!("testactie moet parsen: {e}\n{yaml}"))
+    }
+
+    /// Een wereld met die ene actie erin.
+    fn actie_wereld(available_when: &str) -> Result<World> {
+        let mut spec = definition(&actie_cellen(), "2024-01-01", &[], &no_settings());
+        spec.actions = vec![aanvraag_actie(available_when)];
+        World::from_definition(&spec, &regulation_root())
+    }
+
+    /// Het ingevulde formulier van de aanvraag-actie.
+    fn aanvraag_waarden() -> BTreeMap<String, Value> {
+        BTreeMap::from([
+            ("bsn".to_string(), Value::String("999993653".to_string())),
+            ("jaar".to_string(), Value::Int(2024)),
+        ])
+    }
+
+    /// Een actie met `delivers_to` legt hetzelfde feit twee keer vast: bij de
+    /// actor en bij de ontvanger, elk in een eigen kroniek met een eigen kanaal.
+    ///
+    /// Dat zijn twee grammen en niet één gedeeld gram. Zou er maar één komen, dan
+    /// zou één van de twee cellen iets moeten weten uit de kroniek van de ander —
+    /// en dat is precies wat deze opstelling onmogelijk hoort te maken.
+    #[test]
+    fn een_actie_legt_vast_bij_de_actor_en_levert_bij_de_ontvanger() {
+        let mut world =
+            actie_wereld("").unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+        let events = world
+            .act("burger.aanvraag", &aanvraag_waarden())
+            .unwrap_or_else(|e| panic!("de actie moet kunnen: {e}"));
+
+        assert_eq!(events.recordings.len(), 2, "twee grammen, twee kronieken");
+        assert_eq!(events.recordings[0].cell, "burger");
+        assert_eq!(events.recordings[1].cell, "toeslagen");
+        assert_eq!(
+            events.recordings[1].event.recording_actor, "toeslagen",
+            "de ontvanger legt op eigen naam vast, niet op naam van de aanvrager"
+        );
+        assert_eq!(
+            events.recordings[1].event.name, "aanvraag_ontvangen",
+            "bij de ontvanger heet het gram wat het wereldbestand zegt"
+        );
+        assert_eq!(
+            events.recordings[0].event.op_moment,
+            date("2024-01-01"),
+            "een actie gebeurt op de stand van de klok en niet op een eigen datum"
+        );
+
+        let params = BTreeMap::from([("bsn".to_string(), Value::String("999993653".to_string()))]);
+        let answer = world
+            .reduce(
+                "toeslagen",
+                "ontvangen_aanvraag",
+                &params,
+                date("2024-01-01"),
+            )
+            .unwrap_or_else(|e| panic!("de reductie moet slagen: {e}"));
+        assert_eq!(
+            answer
+                .values()
+                .and_then(|values| values.get("jaar"))
+                .cloned(),
+            Some(Value::Int(2024)),
+            "de geleverde waarde hoort bij de ontvanger terug te vinden te zijn"
+        );
+    }
+
+    /// Een actie die op een feit wacht, weigert leesbaar zolang dat feit er niet
+    /// is — en kan zodra het er is.
+    #[test]
+    fn een_actie_met_een_voorwaarde_kan_pas_als_het_feit_er_ligt() {
+        let voorwaarde = "available_when:
+  cell: toeslagen
+  chronicle: aanvragen
+  field: jaar
+  equals: 2024
+";
+        let mut world = actie_wereld(voorwaarde)
+            .unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+
+        let err = world
+            .act("burger.aanvraag", &aanvraag_waarden())
+            .expect_err("zonder het feit hoort de actie te weigeren");
+        let SimulatorError::ActionNotAvailable { reason, .. } = &err else {
+            panic!("verwachtte ActionNotAvailable, kreeg {err}");
+        };
+        assert!(
+            reason.contains("aanvragen") && reason.contains("jaar"),
+            "de weigering hoort te zeggen wat er nog niet ligt, kreeg: {reason}"
+        );
+        assert!(
+            !world
+                .snapshot()
+                .actions
+                .iter()
+                .any(|action| action.available),
+            "en het beeld hoort de actie als nog-niet-mogelijk te tonen"
+        );
+    }
+
+    /// Het formulier van een actie is een belofte, en dus even streng als de
+    /// gedocumenteerde parameters van een lexostatus: precies de velden die er
+    /// staan, van het type dat er staat.
+    #[test]
+    fn een_formulier_weigert_een_veld_dat_het_niet_documenteert() {
+        let mut world =
+            actie_wereld("").unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+
+        let mut erbij = aanvraag_waarden();
+        erbij.insert("toetsingsinkomen".to_string(), Value::Int(81000));
+        let err = world
+            .act("burger.aanvraag", &erbij)
+            .expect_err("een veld dat het formulier niet kent hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UndocumentedParameter { .. }),
+            "verwachtte UndocumentedParameter, kreeg {err}"
+        );
+
+        let mut verkeerd_type = aanvraag_waarden();
+        verkeerd_type.insert("jaar".to_string(), Value::String("2024".to_string()));
+        let err = world
+            .act("burger.aanvraag", &verkeerd_type)
+            .expect_err("een waarde van het verkeerde type hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::ParameterType { .. }),
+            "verwachtte ParameterType, kreeg {err}"
+        );
+    }
+
+    /// Een actie die vastlegt in een stroom die het sleutelveld niet uit haar
+    /// formulier kan krijgen, hoort bij het optuigen te vallen.
+    ///
+    /// Anders is de actie een knop die altijd stuk gaat, en dat merkt iemand pas
+    /// als hij erop drukt.
+    #[test]
+    fn een_actie_zonder_sleutelveld_in_haar_formulier_faalt_bij_het_optuigen() {
+        let mut actie = aanvraag_actie("");
+        let ActionEffect::Records(records) = &mut actie.effect else {
+            panic!("de testactie legt vast");
+        };
+        records.fields.retain(|field| field.name != "bsn");
+
+        let mut spec = definition(&actie_cellen(), "2024-01-01", &[], &no_settings());
+        spec.actions = vec![actie];
+        let err = World::from_definition(&spec, &regulation_root())
+            .expect_err("een formulier zonder het sleutelveld hoort te falen");
+        let SimulatorError::ActionRecording { reason, .. } = &err else {
+            panic!("verwachtte ActionRecording, kreeg {err}");
+        };
+        assert!(
+            reason.contains("bsn"),
+            "de melding hoort het sleutelveld te noemen, kreeg: {reason}"
+        );
+    }
+
+    /// Aan jezelf leveren wat je net zelf vastlegde, is geen tweede feit.
+    #[test]
+    fn een_levering_aan_de_eigen_cel_wordt_geweigerd() {
+        let mut actie = aanvraag_actie("");
+        let ActionEffect::Records(records) = &mut actie.effect else {
+            panic!("de testactie legt vast");
+        };
+        // Onbereikbaar leeg: de testactie levert. De actor legt hier vast in de
+        // kroniek van de ontvanger, zodat de twee kanten samenvallen zonder dat de
+        // lexostatus van de ontvanger haar veld kwijtraakt.
+        if let Some(delivery) = &mut records.delivers_to {
+            records.cell = delivery.cell.clone();
+        }
+
+        let mut spec = definition(&actie_cellen(), "2024-01-01", &[], &no_settings());
+        spec.actions = vec![actie];
+        let err = World::from_definition(&spec, &regulation_root())
+            .expect_err("leveren aan jezelf hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::DeliveryToSelf { .. }),
+            "verwachtte DeliveryToSelf, kreeg {err}"
+        );
+    }
+
+    /// Twee acties met hetzelfde id: de tweede zou de eerste stil schaduwen, want
+    /// een actie wordt op haar id aangeroepen.
+    #[test]
+    fn twee_acties_met_hetzelfde_id_worden_geweigerd() {
+        let mut spec = definition(&actie_cellen(), "2024-01-01", &[], &no_settings());
+        spec.actions = vec![aanvraag_actie(""), aanvraag_actie("")];
+        let err = World::from_definition(&spec, &regulation_root())
+            .expect_err("twee acties met hetzelfde id horen te falen");
+        assert!(
+            matches!(err, SimulatorError::DuplicateAction { .. }),
+            "verwachtte DuplicateAction, kreeg {err}"
+        );
+    }
+
+    /// Een actie die de wereld niet kent, is een fout die opsomt wat er wél is.
+    #[test]
+    fn een_onbekende_actie_noemt_de_acties_die_er_wel_zijn() {
+        let mut world =
+            actie_wereld("").unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+        let err = world
+            .act("burger.verantwoording", &aanvraag_waarden())
+            .expect_err("een actie die er niet is hoort te falen");
+        let SimulatorError::UnknownAction { known, .. } = &err else {
+            panic!("verwachtte UnknownAction, kreeg {err}");
+        };
+        assert_eq!(known, "burger.aanvraag");
+    }
+
+    /// Een verplichting met `schedule: $betalingsritme`, voor de tests over
+    /// instellingen.
+    const RITME_UIT_INSTELLING: &str = "      - amount: $hoogte_zorgtoeslag
+        payer: belastingdienst
+        schedule: $betalingsritme";
+
+    /// De instellingen van een wereld met één betalingsritme.
+    fn ritme(naam: &str) -> BTreeMap<String, Value> {
+        BTreeMap::from([(
+            "betalingsritme".to_string(),
+            Value::String(naam.to_string()),
+        )])
+    }
+
+    /// Een instelling mag om zolang er geen besluit op leunt, en daarna niet meer.
+    ///
+    /// Het gram legt vast waarop besloten is. Een ritme dat er achteraf onder
+    /// vandaan geschoven wordt, laat het gram iets anders zeggen dan er gebeurd
+    /// is — en dan is een decretogram niet meer terug te lezen.
+    #[test]
+    fn een_instelling_die_een_besluit_gebruikte_staat_vast() {
+        let mut world = verplichting_wereld(RITME_UIT_INSTELLING, &ritme("kwartaal"))
+            .unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+
+        world
+            .update_settings(&ritme("maand"))
+            .unwrap_or_else(|e| panic!("vóór het eerste besluit mag het ritme om: {e}"));
+        assert_eq!(
+            beslis(&mut world).obligations.len(),
+            12,
+            "de gewijzigde instelling hoort het besluit te sturen"
+        );
+
+        let err = world
+            .update_settings(&ritme("ineens"))
+            .expect_err("na het besluit hoort de instelling vast te staan");
+        let SimulatorError::SettingInUse {
+            setting, besluit, ..
+        } = &err
+        else {
+            panic!("verwachtte SettingInUse, kreeg {err}");
+        };
+        assert_eq!(setting, "betalingsritme");
+        assert_eq!(besluit, "zorgtoeslag_vaststelling");
+        assert!(
+            world
+                .snapshot()
+                .locked_settings
+                .contains_key("betalingsritme"),
+            "en het beeld hoort te laten zien dat deze knop niet meer om kan"
+        );
+    }
+
+    /// Een instelling die de wereld niet kent, wijzigen: dat is een knop die
+    /// niets doet, en een typfout ziet er precies zo uit.
+    #[test]
+    fn een_onbekende_instelling_wijzigen_wordt_geweigerd() {
+        let mut world = verplichting_wereld(RITME_UIT_INSTELLING, &ritme("kwartaal"))
+            .unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+        let wijziging = BTreeMap::from([(
+            "betalingsrtime".to_string(),
+            Value::String("maand".to_string()),
+        )]);
+        let err = world
+            .update_settings(&wijziging)
+            .expect_err("een instelling die niet bestaat hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownWorldSetting { .. }),
+            "verwachtte UnknownWorldSetting, kreeg {err}"
+        );
+    }
+
+    /// Een instelling die geen ritme is, hoort bij het wijzigen te vallen en niet
+    /// bij het eerstvolgende besluit dat erop leunt.
+    #[test]
+    fn een_instelling_wijzigen_naar_iets_dat_geen_ritme_is_wordt_geweigerd() {
+        let mut world = verplichting_wereld(RITME_UIT_INSTELLING, &ritme("kwartaal"))
+            .unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+        let err = world
+            .update_settings(&ritme("per_week"))
+            .expect_err("een ritme dat niet bestaat hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownSchedule { .. }),
+            "verwachtte UnknownSchedule, kreeg {err}"
+        );
+        assert_eq!(
+            world.snapshot().settings,
+            ritme("kwartaal"),
+            "een geweigerde wijziging hoort niets te veranderen"
+        );
+    }
+
+    /// Terugzetten is opnieuw beginnen, niet terugdraaien.
+    ///
+    /// De klok staat weer op haar startmoment, de besluiten zijn er niet meer, en
+    /// ook de instellingen zijn weer die van het bestand: wie ze wijzigde,
+    /// wijzigde de wereld en niet het bestand.
+    #[test]
+    fn reset_zet_de_wereld_terug_naar_de_startstand() {
+        let mut world = verplichting_wereld(RITME_UIT_INSTELLING, &ritme("kwartaal"))
+            .unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+        world
+            .update_settings(&ritme("maand"))
+            .unwrap_or_else(|e| panic!("het ritme mag hier nog om: {e}"));
+        beslis(&mut world);
+        world
+            .advance(date("2024-12-31"))
+            .unwrap_or_else(|e| panic!("de klok moet vooruit kunnen: {e}"));
+
+        world
+            .reset()
+            .unwrap_or_else(|e| panic!("de wereld moet terug te zetten zijn: {e}"));
+
+        assert_eq!(
+            world.now(),
+            date("2024-01-01"),
+            "de klok staat weer vooraan"
+        );
+        assert_eq!(
+            world.snapshot().settings,
+            ritme("kwartaal"),
+            "de instellingen zijn weer die van het bestand"
+        );
+        assert!(
+            world.snapshot().locked_settings.is_empty(),
+            "en er leunt weer geen besluit op"
+        );
+        assert_eq!(
+            betaald(&world, "belastingdienst", "2024-01-01"),
+            None,
+            "de betalingen van de vorige run zijn er niet meer"
+        );
+    }
+
+    /// Het beeld van de wereld draagt geen receipt.
+    ///
+    /// Het receipt van RFC-013 draagt wandkloktijd, en een beeld dat per run
+    /// verschilt is geen contract. Wat een lezer eraan had — de herkomst van elke
+    /// waarde waarop besloten is — staat er wél, per veld.
+    #[test]
+    fn het_beeld_draagt_geen_receipt_en_wel_de_herkomst_per_waarde() {
+        let mut world = verplichting_wereld(KWARTAAL, &no_settings())
+            .unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+        beslis(&mut world);
+
+        let snapshot = world.snapshot();
+        let grammen: Vec<&crate::snapshot::GramSnapshot> = snapshot
+            .cells
+            .iter()
+            .flat_map(|cell| &cell.chronicles)
+            .flat_map(|chronicle| &chronicle.grams)
+            .filter(|gram| gram.kind == crate::snapshot::GramKind::Decretogram)
+            .collect();
+        assert_eq!(
+            grammen.len(),
+            1,
+            "één besluit hoort één decretogram te zijn"
+        );
+
+        let gram = grammen[0];
+        assert!(
+            !gram.fields.contains_key(crate::cell::RECEIPT),
+            "het receipt hoort niet in het beeld te staan; velden: {:?}",
+            gram.fields.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            matches!(
+                gram.fields.get("is_verzekerde").map(|field| &field.origin),
+                Some(crate::snapshot::FieldOrigin::BesluitInput { .. })
+            ),
+            "een input hoort de herkomst te dragen die het gram vastlegde"
+        );
+        assert!(
+            matches!(
+                gram.fields
+                    .get("hoogte_zorgtoeslag")
+                    .map(|field| &field.origin),
+                Some(crate::snapshot::FieldOrigin::Computed { .. })
+            ),
+            "een uitkomst hoort als berekend door de regeling te verschijnen"
+        );
+        assert!(
+            matches!(
+                gram.fields.get(ZAAKKENMERK).map(|field| &field.origin),
+                Some(crate::snapshot::FieldOrigin::Besluit)
+            ),
+            "en een vast veld van het gram als zodanig"
         );
     }
 }

--- a/packages/simulator/src/world.rs
+++ b/packages/simulator/src/world.rs
@@ -310,6 +310,15 @@ pub struct DecidesAction {
 /// Met opzet klein. Dit is geen tweede reductietaal: er komt geen waarde naar
 /// buiten, alleen ja of nee, en de vraag gaat over de wereld en niet over een
 /// cel die een andere cel bevraagt.
+///
+/// [`Self::cell`] hoeft niet de actor te zijn — de wereld kent alle cellen en
+/// beantwoordt de vraag zelf, zoals ze ook het beeld van alle kronieken maakt.
+/// Twee dingen volgen daaruit, en het is beter ze hier te zeggen dan ze later te
+/// moeten uitleggen: dit is géén contact over een celgrens (het staat dus niet in
+/// het vraaggraf en niet in het observatielog), en het is ook geen weg waarlangs
+/// een cel iets te weten komt. Moet de actor zélf weten dat er iets gebeurd is,
+/// dan hoort dat als levering in zijn eigen kroniek te liggen — `delivers_to` —
+/// en dan wijst de voorwaarde naar die kroniek.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Availability {
@@ -1098,6 +1107,18 @@ impl World {
         // horen de contacten met de fout mee naar buiten.
         let decretogram = outcome?;
 
+        // Welke instellingen dit besluit gebruikte, staan daarmee vast. Hier, en
+        // niet verderop: het gram ligt nu in de kroniek, en van dat moment af zou
+        // een gewijzigd ritme het iets anders laten zeggen dan er gebeurd is. Gaat
+        // er hieronder alsnog iets om — een termijn die niet nagekomen kan worden —
+        // dan komt de fout naar buiten met het gram al vastgelegd, en dan hoort de
+        // instelling ook vast te staan. Een besluit dat omviel vóór het gram komt
+        // hier niet, dus een geslaagd besluit is de enige die iets vastzet.
+        for setting in self.settings_of(cell, besluit) {
+            self.used_settings
+                .insert(setting, (cell.to_string(), besluit.to_string()));
+        }
+
         // De verplichtingen uit dit besluit worden triggers. Een termijn die nu
         // al vervalt — en de eerste termijn valt op het moment van het besluit,
         // tenzij `from` anders zegt — gaat meteen af: de klok staat er al, dus
@@ -1112,14 +1133,6 @@ impl World {
             self.plan(due.vervaldatum, Trigger::Obligation(due.clone()));
         }
         let events = self.fire_due(self.clock)?;
-
-        // Welke instellingen dit besluit gebruikte, staan daarmee vast. Dat moet
-        // hier, bij het besluit dat gelukt is: een besluit dat omviel heeft niets
-        // vastgelegd en hoeft dus niets vast te zetten.
-        for setting in self.settings_of(cell, besluit) {
-            self.used_settings
-                .insert(setting, (cell.to_string(), besluit.to_string()));
-        }
 
         let crossings = bridge.crossings();
         self.crossings.extend(crossings.iter().cloned());
@@ -2630,9 +2643,13 @@ cells:
     /// cel te zijn. Andersom komt de onbekende cel in een melding over de klok te
     /// staan — "cel 'belastingdienst' … ligt ná de klok" — en dan zoekt de lezer
     /// een klokprobleem bij een cel die er niet is.
+    ///
+    /// Langs beide wegen naar een cel, want ze maken dezelfde keuze: een reductie
+    /// en een besluit toetsen eerst het bestaan van de cel en pas daarna het
+    /// moment.
     #[test]
     fn een_onbekende_cel_gaat_voor_het_moment() {
-        let world = world("2024-01-01", &[]);
+        let mut world = world("2024-01-01", &[]);
         let err = world
             .reduce(
                 "belastingdienst",
@@ -2643,7 +2660,20 @@ cells:
             .expect_err("een cel die de wereld niet kent hoort te falen");
         assert!(
             matches!(err, SimulatorError::UnknownCell { .. }),
-            "verwachtte UnknownCell, kreeg {err}"
+            "verwachtte UnknownCell bij een reductie, kreeg {err}"
+        );
+
+        let err = world
+            .decide(
+                "belastingdienst",
+                "zorgtoeslag_vaststelling",
+                &bsn(),
+                date("2024-06-01"),
+            )
+            .expect_err("een besluit bij een cel die er niet is hoort te falen");
+        assert!(
+            matches!(err, SimulatorError::UnknownCell { .. }),
+            "verwachtte UnknownCell bij een besluit, kreeg {err}"
         );
     }
 
@@ -3053,6 +3083,48 @@ records:
             betaald(&world, "belastingdienst", "2024-01-01"),
             None,
             "de betalingen van de vorige run zijn er niet meer"
+        );
+    }
+
+    /// Terugzetten levert hetzelfde beeld als een verse wereld uit hetzelfde
+    /// bestand — byte voor byte, in de vorm waarin dat beeld naar buiten gaat.
+    ///
+    /// `reset` belooft opnieuw beginnen, en dat is alleen waar als er niets van de
+    /// vorige run achterblijft: geen gram, geen betaling, geen contact over een
+    /// celgrens, geen waarschuwing en geen instelling die vast stond. Eén
+    /// vergelijking over het hele contract en niet een assertie per veld, want dat
+    /// laatste mist precies het veld dat iemand later toevoegt.
+    #[test]
+    fn reset_levert_hetzelfde_beeld_als_een_verse_wereld() {
+        let beeld = |world: &World| {
+            serde_json::to_string(&world.snapshot())
+                .unwrap_or_else(|e| panic!("het beeld moet naar JSON te schrijven zijn: {e}"))
+        };
+
+        let mut world = verplichting_wereld(RITME_UIT_INSTELLING, &ritme("kwartaal"))
+            .unwrap_or_else(|e| panic!("de wereld moet op te tuigen zijn: {e}"));
+        let vers = beeld(&world);
+
+        world
+            .update_settings(&ritme("maand"))
+            .unwrap_or_else(|e| panic!("het ritme mag hier nog om: {e}"));
+        beslis(&mut world);
+        world
+            .advance(date("2024-12-31"))
+            .unwrap_or_else(|e| panic!("de klok moet vooruit kunnen: {e}"));
+        assert_ne!(
+            beeld(&world),
+            vers,
+            "de run hoort het beeld te veranderen, anders bewijst deze test niets"
+        );
+
+        world
+            .reset()
+            .unwrap_or_else(|e| panic!("de wereld moet terug te zetten zijn: {e}"));
+        assert_eq!(
+            beeld(&world),
+            vers,
+            "na het terugzetten hoort het beeld dat van een verse wereld te zijn"
         );
     }
 

--- a/packages/simulator/tests/fixtures/snapshot.json
+++ b/packages/simulator/tests/fixtures/snapshot.json
@@ -1,0 +1,1085 @@
+{
+  "clock": "2025-02-01",
+  "settings": {
+    "betalingsritme": "kwartaal"
+  },
+  "locked_settings": {
+    "betalingsritme": {
+      "cell": "toeslagen",
+      "besluit": "zorgtoeslag_toekenning"
+    }
+  },
+  "cells": [
+    {
+      "id": "belastingdienst",
+      "laws": [],
+      "lexostatussen": [
+        "betaald_tot_nu_toe",
+        "toetsingsinkomen"
+      ],
+      "besluiten": [],
+      "chronicles": [
+        {
+          "stream": "aanslagen",
+          "key": "bsn",
+          "grams": [
+            {
+              "kind": "decretogram",
+              "name": "aanslag_vastgesteld",
+              "intake": "eigen_besluit",
+              "recording_actor": "belastingdienst",
+              "grondslag": "Wet inkomstenbelasting 2001, hoofdstuk 2",
+              "op_moment": "2024-03-01",
+              "fields": {
+                "bsn": {
+                  "value": "999993653",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "eigen_besluit",
+                    "grondslag": "Wet inkomstenbelasting 2001, hoofdstuk 2"
+                  }
+                },
+                "competent_authority": {
+                  "value": "Belastingdienst",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "eigen_besluit",
+                    "grondslag": "Wet inkomstenbelasting 2001, hoofdstuk 2"
+                  }
+                },
+                "toetsingsinkomen": {
+                  "value": 81000,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "eigen_besluit",
+                    "grondslag": "Wet inkomstenbelasting 2001, hoofdstuk 2"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "decretogram",
+              "name": "aanslag_herzien",
+              "intake": "eigen_besluit",
+              "recording_actor": "belastingdienst",
+              "grondslag": "Wet inkomstenbelasting 2001, hoofdstuk 2",
+              "op_moment": "2024-12-01",
+              "fields": {
+                "bsn": {
+                  "value": "999993653",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "eigen_besluit",
+                    "grondslag": "Wet inkomstenbelasting 2001, hoofdstuk 2"
+                  }
+                },
+                "competent_authority": {
+                  "value": "Belastingdienst",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "eigen_besluit",
+                    "grondslag": "Wet inkomstenbelasting 2001, hoofdstuk 2"
+                  }
+                },
+                "toetsingsinkomen": {
+                  "value": 85000,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "eigen_besluit",
+                    "grondslag": "Wet inkomstenbelasting 2001, hoofdstuk 2"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "stream": "betalingen",
+          "key": "zaakkenmerk",
+          "grams": [
+            {
+              "kind": "executogram",
+              "name": "betaling",
+              "intake": "betaling",
+              "recording_actor": "belastingdienst",
+              "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 1 van 4",
+              "op_moment": "2024-04-01",
+              "fields": {
+                "bedrag": {
+                  "value": 49294,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 1 van 4"
+                  }
+                },
+                "besluit": {
+                  "value": "zorgtoeslag_toekenning",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 1 van 4"
+                  }
+                },
+                "besluit_cel": {
+                  "value": "toeslagen",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 1 van 4"
+                  }
+                },
+                "besluit_op_moment": {
+                  "value": "2024-04-01",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 1 van 4"
+                  }
+                },
+                "volgnummer": {
+                  "value": 1,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 1 van 4"
+                  }
+                },
+                "zaakkenmerk": {
+                  "value": "zorgtoeslag/999993653",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 1 van 4"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "executogram",
+              "name": "betaling",
+              "intake": "betaling",
+              "recording_actor": "belastingdienst",
+              "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 2 van 4",
+              "op_moment": "2024-07-01",
+              "fields": {
+                "bedrag": {
+                  "value": 49294,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 2 van 4"
+                  }
+                },
+                "besluit": {
+                  "value": "zorgtoeslag_toekenning",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 2 van 4"
+                  }
+                },
+                "besluit_cel": {
+                  "value": "toeslagen",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 2 van 4"
+                  }
+                },
+                "besluit_op_moment": {
+                  "value": "2024-04-01",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 2 van 4"
+                  }
+                },
+                "volgnummer": {
+                  "value": 2,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 2 van 4"
+                  }
+                },
+                "zaakkenmerk": {
+                  "value": "zorgtoeslag/999993653",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 2 van 4"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "executogram",
+              "name": "betaling",
+              "intake": "betaling",
+              "recording_actor": "belastingdienst",
+              "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 3 van 4",
+              "op_moment": "2024-10-01",
+              "fields": {
+                "bedrag": {
+                  "value": 49294,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 3 van 4"
+                  }
+                },
+                "besluit": {
+                  "value": "zorgtoeslag_toekenning",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 3 van 4"
+                  }
+                },
+                "besluit_cel": {
+                  "value": "toeslagen",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 3 van 4"
+                  }
+                },
+                "besluit_op_moment": {
+                  "value": "2024-04-01",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 3 van 4"
+                  }
+                },
+                "volgnummer": {
+                  "value": 3,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 3 van 4"
+                  }
+                },
+                "zaakkenmerk": {
+                  "value": "zorgtoeslag/999993653",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 3 van 4"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "executogram",
+              "name": "betaling",
+              "intake": "betaling",
+              "recording_actor": "belastingdienst",
+              "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 4 van 4",
+              "op_moment": "2025-01-01",
+              "fields": {
+                "bedrag": {
+                  "value": 49296.01,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 4 van 4"
+                  }
+                },
+                "besluit": {
+                  "value": "zorgtoeslag_toekenning",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 4 van 4"
+                  }
+                },
+                "besluit_cel": {
+                  "value": "toeslagen",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 4 van 4"
+                  }
+                },
+                "besluit_op_moment": {
+                  "value": "2024-04-01",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 4 van 4"
+                  }
+                },
+                "volgnummer": {
+                  "value": 4,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 4 van 4"
+                  }
+                },
+                "zaakkenmerk": {
+                  "value": "zorgtoeslag/999993653",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "betaling",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 4 van 4"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "burger",
+      "laws": [],
+      "lexostatussen": [
+        "ingediende_aanvraag"
+      ],
+      "besluiten": [],
+      "chronicles": [
+        {
+          "stream": "aanvragen",
+          "key": "bsn",
+          "grams": [
+            {
+              "kind": "executogram",
+              "name": "aanvraag_ingediend",
+              "intake": "aanvraag",
+              "recording_actor": "burger",
+              "grondslag": "Awir art. 15",
+              "op_moment": "2024-01-10",
+              "fields": {
+                "bsn": {
+                  "value": "999993653",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "aanvraag",
+                    "grondslag": "Awir art. 15"
+                  }
+                },
+                "jaar": {
+                  "value": 2024,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "aanvraag",
+                    "grondslag": "Awir art. 15"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "toeslagen",
+      "laws": [
+        "wet_op_de_zorgtoeslag",
+        "algemene_wet_inkomensafhankelijke_regelingen",
+        "regeling_standaardpremie"
+      ],
+      "lexostatussen": [
+        "betaald_tot_nu_toe",
+        "ontvangen_aanvraag",
+        "zorgtoeslagbeschikking"
+      ],
+      "besluiten": [
+        "zorgtoeslag_toekenning",
+        "zorgtoeslag_vaststelling"
+      ],
+      "chronicles": [
+        {
+          "stream": "aanvragen",
+          "key": "bsn",
+          "grams": [
+            {
+              "kind": "executogram",
+              "name": "aanvraag_ontvangen",
+              "intake": "aanvraag",
+              "recording_actor": "toeslagen",
+              "grondslag": "levering door cel 'burger' met actie 'burger.aanvraag'",
+              "op_moment": "2024-01-10",
+              "fields": {
+                "bsn": {
+                  "value": "999993653",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "aanvraag",
+                    "grondslag": "levering door cel 'burger' met actie 'burger.aanvraag'"
+                  }
+                },
+                "jaar": {
+                  "value": 2024,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "aanvraag",
+                    "grondslag": "levering door cel 'burger' met actie 'burger.aanvraag'"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "stream": "relaties",
+          "key": "bsn",
+          "grams": [
+            {
+              "kind": "executogram",
+              "name": "relatie_gewijzigd",
+              "intake": "levering",
+              "recording_actor": "toeslagen",
+              "grondslag": "melding uit de basisregistratie personen",
+              "op_moment": "2023-01-01",
+              "fields": {
+                "bsn": {
+                  "value": "999993653",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "melding uit de basisregistratie personen"
+                  }
+                },
+                "partnerschap_type": {
+                  "value": "GEEN",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "melding uit de basisregistratie personen"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "stream": "inkomensleveringen",
+          "key": "bsn",
+          "grams": [
+            {
+              "kind": "executogram",
+              "name": "inkomenslevering",
+              "intake": "levering",
+              "recording_actor": "toeslagen",
+              "grondslag": "jaarlijkse inkomenslevering",
+              "op_moment": "2023-11-15",
+              "fields": {
+                "bsn": {
+                  "value": "999993653",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "jaarlijkse inkomenslevering"
+                  }
+                },
+                "is_verzekerde": {
+                  "value": true,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "jaarlijkse inkomenslevering"
+                  }
+                },
+                "vermogen": {
+                  "value": 0,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "jaarlijkse inkomenslevering"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "stream": "betalingen",
+          "key": "zaakkenmerk",
+          "grams": [
+            {
+              "kind": "executogram",
+              "name": "betaling_ontvangen_gemeld",
+              "intake": "levering",
+              "recording_actor": "toeslagen",
+              "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 1 van 4",
+              "op_moment": "2024-04-01",
+              "fields": {
+                "bedrag": {
+                  "value": 49294,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 1 van 4"
+                  }
+                },
+                "besluit": {
+                  "value": "zorgtoeslag_toekenning",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 1 van 4"
+                  }
+                },
+                "besluit_cel": {
+                  "value": "toeslagen",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 1 van 4"
+                  }
+                },
+                "besluit_op_moment": {
+                  "value": "2024-04-01",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 1 van 4"
+                  }
+                },
+                "volgnummer": {
+                  "value": 1,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 1 van 4"
+                  }
+                },
+                "zaakkenmerk": {
+                  "value": "zorgtoeslag/999993653",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 1 van 4"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "executogram",
+              "name": "betaling_ontvangen_gemeld",
+              "intake": "levering",
+              "recording_actor": "toeslagen",
+              "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 2 van 4",
+              "op_moment": "2024-07-01",
+              "fields": {
+                "bedrag": {
+                  "value": 49294,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 2 van 4"
+                  }
+                },
+                "besluit": {
+                  "value": "zorgtoeslag_toekenning",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 2 van 4"
+                  }
+                },
+                "besluit_cel": {
+                  "value": "toeslagen",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 2 van 4"
+                  }
+                },
+                "besluit_op_moment": {
+                  "value": "2024-04-01",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 2 van 4"
+                  }
+                },
+                "volgnummer": {
+                  "value": 2,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 2 van 4"
+                  }
+                },
+                "zaakkenmerk": {
+                  "value": "zorgtoeslag/999993653",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 2 van 4"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "executogram",
+              "name": "betaling_ontvangen_gemeld",
+              "intake": "levering",
+              "recording_actor": "toeslagen",
+              "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 3 van 4",
+              "op_moment": "2024-10-01",
+              "fields": {
+                "bedrag": {
+                  "value": 49294,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 3 van 4"
+                  }
+                },
+                "besluit": {
+                  "value": "zorgtoeslag_toekenning",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 3 van 4"
+                  }
+                },
+                "besluit_cel": {
+                  "value": "toeslagen",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 3 van 4"
+                  }
+                },
+                "besluit_op_moment": {
+                  "value": "2024-04-01",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 3 van 4"
+                  }
+                },
+                "volgnummer": {
+                  "value": 3,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 3 van 4"
+                  }
+                },
+                "zaakkenmerk": {
+                  "value": "zorgtoeslag/999993653",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 3 van 4"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "executogram",
+              "name": "betaling_ontvangen_gemeld",
+              "intake": "levering",
+              "recording_actor": "toeslagen",
+              "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 4 van 4",
+              "op_moment": "2025-01-01",
+              "fields": {
+                "bedrag": {
+                  "value": 49296.01,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 4 van 4"
+                  }
+                },
+                "besluit": {
+                  "value": "zorgtoeslag_toekenning",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 4 van 4"
+                  }
+                },
+                "besluit_cel": {
+                  "value": "toeslagen",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 4 van 4"
+                  }
+                },
+                "besluit_op_moment": {
+                  "value": "2024-04-01",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 4 van 4"
+                  }
+                },
+                "volgnummer": {
+                  "value": 4,
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 4 van 4"
+                  }
+                },
+                "zaakkenmerk": {
+                  "value": "zorgtoeslag/999993653",
+                  "origin": {
+                    "herkomst": "recorded",
+                    "intake": "levering",
+                    "grondslag": "verplichting uit besluit 'zorgtoeslag_toekenning' van cel 'toeslagen' (2024-04-01), termijn 4 van 4"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "stream": "beschikkingen",
+          "key": "zaakkenmerk",
+          "grams": [
+            {
+              "kind": "decretogram",
+              "name": "zorgtoeslag_toekenning",
+              "intake": "eigen_besluit",
+              "recording_actor": "toeslagen",
+              "grondslag": "wet_op_de_zorgtoeslag (versie 2024-01-01)",
+              "op_moment": "2024-04-01",
+              "fields": {
+                "besluit": {
+                  "value": "zorgtoeslag_toekenning",
+                  "origin": {
+                    "herkomst": "besluit"
+                  }
+                },
+                "bsn": {
+                  "value": "999993653",
+                  "origin": {
+                    "herkomst": "besluit_input",
+                    "recorded_origin": {
+                      "herkomst": "parameter",
+                      "parameter": "bsn"
+                    }
+                  }
+                },
+                "competent_authority": {
+                  "value": "Dienst Toeslagen",
+                  "origin": {
+                    "herkomst": "besluit"
+                  }
+                },
+                "heeft_recht_op_zorgtoeslag": {
+                  "value": true,
+                  "origin": {
+                    "herkomst": "computed",
+                    "regulation": "wet_op_de_zorgtoeslag"
+                  }
+                },
+                "hoogte_zorgtoeslag": {
+                  "value": 197178.01,
+                  "origin": {
+                    "herkomst": "computed",
+                    "regulation": "wet_op_de_zorgtoeslag"
+                  }
+                },
+                "is_verzekerde": {
+                  "value": true,
+                  "origin": {
+                    "herkomst": "besluit_input",
+                    "recorded_origin": {
+                      "chronicle": "inkomensleveringen",
+                      "field": "is_verzekerde",
+                      "herkomst": "eigen_kroniek",
+                      "op_moment": "2023-11-15"
+                    }
+                  }
+                },
+                "legal_character": {
+                  "value": "BESCHIKKING",
+                  "origin": {
+                    "herkomst": "besluit"
+                  }
+                },
+                "obligations": {
+                  "value": [
+                    {
+                      "bedrag": 49294,
+                      "payer": "belastingdienst",
+                      "schedule": "kwartaal",
+                      "vervaldatum": "2024-04-01",
+                      "volgnummer": 1
+                    },
+                    {
+                      "bedrag": 49294,
+                      "payer": "belastingdienst",
+                      "schedule": "kwartaal",
+                      "vervaldatum": "2024-07-01",
+                      "volgnummer": 2
+                    },
+                    {
+                      "bedrag": 49294,
+                      "payer": "belastingdienst",
+                      "schedule": "kwartaal",
+                      "vervaldatum": "2024-10-01",
+                      "volgnummer": 3
+                    },
+                    {
+                      "bedrag": 49296.01,
+                      "payer": "belastingdienst",
+                      "schedule": "kwartaal",
+                      "vervaldatum": "2025-01-01",
+                      "volgnummer": 4
+                    }
+                  ],
+                  "origin": {
+                    "herkomst": "besluit"
+                  }
+                },
+                "regulation": {
+                  "value": "wet_op_de_zorgtoeslag",
+                  "origin": {
+                    "herkomst": "besluit"
+                  }
+                },
+                "regulation_valid_from": {
+                  "value": "2024-01-01",
+                  "origin": {
+                    "herkomst": "besluit"
+                  }
+                },
+                "toetsingsinkomen": {
+                  "value": 81000,
+                  "origin": {
+                    "herkomst": "besluit_input",
+                    "recorded_origin": {
+                      "asked_by": "cel:toeslagen",
+                      "cell": "belastingdienst",
+                      "field": "toetsingsinkomen",
+                      "herkomst": "geaccepteerd",
+                      "lexostatus": "toetsingsinkomen",
+                      "op_moment": "2024-04-01",
+                      "signature": "GESIMULEERDE-ONDERTEKENING door cel:toeslagen"
+                    }
+                  }
+                },
+                "zaakkenmerk": {
+                  "value": "zorgtoeslag/999993653",
+                  "origin": {
+                    "herkomst": "besluit"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "decretogram",
+              "name": "zorgtoeslag_vaststelling",
+              "intake": "eigen_besluit",
+              "recording_actor": "toeslagen",
+              "grondslag": "wet_op_de_zorgtoeslag (versie 2024-01-01)",
+              "op_moment": "2024-12-15",
+              "fields": {
+                "besluit": {
+                  "value": "zorgtoeslag_vaststelling",
+                  "origin": {
+                    "herkomst": "besluit"
+                  }
+                },
+                "bsn": {
+                  "value": "999993653",
+                  "origin": {
+                    "herkomst": "besluit_input",
+                    "recorded_origin": {
+                      "herkomst": "parameter",
+                      "parameter": "bsn"
+                    }
+                  }
+                },
+                "competent_authority": {
+                  "value": "Dienst Toeslagen",
+                  "origin": {
+                    "herkomst": "besluit"
+                  }
+                },
+                "heeft_recht_op_zorgtoeslag": {
+                  "value": true,
+                  "origin": {
+                    "herkomst": "computed",
+                    "regulation": "wet_op_de_zorgtoeslag"
+                  }
+                },
+                "hoogte_zorgtoeslag": {
+                  "value": 197102.85,
+                  "origin": {
+                    "herkomst": "computed",
+                    "regulation": "wet_op_de_zorgtoeslag"
+                  }
+                },
+                "is_verzekerde": {
+                  "value": true,
+                  "origin": {
+                    "herkomst": "besluit_input",
+                    "recorded_origin": {
+                      "chronicle": "inkomensleveringen",
+                      "field": "is_verzekerde",
+                      "herkomst": "eigen_kroniek",
+                      "op_moment": "2023-11-15"
+                    }
+                  }
+                },
+                "legal_character": {
+                  "value": "BESCHIKKING",
+                  "origin": {
+                    "herkomst": "besluit"
+                  }
+                },
+                "obligations": {
+                  "value": [],
+                  "origin": {
+                    "herkomst": "besluit"
+                  }
+                },
+                "regulation": {
+                  "value": "wet_op_de_zorgtoeslag",
+                  "origin": {
+                    "herkomst": "besluit"
+                  }
+                },
+                "regulation_valid_from": {
+                  "value": "2024-01-01",
+                  "origin": {
+                    "herkomst": "besluit"
+                  }
+                },
+                "toetsingsinkomen": {
+                  "value": 85000,
+                  "origin": {
+                    "herkomst": "besluit_input",
+                    "recorded_origin": {
+                      "asked_by": "cel:toeslagen",
+                      "cell": "belastingdienst",
+                      "field": "toetsingsinkomen",
+                      "herkomst": "geaccepteerd",
+                      "lexostatus": "toetsingsinkomen",
+                      "op_moment": "2024-12-15",
+                      "signature": "GESIMULEERDE-ONDERTEKENING door cel:toeslagen"
+                    }
+                  }
+                },
+                "zaakkenmerk": {
+                  "value": "zorgtoeslag/999993653",
+                  "origin": {
+                    "herkomst": "besluit"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "id": "burger.aanvraag",
+      "actor": "burger",
+      "label": "Aanvraag zorgtoeslag indienen",
+      "doc": "De aanvrager legt vast wat zij indient, en levert hetzelfde feit aan de uitvoerder. Twee grammen, elk in een eigen kroniek.",
+      "effect": {
+        "soort": "records",
+        "cell": "burger",
+        "chronicle": "aanvragen",
+        "name": "aanvraag_ingediend",
+        "delivers_to": "toeslagen"
+      },
+      "form": [
+        {
+          "name": "bsn",
+          "type": "string"
+        },
+        {
+          "name": "jaar",
+          "type": "number"
+        }
+      ],
+      "available": true,
+      "unavailable_reason": null
+    },
+    {
+      "id": "toeslagen.toekenning",
+      "actor": "toeslagen",
+      "label": "Beslis op de aanvraag",
+      "doc": "Kan pas als er een aanvraag ligt.",
+      "effect": {
+        "soort": "decides",
+        "cell": "toeslagen",
+        "besluit": "zorgtoeslag_toekenning"
+      },
+      "form": [
+        {
+          "name": "bsn",
+          "type": "string"
+        }
+      ],
+      "available": true,
+      "unavailable_reason": null
+    },
+    {
+      "id": "toeslagen.vaststelling",
+      "actor": "toeslagen",
+      "label": "Stel de zorgtoeslag definitief vast",
+      "doc": "Kan pas als er een toekenning ligt.",
+      "effect": {
+        "soort": "decides",
+        "cell": "toeslagen",
+        "besluit": "zorgtoeslag_vaststelling"
+      },
+      "form": [
+        {
+          "name": "bsn",
+          "type": "string"
+        }
+      ],
+      "available": true,
+      "unavailable_reason": null
+    }
+  ],
+  "crossings": [
+    {
+      "asked_by": "cel:toeslagen",
+      "signature": "GESIMULEERDE-ONDERTEKENING door cel:toeslagen",
+      "params": {
+        "bsn": "999993653"
+      },
+      "answer": {
+        "cell": "belastingdienst",
+        "name": "toetsingsinkomen",
+        "op_moment": "2024-04-01",
+        "outcome": {
+          "established": {
+            "competent_authority": "Belastingdienst",
+            "toetsingsinkomen": 81000
+          }
+        }
+      }
+    },
+    {
+      "asked_by": "cel:toeslagen",
+      "signature": "GESIMULEERDE-ONDERTEKENING door cel:toeslagen",
+      "params": {
+        "bsn": "999993653"
+      },
+      "answer": {
+        "cell": "belastingdienst",
+        "name": "toetsingsinkomen",
+        "op_moment": "2024-12-15",
+        "outcome": {
+          "established": {
+            "competent_authority": "Belastingdienst",
+            "toetsingsinkomen": 85000
+          }
+        }
+      }
+    }
+  ],
+  "warnings": []
+}

--- a/packages/simulator/tests/invarianten.rs
+++ b/packages/simulator/tests/invarianten.rs
@@ -40,9 +40,19 @@ type Expected = fn(&InvariantFailure) -> bool;
 /// omdraaien, en dan is "dit scenario is groen" geen uitspraak meer. Wat er wél
 /// afgedwongen wordt, is dat de tabel volledig is — zie
 /// [`elke_negatieve_fixture_staat_in_de_tabel`].
-const FIXTURES: [(&str, &str, Expected, usize); 5] = [
+const FIXTURES: [(&str, &str, Expected, usize); 6] = [
     (
         "niet_gedeclareerde_call.yaml",
+        "I3",
+        |failure| matches!(failure, InvariantFailure::UndeclaredCall { .. }),
+        1,
+    ),
+    (
+        // Dezelfde schending langs de andere weg naar het besluit-pad: een actie
+        // lokt het besluit uit. Zou de gate alleen de rechtstreekse besluiten
+        // lezen, dan zou een wereldbestand elke celgrens over kunnen door een
+        // actie ervoor te zetten, en blijft deze fixture groen.
+        "actie_lokt_niet_gedeclareerde_call_uit.yaml",
         "I3",
         |failure| matches!(failure, InvariantFailure::UndeclaredCall { .. }),
         1,
@@ -201,15 +211,17 @@ fn de_negatieve_fixtures_halen_hun_gewone_verwachtingen_wel() {
         let run = run(&path);
 
         let gewone_fouten: Vec<String> = run
-            .decisions
+            .acts
             .iter()
             .map(|outcome| outcome.failures.len())
+            .chain(run.decisions.iter().map(|outcome| outcome.failures.len()))
             .chain(run.outcomes.iter().map(|outcome| outcome.failures.len()))
             .chain(
                 run.transport_outcomes
                     .iter()
                     .map(|outcome| outcome.failures.len()),
             )
+            .chain(std::iter::once(run.failures.len()))
             .filter(|count| *count > 0)
             .map(|count| count.to_string())
             .collect();
@@ -217,7 +229,8 @@ fn de_negatieve_fixtures_halen_hun_gewone_verwachtingen_wel() {
         assert!(
             gewone_fouten.is_empty(),
             "{name}: deze fixture hoort uitsluitend op een invariant te falen, niet op \
-             een verwachting bij een vraag of een besluit:\n{}",
+             een verwachting bij een actie, een besluit, een vraag of de run als \
+             geheel:\n{}",
             run.report()
         );
     }

--- a/packages/simulator/tests/snapshot.rs
+++ b/packages/simulator/tests/snapshot.rs
@@ -1,0 +1,251 @@
+//! Het beeld van de wereld, vastgepind als contract.
+//!
+//! `tests/fixtures/snapshot.json` is wat een frontend van deze crate te zien
+//! krijgt. Het staat in de repo en niet alleen in een assertie, om twee redenen:
+//! wie het contract wijzigt, ziet dat in de diff van zijn eigen pull request, en
+//! wie een frontend bouwt heeft een bestand om tegen te renderen zonder de crate
+//! te draaien.
+//!
+//! De fixture wordt hier **opnieuw opgebouwd** en dan vergeleken. Een fixture die
+//! alleen gelezen wordt, loopt achter zonder dat iemand het merkt; een fixture die
+//! alleen geschreven wordt, keurt elke wijziging goed. Bijwerken doe je met
+//! `UPDATE_SNAPSHOT=1`, en dan hoort de diff in de review te staan.
+
+use regelrecht_simulator::{regulation_root, GramKind, Scenario, ScenarioRun, Snapshot};
+use std::path::{Path, PathBuf};
+
+/// De wereld waaruit het contract komt: het volledige verhaal van de publieke
+/// wereld, met een aanvraag, een besluit, betalingen en een tweede besluit.
+///
+/// Dat scenario en niet een kleiner: een contract dat alleen een lege wereld dekt,
+/// zegt niets over de vorm van een decretogram, een verplichting of een contact
+/// over een celgrens.
+fn scenario_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("scenarios")
+        .join("toeslagen_volledig_verhaal.yaml")
+}
+
+fn fixture_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("snapshot.json")
+}
+
+/// Speel het scenario af.
+fn run() -> ScenarioRun {
+    let path = scenario_path();
+    let scenario = Scenario::load(&path).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    let run = scenario
+        .run(&regulation_root())
+        .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    assert!(run.passed(), "{}:\n{}", path.display(), run.report());
+    run
+}
+
+/// Het beeld dat uit die run volgde.
+fn snapshot() -> Snapshot {
+    run().snapshot
+}
+
+/// Het beeld als JSON, zoals het in de fixture staat.
+fn rendered() -> String {
+    let mut json = serde_json::to_string_pretty(&snapshot())
+        .unwrap_or_else(|e| panic!("het beeld moet naar JSON te schrijven zijn: {e}"));
+    json.push('\n');
+    json
+}
+
+#[test]
+fn de_fixture_is_het_beeld_van_de_publieke_wereld() {
+    let json = rendered();
+    let path = fixture_path();
+
+    if std::env::var_os("UPDATE_SNAPSHOT").is_some() {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .unwrap_or_else(|e| panic!("kan {} niet maken: {e}", parent.display()));
+        }
+        std::fs::write(&path, &json)
+            .unwrap_or_else(|e| panic!("kan {} niet schrijven: {e}", path.display()));
+    }
+
+    let stored = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("kan {} niet lezen: {e}", path.display()));
+    assert_eq!(
+        stored,
+        json,
+        "het beeld van de wereld wijkt af van {}. Is dat de bedoeling, draai dan \
+         `UPDATE_SNAPSHOT=1 cargo test -p regelrecht-simulator --test snapshot` en \
+         zet de diff in de review: dit is het contract naar de frontend.",
+        path.display()
+    );
+}
+
+/// Twee runs leveren hetzelfde beeld.
+///
+/// Een contract dat per run verschilt is geen contract. Dit is de reden dat het
+/// receipt van een decretogram er níet in staat: dat draagt wandkloktijd.
+#[test]
+fn twee_runs_leveren_hetzelfde_beeld() {
+    assert_eq!(
+        rendered(),
+        rendered(),
+        "het beeld hoort niet van de wandklok of van een willekeurige volgorde af \
+         te hangen"
+    );
+}
+
+/// Wat het beeld hoort te dragen, los van hoe het eruitziet.
+///
+/// Deze asserties staan naast de fixture en niet erin: een bijgewerkte fixture
+/// legt elke wijziging vast, ook een die iets weghaalt wat er hoort te zijn.
+#[test]
+fn het_beeld_draagt_de_cellen_de_grammen_en_de_herkomst() {
+    let snapshot = snapshot();
+
+    assert_eq!(
+        snapshot
+            .cells
+            .iter()
+            .map(|cell| cell.id.as_str())
+            .collect::<Vec<_>>(),
+        ["belastingdienst", "burger", "toeslagen"],
+        "elke cel van de wereld hoort in het beeld te staan"
+    );
+    assert!(
+        snapshot
+            .cells
+            .iter()
+            .any(|cell| cell.laws.is_empty() && !cell.chronicles.is_empty()),
+        "een bron-cel is aan haar lege wettenlijst te herkennen"
+    );
+
+    let grams: Vec<&regelrecht_simulator::GramSnapshot> = snapshot
+        .cells
+        .iter()
+        .flat_map(|cell| &cell.chronicles)
+        .flat_map(|chronicle| &chronicle.grams)
+        .collect();
+    let beschikkingen = snapshot
+        .cells
+        .iter()
+        .flat_map(|cell| &cell.chronicles)
+        .filter(|chronicle| chronicle.stream == "beschikkingen")
+        .flat_map(|chronicle| &chronicle.grams);
+    assert_eq!(
+        beschikkingen
+            .filter(|gram| gram.kind == GramKind::Decretogram)
+            .count(),
+        2,
+        "de twee besluiten van dit verhaal horen twee decretogrammen te zijn"
+    );
+    assert!(
+        grams.iter().any(|gram| gram.kind == GramKind::Executogram),
+        "en de leveringen en betalingen executogrammen"
+    );
+    assert!(
+        grams.iter().all(|gram| !gram.fields.is_empty()),
+        "elk gram hoort zijn velden te dragen"
+    );
+
+    // Het observatielog-materiaal: twee besluiten die elk één waarde accepteren,
+    // is precies twee contacten over een celgrens.
+    assert_eq!(
+        snapshot.crossings.len(),
+        2,
+        "twee geaccepteerde waarden horen twee contacten te zijn"
+    );
+    assert!(
+        snapshot
+            .crossings
+            .iter()
+            .all(|crossing| crossing.signature.contains("GESIMULEERDE")),
+        "en dat de ondertekening nep is, hoort in het beeld te staan"
+    );
+
+    // Elke actie staat erin, met haar formulier. Aan het eind van het verhaal kan
+    // alles, want elk feit waarop een actie wacht, ligt er dan.
+    assert_eq!(snapshot.actions.len(), 3);
+    assert!(
+        snapshot.actions.iter().all(|action| action.available),
+        "aan het eind van het verhaal kan elke actie"
+    );
+    assert!(
+        snapshot
+            .actions
+            .iter()
+            .all(|action| !action.form.is_empty() && !action.label.is_empty()),
+        "een actie zonder formulier of label is niet te tonen"
+    );
+
+    assert!(
+        snapshot.warnings.is_empty(),
+        "in dit verhaal is geen termijn gemist: {:?}",
+        snapshot.warnings
+    );
+    assert!(
+        snapshot.locked_settings.contains_key("betalingsritme"),
+        "het ritme is door een besluit gebruikt en staat daarmee vast"
+    );
+}
+
+/// De contacten in het beeld zijn dezelfde als die de invarianten-gate leest.
+///
+/// Twee wegen naar dezelfde rij bewijsstukken: de wereld bewaart wat elk besluit
+/// over de grens haalde, en de runner leidt zijn verkeer af uit de uitkomsten van
+/// zijn stappen. Zouden die uiteenlopen, dan zou het beeld een contact kunnen
+/// tonen dat de gate niet ziet — of, erger, de gate er een missen die wél gebeurde.
+/// Dat de acties in dit verhaal de besluiten uitlokken, maakt het juist scherp:
+/// een besluit via `act` moet in beide rijen staan.
+#[test]
+fn het_beeld_en_de_gate_zien_dezelfde_contacten() {
+    let run = run();
+    let gate: Vec<String> = run
+        .crossings()
+        .iter()
+        .map(|signed| {
+            format!(
+                "{} -> {}.{} op {}",
+                signed.asked_by, signed.answer.cell, signed.answer.name, signed.answer.op_moment
+            )
+        })
+        .collect();
+    let beeld: Vec<String> = run
+        .snapshot
+        .crossings
+        .iter()
+        .map(|crossing| {
+            format!(
+                "{} -> {}.{} op {}",
+                crossing.asked_by,
+                crossing.answer.cell,
+                crossing.answer.name,
+                crossing.answer.op_moment
+            )
+        })
+        .collect();
+
+    assert!(
+        !gate.is_empty(),
+        "dit verhaal gaat twee keer over een celgrens"
+    );
+    assert_eq!(
+        beeld, gate,
+        "het beeld van de wereld en de invarianten-gate horen dezelfde contacten \
+         te zien, in dezelfde volgorde"
+    );
+}
+
+/// Het receipt gaat niet mee, en dat is te zien aan de JSON zelf.
+///
+/// Via de tekst en niet via een veld, want het receipt is een geneste structuur:
+/// wie hem ooit alsnog meestuurt, zet er `"receipt"` in, waar dan ook.
+#[test]
+fn het_beeld_draagt_geen_receipt() {
+    assert!(
+        !rendered().contains("\"receipt\""),
+        "het receipt draagt wandkloktijd en hoort niet in het contract"
+    );
+}


### PR DESCRIPTION
De wereld is nu van buitenaf te besturen, en die besturing is **casusdata**. Het
wereldbestand kent twee nieuwe secties; `World` biedt er vijf ingangen op.

## Wat erbij komt

**`actions`** — wat een actor op de tijdlijn kan doen. Twee vormen, precies één per
actie:

- `records` legt een executogram vast in een eigen kroniek, met een formulier van
  gedocumenteerde velden. Staat er `delivers_to`, dan landt hetzelfde feit óók bij
  de ontvanger — als **tweede gram in diens eigen kroniek**, op diens naam, met
  diens kanaal. Dat is de eerlijke vorm van een aanvraag: de aanvrager weet wat ze
  indiende, de ontvanger weet wat hem geleverd is, en geen van beide leest de
  kroniek van de ander.
- `decides` start het besluit-pad van een cel. Het formulier is dan dat van het
  besluit zelf (zijn `params`); een tweede lijst ernaast zou daarvan gaan afwijken.

`available_when` is één simpele voorwaarde over een kroniek, zodat een actie kan
wachten tot het verhaal zover is zonder dat die volgorde in Rust komt te staan.

**`deadlines`** — termijnen die bij het passeren een waarschuwing geven als het
feit ontbreekt, en die **nooit blokkeren**. Dat is een standpunt: de wet zegt wat
de termijn was, niet dat er daarna niets meer mag. De waarschuwing valt op het
moment dat de termijn passeert en niet aan het eind van een run — een feit dat er
een dag later wél ligt, lag er op de termijn niet.

## De wereld besturen

`from_definition`, `act`, `advance`, `update_settings`, `reset` en `snapshot`.
Samen is dat wat een latere web-laag nodig heeft; HTTP en sessies zitten hier niet
in.

`update_settings` weigert een instelling te wijzigen die al door een besluit
gebruikt is. Het gram legt vast waarop besloten is, dus een ritme dat er achteraf
onder vandaan wordt geschoven laat het gram iets anders zeggen dan er gebeurd is.
`reset` begint opnieuw uit hetzelfde bestand in plaats van de geschiedenis terug te
draaien — een kroniek groeit en wijzigt nooit, dus "terug" bestaat niet.

`snapshot` is het contract naar een frontend (`serde`-`Serialize`): klok,
instellingen met wat er al vastligt, per cel haar kronieken met elk gram, de
**herkomst per waarde**, de acties met hun formulier en of ze nu kunnen, wat er over
een celgrens ging, en de waarschuwingen. Er staat geen casusnaam in — elk label komt
uit het wereldbestand. Het RFC-013-receipt gaat er níet in: dat draagt wandkloktijd,
en een beeld dat per run verschilt is geen contract. Wat een lezer eraan had, staat
er wel: een geaccepteerde waarde draagt bron, lexostatus, moment en ondertekening en
lijkt daarmee niet op een berekende.

## Scenario's

De runner kent `act`-stappen en `expect_warnings` (altijd afgerekend, ook als de
lijst niet in het bestand staat). Twee nieuwe wereldbestanden:

- `toeslagen_volledig_verhaal.yaml` — aanvraag, besluit, betalingen en een tweede
  besluit, volledig door acties gedreven. De belastingdienst herziet het
  toetsingsinkomen ná de toekenning, en het tweede besluit komt daardoor op een
  ander bedrag uit: het vraagt opnieuw bij de bron, want er is nergens een kopie.
- `termijn_gemist.yaml` — een te late aanvraag waarschuwt en landt alsnog.

`tests/fixtures/snapshot.json` is het beeld van die eerste wereld, door een test
opnieuw opgebouwd en vergeleken. Een test houdt dat beeld naast de invarianten-gate:
beide horen dezelfde contacten over de celgrens te zien, ook als een actie het
besluit uitlokt.

## Meegenomen

`World::reduce` en `World::decide` toetsen nu eerst of de cel bestaat en pas daarna
het moment. Andersom kwam een onbekende cel in een melding over de klok terecht, en
dat stuurt de lezer naar de verkeerde regel in het bestand.

## Gates

`just format`, `just lint`, `just build-check` en de hele testsuite van
`regelrecht-simulator` (198 tests) zijn groen.

Basis: `simulator-poc`, gerebased op de invarianten-gate.