### PR TITLE
feat: http-laag om de chronolexografie-simulator, met een wereld per browsersessie

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `packages/editor-api/` - Rust backend API for the editor frontend
 - `packages/corpus/` - Shared library for working with YAML regulation files
 - `packages/shared/` - Common types/utilities across packages
+- `packages/chrono-poc-web/` - HTTP-laag om de simulator: axum + OIDC, één `World` per browsersessie in geheugen, de wereld-API als JSON, geen database
 - `packages/simulator/` - Chronolexografie testopstelling (RFC-022): cellen met een privé kroniekstore, lexostatus-reducties, een veiligheidscontext plus `CellTransport` als enige weg over een celgrens, het test-only observatielog en een scenario-loader
 - `packages/tui/` - Terminal UI dashboard
 - `packages/grafana/` - Grafana monitoring with provisioned dashboards

--- a/Justfile
+++ b/Justfile
@@ -96,6 +96,20 @@ conformance:
 simulate SCENARIO='packages/simulator/scenarios/toeslagen_zorgtoeslag.yaml':
     cd packages && cargo run -q -p regelrecht-simulator --bin run-scenario -- {{justfile_directory()}}/{{SCENARIO}}
 
+# Start de chronolexografie-PoC lokaal, met de login UIT, op de publieke wereld.
+#
+# Poort 7160 en niet 8000: 8000 is wat de container binnen het cluster gebruikt,
+# 7100-7300 is wat de dev-container naar de host doorzet. Het corpus komt uit deze
+# checkout (REGULATION_PATH of `corpus/regulation`), de wereld uit
+# packages/simulator/worlds/. Een andere wereld is een ander pad in
+# CHRONO_POC_WORLD_SOURCE; een privécorpus is een `github:`-bron plus een token.
+# Zie packages/chrono-poc-web/README.md.
+[doc("Start de chronolexografie-PoC lokaal op http://localhost:7160")]
+chrono-poc WORLD='packages/simulator/worlds/publieke_wereld.yaml' PORT='7160':
+    cd packages && CHRONO_POC_PORT={{PORT}} \
+        CHRONO_POC_WORLD_SOURCE=local:{{justfile_directory()}}/{{WORLD}} \
+        cargo run -p regelrecht-chrono-poc-web --bin chrono-poc-web
+
 # Pins the deploy filters against the real cargo graph. Node's built-in test
 # runner, so no dependency for one file. Needs `cargo metadata`, not a build.
 [doc("Check the deploy filters against the real cargo dependency graph")]

--- a/Justfile
+++ b/Justfile
@@ -96,20 +96,6 @@ conformance:
 simulate SCENARIO='packages/simulator/scenarios/toeslagen_zorgtoeslag.yaml':
     cd packages && cargo run -q -p regelrecht-simulator --bin run-scenario -- {{justfile_directory()}}/{{SCENARIO}}
 
-# Start de chronolexografie-PoC lokaal, met de login UIT, op de publieke wereld.
-#
-# Poort 7160 en niet 8000: 8000 is wat de container binnen het cluster gebruikt,
-# 7100-7300 is wat de dev-container naar de host doorzet. Het corpus komt uit deze
-# checkout (REGULATION_PATH of `corpus/regulation`), de wereld uit
-# packages/simulator/worlds/. Een andere wereld is een ander pad in
-# CHRONO_POC_WORLD_SOURCE; een privécorpus is een `github:`-bron plus een token.
-# Zie packages/chrono-poc-web/README.md.
-[doc("Start de chronolexografie-PoC lokaal op http://localhost:7160")]
-chrono-poc WORLD='packages/simulator/worlds/publieke_wereld.yaml' PORT='7160':
-    cd packages && CHRONO_POC_PORT={{PORT}} \
-        CHRONO_POC_WORLD_SOURCE=local:{{justfile_directory()}}/{{WORLD}} \
-        cargo run -p regelrecht-chrono-poc-web --bin chrono-poc-web
-
 # Pins the deploy filters against the real cargo graph. Node's built-in test
 # runner, so no dependency for one file. Needs `cargo metadata`, not a build.
 [doc("Check the deploy filters against the real cargo dependency graph")]
@@ -281,19 +267,21 @@ build-chrono-poc:
     cd frontend-chrono-poc && npx vite build
 
 # Serveer de gebouwde frontend via de server: eerst de bundel, dan de server die
-# hem uitdeelt. De serverkant landt met zijn eigen wijziging; tot die er is zegt
-# deze opdracht wat er ontbreekt in plaats van een onleesbare cargo-fout.
-[doc("Serveer de gebouwde frontend van de testopstelling via de server")]
-chrono-poc: build-chrono-poc
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [ ! -d packages/chrono-poc-web ]; then
-        printf "De bundel staat in frontend-chrono-poc/dist.\n"
-        printf "De server (packages/chrono-poc-web) staat nog niet in deze boom; draai\n"
-        printf "ondertussen 'just dev-chrono-poc' voor de frontend met een proxy.\n"
-        exit 1
-    fi
-    cd packages && cargo run -p regelrecht-chrono-poc-web
+# hem uitdeelt.
+#
+# Poort 7160 en niet 8000: 8000 is wat de container binnen het cluster gebruikt,
+# 7100-7300 is wat de dev-container naar de host doorzet. Het corpus komt uit deze
+# checkout (REGULATION_PATH of `corpus/regulation`), de wereld uit
+# packages/simulator/worlds/. Een andere wereld is een ander pad in
+# CHRONO_POC_WORLD_SOURCE; een privécorpus is een `github:`-bron plus een token.
+# STATIC_DIR wijst naar de zojuist gebouwde bundel; zonder die regel zoekt de
+# server de bundel op de verkeerde plek. Zie packages/chrono-poc-web/README.md.
+[doc("Serveer de gebouwde frontend van de testopstelling via de server op http://localhost:7160")]
+chrono-poc WORLD='packages/simulator/worlds/publieke_wereld.yaml' PORT='7160': build-chrono-poc
+    cd packages && CHRONO_POC_PORT={{PORT}} \
+        CHRONO_POC_WORLD_SOURCE=local:{{justfile_directory()}}/{{WORLD}} \
+        STATIC_DIR={{justfile_directory()}}/frontend-chrono-poc/dist \
+        cargo run -p regelrecht-chrono-poc-web --bin chrono-poc-web
 
 # Alles wat de frontend van de testopstelling is: tests, de import-guard van het
 # ontwerpsysteem, en de bundel. Eén opdracht om te draaien voor je hem pusht.

--- a/frontend-demo/Dockerfile
+++ b/frontend-demo/Dockerfile
@@ -43,7 +43,7 @@ RUN set -eu; \
 # Trim workspace members to engine + law-model + shared. When adding a new
 # workspace member that this image does NOT build, add it here as well.
 RUN grep -qE '^members = \[$' Cargo.toml && \
-    sed -i '/"admin"/d; /"arch-extract"/d; /"auth"/d; /"corpus"/d; /"editor-api"/d; /"github"/d; /"harvester"/d; /"pipeline"/d; /"simulator"/d; /"tui"/d' Cargo.toml
+    sed -i '/"admin"/d; /"arch-extract"/d; /"auth"/d; /"chrono-poc-web"/d; /"corpus"/d; /"editor-api"/d; /"github"/d; /"harvester"/d; /"pipeline"/d; /"simulator"/d; /"tui"/d' Cargo.toml
 COPY packages/engine/ engine/
 COPY packages/law-model/ law-model/
 COPY packages/shared/ shared/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -52,7 +52,7 @@ RUN set -eu; \
 # When adding a new workspace member that this image does NOT build, add it
 # to this exclusion list as well; otherwise chef will fail to find its source.
 RUN grep -qE '^members = \[$' Cargo.toml && \
-    sed -i '/"admin"/d; /"arch-extract"/d; /"auth"/d; /"corpus"/d; /"editor-api"/d; /"github"/d; /"harvester"/d; /"pipeline"/d; /"simulator"/d; /"tui"/d' Cargo.toml
+    sed -i '/"admin"/d; /"arch-extract"/d; /"auth"/d; /"chrono-poc-web"/d; /"corpus"/d; /"editor-api"/d; /"github"/d; /"harvester"/d; /"pipeline"/d; /"simulator"/d; /"tui"/d' Cargo.toml
 COPY packages/engine/ engine/
 COPY packages/law-model/ law-model/
 COPY packages/shared/ shared/
@@ -116,7 +116,7 @@ COPY packages/Cargo.lock packages/Cargo.toml ./
 # When adding a new workspace member that this image does NOT build, add it
 # to this exclusion list as well; otherwise chef will fail to find its source.
 RUN grep -qE '^members = \[$' Cargo.toml && \
-    sed -i '/"admin"/d; /"arch-extract"/d; /"simulator"/d; /"tui"/d' Cargo.toml
+    sed -i '/"admin"/d; /"arch-extract"/d; /"chrono-poc-web"/d; /"simulator"/d; /"tui"/d' Cargo.toml
 COPY packages/auth/ auth/
 COPY packages/editor-api/ editor-api/
 COPY packages/corpus/ corpus/

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -1170,6 +1170,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1880,6 +1894,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -4029,6 +4049,36 @@ dependencies = [
  "tower-sessions-memory-store",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "regelrecht-chrono-poc-web"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "dashmap",
+ "flate2",
+ "http-body-util",
+ "regelrecht-auth",
+ "regelrecht-corpus",
+ "regelrecht-github",
+ "regelrecht-shared",
+ "regelrecht-simulator",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "time",
+ "tokio",
+ "tower",
+ "tower-http 0.7.1",
+ "tower-sessions",
+ "tower-sessions-memory-store",
+ "tracing",
+ "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "admin",
     "arch-extract",
     "auth",
+    "chrono-poc-web",
     "corpus",
     "editor-api",
     "engine",
@@ -62,6 +63,10 @@ sha2 = "0.10"
 sqlx = "0.8"
 strum = { version = "0.28", features = ["derive"] }
 subtle = "2"
+# Ook een runtime-dependency: chrono-poc-web haalt een corpus naar een
+# tijdelijke map en houdt de `TempDir` aan zolang het proces leeft, zodat hij
+# bij het afsluiten weer opgeruimd wordt.
+tempfile = "3"
 thiserror = "2.0"
 time = "0.3"
 tokio = "1"
@@ -77,7 +82,6 @@ walkdir = "2"
 # Test/dev deps.
 http-body-util = "0.1"
 pretty_assertions = "1.4"
-tempfile = "3"
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["postgres"] }
 tower = "0.5"

--- a/packages/admin/Dockerfile
+++ b/packages/admin/Dockerfile
@@ -42,7 +42,7 @@ COPY packages/Cargo.lock packages/Cargo.toml ./
 # When adding a new workspace member that this image does NOT build, add it
 # to this exclusion list as well; otherwise chef will fail to find its source.
 RUN grep -qE '^members = \[$' Cargo.toml && \
-    sed -i '/"arch-extract"/d; /"editor-api"/d; /"simulator"/d; /"tui"/d' Cargo.toml
+    sed -i '/"arch-extract"/d; /"chrono-poc-web"/d; /"editor-api"/d; /"simulator"/d; /"tui"/d' Cargo.toml
 COPY packages/admin/ admin/
 COPY packages/auth/ auth/
 COPY packages/corpus/ corpus/

--- a/packages/arch-extract/prose/crate-chrono-poc-web.md
+++ b/packages/arch-extract/prose/crate-chrono-poc-web.md
@@ -1,0 +1,19 @@
+---
+node: crate:chrono-poc-web
+fingerprint: d06e93de282db18a
+---
+**Wat.** De HTTP-laag om de chronolexografie-simulator: axum achter de bestaande
+OIDC-login, die bij het starten een wereldbestand en een regelingencorpus ophaalt
+en per browsersessie één `World` in geheugen houdt, opvraagbaar en bespeelbaar als
+JSON.
+
+**Waarom.** De simulator kent geen HTTP, geen sessie en geen casus, en dat hoort zo
+te blijven: de opstelling moet in `just test` kunnen draaien zonder server. Wat
+daar dan nog aan ontbreekt is dat een mens haar kan bespelen, en dat is precies
+wat deze crate toevoegt — elke route is één aanroep op `World`, er is geen
+database, en de casus zit in een wereldbestand dat uit de omgeving komt in plaats
+van in de code. Twee dingen bepalen de vorm: er is geen totaalbeeld om te bewaren
+(een wereld is een gedachte-experiment, geen dossier, dus sessies en werelden staan
+in geheugen), en een `World` is niet `Send` (een cel houdt haar engine in een
+`RefCell` met een `Rc` erin), dus elke sessie krijgt een eigen thread die haar
+wereld bezit in plaats van een slot om een gedeelde map.

--- a/packages/arch-extract/tests/model_validation.rs
+++ b/packages/arch-extract/tests/model_validation.rs
@@ -288,10 +288,11 @@ fn ids_of_kind(model: &Value, kind: &str) -> std::collections::BTreeSet<String> 
 fn frontend_apps_extracted() {
     let model = model();
 
-    // The four npm-workspace frontends appear as `app` containers.
+    // The five npm-workspace frontends appear as `app` containers.
     let apps = ids_of_kind(model, "app");
     let expected_apps: std::collections::BTreeSet<String> = [
         "app:frontend",
+        "app:frontend-chrono-poc",
         "app:frontend-demo",
         "app:frontend-lawmaking",
         "app:frontend-shared",
@@ -299,7 +300,7 @@ fn frontend_apps_extracted() {
     .iter()
     .map(|s| s.to_string())
     .collect();
-    assert_eq!(apps, expected_apps, "expected the four frontend apps");
+    assert_eq!(apps, expected_apps, "expected the five frontend apps");
 
     // Components (.vue) and composables (useXxx) are extracted, with lang set.
     let nodes = model["nodes"].as_array().expect("nodes array");

--- a/packages/arch-extract/tests/model_validation.rs
+++ b/packages/arch-extract/tests/model_validation.rs
@@ -97,6 +97,7 @@ fn product_crates_present() {
     let expected: std::collections::BTreeSet<String> = [
         "admin",
         "auth",
+        "chrono-poc-web",
         "corpus",
         "editor-api",
         "engine",

--- a/packages/chrono-poc-web/Cargo.toml
+++ b/packages/chrono-poc-web/Cargo.toml
@@ -1,0 +1,61 @@
+[package]
+name = "regelrecht-chrono-poc-web"
+version = "0.1.0"
+edition = "2021"
+authors = ["MinBZK <noreply@minbzk.nl>"]
+description = "HTTP-laag om de chronolexografie-simulator: een wereld per browsersessie, als JSON"
+license = "EUPL-1.2"
+repository = "https://github.com/MinBZK/regelrecht"
+homepage = "https://github.com/MinBZK/regelrecht"
+
+[lib]
+name = "regelrecht_chrono_poc_web"
+path = "src/lib.rs"
+
+[[bin]]
+name = "chrono-poc-web"
+path = "src/main.rs"
+
+[dependencies]
+regelrecht-simulator = { path = "../simulator" }
+regelrecht-auth = { path = "../auth" }
+# Voor het ophalen van een privérepo bij het starten: de domeinlaag
+# (`github::fetch_archive_to_dir`) plus de gedeelde tokenconventie
+# (`auth::CredentialResolver`). Geen tweede GitHub-client in deze crate.
+regelrecht-corpus = { path = "../corpus" }
+regelrecht-github = { path = "../github" }
+regelrecht-shared = { path = "../shared", features = ["telemetry"] }
+axum.workspace = true
+chrono.workspace = true
+# Eén wereld per sessie, en die werelden worden onafhankelijk van elkaar
+# aangeraakt: een map met een slot per shard in plaats van één slot om alles.
+dashmap = "6"
+# De OIDC-kant van de workspace staat op reqwest 0.12 (openidconnect pint die
+# versie); corpus en github staan op 0.13. Zie de notitie bij `reqwest` in
+# packages/Cargo.toml — dit binary draagt, net als admin en editor-api, beide.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots-no-provider", "json"] }
+serde.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
+time.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
+# `util` voor `ServiceExt::oneshot`: de SPA-fallback zet de statische service als
+# handler in, precies zoals editor-api.
+tower = { workspace = true, features = ["util"] }
+tower-http = { workspace = true, features = ["fs", "trace"] }
+tower-sessions.workspace = true
+tower-sessions-memory-store.workspace = true
+tracing.workspace = true
+uuid = { workspace = true, features = ["v4"] }
+
+[dev-dependencies]
+http-body-util.workspace = true
+# Om een GitHub-tarball te máken in de test die het ophalen bij het starten
+# nabootst. Inline zoals in `corpus`, de enige andere crate die ze gebruikt: het
+# zijn geen workspace-brede deps maar het gereedschap van één pad.
+flate2 = "1"
+tar = "0.4"
+wiremock.workspace = true
+
+[lints]
+workspace = true

--- a/packages/chrono-poc-web/README.md
+++ b/packages/chrono-poc-web/README.md
@@ -1,0 +1,147 @@
+# regelrecht-chrono-poc-web
+
+De HTTP-laag om [`regelrecht-simulator`](../simulator/README.md): één **wereld per
+browsersessie**, in geheugen, als JSON, achter de login van RegelRecht.
+
+Wat deze crate toevoegt is precies één ding: dat een mens de opstelling kan
+bespelen. De simulator kent geen HTTP, geen sessie en geen casus; hier komt daar
+een server om, en verder niets. Elke route is één aanroep op `World`, en er wordt
+nergens iets bijgehouden dat niet in een cel ligt.
+
+Lokaal starten (login uit, publieke wereld, corpus uit deze checkout):
+
+```bash
+just chrono-poc
+# → http://localhost:7160
+```
+
+## Drie keuzes die de vorm bepalen
+
+**Geen database.** De sessies staan in geheugen (`tower-sessions` `MemoryStore`)
+en de werelden ook. Dat betekent één replica en een herstart die alles wist, en
+dat is voor een opstelling om iets aan te tonen de juiste ruil: een wereld is een
+gedachte-experiment en geen dossier.
+
+**De casus zit niet in de code.** Het wereldbestand en de regelingen komen bij het
+starten uit een bron die de omgeving noemt — een pad op schijf of een repo met een
+token. Het image dat hieruit rolt bevat dus geen casusinhoud, en een andere casus
+is een andere env-variabele. Daarom staat de bron ook niet in
+`corpus-registry.yaml`: dat is een publiek bestand, en de naam van een privérepo
+hoort daar niet in.
+
+**Een wereld per thread.** Een `World` is niet `Send` — een cel houdt haar engine
+in een `RefCell` en die engine kan tijdens een besluit een `Rc<dyn CellResolver>`
+dragen. Een `DashMap<SessionId, World>` kan dus niet: axum wil zijn state
+`Send + Sync`. Elke sessie krijgt daarom een eigen thread die haar wereld bezit, en
+wat er in de map staat is de *greep* op die thread. Dat levert op wat een wereld in
+de map ook opgeleverd zou hebben — sessies raken elkaar niet — plus iets extra's:
+twee sessies wachten ook niet op elkaar, want ze delen geen slot. De prijs is een
+thread per actieve sessie, en de TTL van een uur is wat die prijs begrenst. Zie de
+moduledocs van `src/worlds.rs`.
+
+## Configuratie
+
+| variabele | wat |
+|---|---|
+| `CHRONO_POC_WORLD_SOURCE` | **verplicht.** `local:<pad>` of `github:<owner>/<repo>@<ref>:<pad>` naar het wereldbestand |
+| `CHRONO_POC_CORPUS_SOURCE` | de regelingenmap, dezelfde twee vormen. Afwezig: `REGULATION_PATH`, anders `corpus/regulation` in deze checkout |
+| `CHRONO_POC_AUTH_REF` | de sleutel waaronder het GitHub-token opgezocht wordt; standaard de reponaam van de bron |
+| `CHRONO_POC_REQUIRED_ROLE` | de rol waarachter `/api/*` staat; standaard `editor-reader` |
+| `CHRONO_POC_PORT` | de poort; standaard `8000` (de container). Lokaal 7100-7300 |
+| `STATIC_DIR` | de map met de gebouwde frontend; standaard `static` |
+| `OIDC_*`, `KEYCLOAK_*`, `BASE_URL` | de login, zoals in editor-api en admin. Zonder `OIDC_CLIENT_ID` staat de login **uit** en is elke route open — alleen lokaal |
+
+Het **token** volgt de conventie van de rest van de workspace:
+`CORPUS_AUTH_<SLUG>_TOKEN`, opgelost door
+`regelrecht_corpus::auth::CredentialResolver`. De slug is standaard de reponaam
+van de bron (`owner/mijn-corpus` → `CORPUS_AUTH_MIJN_CORPUS_TOKEN`), en
+`CHRONO_POC_AUTH_REF` kiest een kortere naam. De opzoeking is **strikt**: het
+gedeelde `CORPUS_GIT_TOKEN` van de harvester-tijd gaat nooit naar een repo die
+deze app aanwijst.
+
+Het opstarten **faalt luid**. Geen wereldbestand, geen leesbare wereld, geen
+regelingen of een ref die niet bestaat: het proces stopt met de reden. Een server
+die opkomt zonder wereld zou op elke healthcheck groen staan en op elk verzoek
+dezelfde fout geven.
+
+## De API
+
+Veldnamen Engels, meldingen Nederlands. De vorm van een antwoord is het contract
+dat `Snapshot` al vastlegt, en dat is Engels; elke fout die een mens leest komt uit
+de simulator, en die praat Nederlands.
+
+| route | wat |
+|---|---|
+| `GET /health` | leeft dit proces. Zonder login |
+| `GET /api/world` | het beeld: klok, instellingen, cellen met hun kronieken, de acties die nu kunnen, wat er over een celgrens ging, de waarschuwingen |
+| `POST /api/actions/{id}` | voer een actie uit; body = het formulier van die actie. Antwoord: `{ "snapshot": …, "events": … }` |
+| `POST /api/advance` | `{"until": "2024-04-01"}`; de triggers gaan onderweg af. Zelfde antwoord |
+| `GET /api/cells/{cel}/lexostatus/{naam}` | één reductie, alleen lezen. Parameters als queryparameters, `op_moment` optioneel |
+| `PUT /api/settings` | wijzig instellingen die nog niet vast staan |
+| `POST /api/reset` | terug naar de startstand uit het wereldbestand |
+
+Alles onder `/api/` staat achter de rol uit `CHRONO_POC_REQUIRED_ROLE`. De
+frontend komt uit `STATIC_DIR` met een SPA-fallback, zoals editor-api dat doet.
+
+### Parameters van een lexostatus
+
+De parameters komen als gewone queryparameters binnen en worden omgezet naar het
+type dat de lexostatus **documenteert**:
+
+```
+GET /api/cells/brp/lexostatus/partnerschap?bsn=999993653&op_moment=2024-06-01
+```
+
+`bsn` is daar tekst en geen getal, omdat de definitie `type: string` zegt. Zonder
+die omzetting zou elke waarde tekst zijn (en zou een filter op een getal nooit iets
+vinden) of elke cijferreeks een getal (en zou een BSN met een nul vooraan stil van
+waarde veranderen). De types worden uit het wereldbestand gelezen en niet aan de cel
+gevraagd: een consument vraagt een gepubliceerde naam, hij inspecteert geen cel
+(RFC-022 §4.1).
+
+`op_moment` is gereserveerd en optioneel; afwezig betekent "op de stand van de
+klok". Een moment ná de klok is een 409 — dat zou een voorspelling zijn.
+
+### Wat geen fout is
+
+- **"Niets vastgesteld"** is een antwoord met een reden: HTTP 200, met
+  `outcome.not_established`. Een cel die op het gevraagde moment geen feit had, is
+  niet stuk.
+- **Een actie die nu niet kan** is een 409 met de uitleg van de wereld erin: het
+  verhaal is nog niet zover, en dat is een stand en geen vergissing.
+- **Een verstreken termijn** is een waarschuwing in het antwoord en geen fout. De
+  uitvoerder mag alsnog besluiten; de wet zegt alleen wat de termijn was.
+
+Fouten zijn altijd `{"error": "…"}`. De status volgt de foutvariant van de
+simulator: 404 voor wat het pad aanwijst maar niet bestaat, 409 voor een wereld die
+er niet naar staat, 400 voor een verzoek dat niet klopt tegen wat een definitie
+belooft, 500 voor de rest. De hele afbeelding staat in `src/error.rs`.
+
+## Wereldbestanden
+
+Een **wereldbestand** is wat een wereld *is*: een klok, de cellen, de
+instellingen, de startstand, de acties en de termijnen. Een scenariobestand draagt
+zijn wereld in dezelfde velden inline en zet er een run overheen (`act`, `decide`,
+`queries`); dit is het omgekeerde — een wereld zonder run, om door een mens
+bespeeld te worden.
+
+De publieke wereld staat in
+[`packages/simulator/worlds/publieke_wereld.yaml`](../simulator/worlds/publieke_wereld.yaml)
+(`burger`, `brp`, `belastingdienst`, `toeslagen`) en is waar `just chrono-poc` en
+de tests van deze crate op draaien.
+
+## Tests
+
+`cargo test -p regelrecht-chrono-poc-web` draait mee in `just test`. De
+HTTP-tests draaien de **echte** router over die **echte** wereld en het echte
+corpus, met de login uit: het beeld, een actie, de klok vooruit, een besluit dat
+een waarde over een celgrens accepteert, instellingen, terugzetten, en twee sessies
+die twee werelden zijn. Een wereldbestand dat onleesbaar wordt, wordt hier rood en
+niet in een container.
+
+`tests/github_source.rs` doet hetzelfde voor het pad dat lokaal nooit aan bod komt:
+een wiremock-GitHub in plaats van de echte (via de `GITHUB_API_BASE`-naad van
+`regelrecht-github`), met een echt tarball erachter. Dat pint vast dat het archief
+uitgepakt wordt zonder de `{owner}-{repo}-{sha}/`-laag, dat twee bronnen in
+dezelfde repo op dezelfde ref **één** verzoek kosten, dat het token uit
+`CORPUS_AUTH_<SLUG>_TOKEN` meegaat, en dat de tijdelijke map weer opgeruimd wordt.

--- a/packages/chrono-poc-web/README.md
+++ b/packages/chrono-poc-web/README.md
@@ -60,8 +60,12 @@ gedeelde `CORPUS_GIT_TOKEN` van de harvester-tijd gaat nooit naar een repo die
 deze app aanwijst.
 
 Het opstarten **faalt luid**. Geen wereldbestand, geen leesbare wereld, geen
-regelingen of een ref die niet bestaat: het proces stopt met de reden. Een server
-die opkomt zonder wereld zou op elke healthcheck groen staan en op elk verzoek
+regelingen of een ref die niet bestaat: het proces stopt met de reden. Leesbaar is
+daarbij niet genoeg, dus het opstarten bouwt één wereld voordat de listener
+opengaat (`WorldRegistry::check_buildable`): zo komt ook een wereldbestand boven
+dat een regeling noemt die niet in de opgehaalde map staat — een corpusbron die
+één map te hoog wijst, een ref waarin die wet nog niet bestond. Een server die
+opkomt zonder wereld zou op elke healthcheck groen staan en op elk verzoek
 dezelfde fout geven.
 
 ## De API

--- a/packages/chrono-poc-web/src/api.rs
+++ b/packages/chrono-poc-web/src/api.rs
@@ -142,9 +142,11 @@ fn static_service(static_dir: &str) -> MethodRouter {
 
 /// Leeft dit proces? Zonder login, want een healthcheck heeft er geen.
 ///
-/// Zegt niets over de werelden: die worden per sessie opgetuigd, en het
-/// wereldbestand is bij het starten al gelezen — een proces dat hier antwoordt,
-/// heeft een leesbare wereld (zie [`crate::sources::resolve`]).
+/// Zegt niets over de werelden: die worden per sessie opgetuigd. Dat het over
+/// die werelden niets hoeft te zeggen, komt doordat het opstarten er al één
+/// gebouwd heeft (zie [`crate::sources::resolve`] en
+/// [`crate::worlds::WorldRegistry::check_buildable`]) — een proces dat hier
+/// antwoordt, heeft een wereld die te bouwen is.
 async fn health() -> &'static str {
     "OK"
 }

--- a/packages/chrono-poc-web/src/api.rs
+++ b/packages/chrono-poc-web/src/api.rs
@@ -1,0 +1,721 @@
+//! De JSON-API en de router eromheen.
+//!
+//! Alles wat een client kan doen, doet hij met de wereld van zijn eigen sessie:
+//! kijken (`GET /api/world`), er iets in doen (`POST /api/actions/{id}`), de tijd
+//! laten lopen (`POST /api/advance`), een cel bevragen
+//! (`GET /api/cells/{cel}/lexostatus/{naam}`), een instelling wijzigen
+//! (`PUT /api/settings`) of opnieuw beginnen (`POST /api/reset`).
+//!
+//! **Veldnamen Engels, meldingen Nederlands.** De vorm van het antwoord is het
+//! contract dat [`regelrecht_simulator::Snapshot`] al vastlegt, en dat is Engels;
+//! elke fout die een mens leest komt uit de simulator, en die praat Nederlands.
+//! Eén van de twee omzetten zou betekenen dat er ergens een woordenlijst
+//! bijgehouden moet worden die niemand bijhoudt.
+//!
+//! **Wat geen fout is.** "Niets vastgesteld" is een antwoord met een reden en
+//! komt als 200 terug — een cel die op het gevraagde moment geen feit had, is
+//! niet stuk. Een actie die nu niet kan is een 409 met de uitleg van de wereld
+//! erin: het verhaal is nog niet zover, en dat is een stand en geen vergissing.
+
+use std::collections::BTreeMap;
+
+use axum::extract::{Path, Query, Request, State};
+use axum::middleware as axum_middleware;
+use axum::routing::{get, post, put, MethodRouter};
+use axum::{Json, Router};
+use chrono::NaiveDate;
+use regelrecht_simulator::{
+    Events, Lexostatus, ParameterType, Snapshot, Value, Warning, World, WorldDefinition,
+};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use tower::ServiceExt;
+use tower_http::services::{ServeDir, ServeFile};
+use tower_http::trace::TraceLayer;
+use tower_sessions::{Expiry, Session, SessionManagerLayer};
+use tower_sessions_memory_store::MemoryStore;
+
+use crate::config::SESSION_TTL;
+use crate::error::ApiError;
+use crate::state::AppState;
+
+/// Onder welke sleutel de sessie haar wereld-id bewaart.
+///
+/// Een eigen id en niet [`tower_sessions::Session::id`]: die is `None` tot de
+/// sessie voor het eerst opgeslagen is, dus het eerste verzoek van een bezoeker
+/// zou geen sleutel hebben — precies het verzoek waarin zijn wereld ontstaat.
+const SESSION_KEY_WORLD: &str = "chrono_poc.world";
+
+/// Bouw de hele applicatie: de routes, de sessies, de statische frontend.
+///
+/// Eén functie, gebruikt door `main` én door de tests. Een tweede plek die
+/// routers samenstelt is een tweede plek waar een route buiten de rol-gate kan
+/// vallen.
+pub fn router(state: AppState) -> Router {
+    let role = state.config.required_role;
+    let secure_cookies = state.config.is_auth_enabled();
+    let static_dir = state.config.static_dir.clone();
+
+    // Elke route hieronder raakt de wereld van een sessie; er is er geen die
+    // open hoort te staan. `/health` en `/auth/*` staan er daarom buiten, en
+    // niet in deze lijst met een uitzondering erbij.
+    let api = Router::new()
+        .route("/api/world", get(world))
+        .route("/api/actions/{action}", post(act))
+        .route("/api/advance", post(advance))
+        .route("/api/cells/{cell}/lexostatus/{name}", get(lexostatus))
+        .route("/api/settings", put(settings))
+        .route("/api/reset", post(reset))
+        .route_layer(axum_middleware::from_fn_with_state(
+            state.clone(),
+            regelrecht_auth::require_role::<AppState>(role),
+        ));
+
+    // Geen `with_secure(true)` in de auth-uit-modus: die draait lokaal over
+    // plain HTTP, en een secure cookie komt daar nooit terug. In productie staat
+    // OIDC altijd aan.
+    let sessions = SessionManagerLayer::new(MemoryStore::default())
+        .with_expiry(Expiry::OnInactivity(time::Duration::seconds(
+            i64::try_from(SESSION_TTL.as_secs()).unwrap_or(i64::MAX),
+        )))
+        .with_same_site(tower_sessions::cookie::SameSite::Lax)
+        .with_http_only(true)
+        .with_secure(secure_cookies);
+
+    let refresh_state = state.clone();
+    let auth_enabled = state.config.is_auth_enabled();
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .merge(regelrecht_auth::auth_routes::<AppState>())
+        .merge(api)
+        .with_state(state);
+
+    // Binnen de sessielaag (de sessie is geladen) en buiten de rol-gate (een
+    // verse rollenlijst of een weggevallen login wordt door de gate gezien).
+    // Alleen zinvol als er een IdP is om bij te vragen.
+    let app = if auth_enabled {
+        app.layer(axum_middleware::from_fn_with_state(
+            refresh_state,
+            regelrecht_auth::refresh_session_token::<AppState>,
+        ))
+    } else {
+        app
+    };
+
+    app.layer(sessions)
+        // Ná de sessielaag, dus de statische bestanden gaan er niet door: een
+        // plaatje hoort geen sessie aan te maken. Zelfde reden als in editor-api.
+        .fallback_service(static_service(&static_dir))
+        .layer(axum_middleware::from_fn(
+            regelrecht_auth::security_headers::security_headers(regelrecht_auth::EDITOR_CSP),
+        ))
+        .layer(TraceLayer::new_for_http())
+}
+
+/// Statische bestanden met SPA-fallback, zoals editor-api ze serveert.
+///
+/// `index.html` als not-found-service: een diepe link in de frontend is geen
+/// bestand en hoort de app te openen, niet een 404. Zonder gebouwde frontend
+/// bestaat de map niet en antwoordt dit een gewone 404 — een server zonder
+/// frontend is nog steeds een werkende API.
+///
+/// Geen precompressie zoals in editor-api: die leunt op `.br`/`.gz`-varianten
+/// die de bouwstap van díe frontend schrijft. Zodra hier hetzelfde gebeurt,
+/// horen de vlaggen erbij.
+fn static_service(static_dir: &str) -> MethodRouter {
+    let index = ServeFile::new(std::path::Path::new(static_dir).join("index.html"));
+    let files = ServeDir::new(static_dir).not_found_service(index);
+    get(move |request: Request| {
+        let files = files.clone();
+        async move {
+            // Het foutype van `ServeDir` is `Infallible` zodra er een
+            // not-found-service staat, dus dit kan niet mislukken.
+            files
+                .oneshot(request)
+                .await
+                .unwrap_or_else(|e| match e {})
+                .map(axum::body::Body::new)
+        }
+    })
+}
+
+/// Leeft dit proces? Zonder login, want een healthcheck heeft er geen.
+///
+/// Zegt niets over de werelden: die worden per sessie opgetuigd, en het
+/// wereldbestand is bij het starten al gelezen — een proces dat hier antwoordt,
+/// heeft een leesbare wereld (zie [`crate::sources::resolve`]).
+async fn health() -> &'static str {
+    "OK"
+}
+
+/// `GET /api/world` — het beeld van de wereld van deze sessie.
+async fn world(
+    State(state): State<AppState>,
+    session: Session,
+) -> Result<Json<Snapshot>, ApiError> {
+    let key = world_key(&session).await?;
+    let snapshot = state
+        .worlds
+        .with_world(&key, |world| Ok(world.snapshot()))
+        .await?;
+    Ok(Json(snapshot))
+}
+
+/// `POST /api/actions/{action}` — voer een actie uit met de velden uit de body.
+async fn act(
+    State(state): State<AppState>,
+    session: Session,
+    Path(action): Path<String>,
+    JsonBody(form): JsonBody<BTreeMap<String, Value>>,
+) -> Result<Json<Step>, ApiError> {
+    let key = world_key(&session).await?;
+    let step = state
+        .worlds
+        .with_world(&key, move |world| {
+            let events = world.act(&action, &form)?;
+            Ok(Step::new(world, &events))
+        })
+        .await?;
+    Ok(Json(step))
+}
+
+/// De body van `POST /api/advance`.
+#[derive(Debug, Deserialize)]
+pub struct AdvanceRequest {
+    /// Tot welke dag de klok gezet wordt. Achteruit is een 409: een logische
+    /// klok die terugloopt zou een feit kunnen laten ontstaan vóór het feit
+    /// waarop het rust.
+    pub until: NaiveDate,
+}
+
+/// `POST /api/advance` — zet de klok vooruit en laat de triggers onderweg afgaan.
+async fn advance(
+    State(state): State<AppState>,
+    session: Session,
+    JsonBody(body): JsonBody<AdvanceRequest>,
+) -> Result<Json<Step>, ApiError> {
+    let key = world_key(&session).await?;
+    let step = state
+        .worlds
+        .with_world(&key, move |world| {
+            let events = world.advance(body.until)?;
+            Ok(Step::new(world, &events))
+        })
+        .await?;
+    Ok(Json(step))
+}
+
+/// `GET /api/cells/{cell}/lexostatus/{name}` — één reductie, alleen lezen.
+///
+/// De parameters komen als gewone queryparameters binnen en worden omgezet naar
+/// het type dat de lexostatus documenteert: een BSN is een string ook al ziet hij
+/// uit als een getal, en een jaar is een getal ook al staat het in een URL. Zonder
+/// die stap zou elke waarde tekst zijn en zou een kroniekfilter op een getal
+/// nooit iets vinden.
+///
+/// `op_moment` is gereserveerd: geen waarde betekent "op de stand van de klok".
+async fn lexostatus(
+    State(state): State<AppState>,
+    session: Session,
+    Path((cell, name)): Path<(String, String)>,
+    QueryParams(query): QueryParams,
+) -> Result<Json<Lexostatus>, ApiError> {
+    let key = world_key(&session).await?;
+    let Question { params, op_moment } =
+        Question::read(state.worlds.definition(), &cell, &name, &query)?;
+    let answer = state
+        .worlds
+        .with_world(&key, move |world| {
+            let moment = op_moment.unwrap_or_else(|| world.now());
+            Ok(world.reduce(&cell, &name, &params, moment)?)
+        })
+        .await?;
+    Ok(Json(answer))
+}
+
+/// `PUT /api/settings` — wijzig instellingen die nog niet vast staan.
+async fn settings(
+    State(state): State<AppState>,
+    session: Session,
+    JsonBody(changes): JsonBody<BTreeMap<String, Value>>,
+) -> Result<Json<Snapshot>, ApiError> {
+    let key = world_key(&session).await?;
+    let snapshot = state
+        .worlds
+        .with_world(&key, move |world| {
+            world.update_settings(&changes)?;
+            Ok(world.snapshot())
+        })
+        .await?;
+    Ok(Json(snapshot))
+}
+
+/// `POST /api/reset` — terug naar de startstand uit het wereldbestand.
+async fn reset(
+    State(state): State<AppState>,
+    session: Session,
+) -> Result<Json<Snapshot>, ApiError> {
+    let key = world_key(&session).await?;
+    let snapshot = state
+        .worlds
+        .with_world(&key, |world| {
+            world.reset()?;
+            Ok(world.snapshot())
+        })
+        .await?;
+    Ok(Json(snapshot))
+}
+
+/// De wereld-sleutel van deze sessie; maak hem aan als hij er nog niet is.
+async fn world_key(session: &Session) -> Result<String, ApiError> {
+    let existing: Option<String> = session
+        .get(SESSION_KEY_WORLD)
+        .await
+        .map_err(|e| ApiError::internal(format!("kon de sessie niet lezen: {e}")))?;
+    if let Some(key) = existing {
+        return Ok(key);
+    }
+    let key = uuid::Uuid::new_v4().to_string();
+    session
+        .insert(SESSION_KEY_WORLD, &key)
+        .await
+        .map_err(|e| ApiError::internal(format!("kon de sessie niet opslaan: {e}")))?;
+    Ok(key)
+}
+
+/// Wat één stap opleverde: de nieuwe stand, en wat er gebeurde.
+#[derive(Debug, Serialize)]
+pub struct Step {
+    /// Het beeld van de wereld ná de stap.
+    pub snapshot: Snapshot,
+    /// Wat er tijdens de stap gebeurde.
+    pub events: EventsView,
+}
+
+impl Step {
+    fn new(world: &World, events: &Events) -> Self {
+        Self {
+            snapshot: world.snapshot(),
+            events: EventsView::new(events),
+        }
+    }
+}
+
+/// Wat er tijdens één stap gebeurde.
+///
+/// Een **verwijzing** naar wat er in het beeld staat en geen tweede uitgave
+/// ervan: elk gram dat hier genoemd wordt, ligt met al zijn velden in
+/// `snapshot.cells`. Wat deze lijst toevoegt, is de volgorde en het feit dat het
+/// nú gebeurde — zonder dat zou een client twee beelden moeten vergelijken om te
+/// zien wat zijn eigen klik deed.
+#[derive(Debug, Serialize)]
+pub struct EventsView {
+    /// De feiten die vastgelegd zijn, in volgorde.
+    pub recordings: Vec<RecordingView>,
+    /// De besluiten die genomen zijn, in volgorde.
+    pub decisions: Vec<DecisionView>,
+    /// De termijnen die onderweg verstreken zonder dat het feit er lag.
+    pub warnings: Vec<Warning>,
+}
+
+impl EventsView {
+    fn new(events: &Events) -> Self {
+        Self {
+            recordings: events
+                .recordings
+                .iter()
+                .map(|fact| RecordingView {
+                    cell: fact.cell.clone(),
+                    chronicle: fact.chronicle.clone(),
+                    gram: fact.event.name.clone(),
+                    op_moment: fact.event.op_moment,
+                })
+                .collect(),
+            decisions: events
+                .decisions
+                .iter()
+                .map(|decision| DecisionView {
+                    cell: decision.decretogram.cell.clone(),
+                    besluit: decision.decretogram.besluit.clone(),
+                    zaakkenmerk: decision.decretogram.zaakkenmerk.clone(),
+                    op_moment: decision.decretogram.op_moment,
+                    legal_character: decision.decretogram.legal_character.clone(),
+                    crossings: decision.crossings.len(),
+                })
+                .collect(),
+            warnings: events.warnings.clone(),
+        }
+    }
+}
+
+/// Eén vastgelegd feit, als verwijzing naar het gram in het beeld.
+#[derive(Debug, Serialize)]
+pub struct RecordingView {
+    /// De cel waarin het gram landde.
+    pub cell: String,
+    /// De kroniekstroom.
+    pub chronicle: String,
+    /// Hoe het gram heet.
+    pub gram: String,
+    /// Het moment waarop dit feit in die cel feit werd.
+    pub op_moment: NaiveDate,
+}
+
+/// Eén genomen besluit, als verwijzing naar het decretogram in het beeld.
+#[derive(Debug, Serialize)]
+pub struct DecisionView {
+    /// De cel die besloot.
+    pub cell: String,
+    /// De besluit-definitie die uitgevoerd is.
+    pub besluit: String,
+    /// Waaronder deze zaak terug te vinden is.
+    pub zaakkenmerk: String,
+    /// Het moment waarop besloten is.
+    pub op_moment: NaiveDate,
+    /// Het rechtskarakter dat de regeling aan de uitkomst geeft.
+    pub legal_character: Option<String>,
+    /// Hoeveel contacten dit besluit over een celgrens nodig had. De contacten
+    /// zelf staan in `snapshot.crossings`.
+    pub crossings: usize,
+}
+
+/// Een vraag aan een cel, na omzetting naar wat de definitie documenteert.
+#[derive(Debug)]
+struct Question {
+    params: BTreeMap<String, Value>,
+    op_moment: Option<NaiveDate>,
+}
+
+impl Question {
+    /// Lees de queryparameters tegen de lexostatus-definitie uit het
+    /// wereldbestand.
+    ///
+    /// Dat de definitie hier gelezen wordt en niet de cel zelf, is met opzet: de
+    /// cel geeft geen inkijk in haar definities (RFC-022 §4.1 — een consument
+    /// vraagt een naam, hij inspecteert geen cel), terwijl het wereldbestand
+    /// gewoon configuratie is die dit proces zelf inlas.
+    fn read(
+        definition: &WorldDefinition,
+        cell: &str,
+        name: &str,
+        query: &BTreeMap<String, String>,
+    ) -> Result<Self, ApiError> {
+        let cell_config = definition
+            .cells
+            .iter()
+            .find(|candidate| candidate.id == cell)
+            .ok_or_else(|| {
+                ApiError::not_found(format!(
+                    "de wereld kent geen cel '{cell}' (wel: {})",
+                    names(definition.cells.iter().map(|c| c.id.as_str()))
+                ))
+            })?;
+        let lexostatus = cell_config
+            .lexostatus_definitions
+            .iter()
+            .find(|candidate| candidate.name == name)
+            .ok_or_else(|| {
+                ApiError::not_found(format!(
+                    "cel '{cell}' publiceert geen lexostatus '{name}' (wel: {})",
+                    names(
+                        cell_config
+                            .lexostatus_definitions
+                            .iter()
+                            .map(|l| l.name.as_str())
+                    )
+                ))
+            })?;
+
+        if lexostatus
+            .inputs
+            .iter()
+            .any(|input| input.name == OP_MOMENT)
+        {
+            return Err(ApiError::internal(format!(
+                "lexostatus '{cell}.{name}' documenteert een parameter '{OP_MOMENT}', en die naam \
+                 is in deze API het moment van de vraag. Noem de parameter anders in het \
+                 wereldbestand."
+            )));
+        }
+
+        let mut params = BTreeMap::new();
+        let mut op_moment = None;
+        for (key, raw) in query {
+            if key == OP_MOMENT {
+                op_moment = Some(raw.parse::<NaiveDate>().map_err(|e| {
+                    ApiError::bad_request(format!(
+                        "'{OP_MOMENT}={raw}' is geen datum (verwacht jjjj-mm-dd): {e}"
+                    ))
+                })?);
+                continue;
+            }
+            let documented = lexostatus
+                .inputs
+                .iter()
+                .find(|input| &input.name == key)
+                .ok_or_else(|| {
+                    ApiError::bad_request(format!(
+                        "lexostatus '{cell}.{name}' kent geen parameter '{key}' \
+                         (gedocumenteerd: {})",
+                        names(lexostatus.inputs.iter().map(|i| i.name.as_str()))
+                    ))
+                })?;
+            params.insert(
+                key.clone(),
+                coerce(cell, name, key, raw, documented.value_type)?,
+            );
+        }
+
+        Ok(Self { params, op_moment })
+    }
+}
+
+/// De queryparameter die het moment van de vraag draagt.
+const OP_MOMENT: &str = "op_moment";
+
+/// Zet één queryparameter om naar het gedocumenteerde type.
+///
+/// Getallen en booleans gaan langs de JSON-lezer van [`Value`], zodat een `1` en
+/// een `1.5` hier precies dezelfde waarden opleveren als in een wereldbestand of
+/// in een body — één plek die getallen leest, en niet drie.
+fn coerce(
+    cell: &str,
+    name: &str,
+    parameter: &str,
+    raw: &str,
+    expected: ParameterType,
+) -> Result<Value, ApiError> {
+    let wrong = |wanted: &str| {
+        ApiError::bad_request(format!(
+            "parameter '{parameter}' van lexostatus '{cell}.{name}' is {wanted}, en '{raw}' is \
+             dat niet"
+        ))
+    };
+    match expected {
+        // Altijd tekst, ook als het een getal lijkt: een BSN met een nul vooraan
+        // is geen getal, en een BSN zonder nul vooraan is dat ook niet.
+        ParameterType::String => Ok(Value::String(raw.to_string())),
+        ParameterType::Number => serde_json::from_str::<Value>(raw)
+            .ok()
+            .filter(|value| matches!(value, Value::Int(_) | Value::Decimal(_)))
+            .ok_or_else(|| wrong("een getal")),
+        ParameterType::Boolean => serde_json::from_str::<bool>(raw)
+            .map(Value::Bool)
+            .map_err(|_| wrong("waar of niet waar")),
+    }
+}
+
+/// Een komma-gescheiden opsomming, zoals de simulator ze in zijn meldingen zet.
+fn names<'a>(items: impl Iterator<Item = &'a str>) -> String {
+    let joined = items.collect::<Vec<_>>().join(", ");
+    if joined.is_empty() {
+        "geen".to_string()
+    } else {
+        joined
+    }
+}
+
+/// Een JSON-body die zijn afwijzing als [`ApiError`] geeft.
+///
+/// Zonder dit antwoordt axum op een onleesbare body met platte tekst, en dan is
+/// er één soort fout die niet op de andere lijkt — precies de fout die een client
+/// niet verwacht en dus niet uitpakt. Een **lege** body wordt gelezen als `{}`,
+/// zodat een actie zonder velden geen body nodig heeft.
+pub struct JsonBody<T>(pub T);
+
+impl<S, T> axum::extract::FromRequest<S> for JsonBody<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request(request: Request, state: &S) -> Result<Self, Self::Rejection> {
+        let bytes = axum::body::Bytes::from_request(request, state)
+            .await
+            .map_err(|e| {
+                ApiError::bad_request(format!("kon de body van dit verzoek niet lezen: {e}"))
+            })?;
+        let json: &[u8] = if bytes.is_empty() { b"{}" } else { &bytes };
+        serde_json::from_slice(json)
+            .map(Self)
+            .map_err(|e| ApiError::bad_request(format!("de body is geen geldige JSON: {e}")))
+    }
+}
+
+/// Queryparameters die hun afwijzing als [`ApiError`] geven. Zelfde reden als
+/// bij [`JsonBody`].
+pub struct QueryParams(pub BTreeMap<String, String>);
+
+impl<S> axum::extract::FromRequestParts<S> for QueryParams
+where
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        Query::<BTreeMap<String, String>>::from_request_parts(parts, state)
+            .await
+            .map(|Query(params)| Self(params))
+            .map_err(|e| ApiError::bad_request(format!("kon de queryparameters niet lezen: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    fn definition() -> WorldDefinition {
+        WorldDefinition::from_yaml(
+            r"
+clock:
+  start: 2024-01-01
+cells:
+  - id: brp
+    laws: []
+    chronicles:
+      - stream: relaties
+        key: bsn
+    lexostatus_definitions:
+      - name: partnerschap
+        inputs:
+          - name: bsn
+            type: string
+          - name: jaar
+            type: number
+          - name: met_partner
+            type: boolean
+        outputs:
+          - partnerschap_type
+        reduction:
+          chronicle: relaties
+          key: bsn
+          latest: true
+",
+        )
+        .expect("de testwereld moet te lezen zijn")
+    }
+
+    fn query(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    /// Het hele punt van de omzetting: een BSN die uit een getal bestaat blijft
+    /// tekst, en een jaar wordt een getal. Was alles tekst, dan zou een
+    /// kroniekfilter op `jaar` nooit iets vinden; was alles een getal, dan zou
+    /// een BSN met een nul vooraan stil van waarde veranderen.
+    #[test]
+    fn parameters_krijgen_het_type_dat_de_definitie_documenteert() {
+        let vraag = Question::read(
+            &definition(),
+            "brp",
+            "partnerschap",
+            &query(&[
+                ("bsn", "999993653"),
+                ("jaar", "2024"),
+                ("met_partner", "true"),
+                ("op_moment", "2024-06-01"),
+            ]),
+        )
+        .expect("deze vraag hoort te kloppen");
+
+        assert_eq!(
+            vraag.params.get("bsn"),
+            Some(&Value::String("999993653".to_string()))
+        );
+        assert_eq!(vraag.params.get("jaar"), Some(&Value::Int(2024)));
+        assert_eq!(vraag.params.get("met_partner"), Some(&Value::Bool(true)));
+        assert_eq!(
+            vraag.op_moment.map(|d| d.to_string()),
+            Some("2024-06-01".to_string())
+        );
+    }
+
+    /// Geen `op_moment` betekent "op de stand van de klok", en dat besluit valt
+    /// bij de wereld — hier hoort alleen `None` uit te komen.
+    #[test]
+    fn zonder_op_moment_blijft_het_moment_open() {
+        let vraag = Question::read(
+            &definition(),
+            "brp",
+            "partnerschap",
+            &query(&[("bsn", "999993653")]),
+        )
+        .expect("deze vraag hoort te kloppen");
+        assert_eq!(vraag.op_moment, None);
+    }
+
+    /// Een onbekende cel of lexostatus is een 404 met de namen die er wél zijn.
+    /// Een parameter die de definitie niet documenteert is een 400, om dezelfde
+    /// reden als bij de cel zelf: wat niet belooft is, wordt niet stil genegeerd.
+    #[test]
+    fn onbekende_namen_worden_geweigerd_met_de_bekende_ernaast() {
+        let definition = definition();
+
+        let cel = Question::read(&definition, "kiesraad", "partnerschap", &query(&[]))
+            .expect_err("een onbekende cel hoort te falen");
+        assert_eq!(cel.status(), StatusCode::NOT_FOUND);
+        assert!(cel.message().contains("brp"), "{}", cel.message());
+
+        let lexostatus = Question::read(&definition, "brp", "zetelverdeling", &query(&[]))
+            .expect_err("een onbekende lexostatus hoort te falen");
+        assert_eq!(lexostatus.status(), StatusCode::NOT_FOUND);
+        assert!(
+            lexostatus.message().contains("partnerschap"),
+            "{}",
+            lexostatus.message()
+        );
+
+        let parameter = Question::read(
+            &definition,
+            "brp",
+            "partnerschap",
+            &query(&[("burgerservicenummer", "999993653")]),
+        )
+        .expect_err("een ongedocumenteerde parameter hoort te falen");
+        assert_eq!(parameter.status(), StatusCode::BAD_REQUEST);
+        assert!(
+            parameter.message().contains("bsn"),
+            "{}",
+            parameter.message()
+        );
+    }
+
+    /// Een waarde die niet bij het gedocumenteerde type past, en een moment dat
+    /// geen datum is: beide een 400 met de waarde erin, niet een reductie die op
+    /// iets anders rekent dan de aanroeper bedoelde.
+    #[test]
+    fn een_waarde_van_het_verkeerde_type_wordt_geweigerd() {
+        let definition = definition();
+
+        for (parameter, waarde) in [("jaar", "vorig jaar"), ("met_partner", "misschien")] {
+            let err = Question::read(
+                &definition,
+                "brp",
+                "partnerschap",
+                &query(&[(parameter, waarde)]),
+            )
+            .expect_err("een waarde van het verkeerde type hoort te falen");
+            assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+            assert!(err.message().contains(waarde), "{}", err.message());
+        }
+
+        let err = Question::read(
+            &definition,
+            "brp",
+            "partnerschap",
+            &query(&[("op_moment", "gisteren")]),
+        )
+        .expect_err("een onleesbaar moment hoort te falen");
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert!(err.message().contains("jjjj-mm-dd"), "{}", err.message());
+    }
+}

--- a/packages/chrono-poc-web/src/config.rs
+++ b/packages/chrono-poc-web/src/config.rs
@@ -1,0 +1,140 @@
+//! De configuratie, uit de omgeving, één keer bij het starten gelezen.
+
+use std::time::Duration;
+
+pub use regelrecht_auth::OidcConfig;
+
+use crate::sources::Source;
+
+/// Hoe lang een sessie zonder verkeer haar wereld houdt.
+///
+/// Eén uur, en dezelfde waarde voor de sessiecookie en voor de wereld erachter:
+/// twee verschillende getallen leveren één van twee verwarringen op — een cookie
+/// die een wereld aanwijst die er niet meer is, of een wereld die geld kost
+/// zonder dat er nog een browser bij hoort.
+pub const SESSION_TTL: Duration = Duration::from_secs(60 * 60);
+
+/// Hoe vaak er gekeken wordt of er werelden verlopen zijn.
+pub const SWEEP_INTERVAL: Duration = Duration::from_secs(60);
+
+/// De rol die een gebruiker minimaal moet hebben voor `/api/*`.
+///
+/// Standaard de leesrol van de editor, zodat deze PoC achter de bestaande login
+/// staat zonder dat er in Keycloak eerst een rol bij moet. Een eigen rol
+/// (`simulator-reader`) is één env-variabele, niet een codewijziging.
+pub const DEFAULT_REQUIRED_ROLE: &str = "editor-reader";
+
+/// Alles wat dit proces uit zijn omgeving haalt.
+#[derive(Clone)]
+pub struct AppConfig {
+    /// OIDC, of `None` voor de auth-uit-modus (lokaal).
+    pub oidc: Option<OidcConfig>,
+    /// `BASE_URL`, voor de redirect-URL's van de login.
+    pub base_url: Option<String>,
+    /// De rol waarachter `/api/*` staat.
+    ///
+    /// `&'static str` omdat de route-gate van `regelrecht-auth` dat vraagt: de
+    /// middleware wordt één keer gebouwd en leeft even lang als het proces. De
+    /// waarde uit de omgeving wordt daarom bij het starten geleaked — één keer,
+    /// voor één string.
+    pub required_role: &'static str,
+    /// Waar het wereldbestand staat.
+    pub world: Source,
+    /// Waar de regelingen staan; `None` laat de simulator kiezen
+    /// (`REGULATION_PATH`, anders het corpus in deze checkout).
+    pub corpus: Option<Source>,
+    /// De sleutel waaronder het GitHub-token opgezocht wordt; `None` gebruikt de
+    /// reponaam van de bron.
+    pub auth_ref: Option<String>,
+    /// De map met de gebouwde frontend.
+    pub static_dir: String,
+    /// De poort waarop dit proces luistert.
+    pub port: u16,
+}
+
+impl AppConfig {
+    /// Lees de configuratie, of stop het proces met de reden.
+    pub fn from_env() -> Self {
+        match Self::try_from_env() {
+            Ok(config) => config,
+            Err(e) => {
+                tracing::error!("{e}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    /// Lees de configuratie en geef de eerste fout terug.
+    pub fn try_from_env() -> Result<Self, String> {
+        let oidc = regelrecht_auth::parse_oidc_from_env()?;
+        if oidc.is_some() {
+            tracing::info!("OIDC-authenticatie staat aan");
+        } else {
+            tracing::warn!(
+                "OIDC-authenticatie staat UIT — elke route is open. Dit is de lokale modus; \
+                 draai deze configuratie niet in productie."
+            );
+        }
+        let base_url = regelrecht_auth::parse_base_url()?;
+
+        let world = match env_value("CHRONO_POC_WORLD_SOURCE") {
+            Some(spec) => {
+                Source::parse(&spec).map_err(|e| format!("CHRONO_POC_WORLD_SOURCE: {e}"))?
+            }
+            None => {
+                return Err("CHRONO_POC_WORLD_SOURCE is niet gezet. Verwacht \
+                     'local:<pad-naar-wereldbestand>' of \
+                     'github:<owner>/<repo>@<ref>:<pad-naar-wereldbestand>'."
+                    .to_string())
+            }
+        };
+        let corpus = match env_value("CHRONO_POC_CORPUS_SOURCE") {
+            Some(spec) => {
+                Some(Source::parse(&spec).map_err(|e| format!("CHRONO_POC_CORPUS_SOURCE: {e}"))?)
+            }
+            None => None,
+        };
+
+        // `leak` en geen `Box::leak` met een cache: dit gebeurt één keer per
+        // proces, voor één string, omdat de route-gate een `&'static str` wil.
+        let required_role: &'static str = match env_value("CHRONO_POC_REQUIRED_ROLE") {
+            Some(role) => role.leak(),
+            None => DEFAULT_REQUIRED_ROLE,
+        };
+        tracing::info!(role = %required_role, "/api/* staat achter deze rol");
+
+        let port = match env_value("CHRONO_POC_PORT") {
+            Some(raw) => raw
+                .parse()
+                .map_err(|e| format!("CHRONO_POC_PORT={raw:?} is geen poortnummer: {e}"))?,
+            None => 8000,
+        };
+
+        Ok(Self {
+            oidc,
+            base_url,
+            required_role,
+            world,
+            corpus,
+            auth_ref: env_value("CHRONO_POC_AUTH_REF"),
+            static_dir: env_value("STATIC_DIR").unwrap_or_else(|| "static".to_string()),
+            port,
+        })
+    }
+
+    /// Staat de login aan?
+    pub fn is_auth_enabled(&self) -> bool {
+        self.oidc.is_some()
+    }
+}
+
+/// Een env-variabele, waarbij "leeg" hetzelfde is als "niet gezet".
+///
+/// Een deployment die een variabele op de lege string zet, bedoelt "geen
+/// waarde"; zonder dit zou dat een lege bron of een lege rol opleveren.
+fn env_value(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}

--- a/packages/chrono-poc-web/src/error.rs
+++ b/packages/chrono-poc-web/src/error.rs
@@ -1,0 +1,190 @@
+//! De fout die deze laag naar buiten geeft: een status en een Nederlandse
+//! melding, als JSON.
+//!
+//! Eén type voor alles wat er mis kan gaan, want er is maar één soort
+//! consument: een frontend die de melding aan een mens laat zien. De melding is
+//! Nederlands omdat de simulator dat is — de uitleg die een cel geeft over een
+//! actie die nog niet kan, of een parameter die niet gedocumenteerd is, is wat
+//! hier doorkomt, en die zou door hertalen alleen maar armer worden.
+//!
+//! De **status** komt uit de foutvariant van de simulator en niet uit de plek
+//! waar hij vandaan kwam. Een onbekende cel is een 404 of hij opgevraagd wordt
+//! via `/api/cells/...` of langs een actie; een wereld die bij het optuigen
+//! omvalt is een 500, ook al deed de aanroeper niets fout. Zie
+//! [`ApiError::from_simulator`] voor de hele afbeelding.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use regelrecht_simulator::SimulatorError;
+use serde::Serialize;
+
+/// Een mislukt verzoek: een HTTP-status plus wat er aan de hand is.
+#[derive(Debug)]
+pub struct ApiError {
+    status: StatusCode,
+    message: String,
+}
+
+/// Het lichaam van een fout. Één veld, altijd hetzelfde veld: een client die
+/// per status een andere vorm moet uitpakken, pakt er één verkeerd uit.
+#[derive(Serialize)]
+struct ErrorBody<'a> {
+    error: &'a str,
+}
+
+impl ApiError {
+    /// Het verzoek zelf klopt niet: een onleesbare datum, een parameter die
+    /// deze lexostatus niet documenteert.
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            message: message.into(),
+        }
+    }
+
+    /// Er bestaat niet wat er gevraagd wordt: een cel, een lexostatus, een
+    /// actie.
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            message: message.into(),
+        }
+    }
+
+    /// Onze fout. De melding gaat mee naar de client omdat er aan de andere
+    /// kant van deze PoC een ontwikkelaar zit en geen burger; er zit geen
+    /// gegeven van een ander in een simulatorfout dat een ander niet mag zien.
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: message.into(),
+        }
+    }
+
+    /// De status waarmee deze fout naar buiten gaat.
+    pub fn status(&self) -> StatusCode {
+        self.status
+    }
+
+    /// De melding waarmee deze fout naar buiten gaat.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Een fout van de simulator, met de status die bij de variant hoort.
+    ///
+    /// Drie groepen, en de rest is onze schuld:
+    ///
+    /// * **404** — wat het pad aanwijst bestaat niet: een cel, een lexostatus,
+    ///   een actie. De simulator zet in zijn melding welke namen er wél zijn, en
+    ///   die hoort een client te zien.
+    /// * **409** — het bestaat, maar de wereld staat er nu niet naar. Dit is
+    ///   geen verkeerd verzoek en geen defect: het verhaal is er nog niet.
+    /// * **400** — het verzoek klopt niet tegen wat de definitie belooft: een
+    ///   parameter of instelling te veel, te weinig, of van het verkeerde type.
+    /// * **500** — al het andere. Een wereld die niet opgetuigd kan worden, een
+    ///   regeling die niet gelezen kan worden, een definitie die niet klopt:
+    ///   dat zijn eigenschappen van het wereldbestand waarmee dit proces
+    ///   gestart is, en niet van het verzoek dat het net binnenkreeg.
+    pub fn from_simulator(error: &SimulatorError) -> Self {
+        use SimulatorError as E;
+        let status = match error {
+            E::UnknownCell { .. } | E::UnknownLexostatus { .. } | E::UnknownAction { .. } => {
+                StatusCode::NOT_FOUND
+            }
+
+            E::ActionNotAvailable { .. }
+            | E::SettingInUse { .. }
+            | E::ClockRunsBackwards { .. }
+            | E::MomentAfterClock { .. } => StatusCode::CONFLICT,
+
+            E::MissingParameter { .. }
+            | E::UndocumentedParameter { .. }
+            | E::ParameterType { .. }
+            | E::UnknownWorldSetting { .. } => StatusCode::BAD_REQUEST,
+
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        Self {
+            status,
+            message: error.to_string(),
+        }
+    }
+}
+
+impl From<SimulatorError> for ApiError {
+    fn from(error: SimulatorError) -> Self {
+        Self::from_simulator(&error)
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        // Een 500 hoort in het log te staan ook als de client hem wegklikt; de
+        // andere statussen zijn antwoorden en geen storingen.
+        if self.status.is_server_error() {
+            tracing::error!(error = %self.message, "verzoek mislukt");
+        }
+        (
+            self.status,
+            Json(ErrorBody {
+                error: &self.message,
+            }),
+        )
+            .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// De drie groepen uit de doc-comment, vastgepind op een echte fout per
+    /// groep. Zonder dit is de afbeelding proza: een variant die van groep
+    /// wisselt verandert dan stil een 409 in een 500 (of erger, andersom).
+    #[test]
+    fn de_statusafbeelding_volgt_de_soort_fout() {
+        let onbekende_cel = SimulatorError::UnknownCell {
+            cell: "kiesraad".to_string(),
+        };
+        assert_eq!(
+            ApiError::from_simulator(&onbekende_cel).status(),
+            StatusCode::NOT_FOUND
+        );
+
+        let kan_nu_niet = SimulatorError::ActionNotAvailable {
+            action: "toeslagen.toekenning".to_string(),
+            reason: "er ligt nog geen aanvraag".to_string(),
+        };
+        let conflict = ApiError::from_simulator(&kan_nu_niet);
+        assert_eq!(conflict.status(), StatusCode::CONFLICT);
+        assert!(
+            conflict.message().contains("er ligt nog geen aanvraag"),
+            "de uitleg van de simulator hoort door te komen, kreeg {}",
+            conflict.message()
+        );
+
+        let verkeerd_type = SimulatorError::ParameterType {
+            cell: "brp".to_string(),
+            subject: regelrecht_simulator::Subject::Lexostatus,
+            name: "partnerschap".to_string(),
+            parameter: "bsn".to_string(),
+            expected: "string",
+            actual: "number",
+        };
+        assert_eq!(
+            ApiError::from_simulator(&verkeerd_type).status(),
+            StatusCode::BAD_REQUEST
+        );
+
+        let gebroken_wereld = SimulatorError::RegulationNotFound {
+            regulation: "wet_op_de_zorgtoeslag".to_string(),
+            root: std::path::PathBuf::from("/corpus"),
+        };
+        assert_eq!(
+            ApiError::from_simulator(&gebroken_wereld).status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+}

--- a/packages/chrono-poc-web/src/lib.rs
+++ b/packages/chrono-poc-web/src/lib.rs
@@ -1,0 +1,44 @@
+//! De HTTP-laag om de chronolexografie-simulator: één wereld per browsersessie,
+//! als JSON, achter de login van RegelRecht.
+//!
+//! Wat deze crate toevoegt aan [`regelrecht_simulator`] is precies één ding: dat
+//! een mens de opstelling kan bespelen. De simulator kent geen HTTP, geen sessie
+//! en geen casus; hier komt daar een server om, en verder niets — elke route
+//! hieronder is één aanroep op [`regelrecht_simulator::World`], en er wordt
+//! nergens iets bijgehouden dat niet in een cel ligt.
+//!
+//! Drie keuzes bepalen de vorm:
+//!
+//! 1. **Geen database.** De sessies staan in geheugen ([`tower_sessions`]
+//!    `MemoryStore`) en de werelden ook. Dat betekent één replica en een
+//!    herstart die alles wist, en dat is voor een opstelling om iets aan te tonen
+//!    de juiste ruil: een wereld is een gedachte-experiment en geen dossier.
+//! 2. **De casus zit niet in de code.** Het wereldbestand en de regelingen komen
+//!    bij het starten uit een bron die de omgeving noemt (zie [`sources`]) — een
+//!    pad op schijf of een repo met een token. Het image dat hieruit rolt bevat
+//!    dus geen casusinhoud, en een andere casus is een andere env-variabele.
+//! 3. **Een wereld per thread.** Een [`regelrecht_simulator::World`] is niet
+//!    `Send`, dus hij kan niet in de state van een axum-app liggen. Elke sessie
+//!    krijgt daarom een eigen thread die haar wereld bezit; zie [`worlds`] voor
+//!    waarom dat niet alleen een omweg is maar ook de nette uitkomst.
+//!
+//! Het opstarten faalt luid: geen wereldbestand, geen leesbare wereld of geen
+//! regelingen betekent dat het proces stopt met de reden. Een server die opkomt
+//! zonder wereld zou op elke healthcheck groen staan en op elk verzoek dezelfde
+//! fout geven.
+
+#![deny(missing_docs)]
+
+pub mod api;
+pub mod config;
+pub mod error;
+pub mod sources;
+pub mod state;
+pub mod worlds;
+
+pub use api::router;
+pub use config::AppConfig;
+pub use error::ApiError;
+pub use sources::Source;
+pub use state::AppState;
+pub use worlds::WorldRegistry;

--- a/packages/chrono-poc-web/src/lib.rs
+++ b/packages/chrono-poc-web/src/lib.rs
@@ -23,7 +23,10 @@
 //!    waarom dat niet alleen een omweg is maar ook de nette uitkomst.
 //!
 //! Het opstarten faalt luid: geen wereldbestand, geen leesbare wereld of geen
-//! regelingen betekent dat het proces stopt met de reden. Een server die opkomt
+//! regelingen betekent dat het proces stopt met de reden. Leesbaar is daarbij
+//! niet genoeg — het opstarten bouwt één wereld
+//! ([`WorldRegistry::check_buildable`]) om ook een wereldbestand te zien dat een
+//! regeling noemt die niet in de opgehaalde map staat. Een server die opkomt
 //! zonder wereld zou op elke healthcheck groen staan en op elk verzoek dezelfde
 //! fout geven.
 

--- a/packages/chrono-poc-web/src/main.rs
+++ b/packages/chrono-poc-web/src/main.rs
@@ -50,6 +50,18 @@ async fn main() {
         "wereldbestand gelezen"
     );
 
+    let worlds = Arc::new(WorldRegistry::new(definition, regulation_root, SESSION_TTL));
+
+    // Leesbaar is niet hetzelfde als bouwbaar: een wereldbestand dat een regeling
+    // noemt die niet in de opgehaalde map staat, komt hier pas boven. Zonder deze
+    // toets zou dat proces opkomen, groen staan op `/health` en op elk verzoek
+    // dezelfde 500 geven — de duurste vorm van "hij draait".
+    if let Err(e) = worlds.check_buildable().await {
+        tracing::error!("kon uit dit wereldbestand en deze regelingen geen wereld bouwen: {e}");
+        std::process::exit(1);
+    }
+    tracing::info!("wereld bouwbaar");
+
     let (oidc_client, end_session_url) = match config.oidc.as_ref() {
         Some(oidc) => match regelrecht_auth::discover_client(oidc).await {
             Ok(result) => (Some(Arc::new(result.client)), result.end_session_url),
@@ -74,7 +86,6 @@ async fn main() {
     };
 
     let port = config.port;
-    let worlds = Arc::new(WorldRegistry::new(definition, regulation_root, SESSION_TTL));
     let state = AppState {
         config: Arc::new(config),
         worlds: Arc::clone(&worlds),

--- a/packages/chrono-poc-web/src/main.rs
+++ b/packages/chrono-poc-web/src/main.rs
@@ -1,0 +1,139 @@
+//! Het proces: configuratie lezen, wereld ophalen, luisteren.
+//!
+//! De vorm van `packages/admin` — telemetry, OIDC-discovery, binden op
+//! `0.0.0.0`, netjes afsluiten op SIGTERM — zonder iets van zijn database. Wat
+//! er hier bij komt is het ophalen van de wereld, en dat gebeurt vóór de
+//! listener opengaat: mislukt het, dan is er niets om te bedienen en stopt het
+//! proces met de reden.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use regelrecht_chrono_poc_web::config::{AppConfig, SESSION_TTL, SWEEP_INTERVAL};
+use regelrecht_chrono_poc_web::state::AppState;
+use regelrecht_chrono_poc_web::worlds::WorldRegistry;
+use regelrecht_chrono_poc_web::{router, sources};
+
+#[tokio::main]
+async fn main() {
+    regelrecht_shared::telemetry::init_subscriber("info");
+    regelrecht_auth::install_crypto_provider();
+
+    let config = AppConfig::from_env();
+
+    // Vóór de OIDC-discovery: dit is de stap die het vaakst misgaat (een token
+    // dat er niet is, een ref die niet bestaat), en dan hoort de melding daarover
+    // te gaan en niet over een IdP.
+    let resolved = match sources::resolve(
+        &config.world,
+        config.corpus.as_ref(),
+        config.auth_ref.as_deref(),
+    )
+    .await
+    {
+        Ok(resolved) => resolved,
+        Err(e) => {
+            tracing::error!("kon de wereld niet klaarzetten: {e}");
+            std::process::exit(1);
+        }
+    };
+    let sources::Resolved {
+        definition,
+        regulation_root,
+        // Blijft leven tot `main` eindigt: dit houdt een opgehaald corpus op
+        // schijf. Zie de doc-comment op het veld.
+        fetched: _fetched,
+    } = resolved;
+    tracing::info!(
+        cells = definition.cells.len(),
+        regulation_root = %regulation_root.display(),
+        "wereldbestand gelezen"
+    );
+
+    let (oidc_client, end_session_url) = match config.oidc.as_ref() {
+        Some(oidc) => match regelrecht_auth::discover_client(oidc).await {
+            Ok(result) => (Some(Arc::new(result.client)), result.end_session_url),
+            Err(e) => {
+                tracing::error!(error = %e, "OIDC-discovery mislukt");
+                std::process::exit(1);
+            }
+        },
+        None => (None, None),
+    };
+
+    let http_client = match reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+    {
+        Ok(client) => client,
+        Err(e) => {
+            tracing::error!(error = %e, "kon geen HTTP-client bouwen");
+            std::process::exit(1);
+        }
+    };
+
+    let port = config.port;
+    let worlds = Arc::new(WorldRegistry::new(definition, regulation_root, SESSION_TTL));
+    let state = AppState {
+        config: Arc::new(config),
+        worlds: Arc::clone(&worlds),
+        oidc_client,
+        end_session_url,
+        http_client,
+    };
+
+    // De ruimer: zonder hem houdt elke bezoeker die ooit langskwam een thread en
+    // een wereld bezet tot het proces stopt.
+    let sweeper = Arc::clone(&worlds);
+    tokio::spawn(async move {
+        let mut ticks = tokio::time::interval(SWEEP_INTERVAL);
+        loop {
+            ticks.tick().await;
+            let removed = sweeper.sweep();
+            if removed > 0 {
+                tracing::info!(
+                    removed,
+                    active = sweeper.len(),
+                    "verlopen werelden opgeruimd"
+                );
+            }
+        }
+    });
+
+    let app = router(state);
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let listener = match tokio::net::TcpListener::bind(addr).await {
+        Ok(listener) => listener,
+        Err(e) => {
+            tracing::error!(error = %e, "kon niet binden op {addr}");
+            std::process::exit(1);
+        }
+    };
+    tracing::info!("luistert op {addr}");
+
+    let shutdown = async {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(sigterm) => sigterm,
+            Err(e) => {
+                tracing::error!(error = %e, "kon geen SIGTERM-handler installeren");
+                std::process::exit(1);
+            }
+        };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = sigterm.recv() => {}
+        }
+        tracing::info!("afsluitsignaal ontvangen, verbindingen aflaten");
+    };
+
+    if let Err(e) = axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await
+    {
+        tracing::error!(error = %e, "serverfout");
+        std::process::exit(1);
+    }
+}

--- a/packages/chrono-poc-web/src/sources.rs
+++ b/packages/chrono-poc-web/src/sources.rs
@@ -218,7 +218,13 @@ impl<'a> Fetcher<'a> {
             } => {
                 let key = (repo.clone(), git_ref.clone());
                 if let Some(root) = self.fetched.get(&key) {
-                    return join_in_repo(root, path);
+                    // Dezelfde toets als na een verse haal: een tweede bron uit
+                    // een al opgehaalde momentopname hoort dezelfde melding te
+                    // krijgen als de eerste. Zonder dit zou een corpuspad dat er
+                    // niet in staat als "de regelingenmap bestaat niet — zet
+                    // CHRONO_POC_CORPUS_SOURCE" terugkomen, van een variabele die
+                    // wél gezet is en alleen het verkeerde pad noemt.
+                    return located_in_repo(root, path, repo, git_ref);
                 }
                 let token = resolve_token(source, self.auth_ref_override)?;
                 let dir = tempfile::Builder::new()
@@ -240,17 +246,21 @@ impl<'a> Fetcher<'a> {
                 let root = dir.path().to_path_buf();
                 self.dirs.push(dir);
                 self.fetched.insert(key, root.clone());
-                let located = join_in_repo(&root, path)?;
-                if !located.exists() {
-                    return Err(format!(
-                        "'{path}' staat niet in {repo}@{git_ref} (wel opgehaald, maar dit pad \
-                         bestaat er niet)"
-                    ));
-                }
-                Ok(located)
+                located_in_repo(&root, path, repo, git_ref)
             }
         }
     }
+}
+
+/// Het pad ín een opgehaalde momentopname, mits het er ook echt in staat.
+fn located_in_repo(root: &Path, path: &str, repo: &str, git_ref: &str) -> Result<PathBuf, String> {
+    let located = join_in_repo(root, path)?;
+    if !located.exists() {
+        return Err(format!(
+            "'{path}' staat niet in {repo}@{git_ref} (wel opgehaald, maar dit pad bestaat er niet)"
+        ));
+    }
+    Ok(located)
 }
 
 /// Voeg een repo-relatief pad samen met de map waarin de repo staat.

--- a/packages/chrono-poc-web/src/sources.rs
+++ b/packages/chrono-poc-web/src/sources.rs
@@ -1,0 +1,437 @@
+//! Waar de wereld en het corpus vandaan komen, en hoe ze bij het starten op
+//! schijf belanden.
+//!
+//! Twee bronnen, dezelfde grammatica:
+//!
+//! ```text
+//! local:<pad>
+//! github:<owner>/<repo>@<ref>:<pad>
+//! ```
+//!
+//! De reden dat dit env-configuratie is en geen regel in `corpus-registry.yaml`:
+//! het corpus van een casus kan privé zijn terwijl deze code en het image dat
+//! eruit rolt publiek zijn. Een bron in de registry zou de naam van die repo in
+//! een publiek bestand zetten, en dat is precies het gegeven dat er niet in
+//! hoort. Wat er wél gedeeld wordt met de rest van de workspace is de
+//! **tokenconventie**: `CORPUS_AUTH_<SLUG>_TOKEN`, opgelost door
+//! [`regelrecht_corpus::auth::CredentialResolver`], zodat een operator voor deze
+//! app niets nieuws hoeft te leren.
+//!
+//! Het ophalen gebeurt **één keer, bij het starten**, en falen betekent dat het
+//! proces stopt. Een server die opkomt zonder wereld zou per verzoek dezelfde
+//! fout geven en zou op een healthcheck groen staan; dat is de duurste vorm van
+//! "hij draait".
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use regelrecht_corpus::auth::{token_env_name, CredentialResolver, TokenContext};
+use regelrecht_github::GithubClient;
+use regelrecht_simulator::WorldDefinition;
+use tempfile::TempDir;
+
+/// Waar één ding (het wereldbestand, de regelingenmap) vandaan komt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Source {
+    /// Een pad op de schijf van dit proces.
+    Local(PathBuf),
+    /// Een pad in een GitHub-repo, op een ref.
+    Github {
+        /// `owner/repo`.
+        repo: String,
+        /// Branch, tag of sha.
+        git_ref: String,
+        /// Het pad ín de repo.
+        path: String,
+    },
+}
+
+impl Source {
+    /// Lees een bron uit haar env-waarde.
+    ///
+    /// Faalt met een melding die de hele grammatica noemt: dit wordt gelezen
+    /// door iemand die een ZAD-variabele intypt, en "ongeldige bron" zonder de
+    /// vorm erbij kost die persoon een deploy.
+    pub fn parse(spec: &str) -> Result<Self, String> {
+        let spec = spec.trim();
+        if let Some(path) = spec.strip_prefix("local:") {
+            if path.is_empty() {
+                return Err("'local:' mist een pad. Verwacht 'local:<pad>' of \
+                     'github:<owner>/<repo>@<ref>:<pad>'."
+                    .to_string());
+            }
+            return Ok(Self::Local(PathBuf::from(path)));
+        }
+        if let Some(rest) = spec.strip_prefix("github:") {
+            return Self::parse_github(rest).map_err(|reason| {
+                format!(
+                    "'{spec}' is geen geldige github-bron: {reason}. \
+                     Verwacht 'github:<owner>/<repo>@<ref>:<pad>'."
+                )
+            });
+        }
+        Err(format!(
+            "'{spec}' begint niet met 'local:' of 'github:'. Verwacht \
+             'local:<pad>' of 'github:<owner>/<repo>@<ref>:<pad>'."
+        ))
+    }
+
+    /// `<owner>/<repo>@<ref>:<pad>`.
+    ///
+    /// Gesplitst op de **eerste** `@` en daarna op de **eerste** `:`. Een ref mag
+    /// een `/` bevatten (`release/2027`) en een pad ook; geen van beide mag een
+    /// `:`, en dat is de enige beperking die deze vorm oplegt.
+    fn parse_github(rest: &str) -> Result<Self, String> {
+        let (repo, after) = rest.split_once('@').ok_or("er staat geen '@<ref>' in")?;
+        let (git_ref, path) = after.split_once(':').ok_or("er staat geen ':<pad>' in")?;
+        let segments: Vec<&str> = repo.split('/').collect();
+        if segments.len() != 2 || segments.iter().any(|s| s.is_empty()) {
+            return Err(format!("'{repo}' is geen '<owner>/<repo>'"));
+        }
+        if git_ref.is_empty() {
+            return Err("de ref is leeg".to_string());
+        }
+        if path.is_empty() {
+            return Err("het pad is leeg".to_string());
+        }
+        Ok(Self::Github {
+            repo: repo.to_string(),
+            git_ref: git_ref.to_string(),
+            path: path.to_string(),
+        })
+    }
+
+    /// De sleutel waaronder het token van deze bron opgezocht wordt: de
+    /// reponaam, tenzij de configuratie iets anders noemt.
+    ///
+    /// De reponaam als standaard, zodat een operator die twee privérepo's
+    /// aanspreekt niet twee bronnen op één token ziet uitkomen. De override
+    /// bestaat omdat een reponaam een lange env-variabele oplevert en een
+    /// deployment vaak al een kortere naam voor dezelfde repo heeft.
+    fn auth_ref(&self, override_ref: Option<&str>) -> Option<String> {
+        match self {
+            Self::Local(_) => None,
+            Self::Github { repo, .. } => Some(match override_ref {
+                Some(explicit) => explicit.to_string(),
+                None => repo.rsplit('/').next().unwrap_or(repo).to_string(),
+            }),
+        }
+    }
+}
+
+/// Wat er na het ophalen klaarstaat: de wereld-definitie en de regelingenmap.
+#[derive(Debug)]
+pub struct Resolved {
+    /// Het gelezen wereldbestand. Elke sessie tuigt hier haar eigen wereld uit
+    /// op, en `POST /api/reset` doet dat opnieuw.
+    pub definition: WorldDefinition,
+    /// De wortel waaronder de cellen hun regelingen vinden.
+    pub regulation_root: PathBuf,
+    /// De tijdelijke mappen met opgehaalde repo's.
+    ///
+    /// **Vasthouden zolang het proces leeft.** Een `TempDir` ruimt zichzelf op
+    /// bij `Drop`, dus dit is wat de regelingen op schijf houdt — en wat ze
+    /// opruimt als het proces netjes afsluit. Wie dit veld laat vallen, trekt de
+    /// regelingen onder de cellen vandaan.
+    pub fetched: Vec<TempDir>,
+}
+
+/// Haal wereld en corpus op en lees het wereldbestand.
+///
+/// `corpus` afwezig betekent: de simulator kiest zelf zijn wortel
+/// ([`regelrecht_simulator::regulation_root`], dus `REGULATION_PATH` of het
+/// corpus in deze checkout). Dat is de lokale modus, waarin een ontwikkelaar
+/// niets hoeft te configureren om de publieke wereld te zien.
+///
+/// Twee bronnen in dezelfde repo op dezelfde ref worden **één keer** gehaald.
+/// Dat is niet alleen sneller: het is ook het enige dat consistent is — een
+/// wereldbestand en de regelingen waarop het rust, horen uit dezelfde
+/// momentopname te komen.
+pub async fn resolve(
+    world: &Source,
+    corpus: Option<&Source>,
+    auth_ref_override: Option<&str>,
+) -> Result<Resolved, String> {
+    let mut fetcher = Fetcher::new(auth_ref_override);
+
+    let world_path = fetcher.locate(world).await?;
+    let definition = WorldDefinition::load(&world_path).map_err(|e| {
+        format!(
+            "kon het wereldbestand '{}' niet lezen: {e}",
+            world_path.display()
+        )
+    })?;
+
+    let regulation_root = match corpus {
+        Some(source) => fetcher.locate(source).await?,
+        None => regelrecht_simulator::regulation_root(),
+    };
+    if !regulation_root.is_dir() {
+        return Err(format!(
+            "de regelingenmap '{}' bestaat niet. Zet CHRONO_POC_CORPUS_SOURCE \
+             of REGULATION_PATH naar een map met regelingen.",
+            regulation_root.display()
+        ));
+    }
+
+    Ok(Resolved {
+        definition,
+        regulation_root,
+        fetched: fetcher.into_dirs(),
+    })
+}
+
+/// Haalt repo's op en houdt bij wat er al gehaald is.
+struct Fetcher<'a> {
+    auth_ref_override: Option<&'a str>,
+    /// `(repo, ref)` → de map waarin die momentopname staat.
+    fetched: BTreeMap<(String, String), PathBuf>,
+    dirs: Vec<TempDir>,
+}
+
+impl<'a> Fetcher<'a> {
+    fn new(auth_ref_override: Option<&'a str>) -> Self {
+        Self {
+            auth_ref_override,
+            fetched: BTreeMap::new(),
+            dirs: Vec::new(),
+        }
+    }
+
+    fn into_dirs(self) -> Vec<TempDir> {
+        self.dirs
+    }
+
+    /// Het pad op schijf waar deze bron naar wijst, desnoods na ophalen.
+    async fn locate(&mut self, source: &Source) -> Result<PathBuf, String> {
+        match source {
+            Source::Local(path) => {
+                if !path.exists() {
+                    return Err(format!("'{}' bestaat niet", path.display()));
+                }
+                Ok(path.clone())
+            }
+            Source::Github {
+                repo,
+                git_ref,
+                path,
+            } => {
+                let key = (repo.clone(), git_ref.clone());
+                if let Some(root) = self.fetched.get(&key) {
+                    return join_in_repo(root, path);
+                }
+                let token = resolve_token(source, self.auth_ref_override)?;
+                let dir = tempfile::Builder::new()
+                    .prefix("chrono-poc-")
+                    .tempdir()
+                    .map_err(|e| format!("kon geen tijdelijke map maken: {e}"))?;
+                let client = GithubClient::new()
+                    .map_err(|e| format!("kon geen GitHub-client maken: {e}"))?;
+                tracing::info!(repo = %repo, git_ref = %git_ref, "wereldbron ophalen");
+                regelrecht_corpus::github::fetch_archive_to_dir(
+                    &client,
+                    repo,
+                    git_ref,
+                    token.as_deref(),
+                    dir.path(),
+                )
+                .await
+                .map_err(|e| format!("kon {repo}@{git_ref} niet ophalen: {e}"))?;
+                let root = dir.path().to_path_buf();
+                self.dirs.push(dir);
+                self.fetched.insert(key, root.clone());
+                let located = join_in_repo(&root, path)?;
+                if !located.exists() {
+                    return Err(format!(
+                        "'{path}' staat niet in {repo}@{git_ref} (wel opgehaald, maar dit pad \
+                         bestaat er niet)"
+                    ));
+                }
+                Ok(located)
+            }
+        }
+    }
+}
+
+/// Voeg een repo-relatief pad samen met de map waarin de repo staat.
+///
+/// Een leidende `/` of een `./` hoort niet uit te maken; een `..` wel, en die
+/// wordt geweigerd. Niet omdat een operator zijn eigen server zou aanvallen, maar
+/// omdat `github:owner/repo@main:../etc/passwd` dan iets van de container zou
+/// lezen en als "de wereld" zou aanbieden — en een bron die buiten zijn repo
+/// wijst, is in elk geval een vergissing.
+fn join_in_repo(root: &Path, path: &str) -> Result<PathBuf, String> {
+    use std::path::Component;
+    let mut joined = root.to_path_buf();
+    for component in Path::new(path.trim_start_matches('/')).components() {
+        match component {
+            Component::Normal(part) => joined.push(part),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(format!("'{path}' wijst buiten de opgehaalde repo"))
+            }
+        }
+    }
+    Ok(joined)
+}
+
+/// Zoek het token voor een github-bron op, en zeg in het log welke variabele
+/// bekeken is.
+///
+/// Strikt: de sleutel komt uit onze eigen configuratie en niet uit een verzoek,
+/// maar een strikte opzoeking is wat voorkomt dat een gedeeld token van de
+/// harvester-tijd naar een repo gaat die deze app aanwijst. Geen token is geen
+/// fout — een publieke repo heeft er geen nodig; een privérepo faalt hierna op
+/// de 404 van GitHub, met de naam van de variabele in dit logregel ernaast.
+fn resolve_token(
+    source: &Source,
+    auth_ref_override: Option<&str>,
+) -> Result<Option<String>, String> {
+    let Some(auth_ref) = source.auth_ref(auth_ref_override) else {
+        return Ok(None);
+    };
+    let env_name = token_env_name(&auth_ref);
+    let decision = CredentialResolver::new(None)
+        .resolve(TokenContext::strict(&auth_ref))
+        .map_err(|e| format!("kon het token voor '{auth_ref}' niet opzoeken: {e}"))?;
+    match decision.token() {
+        Some(_) => tracing::info!(auth_ref = %auth_ref, env = %env_name, "token gevonden"),
+        None => tracing::warn!(
+            auth_ref = %auth_ref,
+            env = %env_name,
+            "geen token gevonden; het ophalen gaat onauthenticated en faalt op een privérepo"
+        ),
+    }
+    Ok(decision.into_token())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn een_lokale_bron_is_een_pad() {
+        assert_eq!(
+            Source::parse("local:packages/simulator/worlds/publieke_wereld.yaml"),
+            Ok(Source::Local(PathBuf::from(
+                "packages/simulator/worlds/publieke_wereld.yaml"
+            )))
+        );
+    }
+
+    #[test]
+    fn een_github_bron_valt_uiteen_in_repo_ref_en_pad() {
+        assert_eq!(
+            Source::parse("github:MinBZK/regelrecht@main:packages/simulator/worlds/w.yaml"),
+            Ok(Source::Github {
+                repo: "MinBZK/regelrecht".to_string(),
+                git_ref: "main".to_string(),
+                path: "packages/simulator/worlds/w.yaml".to_string(),
+            })
+        );
+    }
+
+    /// Een ref met een `/` erin is gewoon een ref. Gesplitst op de eerste `@`
+    /// en de eerste `:`, dus `release/2027` blijft heel.
+    #[test]
+    fn een_ref_mag_een_schuine_streep_hebben() {
+        assert_eq!(
+            Source::parse("github:owner/repo@release/2027:simulator/wereld.yaml"),
+            Ok(Source::Github {
+                repo: "owner/repo".to_string(),
+                git_ref: "release/2027".to_string(),
+                path: "simulator/wereld.yaml".to_string(),
+            })
+        );
+    }
+
+    /// Elke afwijzing noemt de hele vorm. Wie een ZAD-variabele intypt, hoort
+    /// niet te hoeven raden welk stukje ontbrak.
+    #[test]
+    fn een_onvolledige_bron_wordt_geweigerd_met_de_vorm_erbij() {
+        for spec in [
+            "",
+            "packages/simulator/worlds/w.yaml",
+            "local:",
+            "github:MinBZK/regelrecht:pad.yaml",
+            "github:MinBZK/regelrecht@main",
+            "github:regelrecht@main:pad.yaml",
+            "github:MinBZK/regelrecht@:pad.yaml",
+            "github:MinBZK/regelrecht@main:",
+        ] {
+            let err = Source::parse(spec).expect_err("'{spec}' moet geweigerd worden");
+            assert!(
+                err.contains("local:<pad>") || err.contains("github:<owner>/<repo>@<ref>:<pad>"),
+                "de melding voor '{spec}' noemt de verwachte vorm niet: {err}"
+            );
+        }
+    }
+
+    /// De standaard-sleutel is de reponaam, en de override wint. Samen met
+    /// `token_env_name` is dat de hele afspraak die een operator moet kennen.
+    #[test]
+    fn de_tokensleutel_komt_uit_de_reponaam_of_uit_de_override() {
+        let source = Source::parse("github:MinBZK/regelrecht-corpus-demo@main:simulator/w.yaml")
+            .expect("geldige bron");
+        assert_eq!(
+            source.auth_ref(None).as_deref(),
+            Some("regelrecht-corpus-demo")
+        );
+        assert_eq!(
+            token_env_name(
+                &source
+                    .auth_ref(None)
+                    .expect("github-bron heeft een sleutel")
+            ),
+            "CORPUS_AUTH_REGELRECHT_CORPUS_DEMO_TOKEN"
+        );
+        assert_eq!(source.auth_ref(Some("kort")).as_deref(), Some("kort"));
+    }
+
+    /// Een lokale bron vraagt nooit om een token: er is geen repo om bij in te
+    /// loggen, en een variabele die niets doet hoort niet in een logregel.
+    #[test]
+    fn een_lokale_bron_heeft_geen_tokensleutel() {
+        assert_eq!(Source::Local(PathBuf::from("w.yaml")).auth_ref(None), None);
+    }
+
+    /// Het pad ín de repo blijft ín de repo. Een leidende `/` of `./` maakt niet
+    /// uit, een `..` wel: die zou buiten de opgehaalde momentopname wijzen en daar
+    /// iets van de container als "de wereld" aanbieden.
+    #[test]
+    fn een_pad_in_de_repo_blijft_in_de_repo() {
+        let root = Path::new("/tmp/opgehaald");
+        for path in [
+            "simulator/w.yaml",
+            "/simulator/w.yaml",
+            "./simulator/w.yaml",
+        ] {
+            assert_eq!(
+                join_in_repo(root, path).as_deref(),
+                Ok(Path::new("/tmp/opgehaald/simulator/w.yaml")),
+                "'{path}' hoort gewoon samengevoegd te worden"
+            );
+        }
+        for path in ["../buiten.yaml", "simulator/../../buiten.yaml"] {
+            let err = join_in_repo(root, path).expect_err("'{path}' moet geweigerd worden");
+            assert!(err.contains("buiten de opgehaalde repo"), "{err}");
+        }
+    }
+
+    /// De belofte uit de moduledocs: een bron die niet bestaat laat het opstarten
+    /// falen met het pad erin, in plaats van een server die opkomt zonder wereld.
+    #[tokio::test]
+    async fn een_ontbrekend_wereldbestand_laat_het_opstarten_falen() {
+        let err = resolve(
+            &Source::Local(PathBuf::from("/bestaat/niet.yaml")),
+            None,
+            None,
+        )
+        .await
+        .expect_err("zonder wereldbestand hoort het opstarten te falen");
+        assert!(
+            err.contains("/bestaat/niet.yaml"),
+            "de melding noemt het pad niet: {err}"
+        );
+    }
+}

--- a/packages/chrono-poc-web/src/state.rs
+++ b/packages/chrono-poc-web/src/state.rs
@@ -1,0 +1,49 @@
+//! De state die elke route deelt.
+
+use std::sync::Arc;
+
+use regelrecht_auth::{ConfiguredClient, OidcAppState, OidcConfig};
+
+use crate::config::AppConfig;
+use crate::worlds::WorldRegistry;
+
+/// Wat elke handler bij zich heeft: de configuratie, de werelden, en wat de
+/// login nodig heeft.
+///
+/// Geen pool en geen sessie-store: er is geen database (de sessies staan in
+/// geheugen, de werelden ook), en dat is de grens die deze opstelling expliciet
+/// stelt.
+#[derive(Clone)]
+pub struct AppState {
+    /// De configuratie, gelezen bij het starten.
+    pub config: Arc<AppConfig>,
+    /// De werelden van alle sessies.
+    pub worlds: Arc<WorldRegistry>,
+    /// De OIDC-client, als de login aan staat.
+    pub oidc_client: Option<Arc<ConfiguredClient>>,
+    /// De logout-URL van de IdP, als die er is.
+    pub end_session_url: Option<String>,
+    /// De HTTP-client waarmee de login met de IdP praat.
+    pub http_client: reqwest::Client,
+}
+
+impl OidcAppState for AppState {
+    fn oidc_client(&self) -> Option<&Arc<ConfiguredClient>> {
+        self.oidc_client.as_ref()
+    }
+    fn end_session_url(&self) -> Option<&str> {
+        self.end_session_url.as_deref()
+    }
+    fn oidc_config(&self) -> Option<&OidcConfig> {
+        self.config.oidc.as_ref()
+    }
+    fn is_auth_enabled(&self) -> bool {
+        self.config.is_auth_enabled()
+    }
+    fn base_url(&self) -> Option<&str> {
+        self.config.base_url.as_deref()
+    }
+    fn http_client(&self) -> &reqwest::Client {
+        &self.http_client
+    }
+}

--- a/packages/chrono-poc-web/src/worlds.rs
+++ b/packages/chrono-poc-web/src/worlds.rs
@@ -86,6 +86,34 @@ impl WorldRegistry {
         &self.definition
     }
 
+    /// Toets of er uit deze definitie en deze regelingen werkelijk een wereld te
+    /// bouwen is, en geef de melding van de simulator als dat niet zo is.
+    ///
+    /// Hoort bij het starten te gebeuren, vóór de listener opengaat. Zonder deze
+    /// toets is "het wereldbestand is leesbaar" alles wat het opstarten
+    /// vaststelt, en dat is minder dan het lijkt: een wereldbestand dat een
+    /// regeling noemt die niet in de opgehaalde map staat — een corpusbron die
+    /// één map te hoog wijst, een ref waarin die wet nog niet bestond — levert
+    /// een proces op dat groen staat op `/health` en op elk verzoek dezelfde 500
+    /// geeft. Precies de vorm van "hij draait" die deze crate belooft niet te
+    /// hebben.
+    ///
+    /// De wereld wordt gebouwd en meteen weggegooid: hij is niet `Send`, dus hij
+    /// verlaat deze thread niet, en wat hier getoetst wordt is dat hij te bouwen
+    /// is. Het kost één keer het inlezen van de regelingen, op een blocking
+    /// thread, op een moment dat er nog niemand wacht.
+    pub async fn check_buildable(&self) -> Result<(), String> {
+        let definition = Arc::clone(&self.definition);
+        let regulation_root = Arc::clone(&self.regulation_root);
+        tokio::task::spawn_blocking(move || {
+            World::from_definition(&definition, &regulation_root)
+                .map(|_| ())
+                .map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| format!("de toets op het wereldbestand liep vast: {e}"))?
+    }
+
     /// Hoeveel sessies er nu een wereld hebben.
     pub fn len(&self) -> usize {
         self.sessions.len()
@@ -207,12 +235,16 @@ impl WorldRegistry {
     /// Geeft terug hoeveel er weg zijn. Het weggooien van de greep sluit het
     /// kanaal, waarna de thread zijn lus verlaat en de wereld laat vallen — er
     /// is dus niets te sluiten dat hier gesloten moet worden.
+    ///
+    /// `saturating_sub` en geen `-`: tussen de twee metingen kan er een sessie
+    /// bijgekomen zijn, en dan is het verschil negatief. Een getal voor een
+    /// logregel hoort het proces niet om te leggen.
     pub fn sweep(&self) -> usize {
         let ttl = self.ttl;
         let before = self.sessions.len();
         self.sessions
             .retain(|_, world| world.last_used.elapsed() < ttl);
-        before - self.sessions.len()
+        before.saturating_sub(self.sessions.len())
     }
 }
 
@@ -332,12 +364,10 @@ cells:
         assert_eq!(clock.to_string(), "2024-01-01");
     }
 
-    /// Een wereld die niet opgetuigd kan worden — hier: een regelingenmap die
-    /// niet bestaat, terwijl de cel wetten laadt — komt als 500 terug met de
-    /// melding van de simulator erin, en niet als een hangend verzoek.
-    #[tokio::test]
-    async fn een_wereld_die_niet_opkomt_geeft_een_leesbare_fout() {
-        let broken = WorldDefinition::from_yaml(
+    /// Een definitie die een regeling noemt die er niet is: leesbaar als YAML,
+    /// maar er valt geen wereld uit te bouwen.
+    fn unbuildable() -> WorldDefinition {
+        WorldDefinition::from_yaml(
             r"
 clock:
   start: 2024-01-01
@@ -347,9 +377,52 @@ cells:
       - wet_die_niet_bestaat
 ",
         )
-        .expect("de definitie zelf is leesbaar");
+        .expect("de definitie zelf is leesbaar")
+    }
+
+    /// De toets bij het starten: een wereldbestand dat een regeling noemt die
+    /// niet in de regelingenmap staat, hoort het proces te laten stoppen met de
+    /// naam van die regeling erin — en niet een server op te leveren die groen
+    /// staat op `/health` en op elk verzoek dezelfde 500 geeft.
+    #[tokio::test]
+    async fn een_onbouwbare_wereld_wordt_bij_het_starten_gezien() {
         let registry = WorldRegistry::new(
-            broken,
+            unbuildable(),
+            PathBuf::from("/bestaat/niet"),
+            Duration::from_secs(60),
+        );
+
+        let err = registry
+            .check_buildable()
+            .await
+            .expect_err("een wereld zonder regelingen hoort bij het starten te falen");
+        assert!(
+            err.contains("wet_die_niet_bestaat"),
+            "de melding noemt de regeling niet: {err}"
+        );
+        assert!(
+            registry.is_empty(),
+            "de toets hoort geen sessie achter te laten"
+        );
+    }
+
+    /// En de andere kant: een wereld die wél te bouwen is, laat het opstarten
+    /// doorlopen. Zonder deze helft zou een toets die altijd faalt ook slagen.
+    #[tokio::test]
+    async fn een_bouwbare_wereld_komt_door_de_toets() {
+        registry(Duration::from_secs(60))
+            .check_buildable()
+            .await
+            .expect("de testwereld heeft geen regelingen nodig en hoort bouwbaar te zijn");
+    }
+
+    /// Een wereld die niet opgetuigd kan worden — hier: een regelingenmap die
+    /// niet bestaat, terwijl de cel wetten laadt — komt als 500 terug met de
+    /// melding van de simulator erin, en niet als een hangend verzoek.
+    #[tokio::test]
+    async fn een_wereld_die_niet_opkomt_geeft_een_leesbare_fout() {
+        let registry = WorldRegistry::new(
+            unbuildable(),
             PathBuf::from("/bestaat/niet"),
             Duration::from_secs(60),
         );

--- a/packages/chrono-poc-web/src/worlds.rs
+++ b/packages/chrono-poc-web/src/worlds.rs
@@ -1,0 +1,369 @@
+//! Eén wereld per browsersessie, in geheugen, met een eigen thread.
+//!
+//! ## Waarom een thread en niet een slot
+//!
+//! Een [`World`] is **niet `Send`**. Dat is geen ongeluk: een cel houdt haar
+//! engine in een `RefCell`, en die engine kan een `Rc<dyn CellResolver>` dragen
+//! voor de duur van een besluit. Beide zijn precies goed voor wat ze zijn — één
+//! wereld is één samenhangend geheel dat nooit over threads verdeeld hoort te
+//! worden — maar ze maken `DashMap<SessionId, World>` onmogelijk: axum wil zijn
+//! state `Send + Sync`, en een `Mutex<World>` is alleen `Sync` als `World`
+//! `Send` is.
+//!
+//! Dus draait elke wereld op haar **eigen thread**, die haar bezit, en gaat elke
+//! aanraking als opdracht over een kanaal naar die thread. Wat er in de map staat
+//! is de *greep* op die thread: een zender en het moment waarop hij het laatst
+//! gebruikt is. Dat levert op wat de wereld-in-de-map ook opgeleverd zou hebben —
+//! sessies raken elkaar niet, twee sessies zijn twee werelden — plus iets extra's:
+//! twee sessies wachten ook niet op elkaar, want ze delen geen slot.
+//!
+//! De prijs is een thread per actieve sessie. Voor een PoC met een handvol
+//! gelijktijdige lezers is dat goedkoper dan de alternatieven (een
+//! single-thread-runtime waarop álle sessies elkaar in de weg zitten, of de
+//! engine `Send` maken), en de TTL hieronder is wat de prijs begrenst.
+//!
+//! ## Lui, en met een houdbaarheidsdatum
+//!
+//! De wereld van een sessie wordt opgetuigd bij de **eerste** opdracht, niet bij
+//! de eerste aanraking van een cookie: een crawler die `/health` opvraagt hoort
+//! geen regelingen te laten inlezen. Hij wordt opgeruimd als er een uur niets
+//! gebeurd is ([`WorldRegistry::sweep`]); de zender verdwijnt uit de map, het
+//! kanaal sluit, de thread eindigt en de wereld valt weg. Er is geen database en
+//! geen tweede replica: wie in een andere pod terechtkomt, begint opnieuw, en
+//! dat is een bewuste grens van deze opstelling.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+use regelrecht_simulator::{World, WorldDefinition};
+use tokio::sync::{mpsc, oneshot};
+
+use crate::error::ApiError;
+
+/// Eén opdracht aan een wereld: doe dit, en stuur het antwoord zelf terug.
+///
+/// Eén type in plaats van een variant per route. Het antwoord zit in de
+/// closure — die houdt zijn eigen `oneshot`-zender vast — dus de typering blijft
+/// staan waar de route staat, en deze module hoeft geen enkele route te kennen.
+/// `Err` draagt de melding van een wereld die niet opgetuigd kon worden.
+type Task = Box<dyn for<'a> FnOnce(Result<&'a mut World, &'a str>) + Send + 'static>;
+
+/// De werelden van alle sessies.
+pub struct WorldRegistry {
+    definition: Arc<WorldDefinition>,
+    regulation_root: Arc<PathBuf>,
+    ttl: Duration,
+    sessions: DashMap<String, SessionWorld>,
+}
+
+/// De greep op één wereld: het kanaal naar haar thread, en wanneer hij het
+/// laatst gebruikt is.
+struct SessionWorld {
+    tasks: mpsc::UnboundedSender<Task>,
+    last_used: Instant,
+}
+
+impl WorldRegistry {
+    /// Een register over één wereld-definitie, met een houdbaarheid per sessie.
+    pub fn new(definition: WorldDefinition, regulation_root: PathBuf, ttl: Duration) -> Self {
+        Self {
+            definition: Arc::new(definition),
+            regulation_root: Arc::new(regulation_root),
+            ttl,
+            sessions: DashMap::new(),
+        }
+    }
+
+    /// Het wereldbestand waaruit elke sessie haar wereld optuigt.
+    ///
+    /// Voor wat er over een wereld te weten valt zonder haar aan te raken: welke
+    /// cellen erin zitten en welke parameters een lexostatus documenteert. Dat
+    /// hoort niet over de thread van een sessie te lopen — het is configuratie en
+    /// geen stand — en het is bij álle sessies hetzelfde.
+    pub fn definition(&self) -> &WorldDefinition {
+        &self.definition
+    }
+
+    /// Hoeveel sessies er nu een wereld hebben.
+    pub fn len(&self) -> usize {
+        self.sessions.len()
+    }
+
+    /// Heeft nog geen enkele sessie een wereld?
+    pub fn is_empty(&self) -> bool {
+        self.sessions.is_empty()
+    }
+
+    /// Doe iets met de wereld van deze sessie, op haar eigen thread.
+    ///
+    /// De enige ingang. Elke route loopt hierlangs, dus er is geen tweede plek
+    /// die een wereld aanraakt — en daarmee geen tweede plek die de `last_used`
+    /// zou kunnen vergeten bij te werken of buiten de eigen thread om zou kunnen
+    /// grijpen.
+    pub async fn with_world<T, F>(&self, session: &str, work: F) -> Result<T, ApiError>
+    where
+        F: for<'a> FnOnce(&'a mut World) -> Result<T, ApiError> + Send + 'static,
+        T: Send + 'static,
+    {
+        // De greep wordt hier gepakt en het slot van de shard valt aan het eind
+        // van dit blok. Een `DashMap`-guard over een `await` heen vasthouden is
+        // hoe je een deadlock bouwt die zich als een hangend verzoek voordoet.
+        let tasks = self.handle(session);
+
+        let (answer, wait) = oneshot::channel();
+        let task: Task = Box::new(move |world| {
+            let result = match world {
+                Ok(world) => work(world),
+                Err(reason) => Err(ApiError::internal(reason.to_string())),
+            };
+            // Geen ontvanger meer: de client is weggelopen terwijl de wereld nog
+            // aan het werk was. Het werk is gedaan en de wereld is bijgewerkt;
+            // er is niets om te melden.
+            let _ = answer.send(result);
+        });
+
+        if tasks.send(task).is_err() {
+            return Err(self.gone(session));
+        }
+        match wait.await {
+            Ok(result) => result,
+            // De thread is weggevallen terwijl hij aan het werk was — een paniek
+            // in de simulator is de enige manier waarop dat kan. Wat er dan aan
+            // die wereld nog waar is, weet niemand; hem weggooien is de enige
+            // eerlijke uitkomst.
+            Err(_) => Err(self.gone(session)),
+        }
+    }
+
+    /// De thread van deze sessie leeft niet meer: gooi de dode greep weg zodat
+    /// een volgend verzoek een verse wereld krijgt.
+    ///
+    /// Alleen als de zender ook echt gesloten is. Tussen het mislukken en dit
+    /// moment kan een ander verzoek al een nieuwe wereld voor dezelfde sessie
+    /// hebben opgetuigd, en die hoort hier niet met de dode weg te gaan.
+    fn gone(&self, session: &str) -> ApiError {
+        self.sessions
+            .remove_if(session, |_, world| world.tasks.is_closed());
+        ApiError::internal("de wereld van deze sessie is gestopt; probeer het opnieuw")
+    }
+
+    /// De zender naar de thread van deze sessie; start hem als hij er nog niet is.
+    fn handle(&self, session: &str) -> mpsc::UnboundedSender<Task> {
+        let mut entry = self
+            .sessions
+            .entry(session.to_string())
+            .or_insert_with(|| SessionWorld {
+                tasks: self.spawn(session),
+                last_used: Instant::now(),
+            });
+        entry.last_used = Instant::now();
+        entry.tasks.clone()
+    }
+
+    /// Start de thread die de wereld van deze sessie bezit.
+    fn spawn(&self, session: &str) -> mpsc::UnboundedSender<Task> {
+        let (tasks, mut queue) = mpsc::unbounded_channel::<Task>();
+        let definition = Arc::clone(&self.definition);
+        let regulation_root = Arc::clone(&self.regulation_root);
+        let label = session.to_string();
+
+        let started = std::thread::Builder::new()
+            .name(format!("wereld-{label}"))
+            .spawn(move || {
+                // Hier, en niet bij het aanmaken van de greep: het inlezen van de
+                // regelingen kost tijd, en die hoort op deze thread te vallen en
+                // niet op de runtime die het verzoek behandelt.
+                let mut world = match World::from_definition(&definition, &regulation_root) {
+                    Ok(world) => Ok(world),
+                    Err(e) => {
+                        tracing::error!(error = %e, "kon de wereld van een sessie niet optuigen");
+                        Err(format!("kon de wereld niet optuigen: {e}"))
+                    }
+                };
+                // `blocking_recv` op een eigen thread, buiten elke runtime: dit
+                // is de hele reden dat die thread bestaat.
+                while let Some(task) = queue.blocking_recv() {
+                    match &mut world {
+                        Ok(world) => task(Ok(world)),
+                        Err(reason) => task(Err(reason)),
+                    }
+                }
+                tracing::debug!(session = %label, "wereld opgeruimd");
+            });
+
+        if let Err(e) = started {
+            // Geen thread: elke opdracht loopt dan op een gesloten kanaal, en
+            // `with_world` maakt daar een 500 van. Niet paniekeren om één
+            // sessie — de rest van de server werkt.
+            tracing::error!(error = %e, "kon geen thread voor een wereld starten");
+        }
+        tasks
+    }
+
+    /// Ruim de sessies op die langer dan de TTL niets gedaan hebben.
+    ///
+    /// Geeft terug hoeveel er weg zijn. Het weggooien van de greep sluit het
+    /// kanaal, waarna de thread zijn lus verlaat en de wereld laat vallen — er
+    /// is dus niets te sluiten dat hier gesloten moet worden.
+    pub fn sweep(&self) -> usize {
+        let ttl = self.ttl;
+        let before = self.sessions.len();
+        self.sessions
+            .retain(|_, world| world.last_used.elapsed() < ttl);
+        before - self.sessions.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Een wereld-definitie die geen regelingen nodig heeft: één bron-cel, geen
+    /// wetten. Genoeg om het gedrag van dit register te toetsen zonder er een
+    /// corpus bij te halen — dat is wat de HTTP-tests doen.
+    fn definition() -> WorldDefinition {
+        WorldDefinition::from_yaml(
+            r"
+clock:
+  start: 2024-01-01
+cells:
+  - id: brp
+    laws: []
+    chronicles:
+      - stream: relaties
+        key: bsn
+        events:
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: brp
+            grondslag: eigen registratie
+            op_moment: 2023-03-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: GEEN
+    lexostatus_definitions:
+      - name: partnerschap
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - partnerschap_type
+        reduction:
+          chronicle: relaties
+          key: bsn
+          latest: true
+",
+        )
+        .expect("de testwereld moet te lezen zijn")
+    }
+
+    fn registry(ttl: Duration) -> WorldRegistry {
+        WorldRegistry::new(definition(), PathBuf::from("/bestaat/niet"), ttl)
+    }
+
+    /// Twee sessies zijn twee werelden. Hier op het niveau van het register: wat
+    /// de ene sessie vooruit zet, staat bij de andere nog op de startdatum.
+    #[tokio::test]
+    async fn twee_sessies_zijn_twee_werelden() {
+        let registry = registry(Duration::from_secs(3600));
+
+        let advanced = registry
+            .with_world("een", |world| {
+                world.advance(chrono::NaiveDate::from_ymd_opt(2024, 6, 1).expect("datum"))?;
+                Ok(world.now())
+            })
+            .await
+            .expect("de wereld van 'een' moet vooruit kunnen");
+        let untouched = registry
+            .with_world("twee", |world| Ok(world.now()))
+            .await
+            .expect("de wereld van 'twee' moet opgetuigd worden");
+
+        assert_eq!(advanced.to_string(), "2024-06-01");
+        assert_eq!(untouched.to_string(), "2024-01-01");
+        assert_eq!(registry.len(), 2);
+    }
+
+    /// Dezelfde sessie krijgt dezelfde wereld: wat er in het ene verzoek
+    /// gebeurde, staat er in het volgende nog.
+    #[tokio::test]
+    async fn dezelfde_sessie_houdt_haar_wereld() {
+        let registry = registry(Duration::from_secs(3600));
+
+        registry
+            .with_world("een", |world| {
+                world.advance(chrono::NaiveDate::from_ymd_opt(2024, 6, 1).expect("datum"))?;
+                Ok(())
+            })
+            .await
+            .expect("vooruit");
+        let clock = registry
+            .with_world("een", |world| Ok(world.now()))
+            .await
+            .expect("beeld");
+
+        assert_eq!(clock.to_string(), "2024-06-01");
+        assert_eq!(registry.len(), 1);
+    }
+
+    /// Een sessie die niets meer doet, verdwijnt. Met een TTL van niets is elke
+    /// sessie meteen verlopen, wat de ruimer toetsbaar maakt zonder een uur te
+    /// wachten — en wat aantoont dat de wereld daarna vers opgetuigd wordt.
+    #[tokio::test]
+    async fn een_stille_sessie_wordt_opgeruimd() {
+        let registry = registry(Duration::ZERO);
+
+        registry
+            .with_world("een", |world| {
+                world.advance(chrono::NaiveDate::from_ymd_opt(2024, 6, 1).expect("datum"))?;
+                Ok(())
+            })
+            .await
+            .expect("vooruit");
+        assert_eq!(registry.sweep(), 1, "de sessie hoort opgeruimd te zijn");
+        assert!(registry.is_empty());
+
+        let clock = registry
+            .with_world("een", |world| Ok(world.now()))
+            .await
+            .expect("dezelfde sleutel krijgt een verse wereld");
+        assert_eq!(clock.to_string(), "2024-01-01");
+    }
+
+    /// Een wereld die niet opgetuigd kan worden — hier: een regelingenmap die
+    /// niet bestaat, terwijl de cel wetten laadt — komt als 500 terug met de
+    /// melding van de simulator erin, en niet als een hangend verzoek.
+    #[tokio::test]
+    async fn een_wereld_die_niet_opkomt_geeft_een_leesbare_fout() {
+        let broken = WorldDefinition::from_yaml(
+            r"
+clock:
+  start: 2024-01-01
+cells:
+  - id: toeslagen
+    laws:
+      - wet_die_niet_bestaat
+",
+        )
+        .expect("de definitie zelf is leesbaar");
+        let registry = WorldRegistry::new(
+            broken,
+            PathBuf::from("/bestaat/niet"),
+            Duration::from_secs(60),
+        );
+
+        let err = registry
+            .with_world("een", |world| Ok(world.now()))
+            .await
+            .expect_err("een wereld zonder regelingen hoort te falen");
+
+        assert_eq!(err.status(), axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(
+            err.message().contains("wet_die_niet_bestaat"),
+            "de melding noemt de regeling niet: {}",
+            err.message()
+        );
+    }
+}

--- a/packages/chrono-poc-web/tests/api.rs
+++ b/packages/chrono-poc-web/tests/api.rs
@@ -1,0 +1,586 @@
+//! De API over de publieke wereld, met de login uit.
+//!
+//! Deze tests draaien de **echte** router over het **echte** wereldbestand
+//! (`packages/simulator/worlds/publieke_wereld.yaml`) en het echte corpus. Dat is
+//! met opzet geen fixture-wereld: wat hier langs HTTP gaat, is precies wat een
+//! frontend en een deployment te zien krijgen, en een wereldbestand dat stilletjes
+//! onleesbaar wordt hoort hier rood te worden en niet in een container.
+//!
+//! De login staat uit (geen `OIDC_CLIENT_ID` in de configuratie), zoals lokaal.
+//! Dat de rol-gate dán doorlaat is gedrag van `regelrecht-auth` en daar getest;
+//! wat hier getoetst wordt is de laag erboven.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::header::{COOKIE, SET_COOKIE};
+use axum::http::{Method, Request, StatusCode};
+use axum::Router;
+use http_body_util::BodyExt;
+use regelrecht_chrono_poc_web::config::{AppConfig, DEFAULT_REQUIRED_ROLE};
+use regelrecht_chrono_poc_web::router;
+use regelrecht_chrono_poc_web::sources::Source;
+use regelrecht_chrono_poc_web::state::AppState;
+use regelrecht_chrono_poc_web::worlds::WorldRegistry;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+/// Het wereldbestand waarmee de app lokaal draait.
+fn world_file() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("simulator")
+        .join("worlds")
+        .join("publieke_wereld.yaml")
+}
+
+/// De app zoals `just chrono-poc` hem start: login uit, publieke wereld, corpus
+/// uit deze checkout.
+async fn app() -> Router {
+    let config = AppConfig {
+        oidc: None,
+        base_url: None,
+        required_role: DEFAULT_REQUIRED_ROLE,
+        world: Source::Local(world_file()),
+        corpus: None,
+        auth_ref: None,
+        static_dir: "static".to_string(),
+        port: 8000,
+    };
+    let resolved = regelrecht_chrono_poc_web::sources::resolve(&config.world, None, None)
+        .await
+        .expect("de publieke wereld moet te lezen zijn");
+    let worlds = WorldRegistry::new(
+        resolved.definition,
+        resolved.regulation_root,
+        Duration::from_secs(3600),
+    );
+    router(AppState {
+        config: Arc::new(config),
+        worlds: Arc::new(worlds),
+        oidc_client: None,
+        end_session_url: None,
+        http_client: regelrecht_auth::http_client(),
+    })
+}
+
+/// Eén browser: houdt zijn sessiecookie vast tussen verzoeken.
+struct Browser {
+    app: Router,
+    cookie: Option<String>,
+}
+
+impl Browser {
+    async fn new() -> Self {
+        Self {
+            app: app().await,
+            cookie: None,
+        }
+    }
+
+    /// Een tweede browser op dezelfde server: dezelfde router, geen cookie. Zo
+    /// zijn twee sessies twee sessies en niet twee servers — anders zou de test
+    /// "twee werelden" ook slagen als de state per router zou leven.
+    fn tweede(&self) -> Self {
+        Self {
+            app: self.app.clone(),
+            cookie: None,
+        }
+    }
+
+    async fn send(
+        &mut self,
+        method: Method,
+        uri: &str,
+        body: Option<Value>,
+    ) -> (StatusCode, Value) {
+        let mut request = Request::builder().method(method).uri(uri);
+        if let Some(cookie) = &self.cookie {
+            request = request.header(COOKIE, cookie);
+        }
+        let request = match body {
+            Some(json) => request
+                .header("content-type", "application/json")
+                .body(Body::from(json.to_string())),
+            None => request.body(Body::empty()),
+        }
+        .expect("verzoek moet te bouwen zijn");
+
+        let response = self
+            .app
+            .clone()
+            .oneshot(request)
+            .await
+            .expect("de app moet antwoorden");
+        let status = response.status();
+        if let Some(set) = response.headers().get(SET_COOKIE) {
+            let raw = set.to_str().expect("cookie is tekst");
+            self.cookie = Some(
+                raw.split(';')
+                    .next()
+                    .expect("een cookie heeft een naam=waarde")
+                    .to_string(),
+            );
+        }
+        let bytes = response
+            .into_body()
+            .collect()
+            .await
+            .expect("body moet te lezen zijn")
+            .to_bytes();
+        let json = if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes)
+                .unwrap_or_else(|_| Value::String(String::from_utf8_lossy(&bytes).to_string()))
+        };
+        (status, json)
+    }
+
+    async fn get(&mut self, uri: &str) -> (StatusCode, Value) {
+        self.send(Method::GET, uri, None).await
+    }
+
+    async fn post(&mut self, uri: &str, body: Value) -> (StatusCode, Value) {
+        self.send(Method::POST, uri, Some(body)).await
+    }
+
+    async fn put(&mut self, uri: &str, body: Value) -> (StatusCode, Value) {
+        self.send(Method::PUT, uri, Some(body)).await
+    }
+
+    /// Het beeld van de wereld, of een panic met de status erin.
+    async fn world(&mut self) -> Value {
+        let (status, body) = self.get("/api/world").await;
+        assert_eq!(status, StatusCode::OK, "GET /api/world: {body}");
+        body
+    }
+}
+
+/// Alle grammen in één kroniek van één cel, uit een beeld.
+fn grams(world: &Value, cell: &str, chronicle: &str) -> Vec<Value> {
+    world["cells"]
+        .as_array()
+        .expect("cells is een lijst")
+        .iter()
+        .find(|candidate| candidate["id"] == cell)
+        .unwrap_or_else(|| panic!("cel '{cell}' hoort in het beeld te staan"))["chronicles"]
+        .as_array()
+        .expect("chronicles is een lijst")
+        .iter()
+        .find(|candidate| candidate["stream"] == chronicle)
+        .unwrap_or_else(|| panic!("kroniek '{chronicle}' hoort bij cel '{cell}' te staan"))["grams"]
+        .as_array()
+        .expect("grams is een lijst")
+        .clone()
+}
+
+/// Of een actie nu kan, volgens het beeld.
+fn available(world: &Value, action: &str) -> bool {
+    world["actions"]
+        .as_array()
+        .expect("actions is een lijst")
+        .iter()
+        .find(|candidate| candidate["id"] == action)
+        .unwrap_or_else(|| panic!("actie '{action}' hoort in het beeld te staan"))["available"]
+        == json!(true)
+}
+
+/// De aanvraag, met de velden die haar formulier documenteert.
+fn aanvraag() -> Value {
+    json!({ "bsn": "999993653", "jaar": 2024 })
+}
+
+/// `/health` is de enige route zonder login, en hij zegt niets over een wereld:
+/// een healthcheck hoort geen regelingen in te lezen.
+#[tokio::test]
+async fn health_staat_open_en_maakt_geen_wereld() {
+    let mut browser = Browser::new().await;
+    let (status, body) = browser.get("/health").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, json!("OK"));
+}
+
+/// Het beeld van een verse wereld: de klok op de startdatum, de vier cellen van
+/// het wereldbestand, en precies één actie die nu kan.
+#[tokio::test]
+async fn een_verse_wereld_staat_op_de_startdatum() {
+    let mut browser = Browser::new().await;
+    let world = browser.world().await;
+
+    assert_eq!(world["clock"], json!("2024-01-01"));
+    let cells: Vec<&str> = world["cells"]
+        .as_array()
+        .expect("cells is een lijst")
+        .iter()
+        .filter_map(|cell| cell["id"].as_str())
+        .collect();
+    assert_eq!(cells, vec!["belastingdienst", "brp", "burger", "toeslagen"]);
+    assert_eq!(world["settings"]["betalingsritme"], json!("kwartaal"));
+
+    assert!(
+        available(&world, "burger.aanvraag"),
+        "een aanvraag indienen kan altijd"
+    );
+    assert!(
+        !available(&world, "toeslagen.toekenning"),
+        "beslissen kan pas als er een aanvraag ligt"
+    );
+}
+
+/// Eén aanvraag is twee grammen: de aanvrager legt vast wat zij indiende, de
+/// uitvoerder wat hem geleverd is. Beide staan in het beeld, en de stap zelf
+/// vertelt in welke volgorde ze ontstonden.
+#[tokio::test]
+async fn een_actie_legt_vast_in_twee_kronieken() {
+    let mut browser = Browser::new().await;
+
+    let (status, step) = browser
+        .post("/api/actions/burger.aanvraag", aanvraag())
+        .await;
+    assert_eq!(status, StatusCode::OK, "{step}");
+
+    let recordings = step["events"]["recordings"]
+        .as_array()
+        .expect("recordings is een lijst");
+    assert_eq!(recordings.len(), 2, "{step}");
+    assert_eq!(recordings[0]["cell"], json!("burger"));
+    assert_eq!(recordings[0]["gram"], json!("aanvraag_ingediend"));
+    assert_eq!(recordings[1]["cell"], json!("toeslagen"));
+    assert_eq!(recordings[1]["gram"], json!("aanvraag_ontvangen"));
+
+    let world = &step["snapshot"];
+    assert_eq!(grams(world, "burger", "aanvragen").len(), 1);
+    assert_eq!(grams(world, "toeslagen", "aanvragen").len(), 1);
+    assert!(
+        available(world, "toeslagen.toekenning"),
+        "nu er een aanvraag ligt, kan beslissen"
+    );
+}
+
+/// Een actie die nu niet kan is geen fout in het verzoek en geen defect: het
+/// verhaal is nog niet zover. 409, met de uitleg van de wereld in het lichaam.
+#[tokio::test]
+async fn een_actie_die_nu_niet_kan_is_een_conflict() {
+    let mut browser = Browser::new().await;
+
+    let (status, body) = browser
+        .post(
+            "/api/actions/toeslagen.toekenning",
+            json!({ "bsn": "999993653" }),
+        )
+        .await;
+
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    let error = body["error"].as_str().expect("een fout heeft een melding");
+    assert!(error.contains("toeslagen.toekenning"), "{error}");
+}
+
+/// De klok doet het werk: een termijn die verstrijkt zonder dat het feit er ligt,
+/// levert een waarschuwing op — geen fout, want de uitvoerder mag alsnog
+/// besluiten en de wet zegt alleen wat de termijn was.
+#[tokio::test]
+async fn de_klok_vooruit_laat_een_termijn_verstrijken() {
+    let mut browser = Browser::new().await;
+
+    let (status, step) = browser
+        .post("/api/advance", json!({ "until": "2024-04-01" }))
+        .await;
+    assert_eq!(status, StatusCode::OK, "{step}");
+    assert_eq!(step["snapshot"]["clock"], json!("2024-04-01"));
+
+    let warnings = step["events"]["warnings"]
+        .as_array()
+        .expect("warnings is een lijst");
+    assert_eq!(warnings.len(), 1, "{step}");
+    assert_eq!(warnings[0]["cell"], json!("toeslagen"));
+    assert_eq!(warnings[0]["name"], json!("aanvraag_ontvangen"));
+
+    // Achteruit kan de logische klok niet: dan zou een feit kunnen ontstaan vóór
+    // het feit waarop het rust.
+    let (status, body) = browser
+        .post("/api/advance", json!({ "until": "2024-01-01" }))
+        .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+}
+
+/// Het volledige verhaal over HTTP: aanvraag, klok vooruit, besluit. Het besluit
+/// haalt het toetsingsinkomen **over een celgrens** bij de cel die het vaststelde
+/// en rekent het niet na — dat contact staat in het beeld, en de stap zegt dat het
+/// er één was.
+#[tokio::test]
+async fn een_besluit_accepteert_een_waarde_over_een_celgrens() {
+    let mut browser = Browser::new().await;
+
+    browser
+        .post("/api/actions/burger.aanvraag", aanvraag())
+        .await;
+    browser
+        .post("/api/advance", json!({ "until": "2024-04-01" }))
+        .await;
+    let (status, step) = browser
+        .post(
+            "/api/actions/toeslagen.toekenning",
+            json!({ "bsn": "999993653" }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{step}");
+
+    let decisions = step["events"]["decisions"]
+        .as_array()
+        .expect("decisions is een lijst");
+    assert_eq!(decisions.len(), 1, "{step}");
+    assert_eq!(decisions[0]["cell"], json!("toeslagen"));
+    assert_eq!(decisions[0]["besluit"], json!("zorgtoeslag_toekenning"));
+    assert_eq!(decisions[0]["zaakkenmerk"], json!("zorgtoeslag/999993653"));
+    assert_eq!(
+        decisions[0]["crossings"],
+        json!(1),
+        "het toetsingsinkomen komt van een andere cel"
+    );
+
+    let crossings = step["snapshot"]["crossings"]
+        .as_array()
+        .expect("crossings is een lijst");
+    assert_eq!(crossings.len(), 1);
+    assert_eq!(crossings[0]["answer"]["cell"], json!("belastingdienst"));
+    assert_eq!(crossings[0]["answer"]["name"], json!("toetsingsinkomen"));
+
+    // De beschikking ligt nu in de kroniek van de cel die besloot, en nergens
+    // anders — op te vragen met een gewone reductie.
+    let (status, answer) = browser
+        .get("/api/cells/toeslagen/lexostatus/zorgtoeslagbeschikking?zaakkenmerk=zorgtoeslag/999993653")
+        .await;
+    assert_eq!(status, StatusCode::OK, "{answer}");
+    assert_eq!(
+        answer["outcome"]["established"]["heeft_recht_op_zorgtoeslag"],
+        json!(true),
+        "{answer}"
+    );
+}
+
+/// Een bron-cel zonder engine antwoordt net zo goed, en "niets vastgesteld" is
+/// een **antwoord** met een reden: 200, en te onderscheiden van een antwoord met
+/// waarden.
+#[tokio::test]
+async fn niets_vastgesteld_is_een_gewoon_antwoord() {
+    let mut browser = Browser::new().await;
+    // De klok moet voorbij de vastlegging staan: een vraag over een moment ná de
+    // klok is geen voorspelling maar een fout.
+    browser
+        .post("/api/advance", json!({ "until": "2024-06-01" }))
+        .await;
+
+    let (status, answer) = browser
+        .get("/api/cells/brp/lexostatus/partnerschap?bsn=999993653")
+        .await;
+    assert_eq!(status, StatusCode::OK, "{answer}");
+    assert_eq!(answer["cell"], json!("brp"));
+    assert_eq!(
+        answer["outcome"]["established"]["partnerschap_type"],
+        json!("GEEN"),
+        "{answer}"
+    );
+
+    let (status, answer) = browser
+        .get("/api/cells/brp/lexostatus/partnerschap?bsn=999993653&op_moment=2023-01-01")
+        .await;
+    assert_eq!(status, StatusCode::OK, "{answer}");
+    assert!(
+        answer["outcome"]["not_established"]["reason"].is_string(),
+        "vóór de vastlegging hoort er een reden te staan: {answer}"
+    );
+}
+
+/// Een BSN is tekst, ook al bestaat hij uit cijfers. Zonder de omzetting naar het
+/// gedocumenteerde type zou dezelfde vraag hier "niets vastgesteld" opleveren
+/// terwijl de vastlegging er ligt — het stilste soort verkeerd antwoord.
+#[tokio::test]
+async fn een_parameter_van_het_verkeerde_type_wordt_geweigerd() {
+    let mut browser = Browser::new().await;
+
+    let (status, body) = browser
+        .get("/api/cells/brp/lexostatus/partnerschap?burgerservicenummer=999993653")
+        .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert!(
+        body["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("bsn")),
+        "{body}"
+    );
+
+    let (status, body) = browser
+        .get("/api/cells/kiesraad/lexostatus/registratie?bsn=999993653")
+        .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+}
+
+/// Een instelling is beleid en geen wet, dus ze mag om — tot een besluit erop
+/// geleund heeft. Daarna staat ze vast, en dat is wat een decretogram betekent.
+#[tokio::test]
+async fn een_instelling_mag_om_tot_een_besluit_haar_gebruikt() {
+    let mut browser = Browser::new().await;
+
+    let (status, world) = browser
+        .put("/api/settings", json!({ "betalingsritme": "maand" }))
+        .await;
+    assert_eq!(status, StatusCode::OK, "{world}");
+    assert_eq!(world["settings"]["betalingsritme"], json!("maand"));
+
+    let (status, body) = browser
+        .put("/api/settings", json!({ "betalingsritmen": "maand" }))
+        .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+
+    // Neem het besluit dat het ritme gebruikt; daarna staat de instelling vast.
+    browser
+        .post("/api/actions/burger.aanvraag", aanvraag())
+        .await;
+    browser
+        .post("/api/advance", json!({ "until": "2024-04-01" }))
+        .await;
+    let (status, step) = browser
+        .post(
+            "/api/actions/toeslagen.toekenning",
+            json!({ "bsn": "999993653" }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{step}");
+    assert_eq!(
+        step["snapshot"]["locked_settings"]["betalingsritme"]["besluit"],
+        json!("zorgtoeslag_toekenning"),
+        "{step}"
+    );
+
+    let (status, body) = browser
+        .put("/api/settings", json!({ "betalingsritme": "kwartaal" }))
+        .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+}
+
+/// Opnieuw beginnen is opnieuw uit het wereldbestand: de klok terug, de kronieken
+/// terug naar de startstand.
+#[tokio::test]
+async fn reset_begint_opnieuw_uit_het_wereldbestand() {
+    let mut browser = Browser::new().await;
+
+    browser
+        .post("/api/actions/burger.aanvraag", aanvraag())
+        .await;
+    browser
+        .post("/api/advance", json!({ "until": "2024-06-01" }))
+        .await;
+
+    let (status, world) = browser.post("/api/reset", json!({})).await;
+    assert_eq!(status, StatusCode::OK, "{world}");
+    assert_eq!(world["clock"], json!("2024-01-01"));
+    assert!(
+        grams(&world, "burger", "aanvragen").is_empty(),
+        "de aanvraag hoort weg te zijn: {world}"
+    );
+    assert_eq!(
+        grams(&world, "belastingdienst", "aanslagen").len(),
+        2,
+        "de startstand uit het wereldbestand hoort er weer te staan: {world}"
+    );
+}
+
+/// De kern van "een wereld per sessie": wat de ene browser doet, ziet de andere
+/// niet. Zelfde server, zelfde wereldbestand, twee werelden.
+#[tokio::test]
+async fn twee_sessies_zijn_twee_werelden() {
+    let mut een = Browser::new().await;
+    let mut twee = een.tweede();
+
+    een.post("/api/actions/burger.aanvraag", aanvraag()).await;
+    een.post("/api/advance", json!({ "until": "2024-06-01" }))
+        .await;
+
+    let van_een = een.world().await;
+    let van_twee = twee.world().await;
+
+    assert_eq!(van_een["clock"], json!("2024-06-01"));
+    assert_eq!(van_twee["clock"], json!("2024-01-01"));
+    assert_eq!(grams(&van_een, "burger", "aanvragen").len(), 1);
+    assert!(
+        grams(&van_twee, "burger", "aanvragen").is_empty(),
+        "de tweede sessie hoort de aanvraag van de eerste niet te zien: {van_twee}"
+    );
+
+    // En de eerste sessie blijft bij haar eigen wereld: de tweede heeft er niets
+    // aan veranderd.
+    assert_eq!(een.world().await["clock"], json!("2024-06-01"));
+}
+
+/// Wat er niet is, is een 404 met de namen die er wél zijn; een body die geen
+/// JSON is, is een 400. Beide als JSON met een Nederlandse melding, want een
+/// client die per status een andere vorm moet uitpakken, pakt er één verkeerd uit.
+#[tokio::test]
+async fn fouten_zijn_json_en_nederlands() {
+    let mut browser = Browser::new().await;
+
+    let (status, body) = browser
+        .post("/api/actions/burger.aanvraagje", aanvraag())
+        .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+    assert!(
+        body["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("burger.aanvraag")),
+        "de melding hoort de acties te noemen die er wél zijn: {body}"
+    );
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/api/advance")
+        .header("content-type", "application/json")
+        .body(Body::from("{ tot:"))
+        .expect("verzoek");
+    let response = app()
+        .await
+        .oneshot(request)
+        .await
+        .expect("de app moet antwoorden");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("body")
+        .to_bytes();
+    let body: Value = serde_json::from_slice(&bytes).expect("een fout is JSON");
+    assert!(
+        body["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("geldige JSON")),
+        "{body}"
+    );
+}
+
+/// Een actie met een veld dat haar formulier niet documenteert, en een veld van
+/// het verkeerde type: beide geweigerd door de wereld zelf, en beide een 400.
+#[tokio::test]
+async fn een_formulier_dat_niet_klopt_wordt_geweigerd() {
+    let mut browser = Browser::new().await;
+
+    let mut te_veel: BTreeMap<&str, Value> = BTreeMap::new();
+    te_veel.insert("bsn", json!("999993653"));
+    te_veel.insert("jaar", json!(2024));
+    te_veel.insert("toeslagjaar", json!(2024));
+    let (status, body) = browser
+        .post("/api/actions/burger.aanvraag", json!(te_veel))
+        .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+
+    let (status, body) = browser
+        .post(
+            "/api/actions/burger.aanvraag",
+            json!({ "bsn": 999_993_653_i64, "jaar": 2024 }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+}

--- a/packages/chrono-poc-web/tests/github_source.rs
+++ b/packages/chrono-poc-web/tests/github_source.rs
@@ -16,7 +16,9 @@
 //!    en de regelingen waarop het rust horen uit dezelfde momentopname te komen;
 //!    en
 //! 3. het token uit `CORPUS_AUTH_<SLUG>_TOKEN` gaat mee als `Authorization`,
-//!    want zonder dat komt een privérepo niet binnen.
+//!    want zonder dat komt een privérepo niet binnen; en
+//! 4. een pad dat in de opgehaalde momentopname niet bestaat, noemt zichzelf —
+//!    ook als het het tweede pad uit dezelfde momentopname is.
 //!
 //! Eén test, want dit is één verhaal dat de env van het hele proces aanpast
 //! (`GITHUB_API_BASE`); twee tests zouden daarop racen.
@@ -93,8 +95,6 @@ async fn een_wereld_uit_een_repo_kost_een_archiefverzoek_met_het_token() {
                 "",
             ),
         ])))
-        // Twee bronnen, één verzoek: het archief wordt hergebruikt.
-        .expect(1)
         .mount(&server)
         .await;
 
@@ -106,6 +106,16 @@ async fn een_wereld_uit_een_repo_kost_een_archiefverzoek_met_het_token() {
     let resolved = resolve(&world, Some(&corpus), None)
         .await
         .unwrap_or_else(|e| panic!("het opstarten uit een repo moet slagen: {e}"));
+
+    // Twee bronnen, één verzoek: het archief wordt hergebruikt.
+    assert_eq!(
+        server
+            .received_requests()
+            .await
+            .map(|requests| requests.len()),
+        Some(1),
+        "twee bronnen uit dezelfde repo op dezelfde ref horen één archiefverzoek te kosten"
+    );
 
     assert_eq!(resolved.definition.cells.len(), 1);
     assert_eq!(resolved.definition.cells[0].id, "brp");
@@ -123,6 +133,20 @@ async fn een_wereld_uit_een_repo_kost_een_archiefverzoek_met_het_token() {
         !root.exists(),
         "de opgehaalde map hoort opgeruimd te worden, {} staat er nog",
         root.display()
+    );
+
+    // Een corpuspad dat in de momentopname niet bestaat, noemt zichzelf. Dit is
+    // het tweede pad uit dezelfde momentopname en loopt dus langs het
+    // hergebruikte archief; zonder de toets daar zou dit terugkomen als "zet
+    // CHRONO_POC_CORPUS_SOURCE", van een variabele die wél gezet is.
+    let mis = Source::parse("github:example-org/corpus-voorbeeld@main:regelingen")
+        .expect("geldige corpusbron");
+    let err = resolve(&world, Some(&mis), None)
+        .await
+        .expect_err("een corpuspad dat er niet in staat hoort het opstarten te laten falen");
+    assert!(
+        err.contains("regelingen") && err.contains("staat niet in"),
+        "de melding hoort het pad in de repo te noemen: {err}"
     );
 
     std::env::remove_var("GITHUB_API_BASE");

--- a/packages/chrono-poc-web/tests/github_source.rs
+++ b/packages/chrono-poc-web/tests/github_source.rs
@@ -1,0 +1,130 @@
+//! Het opstarten uit een repo: één archiefverzoek, en daarna een wereld.
+//!
+//! Dit is het pad dat in een deployment gelopen wordt en dat lokaal nooit aan bod
+//! komt: het wereldbestand én de regelingen staan in een (privé) repo, en dit
+//! proces haalt ze bij het starten op met een token. Een wiremock-GitHub staat
+//! hier in plaats van de echte, via de `GITHUB_API_BASE`-naad die
+//! `regelrecht-github` daarvoor heeft.
+//!
+//! Er wordt op drie dingen gelet, en alle drie zijn het dingen die in een
+//! container pas zouden opvallen:
+//!
+//! 1. het archief komt binnen en wordt uitgepakt, met de
+//!    `{owner}-{repo}-{sha}/`-laag van GitHub eraf;
+//! 2. twee bronnen in dezelfde repo op dezelfde ref kosten **één** verzoek —
+//!    niet alleen goedkoper, ook het enige dat consistent is: een wereldbestand
+//!    en de regelingen waarop het rust horen uit dezelfde momentopname te komen;
+//!    en
+//! 3. het token uit `CORPUS_AUTH_<SLUG>_TOKEN` gaat mee als `Authorization`,
+//!    want zonder dat komt een privérepo niet binnen.
+//!
+//! Eén test, want dit is één verhaal dat de env van het hele proces aanpast
+//! (`GITHUB_API_BASE`); twee tests zouden daarop racen.
+
+use std::io::Write;
+
+use regelrecht_chrono_poc_web::sources::{resolve, Source};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Een wereldbestand zonder wetten: één bron-cel, dus geen engine en geen
+/// regeling nodig. Wat hier getoetst wordt is het ophalen, niet de simulator.
+const WORLD: &str = r"
+clock:
+  start: 2024-01-01
+cells:
+  - id: brp
+    laws: []
+    chronicles:
+      - stream: relaties
+        key: bsn
+    lexostatus_definitions:
+      - name: partnerschap
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - partnerschap_type
+        reduction:
+          chronicle: relaties
+          key: bsn
+          latest: true
+";
+
+/// Een gzipped tar zoals GitHub's tarball-endpoint hem geeft: alles onder één
+/// map `{owner}-{repo}-{sha}/`.
+fn tarball(entries: &[(&str, &str)]) -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+    for (name, body) in entries {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(body.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, name, body.as_bytes())
+            .expect("tar-entry moet te schrijven zijn");
+    }
+    let tar = builder.into_inner().expect("tar moet af te ronden zijn");
+    let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    gz.write_all(&tar).expect("gzip moet te schrijven zijn");
+    gz.finish().expect("gzip moet af te ronden zijn")
+}
+
+#[tokio::test]
+async fn een_wereld_uit_een_repo_kost_een_archiefverzoek_met_het_token() {
+    let server = MockServer::start().await;
+    // `regelrecht-github` leest deze variabele bij het bouwen van zijn client;
+    // dat is de naad waarmee elke GitHub-aanroep in dit proces bij wiremock
+    // uitkomt. De naam van de repo hieronder is verzonnen — in een publieke
+    // repo hoort geen verwijzing naar een echt privécorpus.
+    std::env::set_var("GITHUB_API_BASE", server.uri());
+    std::env::set_var("CORPUS_AUTH_CORPUS_VOORBEELD_TOKEN", "geheim-token");
+
+    Mock::given(method("GET"))
+        .and(path("/repos/example-org/corpus-voorbeeld/tarball/main"))
+        .and(header("authorization", "Bearer geheim-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(tarball(&[
+            (
+                "example-org-corpus-voorbeeld-abc123/simulator/wereld.yaml",
+                WORLD,
+            ),
+            (
+                "example-org-corpus-voorbeeld-abc123/regulation/nl/wet/.gitkeep",
+                "",
+            ),
+        ])))
+        // Twee bronnen, één verzoek: het archief wordt hergebruikt.
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let world = Source::parse("github:example-org/corpus-voorbeeld@main:simulator/wereld.yaml")
+        .expect("geldige wereldbron");
+    let corpus = Source::parse("github:example-org/corpus-voorbeeld@main:regulation")
+        .expect("geldige corpusbron");
+
+    let resolved = resolve(&world, Some(&corpus), None)
+        .await
+        .unwrap_or_else(|e| panic!("het opstarten uit een repo moet slagen: {e}"));
+
+    assert_eq!(resolved.definition.cells.len(), 1);
+    assert_eq!(resolved.definition.cells[0].id, "brp");
+    assert!(
+        resolved.regulation_root.join("nl/wet").is_dir(),
+        "de regelingenmap hoort uitgepakt te zijn zonder de archieflaag erboven, kreeg {}",
+        resolved.regulation_root.display()
+    );
+
+    // De tijdelijke map leeft zolang `resolved` leeft, en verdwijnt daarna: dat
+    // is wat het `fetched`-veld belooft.
+    let root = resolved.regulation_root.clone();
+    drop(resolved);
+    assert!(
+        !root.exists(),
+        "de opgehaalde map hoort opgeruimd te worden, {} staat er nog",
+        root.display()
+    );
+
+    std::env::remove_var("GITHUB_API_BASE");
+    std::env::remove_var("CORPUS_AUTH_CORPUS_VOORBEELD_TOKEN");
+}

--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -159,6 +159,113 @@ pub async fn fetch_archive_implements(
     Ok(files)
 }
 
+/// Download a repo at `git_ref` and unpack it into `dest` — one archive
+/// request, the whole tree on disk.
+///
+/// The sibling of [`fetch_archive_implements`]: same single tarball, but the
+/// bodies are written out instead of parsed and dropped. For a consumer that
+/// needs the files *as files* rather than as an index — a regulation root the
+/// engine walks itself, for instance, where every version of every law has to
+/// be present and the Trees API's "best version per law" is the wrong answer.
+///
+/// `dest` must exist and is written into directly: the archive's single
+/// top-level `{owner}-{repo}-{sha}/` component is stripped, so `dest` ends up
+/// holding the repo's own top level. An entry that would land outside `dest`
+/// (an absolute path, or one climbing out with `..`) fails the whole unpack
+/// rather than being skipped silently — a tarball is remote input, and a
+/// traversal is the one thing that must never be forgiven halfway.
+///
+/// gunzip, untar and the writes are synchronous and IO/CPU-bound, so they run
+/// on a blocking thread off the async runtime.
+pub async fn fetch_archive_to_dir(
+    client: &GithubClient,
+    repo: &str,
+    git_ref: &str,
+    token: Option<&str>,
+    dest: &std::path::Path,
+) -> Result<()> {
+    let bytes = client.fetch_tarball(repo, git_ref, token).await?;
+    let dest = dest.to_path_buf();
+    tokio::task::spawn_blocking(move || unpack_tar_gz(bytes.as_ref(), &dest))
+        .await
+        .map_err(|e| CorpusError::Config(format!("archive unpack task panicked: {e}")))?
+}
+
+/// Unpack a gzipped tar into `dest`, stripping the archive's single top-level
+/// directory component. See [`fetch_archive_to_dir`] for the contract.
+fn unpack_tar_gz(bytes: &[u8], dest: &std::path::Path) -> Result<()> {
+    let gz = flate2::read::GzDecoder::new(bytes);
+    let mut archive = tar::Archive::new(gz);
+    let entries = archive
+        .entries()
+        .map_err(|e| CorpusError::Git(format!("failed to read archive entries: {e}")))?;
+    for entry in entries {
+        let mut entry =
+            entry.map_err(|e| CorpusError::Git(format!("failed to read archive entry: {e}")))?;
+        let path = entry
+            .path()
+            .map_err(|e| CorpusError::Git(format!("archive entry has no path: {e}")))?
+            .to_path_buf();
+        let Some(relative) = strip_top_level(&path) else {
+            continue;
+        };
+        let target = safe_join(dest, &relative)?;
+        match entry.header().entry_type() {
+            tar::EntryType::Directory => {
+                std::fs::create_dir_all(&target)?;
+            }
+            tar::EntryType::Regular => {
+                if let Some(parent) = target.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                entry.unpack(&target).map_err(|e| {
+                    CorpusError::Git(format!("failed to write {}: {e}", target.display()))
+                })?;
+            }
+            // Symlinks, hardlinks and devices: a regulation corpus has none,
+            // and unpacking them is how an archive reaches outside `dest`
+            // without any component of its own path saying so.
+            other => {
+                tracing::debug!(path = %relative.display(), kind = ?other, "archive entry is not a file or directory; skipping");
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Drop the archive's single top-level directory component. `None` for the
+/// top-level entry itself (nothing left to write).
+fn strip_top_level(path: &std::path::Path) -> Option<std::path::PathBuf> {
+    let mut components = path.components();
+    components.next()?;
+    let rest = components.as_path();
+    (!rest.as_os_str().is_empty()).then(|| rest.to_path_buf())
+}
+
+/// Join `relative` onto `dest`, refusing anything that would leave `dest`.
+///
+/// Checked component by component instead of after the fact: a
+/// `canonicalize` of a path that does not exist yet cannot answer the
+/// question, and a prefix comparison on strings is one symlink away from
+/// being wrong.
+fn safe_join(dest: &std::path::Path, relative: &std::path::Path) -> Result<std::path::PathBuf> {
+    use std::path::Component;
+    let mut target = dest.to_path_buf();
+    for component in relative.components() {
+        match component {
+            Component::Normal(part) => target.push(part),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(CorpusError::Git(format!(
+                    "archive entry {} points outside the destination directory",
+                    relative.display()
+                )));
+            }
+        }
+    }
+    Ok(target)
+}
+
 /// List YAML files under `base_path` in a repo tree via the shared client's
 /// Trees call, keeping the blob sha each entry reported. Returns `None` on a
 /// 304 (tree unchanged). Narrows the crate's blob listing to `.yaml` files
@@ -311,6 +418,100 @@ fn extract_implements_from_tar_gz(bytes: &[u8]) -> Result<Vec<(String, Vec<Strin
         // `content` dropped here — bodies never accumulate.
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod unpack_tests {
+    use super::unpack_tar_gz;
+    use std::io::Write;
+
+    /// Build a gzipped tar from `(path, body)` pairs, exactly as GitHub's
+    /// tarball endpoint does: everything under one top-level directory.
+    fn tar_gz(entries: &[(&str, &str)]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+        for (path, body) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, path, body.as_bytes())
+                .expect("tar entry moet te schrijven zijn");
+        }
+        let tar = builder.into_inner().expect("tar moet af te ronden zijn");
+        let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        gz.write_all(&tar).expect("gzip moet te schrijven zijn");
+        gz.finish().expect("gzip moet af te ronden zijn")
+    }
+
+    /// The whole tree lands on disk, the archive's `{owner}-{repo}-{sha}/`
+    /// wrapper stripped — and *every* version of a law is there. That last
+    /// part is the reason this function exists next to the Trees-API path,
+    /// which keeps one version per law: an engine that picks its version on a
+    /// moment needs all of them.
+    #[test]
+    fn unpack_strips_the_top_level_and_keeps_every_version() {
+        let archive = tar_gz(&[
+            ("owner-repo-abc123/README.md", "hoi"),
+            ("owner-repo-abc123/regulation/nl/wet/w/2024-01-01.yaml", "a"),
+            ("owner-repo-abc123/regulation/nl/wet/w/2025-01-01.yaml", "b"),
+        ]);
+        let dest = tempfile::tempdir().expect("tempdir");
+
+        unpack_tar_gz(&archive, dest.path()).expect("unpack moet slagen");
+
+        let laws = dest.path().join("regulation/nl/wet/w");
+        assert_eq!(
+            std::fs::read_to_string(laws.join("2024-01-01.yaml")).ok(),
+            Some("a".to_string())
+        );
+        assert_eq!(
+            std::fs::read_to_string(laws.join("2025-01-01.yaml")).ok(),
+            Some("b".to_string())
+        );
+        assert!(dest.path().join("README.md").is_file());
+    }
+
+    /// A tarball is remote input. An entry that climbs out of the destination,
+    /// or names an absolute path, is refused — and refused as an error, not
+    /// skipped: half an unpacked corpus is a state nobody should have to
+    /// reason about, and a write outside the temp directory is a state nobody
+    /// should have at all.
+    ///
+    /// Asserted on the guard rather than through a crafted archive, because
+    /// `tar::Builder` refuses to *write* a `..` path at all — the attack only
+    /// arrives in bytes produced elsewhere.
+    #[test]
+    fn join_refuses_a_path_that_leaves_the_destination() {
+        let dest = std::path::Path::new("/tmp/bestemming");
+        for evil in [
+            "../buiten.yaml",
+            "regulation/../../buiten.yaml",
+            "/etc/passwd",
+        ] {
+            let err = super::safe_join(dest, std::path::Path::new(evil))
+                .expect_err("{evil} moet geweigerd worden");
+            assert!(
+                err.to_string().contains("outside the destination"),
+                "verwachtte een traversal-melding voor {evil}, kreeg {err}"
+            );
+        }
+    }
+
+    /// The other half of the same guard: a plain nested path is joined as-is,
+    /// and `./` is a no-op rather than a refusal.
+    #[test]
+    fn join_keeps_a_plain_nested_path() {
+        let joined = super::safe_join(
+            std::path::Path::new("/tmp/bestemming"),
+            std::path::Path::new("./regulation/nl/wet/w/2024-01-01.yaml"),
+        )
+        .expect("een gewoon pad moet gewoon samengevoegd worden");
+        assert_eq!(
+            joined,
+            std::path::Path::new("/tmp/bestemming/regulation/nl/wet/w/2024-01-01.yaml")
+        );
+    }
 }
 
 #[cfg(test)]

--- a/packages/pipeline/Dockerfile
+++ b/packages/pipeline/Dockerfile
@@ -53,7 +53,7 @@ COPY packages/Cargo.lock packages/Cargo.toml ./
 # When adding a new workspace member that this image does NOT build, add it
 # to this exclusion list as well; otherwise chef will fail to find its source.
 RUN grep -qE '^members = \[$' Cargo.toml && \
-    sed -i '/"admin"/d; /"arch-extract"/d; /"auth"/d; /"editor-api"/d; /"simulator"/d; /"tui"/d' Cargo.toml
+    sed -i '/"admin"/d; /"arch-extract"/d; /"auth"/d; /"chrono-poc-web"/d; /"editor-api"/d; /"simulator"/d; /"tui"/d' Cargo.toml
 COPY packages/corpus/ corpus/
 COPY packages/github/ github/
 COPY packages/engine/ engine/

--- a/packages/simulator/src/lib.rs
+++ b/packages/simulator/src/lib.rs
@@ -106,11 +106,16 @@ pub use cell::{
     BETALINGEN,
 };
 pub use corpus::regulation_root;
+// De waarde waarin deze crate praat. Ze komt uit de engine en blijft dat, maar
+// ze staat in elke publieke signatuur hier — een actie invullen, een lexostatus
+// bevragen, een instelling wijzigen — dus een aanroeper hoort haar niet bij een
+// tweede crate te hoeven halen.
 pub use error::{Result, SimulatorError, Subject};
 pub use invariant::{
     check_invariants, defined_graph, observed_graph, DecisionTraffic, DeclaredQuery,
     InvariantFailure, QueryEdge, Traffic,
 };
+pub use regelrecht_engine::Value;
 pub use scenario::{
     check_provenance, Act, ActOutcome, Decision, DecisionOutcome, ExpectationFailure, Query,
     QueryOutcome, Scenario, ScenarioRun, TransportOutcome, TransportQuery,

--- a/packages/simulator/worlds/publieke_wereld.yaml
+++ b/packages/simulator/worlds/publieke_wereld.yaml
@@ -1,0 +1,350 @@
+---
+# De publieke wereld: het wereldbestand waarmee de HTTP-laag lokaal draait.
+#
+# Een **wereldbestand** is wat een wereld *is* — een klok, de cellen, de
+# instellingen, de startstand, de acties en de termijnen — en niets van wat een
+# scenario eroverheen legt (`act`, `decide`, `queries`, `query_graph`,
+# `expect_*`). Een scenariobestand draagt zijn wereld in dezelfde velden inline,
+# want een scenario is een run en niet een app; dit bestand is het omgekeerde:
+# een wereld zonder run, om door een mens bespeeld te worden.
+#
+# De inhoud is die van `scenarios/toeslagen_volledig_verhaal.yaml`, met één cel
+# erbij (`brp`) en zonder de stappen: aanvraag → besluit → betalingen → tweede
+# besluit, allemaal aan te sturen via `actions`. Wat er in deze wereld gebeurt,
+# gebeurt dus doordat iemand een actie kiest of de klok vooruit zet — precies
+# waarvoor `packages/chrono-poc-web` bestaat.
+#
+# Er staat geen casus in Rust en geen casus in de frontend: elk label hieronder
+# is data. Een andere casus is een ander bestand.
+
+clock:
+  start: 2024-01-01
+
+settings:
+  # Beleid en geen wet: de besluit-definitie verwijst ernaar met
+  # `$betalingsritme` in plaats van een ritme voor te schrijven. Zodra het
+  # besluit genomen is, staat deze instelling vast — het gram legt vast waarop
+  # besloten is, en `PUT /api/settings` weigert haar daarna.
+  betalingsritme: kwartaal
+
+cells:
+  # De aanvrager. Een bron-cel: geen wetten, geen engine. Wat zij houdt is haar
+  # eigen journaal van wat zij indiende.
+  - id: burger
+    laws: []
+    chronicles:
+      - stream: aanvragen
+        key: bsn
+
+    lexostatus_definitions:
+      - name: ingediende_aanvraag
+        doc: wat deze aanvrager zelf indiende, en wanneer
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - jaar
+        reduction:
+          chronicle: aanvragen
+          key: bsn
+          latest: true
+
+  # Het register. Ook een bron-cel: ze legt vast en reduceert, en heeft geen
+  # engine nodig om een gepubliceerde lexostatus te kunnen geven. Ze staat hier
+  # zodat er in deze wereld één cel te bevragen is die niets berekent —
+  # `GET /api/cells/brp/lexostatus/partnerschap` is het eenvoudigste antwoord
+  # dat de opstelling kan geven, inclusief "niets vastgesteld" vóór 2023-03-01.
+  - id: brp
+    laws: []
+    chronicles:
+      - stream: relaties
+        key: bsn
+        events:
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: brp
+            grondslag: eigen registratie
+            op_moment: 2023-03-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: GEEN
+              # Uitdrukkelijk leeg: het register is hier gezaghebbend en zegt
+              # dat er geen partner is. Dat is een waarde, geen ontbrekend feit.
+              partner_bsn: null
+
+    lexostatus_definitions:
+      - name: partnerschap
+        doc: >-
+          De relatievorm van één persoon op één moment, zoals deze cel die
+          vastlegde. Geen berekening: de laatste vastlegging op of vóór het
+          gevraagde moment.
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - partnerschap_type
+          - partner_bsn
+        reduction:
+          chronicle: relaties
+          key: bsn
+          latest: true
+
+  # De cel die het toetsingsinkomen vaststelt, en die later de verplichtingen
+  # nakomt. Twee aanslagen: de tweede corrigeert de eerste, en dat verschil is
+  # wat een tweede besluit zichtbaar maakt.
+  - id: belastingdienst
+    laws: []
+    chronicles:
+      - stream: aanslagen
+        key: bsn
+        events:
+          - name: aanslag_vastgesteld
+            intake: eigen_besluit
+            recording_actor: belastingdienst
+            grondslag: Wet inkomstenbelasting 2001, hoofdstuk 2
+            op_moment: 2024-03-01
+            fields:
+              bsn: '999993653'
+              toetsingsinkomen: 81000
+              competent_authority: Belastingdienst
+
+          - name: aanslag_herzien
+            intake: eigen_besluit
+            recording_actor: belastingdienst
+            grondslag: Wet inkomstenbelasting 2001, hoofdstuk 2
+            op_moment: 2024-12-01
+            fields:
+              bsn: '999993653'
+              toetsingsinkomen: 85000
+              competent_authority: Belastingdienst
+
+      - stream: betalingen
+        key: zaakkenmerk
+
+    lexostatus_definitions:
+      - name: toetsingsinkomen
+        doc: >-
+          Het vastgestelde toetsingsinkomen op het gevraagde moment, met het
+          bevoegd gezag erbij. Een consument die hierop leunt, hoort te kunnen
+          zien wiens vaststelling dit is.
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - toetsingsinkomen
+          - competent_authority
+        reduction:
+          chronicle: aanslagen
+          key: bsn
+          latest: true
+
+      - name: betaald_tot_nu_toe
+        doc: wat deze cel op deze zaak betaald heeft, opgeteld
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - bedrag
+        reduction:
+          chronicle: betalingen
+          key: zaakkenmerk
+          sum: bedrag
+
+  - id: toeslagen
+    laws:
+      - wet_op_de_zorgtoeslag
+      - algemene_wet_inkomensafhankelijke_regelingen
+      - regeling_standaardpremie
+
+    chronicles:
+      # De kroniek waarin de levering van de burger landt. Leeg opgetuigd: wat
+      # erin komt, komt van een actie.
+      - stream: aanvragen
+        key: bsn
+
+      - stream: relaties
+        key: bsn
+        events:
+          - name: relatie_gewijzigd
+            intake: levering
+            recording_actor: toeslagen
+            grondslag: melding uit de basisregistratie personen
+            op_moment: 2023-01-01
+            fields:
+              bsn: '999993653'
+              partnerschap_type: GEEN
+
+      - stream: inkomensleveringen
+        key: bsn
+        events:
+          - name: inkomenslevering
+            intake: levering
+            recording_actor: toeslagen
+            grondslag: jaarlijkse inkomenslevering
+            op_moment: 2023-11-15
+            fields:
+              bsn: '999993653'
+              is_verzekerde: true
+              vermogen: 0
+
+      # De besluitende cel houdt zelf ook een betalingsstroom: zij legt vast dat
+      # haar gemeld is dat er betaald is.
+      - stream: betalingen
+        key: zaakkenmerk
+
+    besluit_definitions:
+      - name: zorgtoeslag_toekenning
+        doc: >-
+          Het eerste besluit over de zaak: recht en hoogte, met een
+          betalingsverplichting eraan. Het toetsingsinkomen wordt geaccepteerd
+          van de cel die het vaststelde en hier niet nagerekend (invariant I5).
+        regulation: wet_op_de_zorgtoeslag
+        output: heeft_recht_op_zorgtoeslag
+        outputs:
+          - hoogte_zorgtoeslag
+        zaakkenmerk: zorgtoeslag/{bsn}
+        params:
+          - name: bsn
+            type: string
+        inputs:
+          bsn:
+            param: bsn
+          is_verzekerde:
+            from_chronicle: inkomensleveringen
+            field: is_verzekerde
+          toetsingsinkomen:
+            accept_from: belastingdienst
+            lexostatus: toetsingsinkomen
+            field: toetsingsinkomen
+            params:
+              bsn: $bsn
+        obligations:
+          - amount: $hoogte_zorgtoeslag
+            payer: belastingdienst
+            schedule: $betalingsritme
+
+      - name: zorgtoeslag_vaststelling
+        doc: >-
+          Het tweede besluit over dezelfde zaak. Hetzelfde zaakkenmerk, dus het
+          ligt in dezelfde kroniek van dezelfde cel — en het gaat opnieuw naar de
+          bron voor het toetsingsinkomen, want er is nergens een kopie van het
+          eerste antwoord.
+        regulation: wet_op_de_zorgtoeslag
+        output: heeft_recht_op_zorgtoeslag
+        outputs:
+          - hoogte_zorgtoeslag
+        zaakkenmerk: zorgtoeslag/{bsn}
+        params:
+          - name: bsn
+            type: string
+        inputs:
+          bsn:
+            param: bsn
+          is_verzekerde:
+            from_chronicle: inkomensleveringen
+            field: is_verzekerde
+          toetsingsinkomen:
+            accept_from: belastingdienst
+            lexostatus: toetsingsinkomen
+            field: toetsingsinkomen
+            params:
+              bsn: $bsn
+
+    lexostatus_definitions:
+      - name: ontvangen_aanvraag
+        doc: wat deze cel over deze persoon geleverd kreeg
+        inputs:
+          - name: bsn
+            type: string
+        outputs:
+          - jaar
+        reduction:
+          chronicle: aanvragen
+          key: bsn
+          latest: true
+
+      - name: zorgtoeslagbeschikking
+        doc: wat deze cel over deze zaak besloten heeft, op het gevraagde moment
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - heeft_recht_op_zorgtoeslag
+          - hoogte_zorgtoeslag
+        reduction:
+          chronicle: beschikkingen
+          key: zaakkenmerk
+          latest: true
+
+      - name: betaald_tot_nu_toe
+        doc: >-
+          Wat er op deze zaak betaald is, voor zover deze cel dat weet: een som
+          over haar eigen meldingen, en dus een reductie — geen saldo dat naast
+          de kroniek wordt bijgehouden.
+        inputs:
+          - name: zaakkenmerk
+            type: string
+        outputs:
+          - bedrag
+        reduction:
+          chronicle: betalingen
+          key: zaakkenmerk
+          sum: bedrag
+
+actions:
+  - id: burger.aanvraag
+    actor: burger
+    label: Aanvraag zorgtoeslag indienen
+    doc: >-
+      De aanvrager legt vast wat zij indient, en levert hetzelfde feit aan de
+      uitvoerder. Twee grammen, elk in een eigen kroniek.
+    records:
+      cell: burger
+      chronicle: aanvragen
+      name: aanvraag_ingediend
+      intake: aanvraag
+      grondslag: Awir art. 15
+      fields:
+        - name: bsn
+          type: string
+        - name: jaar
+          type: number
+      delivers_to:
+        cell: toeslagen
+        chronicle: aanvragen
+        name: aanvraag_ontvangen
+        intake: aanvraag
+
+  - id: toeslagen.toekenning
+    actor: toeslagen
+    label: Beslis op de aanvraag
+    doc: Kan pas als er een aanvraag ligt.
+    decides:
+      cell: toeslagen
+      besluit: zorgtoeslag_toekenning
+    available_when:
+      cell: toeslagen
+      chronicle: aanvragen
+      field: jaar
+      equals: 2024
+
+  - id: toeslagen.vaststelling
+    actor: toeslagen
+    label: Stel de zorgtoeslag definitief vast
+    doc: Kan pas als er een toekenning ligt.
+    decides:
+      cell: toeslagen
+      besluit: zorgtoeslag_vaststelling
+    available_when:
+      cell: toeslagen
+      chronicle: beschikkingen
+      field: besluit
+      equals: zorgtoeslag_toekenning
+
+deadlines:
+  - label: aanvraag ontvangen vóór 1 maart
+    at: 2024-03-01
+    warn_if_missing:
+      cell: toeslagen
+      chronicle: aanvragen
+      name: aanvraag_ontvangen


### PR DESCRIPTION
Een nieuwe crate `packages/chrono-poc-web`: axum achter de bestaande OIDC-login, die de wereld-API van `packages/simulator` als JSON aanbiedt en per browsersessie één `World` in geheugen houdt. Geen database, geen sqlx. Lokaal starten met `just chrono-poc` (login uit, poort 7160).

Wat de simulator mist om door een mens bespeeld te kunnen worden, is precies dit en niets meer: elke route is één aanroep op `World`, en er wordt nergens iets bijgehouden dat niet in een cel ligt.

## Drie keuzes die de vorm bepalen

**De casus zit niet in de code.** Het wereldbestand en de regelingenmap komen bij het starten uit een bron die de omgeving noemt: `local:<pad>` of `github:<owner>/<repo>@<ref>:<pad>`. Niet uit `corpus-registry.yaml` — dat is een publiek bestand, en de naam van een privérepo hoort daar niet in. Het token volgt wél de bestaande conventie (`CORPUS_AUTH_<SLUG>_TOKEN`, opgelost door de `CredentialResolver` van `packages/corpus`), zodat een operator niets nieuws hoeft te leren. Het ophalen gebeurt één keer en falen stopt het proces met de reden: een server die opkomt zonder wereld staat groen op elke healthcheck en geeft op elk verzoek dezelfde fout.

**Een wereld per thread, niet per slot.** Een `World` is niet `Send` — een cel houdt haar engine in een `RefCell`, en die engine kan tijdens een besluit een `Rc<dyn CellResolver>` dragen — dus een map van werelden kan niet in de state van een axum-app liggen. Elke sessie krijgt daarom een eigen thread die haar wereld bezit; wat er in de `DashMap` staat is de *greep* op die thread plus het moment waarop hij het laatst gebruikt is. Dat levert op wat een wereld-in-de-map ook opgeleverd zou hebben (twee sessies zijn twee werelden) plus iets extra's: twee sessies wachten ook niet op elkaar. Een uur zonder verkeer ruimt de wereld op; de afweging staat in de moduledocs van `src/worlds.rs`.

**Veldnamen Engels, meldingen Nederlands.** De vorm van een antwoord is het contract dat `Snapshot` al vastlegt; elke fout die een mens leest komt uit de simulator. Drie dingen zijn met opzet géén fout: "niets vastgesteld" is een 200 met een reden, een actie die nu niet kan een 409 met de uitleg van de wereld erin, en een verstreken termijn een waarschuwing in het antwoord. De parameters van een lexostatus worden omgezet naar het type dat de definitie documenteert, zodat een BSN tekst blijft en een jaar een getal wordt — zonder die stap zou dezelfde vraag stil "niets vastgesteld" opleveren terwijl de vastlegging er ligt.

## Routes

`GET /health` (open), en achter de rol uit `CHRONO_POC_REQUIRED_ROLE` (default `editor-reader`): `GET /api/world`, `POST /api/actions/{id}`, `POST /api/advance`, `GET /api/cells/{cel}/lexostatus/{naam}`, `PUT /api/settings`, `POST /api/reset`. De frontend komt uit `STATIC_DIR` met SPA-fallback, zoals editor-api dat doet. Alle configuratie staat in `packages/chrono-poc-web/README.md`.

## Erbij

- `packages/simulator/worlds/publieke_wereld.yaml` — een **wereldbestand**: wat een wereld *is* (klok, cellen, instellingen, startstand, acties, termijnen), zonder de run die een scenariobestand eroverheen legt. Hier draait `just chrono-poc` op, en de tests van deze crate ook.
- `regelrecht_corpus::github::fetch_archive_to_dir` — de tegenhanger van de bestaande archief-scan: hetzelfde ene tarball-verzoek, maar de bodies worden weggeschreven in plaats van geïndexeerd. Nodig omdat een regelingenwortel *álle* versies van een wet nodig heeft en de Trees-API er één per wet kiest. Een entry die buiten de bestemming zou landen laat het uitpakken falen.
- `regelrecht_simulator` exporteert `Value`, want die staat in elke publieke signatuur die deze laag aanroept.
- De gebruikelijke poorten van een nieuwe workspace-member: `packages/Cargo.toml`, de vier Dockerfile-uitsluitingslijsten, de arch-extract-cratelijst met proza, CLAUDE.md.

## Buiten scope

Dockerfile en ZAD-component, en de frontend. Beide hebben een eigen ticket.

## Gates

`cargo fmt`, `clippy --workspace` en `cargo check --workspace` groen; de hele Rust-suite groen behalve de container-backed crates, die in deze omgeving ook op de ongewijzigde base op `PoolTimedOut` vallen (nagegaan op een verse worktree van de base). Pre-commit groen. De nieuwe tests draaien over de echte wereld en het echte corpus: het beeld, een actie die in twee kronieken vastlegt, de klok vooruit met een verstreken termijn, een besluit dat een waarde over een celgrens accepteert, instellingen die vast komen te staan, terugzetten, twee sessies die twee werelden zijn, en het opstarten dat netjes faalt zonder wereldbestand. Het ophalen uit een repo staat vast met een wiremock-GitHub en een echt tarball (archieflaag eraf, één verzoek voor twee bronnen, token in de header, tijdelijke map opgeruimd).