### PR TITLE
feat(chrono-poc): rol de testopstelling uit als eigen ZAD-component

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,10 @@ frontend
 # Same for the demo: the workspace needs its manifest, nothing else of it.
 frontend-demo
 !frontend-demo/package.json
+# frontend-chrono-poc/ staat hier met opzet NIET bij: packages/chrono-poc-web
+# bouwt die bundel in zijn eigen image en heeft dus de hele map nodig, niet
+# alleen het manifest. Sluit hem hier niet af zonder dat image mee te nemen —
+# de node-stage valt dan om op een ontbrekende workspace.
 doc
 *.md
 *.png

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -813,11 +813,10 @@ jobs:
   # release-profiel, de cargo-chef-lagen, de `COPY schema/` waar include_str!
   # aan hangt, en de bin-naam in `COPY --from=builder`.
   #
-  # Eén image is genoeg. De drie Rust-Dockerfiles delen deze hele machinerie en
+  # Eén image is genoeg. De Rust-Dockerfiles delen deze hele machinerie en
   # verschillen alleen in welke members ze kopiëren en welke binary ze eruit
   # halen; dat verschil dekt script/dockerfile-consistency.test.mjs statisch af.
-  # pipeline-api is de goedkoopste van de drie: gemeten 4,4 tot 4,8 minuut met
-  # warme cache.
+  # pipeline-api is de goedkoopste: gemeten 4,4 tot 4,8 minuut met warme cache.
   #
   # Hij hangt aan de `Test`-poort en blokkeert dus. Een build waarop gewacht
   # wordt maar die niets tegenhoudt kost de wandklok zonder de garantie te

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,7 @@ jobs:
       harvester-worker: ${{ steps.filter.outputs.harvester-worker }}
       enrich-worker: ${{ steps.filter.outputs.enrich-worker }}
       pipeline-api: ${{ steps.filter.outputs.pipeline-api }}
+      chrono-poc: ${{ steps.filter.outputs.chrono-poc }}
       grafana: ${{ steps.filter.outputs.grafana }}
       lawmaking: ${{ steps.filter.outputs.lawmaking }}
       docs: ${{ steps.filter.outputs.docs }}
@@ -207,6 +208,21 @@ jobs:
       build-args: BIN=regelrecht-pipeline-api
       cache-scope: pipeline-api
 
+  # De testopstelling: één image met het axum-binary en de Vue-bundel die erop
+  # draait. Geen target en geen BIN-build-arg; deze Dockerfile bouwt één ding.
+  build-chrono-poc:
+    needs: [changes, ci-green]
+    if: github.event.action != 'closed' && needs.changes.outputs.chrono-poc == 'true'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image-name: minbzk/regelrecht-chrono-poc
+      dockerfile: packages/chrono-poc-web/Dockerfile
+      cache-scope: chrono-poc
+    # Only GITHUB_TOKEN is needed; it is automatically available to called workflows
+
   build-grafana:
     needs: [changes, ci-green]
     if: >-
@@ -268,7 +284,7 @@ jobs:
   deploy-preview:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [build, build-admin, build-harvester-worker, build-enrich-worker, build-pipeline-api, build-lawmaking, build-docs, build-demo, changes]
+    needs: [build, build-admin, build-harvester-worker, build-enrich-worker, build-pipeline-api, build-chrono-poc, build-lawmaking, build-docs, build-demo, changes]
     if: >-
       always() &&
       github.event_name == 'pull_request' && github.event.action != 'closed' &&
@@ -279,6 +295,7 @@ jobs:
         needs.build-harvester-worker.result == 'success' ||
         needs.build-enrich-worker.result == 'success' ||
         needs.build-pipeline-api.result == 'success' ||
+        needs.build-chrono-poc.result == 'success' ||
         needs.build-lawmaking.result == 'success' ||
         needs.build-demo.result == 'success' ||
         needs.build-docs.result == 'success'
@@ -307,6 +324,7 @@ jobs:
           HARVESTER_WORKER: ${{ needs.build-harvester-worker.result }}
           ENRICH_WORKER: ${{ needs.build-enrich-worker.result }}
           PIPELINE_API: ${{ needs.build-pipeline-api.result }}
+          CHRONO_POC: ${{ needs.build-chrono-poc.result }}
           LAWMAKING: ${{ needs.build-lawmaking.result }}
           DEMO: ${{ needs.build-demo.result }}
           DOCS: ${{ needs.build-docs.result }}
@@ -325,6 +343,7 @@ jobs:
           if [ "$HARVESTER_WORKER" = success ]; then add harvester-worker regelrecht-harvester-worker; fi
           if [ "$ENRICH_WORKER" = success ]; then add enrichworker regelrecht-enrich-worker; fi
           if [ "$PIPELINE_API" = success ]; then add pipelineapi regelrecht-pipeline-api; fi
+          if [ "$CHRONO_POC" = success ]; then add chrono-poc regelrecht-chrono-poc; fi
           if [ "$LAWMAKING" = success ]; then add lawmaking regelrecht-lawmaking; fi
           if [ "$DEMO" = success ]; then add demo regelrecht-demo; fi
           if [ "$DOCS" = success ]; then add docs regelrecht-docs; fi
@@ -372,7 +391,7 @@ jobs:
   deploy-production:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [build, build-admin, build-harvester-worker, build-enrich-worker, build-pipeline-api, build-grafana, build-lawmaking, build-docs, build-demo]
+    needs: [build, build-admin, build-harvester-worker, build-enrich-worker, build-pipeline-api, build-chrono-poc, build-grafana, build-lawmaking, build-docs, build-demo]
     if: >-
       always() &&
       github.ref == 'refs/heads/main' && github.event_name == 'push' &&
@@ -383,6 +402,7 @@ jobs:
         needs.build-harvester-worker.result == 'success' ||
         needs.build-enrich-worker.result == 'success' ||
         needs.build-pipeline-api.result == 'success' ||
+        needs.build-chrono-poc.result == 'success' ||
         needs.build-grafana.result == 'success' ||
         needs.build-lawmaking.result == 'success' ||
         needs.build-demo.result == 'success' ||
@@ -412,7 +432,8 @@ jobs:
           RESULTS: >-
             ${{ needs.build.result }} ${{ needs.build-admin.result }}
             ${{ needs.build-harvester-worker.result }} ${{ needs.build-enrich-worker.result }}
-            ${{ needs.build-pipeline-api.result }} ${{ needs.build-grafana.result }}
+            ${{ needs.build-pipeline-api.result }} ${{ needs.build-chrono-poc.result }}
+            ${{ needs.build-grafana.result }}
             ${{ needs.build-lawmaking.result }} ${{ needs.build-docs.result }}
             ${{ needs.build-demo.result }}
         run: |
@@ -440,6 +461,7 @@ jobs:
           HARVESTER_WORKER: ${{ needs.build-harvester-worker.result }}
           ENRICH_WORKER: ${{ needs.build-enrich-worker.result }}
           PIPELINE_API: ${{ needs.build-pipeline-api.result }}
+          CHRONO_POC: ${{ needs.build-chrono-poc.result }}
           GRAFANA: ${{ needs.build-grafana.result }}
           LAWMAKING: ${{ needs.build-lawmaking.result }}
           DEMO: ${{ needs.build-demo.result }}
@@ -459,6 +481,7 @@ jobs:
           if [ "$HARVESTER_WORKER" = success ]; then add harvester-worker regelrecht-harvester-worker; fi
           if [ "$ENRICH_WORKER" = success ]; then add enrichworker regelrecht-enrich-worker; fi
           if [ "$PIPELINE_API" = success ]; then add pipelineapi regelrecht-pipeline-api; fi
+          if [ "$CHRONO_POC" = success ]; then add chrono-poc regelrecht-chrono-poc; fi
           # Grafana bouwt alleen op main, dus alleen productie kent deze regel.
           if [ "$GRAFANA" = success ]; then add grafana regelrecht-grafana; fi
           if [ "$LAWMAKING" = success ]; then add lawmaking regelrecht-lawmaking; fi
@@ -545,6 +568,7 @@ jobs:
               {"org": "${{ github.repository_owner }}", "name": "regelrecht-harvester-worker", "tag": "pr-${{ github.event.pull_request.number }}"},
               {"org": "${{ github.repository_owner }}", "name": "regelrecht-enrich-worker", "tag": "pr-${{ github.event.pull_request.number }}"},
               {"org": "${{ github.repository_owner }}", "name": "regelrecht-pipeline-api", "tag": "pr-${{ github.event.pull_request.number }}"},
+              {"org": "${{ github.repository_owner }}", "name": "regelrecht-chrono-poc", "tag": "pr-${{ github.event.pull_request.number }}"},
               {"org": "${{ github.repository_owner }}", "name": "regelrecht-lawmaking", "tag": "pr-${{ github.event.pull_request.number }}"},
               {"org": "${{ github.repository_owner }}", "name": "regelrecht-demo", "tag": "pr-${{ github.event.pull_request.number }}"},
               {"org": "${{ github.repository_owner }}", "name": "regelrecht-docs", "tag": "pr-${{ github.event.pull_request.number }}"}

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -35,13 +35,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Dezelfde acht als de image-name-regels in deploy.yml.
+        # De image-name-regels uit deploy.yml, op demo na: die heeft nog geen
+        # `latest` op GHCR en zou dus alleen een niet-bestaande tag scannen.
         image:
           - regelrecht-editor
           - regelrecht-admin
           - regelrecht-harvester-worker
           - regelrecht-enrich-worker
           - regelrecht-pipeline-api
+          - regelrecht-chrono-poc
           - regelrecht-grafana
           - regelrecht-lawmaking
           - regelrecht-docs

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -35,8 +35,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # De image-name-regels uit deploy.yml, op demo na: die heeft nog geen
-        # `latest` op GHCR en zou dus alleen een niet-bestaande tag scannen.
+        # De image-name-regels uit deploy.yml, op demo na. Dat is een gat en
+        # geen afweging: `ghcr.io/minbzk/regelrecht-demo` heeft wél een
+        # `latest` en wordt hier dus niet nagekeken.
+        #
+        # Elk image hier moet een `latest` hebben, want dat is de tag die
+        # hieronder gescand wordt, en een tag die niet bestaat zet de baan op
+        # rood. Dat komt goed uit: deze workflow draait van de default branch,
+        # en `build-image.yml` tagt `latest` alleen op main — een nieuwe naam in
+        # deze lijst gaat dus pas gelden op het moment dat de eerste
+        # productiebouw die tag publiceert.
         image:
           - regelrecht-editor
           - regelrecht-admin

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -38,6 +38,7 @@ jobs:
             frontend
             lawmaking
             demo
+            chrono-poc
             docs
             grafana
             ci

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
         entry: script/check-tool-pins.sh
         language: system
         pass_filenames: false
-        files: (^frontend/Dockerfile$|^packages/(admin|pipeline)/Dockerfile$)
+        files: (^frontend/Dockerfile$|^packages/(admin|chrono-poc-web|pipeline)/Dockerfile$)
 
       - id: review-gate-tests
         name: Merge-poort op de Claude-review doet wat hij belooft
@@ -115,7 +115,7 @@ repos:
         entry: just dockerfile-consistency-test
         language: system
         pass_filenames: false
-        files: ^(frontend/Dockerfile|packages/(admin|pipeline)/Dockerfile|packages/Cargo\.toml|rust-toolchain\.toml|\.github/workflows/deploy\.yml|script/dockerfile-consistency\.test\.mjs)$
+        files: ^(frontend/Dockerfile|packages/(admin|chrono-poc-web|pipeline)/Dockerfile|packages/Cargo\.toml|rust-toolchain\.toml|\.github/workflows/deploy\.yml|script/dockerfile-consistency\.test\.mjs)$
 
       - id: deploy-gate-tests
         name: Deploy-poort op een groene CI doet wat hij belooft

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,7 +115,10 @@ repos:
         entry: just dockerfile-consistency-test
         language: system
         pass_filenames: false
-        files: ^(frontend/Dockerfile|packages/(admin|chrono-poc-web|pipeline)/Dockerfile|packages/Cargo\.toml|rust-toolchain\.toml|\.github/workflows/deploy\.yml|script/dockerfile-consistency\.test\.mjs)$
+        # Elke Dockerfile uit de DOCKERFILES-lijst van de test hoort hier te
+        # staan, anders knipt hij mee zonder dat het commit dat hem wijzigt de
+        # toets langsgaat. frontend-demo/Dockerfile stond er niet in.
+        files: ^(frontend/Dockerfile|frontend-demo/Dockerfile|packages/(admin|chrono-poc-web|pipeline)/Dockerfile|packages/Cargo\.toml|rust-toolchain\.toml|\.github/workflows/deploy\.yml|script/dockerfile-consistency\.test\.mjs)$
 
       - id: deploy-gate-tests
         name: Deploy-poort op een groene CI doet wat hij belooft

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `packages/editor-api/` - Rust backend API for the editor frontend
 - `packages/corpus/` - Shared library for working with YAML regulation files
 - `packages/shared/` - Common types/utilities across packages
-- `packages/chrono-poc-web/` - HTTP-laag om de simulator: axum + OIDC, één `World` per browsersessie in geheugen, de wereld-API als JSON, geen database
+- `packages/chrono-poc-web/` - HTTP-laag om de simulator: axum + OIDC, één `World` per browsersessie in geheugen, de wereld-API als JSON, geen database. `packages/chrono-poc-web/Dockerfile` bakt dit binary samen met de `frontend-chrono-poc`-bundel tot het image `regelrecht-chrono-poc`, doeldomein `chrono-poc.regelrecht.rijks.app`. De wereld en de regelingen zitten **niet** in het image: die komen bij het starten uit `CHRONO_POC_WORLD_SOURCE`/`CHRONO_POC_CORPUS_SOURCE`, zodat het image publiek kan zijn ook als de wereld die het draait dat niet is
 - `packages/simulator/` - Chronolexografie testopstelling (RFC-022): cellen met een privé kroniekstore, lexostatus-reducties, een veiligheidscontext plus `CellTransport` als enige weg over een celgrens, het test-only observatielog en een scenario-loader
 - `packages/tui/` - Terminal UI dashboard
 - `packages/grafana/` - Grafana monitoring with provisioned dashboards
@@ -87,8 +87,9 @@ merge). The format is **Conventional Commits**: `type(scope): subject`, where
 - **Allowed types**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`,
   `test`, `chore`, `build`, `ci`.
 - **Allowed scopes** (optional): `engine`, `admin`, `pipeline`, `harvester`,
-  `editor`, `corpus`, `github`, `frontend`, `lawmaking`, `demo`, `docs`, `grafana`,
-  `ci`, `schema`, `deps`, `dev`. An unlisted scope fails the lint.
+  `editor`, `corpus`, `github`, `frontend`, `lawmaking`, `demo`, `chrono-poc`,
+  `docs`, `grafana`, `ci`, `schema`, `deps`, `dev`. An unlisted scope fails the
+  lint.
 - **The subject MUST start with a lowercase letter** (`subjectPattern:
   ^[a-z].*$`). This is the easiest rule to trip on: `docs: RFC-…` fails because
   "RFC" is uppercase — write `docs: verwijzingen naar RFC's …` instead. Editing
@@ -474,6 +475,7 @@ de job staat in het workflowbestand dat de PR meebrengt.
 | harvester-worker | `regelrecht-harvester-worker` | (no web UI) |
 | enrichworker | `regelrecht-enrich-worker` | (no web UI) |
 | pipeline-api | `regelrecht-pipeline-api` | (internal) |
+| chrono-poc | `regelrecht-chrono-poc` | `chrono-poc.regelrecht.rijks.app` |
 | lawmaking | `regelrecht-lawmaking` | `lawmaking.regelrecht.rijks.app` |
 | demo | `regelrecht-demo` | `demo.regelrecht.rijks.app` (ZAD component still to be created) |
 | docs | `regelrecht-docs` | `docs.regelrecht.rijks.app` + `regelrecht.rijks.app` (landing) |

--- a/Justfile
+++ b/Justfile
@@ -145,7 +145,7 @@ ci-gate-test:
 nldd-imports-test:
     node --test script/nldd-imports.test.mjs
 
-# Houdt de drie Rust-Dockerfiles bij de workspace: elke member wordt ge-COPYd
+# Houdt de Rust-Dockerfiles bij de workspace: elke member wordt ge-COPYd
 # of weggeknipt, de rust-tag volgt rust-toolchain.toml en elke binary-naam
 # bestaat. Die drie zijn stringliteralen die verder niets nakijkt.
 [doc("Check the Rust Dockerfiles against the cargo workspace")]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Machine-readable Dutch law execution. regelrecht takes legal texts, encodes them
 | [packages/github/](packages/github/) | Shared GitHub REST client |
 | [packages/shared/](packages/shared/) | Shared domain types across crates |
 | [packages/arch-extract/](packages/arch-extract/) | Derives the architecture model from the code (`just arch-explore`) |
+| [packages/simulator/](packages/simulator/) | The chronolexography test rig: cells with a private chronicle store, lexostatus reductions, and a single transport across every cell boundary |
+| [packages/chrono-poc-web/](packages/chrono-poc-web/) | HTTP layer over the test rig: one world per browser session, the world API as JSON |
 | [packages/tui/](packages/tui/) | Terminal dashboard (Ratatui) |
 
 ### Frontends and sites
@@ -40,6 +42,7 @@ Machine-readable Dutch law execution. regelrecht takes legal texts, encodes them
 |-----------|-------------|
 | [frontend/](frontend/) | Law editor UI (Vue 3 + Vite) |
 | [frontend-lawmaking/](frontend-lawmaking/) | Law-making process visualization (Vue 3 + Vite) |
+| [frontend-chrono-poc/](frontend-chrono-poc/) | The chronolexography test rig in the browser (Vue 3 + Vite on the world API): a column per cell, a timeline, the actions of the moment, and where every value came from |
 | [packages/frontend-shared/](packages/frontend-shared/) | Shared frontend primitives (auth, colour scheme, API fetch) |
 | [docs/](docs/) | Astro site: landing page + documentation |
 
@@ -82,6 +85,7 @@ editor sessions; they are not meant to be read directly.
 | Documentation | https://docs.regelrecht.rijks.app |
 | Law-making | https://lawmaking.regelrecht.rijks.app |
 | Harvester admin | https://harvester-admin.regelrecht.rijks.app |
+| Chronolexography test rig | https://chrono-poc.regelrecht.rijks.app |
 | Grafana | https://grafana.regelrecht.rijks.app |
 
 The pipeline API and the harvester and enrich workers deploy alongside these but have no web UI of their own.

--- a/docs/src/content/docs/operations/deployment.md
+++ b/docs/src/content/docs/operations/deployment.md
@@ -41,6 +41,7 @@ The preview deployment and its GHCR images are cleaned up automatically.
 | Harvester Worker | `regelrecht-harvester-worker` | (no web UI) |
 | Enrich Worker | `regelrecht-enrich-worker` | (no web UI) |
 | Pipeline API | `regelrecht-pipeline-api` | (no public URL; reached in-cluster) |
+| Chronolexography test rig | `regelrecht-chrono-poc` | `chrono-poc.regelrecht.rijks.app` |
 | Lawmaking | `regelrecht-lawmaking` | `lawmaking.regelrecht.rijks.app` |
 | Demo | `regelrecht-demo` | `demo.regelrecht.rijks.app` (ZAD-component nog aanmaken, zie hieronder) |
 | Docs | `regelrecht-docs` | `docs.regelrecht.rijks.app` + `regelrecht.rijks.app` (landing) |
@@ -73,6 +74,64 @@ De demo (`frontend-demo/`, doel `demo.regelrecht.rijks.app`) is in `deploy.yml` 
 5. **Merge naar main** rolt de demo productie in; de tabel hierboven en `CLAUDE.md` krijgen dan de definitieve regel zonder "still to be wired". Het image valt vanzelf onder `scheduled-cleanup.yml`, dat op `sha-`-tags en de draaiende deployment toetst.
 
 De demo heeft geen backend en geen secrets nodig; de bouw duurt langer dan de andere frontends door de Rust-naar-WASM-stap (de `wasm-builder`-stage is gepind op de Rust-versie uit `rust-toolchain.toml` en de `wasm-bindgen`-versie uit `packages/Cargo.lock`, en faalt luid als die uit elkaar lopen).
+
+## De chronolexografie-testopstelling (`chrono-poc`)
+
+Het image `regelrecht-chrono-poc` bevat twee dingen: het axum-binary uit
+`packages/chrono-poc-web/` en de Vue-bundel uit `frontend-chrono-poc/`
+(gebouwd in dezelfde Dockerfile, op `/app/static`). Wat het **niet** bevat is een
+wereld: geen wetten, geen kronieken, geen startstand. Die haalt het proces bij het
+starten op uit de bron die de omgeving noemt, en daarom is dit image publiek te
+publiceren ook als de wereld die het draait dat niet is.
+
+Het opstarten faalt luid. Ontbreekt de bron, is het wereldbestand onleesbaar, of
+noemt het een regeling die niet in de opgehaalde map staat, dan stopt het proces
+met de reden in plaats van op te komen en op elk verzoek dezelfde fout te geven.
+
+### Instellingen
+
+| variabele | wat |
+|---|---|
+| `CHRONO_POC_WORLD_SOURCE` | **verplicht.** Waar het wereldbestand staat: `local:<pad>` of `github:<owner>/<repo>@<ref>:<pad>` |
+| `CHRONO_POC_CORPUS_SOURCE` | waar de regelingen staan, in dezelfde twee vormen. Afwezig: `REGULATION_PATH`, anders het corpus in de checkout |
+| `CHRONO_POC_AUTH_REF` | de sleutel waaronder het GitHub-token opgezocht wordt; standaard de reponaam uit de bron |
+| `CHRONO_POC_REQUIRED_ROLE` | de rol waarachter `/api/*` staat; standaard `editor-reader`, zodat de bestaande login volstaat |
+| `CHRONO_POC_PORT` | de poort; standaard `8000`, wat de container ook publiceert |
+| `CORPUS_AUTH_<SLUG>_TOKEN` | het GitHub-token voor een bron die niet publiek is. Dezelfde conventie als de rest van de workspace; de opzoeking is strikt, dus het gedeelde `CORPUS_GIT_TOKEN` gaat nooit naar een repo die deze app aanwijst |
+| `OIDC_*`, `BASE_URL` | de login, gelezen door `packages/auth`. In ZAD komt `OIDC_DISCOVERY_URL` (plus client-id en -secret) van de `keycloak`-service op de component; die hoeven dus niet met de hand gezet te worden. Zonder `OIDC_CLIENT_ID` staat de login **uit** en is elke route open — alleen lokaal |
+
+`STATIC_DIR` staat al in het image en hoeft niet gezet te worden.
+
+### De ZAD-component
+
+Eenmalig, met de hand, door iemand met `RIG_API_KEY`, en **nadat het eerste image
+bestaat**: `deploy-production` zet alle componenten in één taak, dus een component
+die ZAD niet kent laat die hele taak falen. De volgorde is daarom: PR labelen met
+`deploy:preview` zodat `build-chrono-poc` een `pr-<N>`-tag publiceert, dan de
+component registreren op die tag, dan de preview opnieuw laten draaien.
+
+```bash
+zad component add chrono-poc \
+    --image ghcr.io/minbzk/regelrecht-chrono-poc:pr-<N> \
+    --deployment regelrecht \
+    --port 8000 \
+    --service publish-on-web \
+    --service keycloak \
+    -e CHRONO_POC_WORLD_SOURCE=... \
+    -e CHRONO_POC_CORPUS_SOURCE=...
+```
+
+Er is geen `zad component edit`: de env-variabelen gaan mee bij `add` (of via de
+deploy-action). Daarna de hostnaam `chrono-poc.regelrecht.rijks.app` aan de
+component koppelen, zoals bij `lawmaking`. Previews erven de instellingen via
+`clone-from: regelrecht`, dus een preview-URL van de vorm
+`chrono-poc-pr<N>-<project>.rig.prd1.gn2.quattro.rijksapps.nl` draait dezelfde
+wereld als productie.
+
+Loopt een preview-deploy op "Task did not complete within 300s", lees dan
+`zad logs pr<N>`. Een timeout hier is bijna altijd een applicatiefout bij het
+starten — een bron die niet bestaat, een ref zonder die wet, een ontbrekend token
+— en niet iets wat een tweede poging oplost.
 
 ## ZAD CLI
 

--- a/docs/src/content/docs/operations/deployment.md
+++ b/docs/src/content/docs/operations/deployment.md
@@ -122,8 +122,10 @@ zad component add chrono-poc \
 ```
 
 Er is geen `zad component edit`: de env-variabelen gaan mee bij `add` (of via de
-deploy-action). Daarna de hostnaam `chrono-poc.regelrecht.rijks.app` aan de
-component koppelen, zoals bij `lawmaking`. Previews erven de instellingen via
+deploy-action). De hostnaam `chrono-poc.regelrecht.rijks.app` volgt uit het
+domeinformaat van de component en hoeft dus niet apart gekoppeld te worden;
+`zad deployment describe regelrecht` laat zien of hij er staat. Previews erven
+de instellingen via
 `clone-from: regelrecht`, dus een preview-URL van de vorm
 `chrono-poc-pr<N>-<project>.rig.prd1.gn2.quattro.rijksapps.nl` draait dezelfde
 wereld als productie.

--- a/packages/chrono-poc-web/Dockerfile
+++ b/packages/chrono-poc-web/Dockerfile
@@ -1,0 +1,124 @@
+# syntax=docker/dockerfile:1
+# De testopstelling: het axum-binary plus de Vue-bundel die erop draait, in één
+# image. Hetzelfde patroon als frontend/Dockerfile (node-stage voor de bundel,
+# cargo-chef voor de Rust-kant, alpine als runtime), zonder de WASM-stap: deze
+# frontend praat met een server en rekent niet zelf.
+#
+# Wat er met opzet NIET in zit: wetten en wereldbestanden. De server haalt die
+# bij het starten op uit de bron die `CHRONO_POC_WORLD_SOURCE` en
+# `CHRONO_POC_CORPUS_SOURCE` noemen, met een token uit de omgeving. Daardoor is
+# dit image publiek te publiceren, ook als de wereld die het draait dat niet is.
+
+# Stage 1: Build frontend (npm workspace root — bouwt de workspace frontend-chrono-poc)
+FROM node:26-alpine@sha256:ef24c5053d50fdc3e4e56eb4e7ddb7861874ab0fdc797046ba897581deb8e868 AS frontend-builder
+WORKDIR /app
+# Workspace manifests first so `npm ci` is cached independently of source.
+# Alleen de twee manifesten die deze bundel nodig heeft: `npm ci` slaat een
+# workspace waarvan de map ontbreekt over, dus de andere frontends kosten hier
+# geen install-tijd. Komt er een manifest bij dat deze bundel wél nodig heeft,
+# dan hoort het hier.
+COPY package.json package-lock.json .npmrc ./
+COPY packages/frontend-shared/package.json packages/frontend-shared/
+COPY frontend-chrono-poc/package.json frontend-chrono-poc/
+# --ignore-scripts: een gekaapte release mag zijn install-hooks hier niet
+# draaien; de build eronder heeft ze niet nodig.
+RUN npm ci --ignore-scripts
+# Source: het gedeelde pakket + deze frontend.
+COPY packages/frontend-shared/ packages/frontend-shared/
+COPY frontend-chrono-poc/ frontend-chrono-poc/
+RUN npm run build -w frontend-chrono-poc
+
+# Stage 2: Chef base
+# Rust version: keep in sync with rust-toolchain.toml (source of truth).
+FROM rust:1.96-alpine@sha256:a41f7740f8b45d45795624eec13a8b42263cc700f19f7e4e86e04d3dda08a479 AS chef
+RUN apk add --no-cache musl-dev curl xz
+# cargo-chef als officiële prebuilt binary van de releasepagina van het project,
+# in plaats van vanaf broncode te compileren. De sha256's zijn de gepubliceerde
+# .sha256-bestanden van diezelfde release; zonder die pin zou een gewijzigd of
+# afgebroken artefact ongemerkt de build in glijden.
+ARG TARGETARCH
+ARG CARGO_CHEF_VERSION=0.1.77
+ARG CARGO_CHEF_SHA256_AMD64=a3733ab416c3ffddd37914cd13919ca05fee1a1cf654f3016dcfe7f399d89cd1
+ARG CARGO_CHEF_SHA256_ARM64=3bff2e7ff979db837c7e820dfd8d51d2d97b9c94283506c6e596ae4887ef178b
+RUN set -eu; \
+    case "${TARGETARCH:-}" in \
+      amd64) arch=x86_64; sha="${CARGO_CHEF_SHA256_AMD64}" ;; \
+      arm64) arch=aarch64; sha="${CARGO_CHEF_SHA256_ARM64}" ;; \
+      *) echo "geen gepinde cargo-chef-binary voor TARGETARCH='${TARGETARCH:-}'" >&2; exit 1 ;; \
+    esac; \
+    dir="cargo-chef-${arch}-unknown-linux-musl"; \
+    curl -fsSLo "/tmp/${dir}.tar.xz" \
+      "https://github.com/LukeMathWalker/cargo-chef/releases/download/v${CARGO_CHEF_VERSION}/${dir}.tar.xz"; \
+    echo "${sha}  /tmp/${dir}.tar.xz" | sha256sum -c -; \
+    tar -xJf "/tmp/${dir}.tar.xz" -C /tmp; \
+    install -m0755 "/tmp/${dir}/cargo-chef" /usr/local/bin/cargo-chef; \
+    rm -rf "/tmp/${dir}.tar.xz" "/tmp/${dir}"; \
+    cargo chef --version
+WORKDIR /build
+
+# Stage 3: Plan dependencies
+FROM chef AS planner
+COPY packages/Cargo.lock packages/Cargo.toml ./
+# Trim workspace members to those actually built by this Dockerfile so chef
+# does not try to resolve crates whose source we do not COPY. The `grep`
+# assertion ensures the multi-line members format is intact; otherwise the
+# `sed` patterns would silently no-op.
+# When adding a new workspace member that this image does NOT build, add it
+# to this exclusion list as well; otherwise chef will fail to find its source.
+RUN grep -qE '^members = \[$' Cargo.toml && \
+    sed -i '/"admin"/d; /"arch-extract"/d; /"editor-api"/d; /"harvester"/d; /"pipeline"/d; /"tui"/d' Cargo.toml
+COPY packages/auth/ auth/
+COPY packages/chrono-poc-web/ chrono-poc-web/
+COPY packages/corpus/ corpus/
+COPY packages/engine/ engine/
+COPY packages/github/ github/
+COPY packages/law-model/ law-model/
+COPY packages/shared/ shared/
+COPY packages/simulator/ simulator/
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Stage 4: Build Rust binary (deps cached separately from source)
+FROM chef AS builder
+COPY packages/Cargo.lock ./
+COPY --from=planner /build/Cargo.toml ./Cargo.toml
+COPY --from=planner /build/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+# `cargo chef cook` rewrites the workspace Cargo.toml without
+# `[workspace.lints]`, which breaks members that declare `[lints] workspace
+# = true`. Re-COPY the real workspace manifest before the final build.
+COPY --from=planner /build/Cargo.toml ./Cargo.toml
+
+COPY packages/auth/ auth/
+COPY packages/chrono-poc-web/ chrono-poc-web/
+COPY packages/corpus/ corpus/
+COPY packages/engine/ engine/
+COPY packages/github/ github/
+COPY packages/law-model/ law-model/
+COPY packages/shared/ shared/
+COPY packages/simulator/ simulator/
+# regelrecht-engine en regelrecht-corpus bakken de JSON-schema's in met
+# `include_str!("../../../schema/...")`, relatief aan hun eigen src/. De crates
+# staan hier op /build/engine en /build/corpus (niet /build/packages/...), dus
+# die literal wijst naar /schema/... — dezelfde layout-truc als in
+# frontend/Dockerfile en packages/admin/Dockerfile.
+COPY schema/ /schema/
+# Invalidate cargo's fingerprint cache so it recompiles with real source
+# instead of using the stub binary from cargo-chef cook.
+RUN find . -name '*.rs' -exec touch {} + && \
+    cargo build --release --bin chrono-poc-web
+
+# Stage 5: Runtime
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+# ca-certificates: het opstarten haalt de wereld en het corpus over HTTPS bij
+# GitHub op. Geen git — dat gaat via de tarball-API, niet via een clone.
+RUN apk add --no-cache ca-certificates && \
+    addgroup -S app && adduser -S app -G app
+
+COPY --from=builder /build/target/release/chrono-poc-web /usr/local/bin/
+COPY --from=frontend-builder /app/frontend-chrono-poc/dist /app/static
+
+WORKDIR /app
+ENV STATIC_DIR=/app/static
+USER app
+EXPOSE 8000
+CMD ["chrono-poc-web"]

--- a/script/check-tool-pins.sh
+++ b/script/check-tool-pins.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-# De cargo-chef-pin (versie + beide checksums) staat in drie Dockerfiles.
+# De cargo-chef-pin (versie + beide checksums) staat in elk van de Dockerfiles
+# hieronder.
 # Uiteenlopen is stil: de build die de verkeerde pin heeft faalt pas als iemand
 # dat image toevallig koud bouwt, en dan met een checksum-fout zonder oorzaak.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-files=(frontend/Dockerfile packages/admin/Dockerfile packages/pipeline/Dockerfile)
+files=(frontend/Dockerfile packages/admin/Dockerfile packages/chrono-poc-web/Dockerfile packages/pipeline/Dockerfile)
 reference=""
 status=0
 

--- a/script/deploy-filters.mjs
+++ b/script/deploy-filters.mjs
@@ -54,6 +54,18 @@ export const COMPONENTS = {
     crate: 'regelrecht-pipeline',
     paths: ['packages/pipeline/Dockerfile'],
   },
+  // De testopstelling: één image met het axum-binary en zijn eigen Vue-bundel.
+  // De crate trekt de simulator, de engine en auth via de graaf mee; wat er met
+  // de hand bij moet is de Dockerfile, de frontend en het gedeelde
+  // frontend-pakket.
+  'chrono-poc': {
+    crate: 'regelrecht-chrono-poc-web',
+    paths: [
+      'packages/chrono-poc-web/Dockerfile',
+      'frontend-chrono-poc/',
+      'packages/frontend-shared/',
+    ],
+  },
   grafana: { crate: null, paths: ['packages/grafana/'] },
   lawmaking: {
     crate: null,

--- a/script/deploy-filters.test.mjs
+++ b/script/deploy-filters.test.mjs
@@ -130,11 +130,40 @@ test('de handmatige paden buiten de graaf blijven werken', () => {
   assert.equal(namesOf(['frontend/src/main.ts']).editor, true);
   assert.equal(namesOf(['frontend/src/main.ts']).lawmaking, false);
 
-  // frontend-shared zit in drie frontends tegelijk.
+  // frontend-shared zit in vier frontends tegelijk.
   const shared = namesOf(['packages/frontend-shared/src/auth.ts']);
   assert.equal(shared.editor, true);
   assert.equal(shared.admin, true);
   assert.equal(shared.lawmaking, true);
+  assert.equal(shared['chrono-poc'], true);
+});
+
+test('de testopstelling hangt aan haar crate, haar frontend en haar Dockerfile', () => {
+  // De simulator zit in geen enkel ander image, dus dit is de enige component
+  // die meebouwt als de kern van de opstelling verandert. Werd dat stil `false`,
+  // dan zou de preview een oude wereld draaien terwijl de code verder is.
+  const simulator = namesOf(['packages/simulator/src/cell.rs']);
+  assert.equal(simulator['chrono-poc'], true);
+  assert.equal(simulator.editor, false);
+  assert.equal(simulator.admin, false);
+  assert.equal(simulator['pipeline-api'], false);
+
+  const web = namesOf(['packages/chrono-poc-web/src/api.rs']);
+  assert.equal(web['chrono-poc'], true);
+  assert.equal(web.editor, false);
+
+  const frontend = namesOf(['frontend-chrono-poc/src/App.vue']);
+  assert.equal(frontend['chrono-poc'], true);
+  assert.equal(frontend.editor, false);
+  assert.equal(frontend.lawmaking, false);
+
+  // De Dockerfile ligt in de cratemap, dus zonder de Dockerfile-uitzondering
+  // zou hij elk image raken dat via de graaf aan die crate hangt. Er is er
+  // maar één.
+  const dockerfile = namesOf(['packages/chrono-poc-web/Dockerfile']);
+  assert.equal(dockerfile['chrono-poc'], true);
+  assert.equal(dockerfile.editor, false);
+  assert.equal(dockerfile.admin, false);
 });
 
 test('de gedeelde nginx-headers raken beide nginx-images', () => {

--- a/script/dockerfile-consistency.test.mjs
+++ b/script/dockerfile-consistency.test.mjs
@@ -20,6 +20,7 @@ const read = (path) => readFileSync(join(root, path), 'utf8');
 
 const DOCKERFILES = [
   'packages/admin/Dockerfile',
+  'packages/chrono-poc-web/Dockerfile',
   'packages/pipeline/Dockerfile',
   'frontend/Dockerfile',
   'frontend-demo/Dockerfile',
@@ -92,7 +93,7 @@ function binTargets() {
 test('elke bouwtrap die knipt is ook gevonden', () => {
   // Zonder deze ondergrens zou een stukgelopen parser als een groene test
   // langskomen: nul trappen halen elke assertie hieronder vacuüm.
-  assert.ok(STAGES.length >= 4, `slechts ${STAGES.length} knippende bouwtrappen gevonden`);
+  assert.ok(STAGES.length >= 5, `slechts ${STAGES.length} knippende bouwtrappen gevonden`);
   assert.ok(MEMBERS.length >= 12, `slechts ${MEMBERS.length} members gelezen`);
 });
 
@@ -130,7 +131,7 @@ test('de rust-tag van elk basisimage volgt rust-toolchain.toml', () => {
       );
     }
   }
-  assert.ok(seen >= 3, `slechts ${seen} rust-basisimages gevonden`);
+  assert.ok(seen >= 4, `slechts ${seen} rust-basisimages gevonden`);
 });
 
 test('elke BIN-build-arg in deploy.yml bestaat als bin-target', () => {
@@ -152,5 +153,5 @@ test('elk binary-pad dat een runtime-trap kopieert bestaat als bin-target', () =
       assert.ok(bins.has(bin), `${path}: kopieert ${bin}, maar dat is geen bin-target van de workspace`);
     }
   }
-  assert.ok(seen >= 4, `slechts ${seen} binary-kopieën gevonden`);
+  assert.ok(seen >= 5, `slechts ${seen} binary-kopieën gevonden`);
 });

--- a/script/ghcr-cleanup.mjs
+++ b/script/ghcr-cleanup.mjs
@@ -74,6 +74,7 @@ export const PACKAGES = [
   'regelrecht-harvester-worker',
   'regelrecht-enrich-worker',
   'regelrecht-pipeline-api',
+  'regelrecht-chrono-poc',
   'regelrecht-grafana',
   'regelrecht-lawmaking',
   'regelrecht-docs',


### PR DESCRIPTION
De chronolexografie-testopstelling heeft een crate (`packages/chrono-poc-web`) en
een frontend (`frontend-chrono-poc`), maar geen weg naar een omgeving. Deze PR
legt die weg aan: één image met beide erin, plus de wiring die het bouwt, uitrolt
en weer opruimt.

## Het image bevat geen wereld

Wetten, kronieken en startstand komen bij het starten uit
`CHRONO_POC_WORLD_SOURCE` en `CHRONO_POC_CORPUS_SOURCE`, met een token uit de
omgeving (`CORPUS_AUTH_<SLUG>_TOKEN`, dezelfde conventie als de rest van de
workspace). Daarmee is `ghcr.io/minbzk/regelrecht-chrono-poc` publiek te
publiceren, ook als de wereld die het draait dat niet is, en is een andere wereld
een andere env-variabele in plaats van een andere build. Het opstarten faalt luid:
zonder leesbare wereld — of met een wereld die een regeling noemt die niet in de
opgehaalde map staat — komt het proces niet op.

## Wat erin zit

- **`packages/chrono-poc-web/Dockerfile`** naar het model van
  `packages/admin/Dockerfile`: cargo-chef, alpine, non-root, poort 8000. Ervoor
  een node-stage die `frontend-chrono-poc` naar `/app/static` bouwt, zoals
  `frontend/Dockerfile` dat voor de editor doet — zonder de WASM-stap, want deze
  frontend praat met een server en rekent niet zelf. De `sed` knipt de members weg
  die dit image niet bouwt.
- **`deploy.yml`**: `build-chrono-poc` via `build-image.yml` (`cache-scope:
  chrono-poc`), meegenomen in `deploy-preview`, in `deploy-production` en in de
  containerlijst van `cleanup-preview`.
- **`script/deploy-filters.mjs`**: het component hangt via de cargo-graaf aan de
  simulator-crate, en met de hand aan zijn Dockerfile, zijn frontend en
  `packages/frontend-shared`. Met een test die vastlegt dat een wijziging in de
  simulator alléén dit image raakt, en dat de Dockerfile niet elk ander image
  meesleept dat via de graaf aan de crate hangt.
- **De randen**: de GHCR-opruimer, de wekelijkse image-scan, de PR-titel-scopes en
  de twee Dockerfile-guards (cargo-chef-pin en workspace-consistentie) kennen het
  nieuwe image nu.
- **Docs**: de componenttabel, de instellingen per env-variabele, en de volgorde
  waarin de ZAD-component aangemaakt moet worden. Die volgorde is de valkuil:
  `deploy-production` zet alle componenten in één taak, dus een component die ZAD
  niet kent laat die hele taak falen. Eerst een `pr-`-image, dan de component
  registreren op die tag, dan de preview opnieuw.

## Nagerekend

Lokaal gebouwd en gedraaid: het image komt op als niet-root (`uid=100(app)`),
`/health` geeft 200 met de security-headers erop, de SPA komt uit `/app/static`, en
`/api/world` levert een echte wereld over de publieke wereld
(`packages/simulator/worlds/publieke_wereld.yaml`) en het corpus in deze repo.
Verder groen: `deploy-filters-test`, `dockerfile-consistency-test`,
`ghcr-cleanup-test`, `ci-gate-test`, `security-headers-test`, `nldd-imports-test`,
yamllint en de volledige pre-commit-set over de gewijzigde bestanden.

Basisbranch is `simulator-poc`, niet `main`.
