### PR TITLE
fix(demo): direct toekennen zonder wijziging, en waarschuwen als een besluit is ingehaald

### DIFF
--- a/frontend-demo/src/components/ApplicationSheet.vue
+++ b/frontend-demo/src/components/ApplicationSheet.vue
@@ -5,6 +5,7 @@ import { fieldSpec, formatDateTime, formatMissing, formatValue, humanize, verdic
 import { lineageFromTrace, leafValues } from '../data/lineage.js';
 import { askedInputsFor, claimKeyFor, evaluationParamsFor, inputKind, nextQuestions, parseAnswer } from '../data/askedInputs.js';
 import { useDemo } from '../store/demoStore.js';
+import { driftRows, driftSentence } from '../data/caseDrift.js';
 
 // The citizen's side of an application, inside the portal. The flow the POC
 // generated per regeling: first the questions only the citizen can answer
@@ -23,7 +24,7 @@ const props = defineProps({
 // opens the same correction sheet for a value corrected from inside the application.
 const emit = defineEmits(['close', 'edit-value']);
 const demo = useDemo();
-const { corpus, profile, personaParams, claimFor, findCase, dataVersion } = demo;
+const { corpus, profile, personaParams, claimFor, findCase, caseDrift, dataVersion } = demo;
 
 const sheet = ref(null);
 const step = ref('gegevens'); // gegevens | controleren | status
@@ -184,6 +185,20 @@ const citizenEvents = computed(() =>
   })),
 );
 const canObject = computed(() => currentCase.value?.status === 'DECIDED' && !currentCase.value?.objection);
+
+/**
+ * De aanvraag die er ligt, tegen wat de wet nu zegt. Zelfde vergelijking als
+ * op de tegel; hier staat de knop waarmee de burger er iets aan kan doen.
+ */
+const drift = computed(() => {
+  void dataVersion.value;
+  return props.law ? caseDrift(props.law, props.evaluation) : null;
+});
+const rows = computed(() => driftRows(drift.value, doc.value));
+const driftText = computed(() => driftSentence(drift.value, doc.value));
+function resubmit() {
+  demo.resubmitCase(currentCase.value.id, props.evaluation, evaluationParamsFor(personaParams(), asked.value));
+}
 function fileObjection() {
   demo.objectToCase(currentCase.value.id, objectionReason.value.trim() || 'Ik ben het niet eens met het besluit.');
   objectionReason.value = '';
@@ -317,6 +332,24 @@ function claimStatus(cl) {
           <template v-else-if="currentCase">
             <nldd-banner :variant="statusView.variant" :icon="statusView.icon" :text="statusView.text" :supporting-text="statusView.supporting"></nldd-banner>
             <nldd-rich-text v-if="justSubmitted" spacing="tight"><p>Uw aanvraag is ingediend bij {{ service }}. U kunt de voortgang hier volgen.</p></nldd-rich-text>
+
+            <!-- Wat er ligt klopt niet meer met wat de wet nu zegt. De demo
+                 rekent niets opnieuw af achter de rug van de burger om: het
+                 besluit blijft staan en hij krijgt te zien wat er veranderd is,
+                 met de weg terug ernaast. Aanvraag per aanvraag, want elke
+                 aanvraag is een eigen besluit. -->
+            <template v-if="drift && !justSubmitted">
+              <nldd-banner variant="warning" text="Uw aanvraag klopt niet meer" :supporting-text="driftText"></nldd-banner>
+              <nldd-list variant="box-tinted" accessible-label="Verschil met uw eerdere aanvraag">
+                <nldd-list-item v-for="row in rows" :key="row.name" size="sm">
+                  <nldd-text-cell size="sm" color="secondary" min-width="50%" :text="humanize(row.name)"></nldd-text-cell>
+                  <nldd-text-cell size="sm" width="fit-content" horizontal-alignment="right" :text="`${row.was} → ${row.now}`"></nldd-text-cell>
+                </nldd-list-item>
+              </nldd-list>
+              <nldd-form-actions>
+                <nldd-button variant="primary" start-icon="paper-plane" text="Aanvraag wijzigen" @click="resubmit"></nldd-button>
+              </nldd-form-actions>
+            </template>
             <nldd-list v-if="claimedPrimary" variant="box-tinted" accessible-label="Aangevraagd">
               <nldd-list-item size="sm">
                 <nldd-text-cell size="sm" color="secondary" :text="`Aangevraagd · ${humanize(claimedPrimary.name)}`"></nldd-text-cell>

--- a/frontend-demo/src/components/ApplicationSheet.vue
+++ b/frontend-demo/src/components/ApplicationSheet.vue
@@ -146,6 +146,36 @@ watch([missing, step], ([m, st]) => {
   if (st === 'gegevens' && m.length === 0 && answered.value > 0) step.value = 'controleren';
 });
 
+/**
+ * Het invoerveld krijgt de aandacht, bij elke volgende vraag opnieuw.
+ *
+ * De wet stelt haar vragen één voor één (just in time), en na een antwoord
+ * staat de volgende vraag er met een leeg veld. Zonder dit moet je er elke keer
+ * eerst heen klikken; met dit kun je een aanvraag al typend en enterend
+ * afmaken, wat in een demo voor de zaal het verschil is tussen vertellen en
+ * laten zien. Enter zit op het omhullende veld, zodat elk soort vraag het erft.
+ *
+ * Welk veld dat is, hangt van de vraag af (tekst, datum, keuzelijst). Ze
+ * melden zich alle drie als invoerveld met `static isFormInput = true` — de
+ * afspraak waarop `nldd-form-field` zelf ook zijn label laat wijzen — en
+ * hebben een eigen `focus()` die het schaduw-DOM afhandelt. Dat is stabieler
+ * dan hier een lijst met tagnamen bijhouden.
+ */
+const questionField = ref(null);
+function isFormInput(el) {
+  return el instanceof HTMLInputElement || el instanceof HTMLSelectElement || el.constructor?.isFormInput === true;
+}
+watch(
+  [question, () => props.open],
+  async ([q, open]) => {
+    if (!q || !open) return;
+    await nextTick();
+    const control = [...(questionField.value?.querySelectorAll?.('*') ?? [])].find(isFormInput);
+    control?.focus?.();
+  },
+  { immediate: true },
+);
+
 // ---- step 2/3: check and submit --------------------------------------------------
 const canSubmit = computed(() => props.evaluation?.ok && verdict.value === true && declared.value && missing.value.length === 0);
 function submitApplication() {
@@ -246,7 +276,10 @@ function claimStatus(cl) {
               <p v-else>Dank u. De wet is opnieuw doorgerekend en loopt tegen nog een gegeven aan dat alleen u weet.</p>
             </nldd-rich-text>
             <template v-if="question">
-              <nldd-form-field :label="labelFor(question)">
+              <!-- Enter op het veld is Verder, wat voor soort vraag het ook is:
+                   een demo loopt zo van vraag naar vraag zonder de muis. Op het
+                   omhullende veld, zodat elk invoertype het erft. -->
+              <nldd-form-field ref="questionField" :label="labelFor(question)" @keydown.enter="canContinue && submitAnswer()">
                 <nldd-dropdown v-if="kindOf(question) === 'enum'" width="full">
                   <select :value="answers[question.name] ?? ''" @change="setAnswer(question, $event)">
                     <option value="" disabled>Maak een keuze</option>
@@ -264,8 +297,8 @@ function claimStatus(cl) {
                 <!-- An unanswered amount is empty, not 0: nldd-number-field has no empty state (it starts at 0 and
                      an emptied field falls back to the last value), so the question is a text field with a numeric
                      keyboard; parseAnswer reads the Dutch notation. -->
-                <nldd-text-field v-else-if="kindOf(question) === 'amount' || kindOf(question) === 'number'" :value="answers[question.name] ?? ''" width="full" :keyboard="kindOf(question) === 'amount' ? 'decimal' : 'numeric'" :placeholder="placeholderFor(question)" @input="setAnswer(question, $event)" @keydown.enter="submitAnswer"></nldd-text-field>
-                <nldd-text-field v-else :value="answers[question.name] ?? ''" width="full" :placeholder="placeholderFor(question)" @input="setAnswer(question, $event)" @keydown.enter="submitAnswer"></nldd-text-field>
+                <nldd-text-field v-else-if="kindOf(question) === 'amount' || kindOf(question) === 'number'" :value="answers[question.name] ?? ''" width="full" :keyboard="kindOf(question) === 'amount' ? 'decimal' : 'numeric'" :placeholder="placeholderFor(question)" @input="setAnswer(question, $event)"></nldd-text-field>
+                <nldd-text-field v-else :value="answers[question.name] ?? ''" width="full" :placeholder="placeholderFor(question)" @input="setAnswer(question, $event)"></nldd-text-field>
                 <nldd-form-field-help-text v-if="question.spec?.description">{{ question.spec.description }}</nldd-form-field-help-text>
               </nldd-form-field>
               <nldd-banner v-if="error" variant="critical" :text="error"></nldd-banner>

--- a/frontend-demo/src/components/DataLineage.vue
+++ b/frontend-demo/src/components/DataLineage.vue
@@ -65,7 +65,7 @@ const slotName = computed(() => (props.nested ? 'children' : undefined));
 </script>
 
 <template>
-  <nldd-list-item v-for="node in values" :key="`${node.law}|${node.name}`" :slot="slotName" size="sm" :button="canSubmitClaims || undefined" @click="canSubmitClaims && emit('edit', node)">
+  <nldd-list-item v-for="node in values" :key="`${node.law}|${node.name}`" :slot="slotName" size="sm" :button="canSubmitClaims || undefined" @click.stop="canSubmitClaims && emit('edit', node)">
     <nldd-spacer-cell v-for="i in depth" :key="i" size="20"></nldd-spacer-cell>
     <nldd-cell v-if="node.service"><OrgLogo :service="node.service" size="sm" /></nldd-cell>
     <nldd-icon-cell v-else-if="node.corrected" icon="edit" size="16" color="accent"></nldd-icon-cell>
@@ -73,8 +73,12 @@ const slotName = computed(() => (props.nested ? 'children' : undefined));
     <nldd-spacer-cell size="8"></nldd-spacer-cell>
     <nldd-text-cell size="sm" min-width="120px" :text="humanize(node.name)" :supporting-text="pending(node) ? `${supportingText(node) ? supportingText(node) + ' · ' : ''}meegerekend, nog te beoordelen` : supportingText(node)"></nldd-text-cell>
     <nldd-text-cell size="sm" width="fit-content" max-width="55%" horizontal-alignment="right" :color="pending(node) ? 'warning' : isUnknown(node.value) ? 'secondary' : 'default'">
+      <!-- Doorgestreept staat de waarde van vóór de correctie, en die komt van
+           de correctie zelf. Niet `node.value`: de engine rekent de burger zijn
+           openstaande correcties al mee (`claimsForEngine`), dus dat ís de
+           nieuwe waarde en er stond tweemaal hetzelfde bedrag. -->
       <template v-if="pending(node)">
-        <s>{{ formatValue(node.value, specFor(node)) }}</s> → {{ formatValue(pending(node).newValue, specFor(node)) }}
+        <s>{{ formatValue(pending(node).oldValue, specFor(node)) }}</s> → {{ formatValue(pending(node).newValue, specFor(node)) }}
       </template>
       <template v-else>{{ formatValue(node.value, specFor(node)) }}</template>
     </nldd-text-cell>
@@ -86,7 +90,15 @@ const slotName = computed(() => (props.nested ? 'children' : undefined));
        data) is a leaf: no disclosure chevron, because there is nothing under it
        to open. Every row stays correctable through its own pencil, an outcome
        of a law included: what the engine computed is a claim like any other,
-       and citizen and caseworker may both dispute it. -->
+       and citizen and caseworker may both dispute it.
+
+       Every click handler in this component is `.stop`, and that is load-
+       bearing: the children of a law row are rendered INSIDE that row
+       (slot="children"), so without it a click on a nested row also reaches
+       every law row above it. Opening "Box1 inkomen" then collapsed "Inkomen"
+       in the same click — the child did open, you just could not see it,
+       because its parent shut over it. The same applied to correcting a
+       nested value. -->
   <nldd-list-item
     v-for="node in laws"
     :key="keyOf(node)"
@@ -94,7 +106,7 @@ const slotName = computed(() => (props.nested ? 'children' : undefined));
     size="sm"
     :button="node.children?.length ? true : undefined"
     :expanded="node.children?.length && open[keyOf(node)] ? true : undefined"
-    @click="node.children?.length && (open[keyOf(node)] = !open[keyOf(node)])"
+    @click.stop="node.children?.length && (open[keyOf(node)] = !open[keyOf(node)])"
   >
     <nldd-spacer-cell v-for="i in depth" :key="i" size="20"></nldd-spacer-cell>
     <nldd-cell v-if="lawService(node.law)"><OrgLogo :service="lawService(node.law)" size="sm" /></nldd-cell>

--- a/frontend-demo/src/components/EditValueSheet.vue
+++ b/frontend-demo/src/components/EditValueSheet.vue
@@ -207,7 +207,11 @@ function submit() {
     input: props.node.name,
     keyField: props.node.keyField ?? 'bsn',
     keyValue: props.node.keyValue ?? props.bsn ?? profile.value?.bsn,
-    oldValue: props.node.value,
+    // Alleen de waarde meegeven als ze van het register komt. Bij een gegeven
+    // dat al gecorrigeerd is, toont de rij de gecorrigeerde waarde, en die als
+    // "oud" vastleggen zou de correctie ervóór wegpoetsen. `null` laat de store
+    // opzoeken wat er zonder correcties staat.
+    oldValue: props.node.corrected ? null : props.node.value,
     newValue: value,
     reason: reason.value.trim(),
     evidence: evidence.value,

--- a/frontend-demo/src/components/LawTile.vue
+++ b/frontend-demo/src/components/LawTile.vue
@@ -7,6 +7,7 @@ import { fieldSpec, formatMissing, formatValue, humanize, isUnknown, verdictOf }
 import { lineageFromTrace, leafValues } from '../data/lineage.js';
 import { askedInputsFor, claimKeyFor, evaluationParamsFor, nextQuestions } from '../data/askedInputs.js';
 import { dateInputFor, phraseOutcome, phrasingFor } from '../data/outcomePhrasing.js';
+import { driftSentence } from '../data/caseDrift.js';
 import { useDemo } from '../store/demoStore.js';
 
 // One regeling on the portal: the outcome of the law for this persona, the
@@ -19,7 +20,7 @@ const props = defineProps({
 const emit = defineEmits(['edit-value', 'evaluated', 'apply']);
 const router = useRouter();
 const demo = useDemo();
-const { corpus, dataVersion, profile, personaParams, findCase, canSubmitClaims, activeDelegation } = demo;
+const { corpus, dataVersion, profile, personaParams, findCase, caseDrift, canSubmitClaims, activeDelegation } = demo;
 
 const evaluation = ref(null);
 const showData = ref(false);
@@ -114,6 +115,16 @@ const lineage = computed(() => {
 const valueCount = computed(() => leafValues(lineage.value).length);
 
 const currentCase = computed(() => findCase(props.law));
+/**
+ * Een lopende aanvraag die niet meer klopt met wat de wet nu zegt.
+ *
+ * De burger heeft ergens een gegeven gewijzigd — misschien bij een hele
+ * andere regeling — en deze wet rekent daar al mee, terwijl de aanvraag nog
+ * op het oude bedrag staat. Dat hoort hij te zien op de plek waar dat besluit
+ * staat, niet pas als het geld anders binnenkomt.
+ */
+const drift = computed(() => caseDrift(props.law, evaluation.value));
+const driftText = computed(() => driftSentence(drift.value, doc.value));
 
 // The questions this regeling has for the citizen (see askedInputs.js): the
 // inputs no register holds and the application-form parameters. Until
@@ -222,6 +233,24 @@ const statusTag = computed(() => {
         <nldd-inline-dialog variant="alert" text="Kon deze regeling niet berekenen" :supporting-text="evaluation.error"></nldd-inline-dialog>
       </template>
       <template v-else>
+        <!-- Wat er al lag klopt niet meer met wat de wet nu zegt. Geen
+             herberekening die iets besluit: alleen de constatering, met de
+             weg terug ernaast (de knop "Wijzigen" in de voettekst). Het
+             besluit zelf blijft staan tot de burger zijn aanvraag wijzigt of
+             een behandelaar ernaar kijkt. Boven de uitkomst en niet in plaats
+             daarvan: het nieuwe bedrag is juist wat hij moet zien.
+
+             Een banner en geen inline-dialog: die laatste is de lege-staat, met
+             het icoon bóven de tekst en alles gecentreerd. Dat leest als een
+             andere soort mededeling dan de rest van de tegel, terwijl dit er
+             juist naast hoort te staan. De aanvraag gebruikt dezelfde banner,
+             dus beide kanten zien hetzelfde. -->
+        <nldd-banner
+          v-if="drift"
+          variant="warning"
+          text="Uw aanvraag klopt niet meer"
+          :supporting-text="driftText"
+        ></nldd-banner>
         <nldd-inline-dialog v-if="verdict === 'unknown'" icon="info" text="Nog niet te bepalen" :supporting-text="`De wet kan met de bekende gegevens geen uitkomst geven; ${verdictMissing}.`"></nldd-inline-dialog>
         <nldd-list v-else variant="box-tinted" accessible-label="Uitkomst">
           <nldd-list-item size="md" :button="primary ? true : undefined" @click="primary && correctOutcome(primary.name, primary.value)">
@@ -315,6 +344,7 @@ const statusTag = computed(() => {
            one onto a second line. "Mijn aanvraag" needed 336px and "Bezwaar
            maken" 347px, so both wrapped; "Aanvraag" and "Bezwaar" fit. -->
       <nldd-button v-if="canObject" variant="primary" size="sm" start-icon="flag" text="Bezwaar" @click="apply"></nldd-button>
+      <nldd-button v-else-if="drift" variant="primary" size="sm" start-icon="edit" text="Wijzigen" @click="apply"></nldd-button>
       <nldd-button v-else-if="currentCase" variant="secondary" size="sm" start-icon="file-text" text="Aanvraag" @click="apply"></nldd-button>
       <nldd-button v-else-if="canSubmitClaims && evaluation && missingInputs.length && produces?.legal_character === 'BESCHIKKING'" variant="primary" size="sm" start-icon="edit" text="Aanvullen" @click="apply"></nldd-button>
       <nldd-button v-else-if="canApply" variant="primary" size="sm" start-icon="paper-plane" text="Aanvragen" @click="apply"></nldd-button>

--- a/frontend-demo/src/data/caseDrift.js
+++ b/frontend-demo/src/data/caseDrift.js
@@ -1,0 +1,97 @@
+/**
+ * Of een lopende aanvraag nog klopt met wat de wet nu zegt.
+ *
+ * Dit is geen opgeslagen toestand en geen herberekening die ergens draait: het
+ * is een vergelijking tussen wat de burger aanvroeg (`claimedResult`) en wat
+ * dezelfde wet nú uitrekent, met alles wat er sindsdien is opgegeven. Precies
+ * wat de POC bij elke render deed: de tegels daar vergeleken
+ * `result.<uitkomst>` met `current_case.claimed_result.<uitkomst>`
+ * (`web/templates/partials/tiles/law/**​/*.html`).
+ *
+ * Dat het zo werkt is de kern en niet een implementatiedetail. Een besluit is
+ * een vaststelling op een moment; er hoort niets achter de rug van de burger om
+ * herrekend te worden. Wat wél moet gebeuren is dat hij ziet dat het niet meer
+ * klopt, en dat hij er iets aan kan doen.
+ *
+ * Het werkt over de hele breedte omdat correcties per BSN staan en niet per
+ * wet: een inkomenswijziging die bij de huurtoeslag is opgegeven, verandert
+ * vanzelf de uitkomst van elke andere wet die datzelfde inkomen gebruikt. Een
+ * toegekende zorgtoeslag komt daardoor uit zichzelf naar voren, zonder dat hier
+ * iets "zorgtoeslag" of "huurtoeslag" bij naam kent.
+ */
+
+import { fieldSpec, formatValue, isUnknown } from './format.js';
+
+/** De statussen waarvan een uitkomst vastligt die niet meer kan kloppen. */
+const LIVE_STATUSES = ['DECIDED', 'IN_REVIEW', 'SUBMITTED'];
+
+/**
+ * Of twee waarden van dezelfde uitkomst hetzelfde zeggen.
+ *
+ * Overgenomen uit de POC (`CaseManager._results_match`): getallen met 1%
+ * tolerantie, waarbij nul alleen gelijk is aan nul, de rest exact. Die
+ * tolerantie is er omdat een herberekening op een andere dag een cent kan
+ * schelen, en een cent geen besluit hoort te heropenen.
+ */
+export function valuesMatch(a, b) {
+  if (typeof a === 'number' && typeof b === 'number') {
+    return b === 0 ? a === 0 : Math.abs(b - a) / Math.abs(b) <= 0.01;
+  }
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/** Of twee volledige uitkomsten van dezelfde wet hetzelfde zeggen. */
+export function resultsMatch(claimed, current) {
+  const keys = new Set([...Object.keys(claimed ?? {}), ...Object.keys(current ?? {})]);
+  return [...keys].every((k) => valuesMatch(claimed?.[k], current?.[k]));
+}
+
+/**
+ * De uitkomsten van deze zaak die niet meer kloppen, of `null` als er niets
+ * aan de hand is.
+ *
+ * Geeft per uitkomst het bedrag van toen en dat van nu, zodat de tekst die de
+ * burger leest ("U vroeg eerder € x aan") uit de wet zelf komt en niet uit een
+ * lijst met een regel per regeling.
+ */
+export function driftOf(caseRecord, evaluation) {
+  if (!caseRecord || !LIVE_STATUSES.includes(caseRecord.status)) return null;
+  if (!evaluation?.ok) return null;
+  const claimed = caseRecord.claimedResult ?? {};
+  const current = evaluation.outputs ?? {};
+  const changed = [...new Set([...Object.keys(claimed), ...Object.keys(current)])]
+    // Een uitkomst die de wet niet kón bepalen zegt niets over het besluit: er
+    // staat een vraag open (RFC-036), er is niets veranderd aan wat iemand
+    // krijgt. Dat als wijziging melden stuurt de burger achter een verschil aan
+    // dat er niet is.
+    .filter((name) => !isUnknown(claimed[name]) && !isUnknown(current[name]))
+    .filter((name) => !valuesMatch(claimed[name], current[name]))
+    .map((name) => ({ name, claimed: claimed[name], current: current[name] }))
+    // Het bedrag eerst: daar ging het besluit over. De rest eronder.
+    .sort((a, b) => Number(typeof b.claimed === 'number') - Number(typeof a.claimed === 'number'));
+  return changed.length ? { case: caseRecord, changed } : null;
+}
+
+/**
+ * De rijen die het verschil laten zien, met de opmaak die de wet aan die
+ * uitkomst geeft (een bedrag als bedrag, een ja/nee als ja/nee).
+ */
+export function driftRows(drift, lawDoc) {
+  return (drift?.changed ?? []).map((d) => {
+    const spec = fieldSpec(lawDoc, d.name);
+    return { ...d, spec, was: formatValue(d.claimed, spec), now: formatValue(d.current, spec) };
+  });
+}
+
+/**
+ * Eén zin voor de burger, met de bedragen erin.
+ *
+ * Staat hier en niet in een component, zodat de tegel en de aanvraag hetzelfde
+ * zeggen. De POC had deze zin acht keer met de hand overgeschreven, met per
+ * regeling het veld erin gehardcodeerd; hier komt het bedrag uit de wet.
+ */
+export function driftSentence(drift, lawDoc) {
+  const row = driftRows(drift, lawDoc)[0];
+  if (!row) return '';
+  return `U vroeg eerder ${row.was} aan. Sindsdien zijn er gegevens gewijzigd waarmee deze regeling nu uitkomt op ${row.now}. Uw besluit blijft gelden totdat u uw aanvraag wijzigt.`;
+}

--- a/frontend-demo/src/data/caseDrift.test.js
+++ b/frontend-demo/src/data/caseDrift.test.js
@@ -1,0 +1,94 @@
+/**
+ * Wanneer een lopende aanvraag niet meer klopt met wat de wet nu zegt.
+ *
+ * De vergelijking is wetonafhankelijk: ze kent geen enkele regeling bij naam en
+ * werkt op de uitkomsten die de wet zelf declareert. Dat is wat hier bewezen
+ * wordt, met namen die net zo goed van een andere wet konden zijn.
+ */
+import { describe, expect, it } from 'vitest';
+import { driftOf, resultsMatch, valuesMatch } from './caseDrift.js';
+
+const decided = (claimedResult) => ({ id: 'zaak-1', status: 'DECIDED', claimedResult });
+const evaluated = (outputs) => ({ ok: true, outputs });
+
+describe('valuesMatch', () => {
+  it('laat een cent verschil op een bedrag lopen', () => {
+    // Een herberekening op een andere dag schuift een cent; dat heropent geen besluit.
+    expect(valuesMatch(160825, 160826)).toBe(true);
+  });
+
+  it('ziet een verschil dat er werkelijk toe doet', () => {
+    expect(valuesMatch(160825, 143200)).toBe(false);
+  });
+
+  it('houdt nul apart: alleen nul is nul', () => {
+    expect(valuesMatch(0, 0)).toBe(true);
+    expect(valuesMatch(0, 100)).toBe(false);
+    expect(valuesMatch(100, 0)).toBe(false);
+  });
+
+  it('vergelijkt niet-getallen exact', () => {
+    expect(valuesMatch(true, false)).toBe(false);
+    expect(valuesMatch('WEEK', 'WEEK')).toBe(true);
+    expect(valuesMatch([1, 2], [1, 2])).toBe(true);
+  });
+});
+
+describe('resultsMatch', () => {
+  it('vindt een uitkomst die er bij is gekomen of weggevallen', () => {
+    expect(resultsMatch({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+  });
+
+  it('is tevreden als alles gelijk is', () => {
+    expect(resultsMatch({ a: 1, b: true }, { a: 1, b: true })).toBe(true);
+  });
+});
+
+describe('driftOf', () => {
+  it('meldt niets als de wet nog op hetzelfde uitkomt', () => {
+    expect(driftOf(decided({ hoogte_toeslag: 160825 }), evaluated({ hoogte_toeslag: 160825 }))).toBeNull();
+  });
+
+  it('meldt het verschil als de uitkomst is veranderd', () => {
+    const drift = driftOf(decided({ hoogte_toeslag: 160825 }), evaluated({ hoogte_toeslag: 143200 }));
+    expect(drift.changed).toEqual([{ name: 'hoogte_toeslag', claimed: 160825, current: 143200 }]);
+  });
+
+  it('werkt op elke wet, want het kent er geen een bij naam', () => {
+    // Dezelfde vergelijking, andere regeling, ander soort uitkomst.
+    const drift = driftOf(decided({ pensioenbedrag: 120000 }), evaluated({ pensioenbedrag: 0 }));
+    expect(drift.changed[0].name).toBe('pensioenbedrag');
+    const ja_nee = driftOf(decided({ heeft_stemrecht: true }), evaluated({ heeft_stemrecht: false }));
+    expect(ja_nee.changed[0]).toEqual({ name: 'heeft_stemrecht', claimed: true, current: false });
+  });
+
+  it('zet het bedrag vooraan, want daar ging het besluit over', () => {
+    const drift = driftOf(
+      decided({ voldoet_aan_voorwaarden: true, subsidiebedrag: 30296 }),
+      evaluated({ voldoet_aan_voorwaarden: false, subsidiebedrag: 0 }),
+    );
+    expect(drift.changed.map((d) => d.name)).toEqual(['subsidiebedrag', 'voldoet_aan_voorwaarden']);
+  });
+
+  it('zwijgt over een uitkomst die de wet niet kon bepalen', () => {
+    // Er staat een vraag open (RFC-036); er is niets veranderd aan wat iemand krijgt.
+    const unknown = { __unknown: true, missing: ['inkomen'] };
+    expect(driftOf(decided({ hoogte_toeslag: 160825 }), evaluated({ hoogte_toeslag: unknown }))).toBeNull();
+  });
+
+  it('zwijgt over een zaak die is ingetrokken', () => {
+    const withdrawn = { id: 'zaak-1', status: 'WITHDRAWN', claimedResult: { hoogte_toeslag: 160825 } };
+    expect(driftOf(withdrawn, evaluated({ hoogte_toeslag: 0 }))).toBeNull();
+  });
+
+  it('meldt ook op een zaak die nog in behandeling is', () => {
+    // Ook daar geldt: de behandelaar beoordeelt iets dat inmiddels is ingehaald.
+    const inReview = { id: 'zaak-1', status: 'IN_REVIEW', claimedResult: { hoogte_toeslag: 160825 } };
+    expect(driftOf(inReview, evaluated({ hoogte_toeslag: 0 })).changed).toHaveLength(1);
+  });
+
+  it('zwijgt als er geen zaak is of de wet niet door te rekenen was', () => {
+    expect(driftOf(null, evaluated({ a: 1 }))).toBeNull();
+    expect(driftOf(decided({ a: 1 }), { ok: false, error: 'stuk' })).toBeNull();
+  });
+});

--- a/frontend-demo/src/data/claimOwnership.js
+++ b/frontend-demo/src/data/claimOwnership.js
@@ -1,0 +1,32 @@
+/**
+ * Welke correcties bij welke zaak horen.
+ *
+ * Twee vragen die op elkaar lijken maar niet hetzelfde zijn:
+ *
+ * - *Moet er een mens naar kijken?* Daarvoor telt élke openstaande correctie
+ *   van deze persoon mee, ook een die bij een andere regeling is opgegeven. Een
+ *   inkomenswijziging bij de huurtoeslag verandert immers ook de zorgtoeslag.
+ * - *Bij welke zaak hoort deze correctie?* Daarvoor telt alleen de regeling
+ *   waarop de correctie is ingediend.
+ *
+ * Die tweede vraag met het antwoord van de eerste beantwoorden, hangt een
+ * correctie voorgoed aan de verkeerde zaak: het veld wordt maar één keer gezet,
+ * dus de zaak waar hij wél bij hoort krijgt hem daarna niet meer.
+ *
+ * Staat hier en niet in de store, zodat de regel die getest wordt dezelfde
+ * regel is die draait.
+ */
+
+/**
+ * Hang de correcties die bij deze regeling horen aan deze zaak.
+ *
+ * Muteert de correcties die eraan toe zijn, en laat de rest staan: een
+ * correctie die al bij een zaak hoort blijft daar, en een correctie van een
+ * andere regeling wordt niet opgeëist.
+ */
+export function assignClaimOwnership(claims, caseRecord) {
+  for (const claim of claims) {
+    if (!claim.caseId && claim.tileLawId === caseRecord.lawId) claim.caseId = caseRecord.id;
+  }
+  return claims;
+}

--- a/frontend-demo/src/data/claimOwnership.test.js
+++ b/frontend-demo/src/data/claimOwnership.test.js
@@ -1,28 +1,13 @@
 /**
- * Welke correcties bij welke zaak horen.
+ * De regel uit `data/claimOwnership.js`, die `demoStore.resubmitCase` draait.
  *
- * Twee vragen die op elkaar lijken maar niet hetzelfde zijn, en die in
- * `resubmitCase` één keer door elkaar liepen:
- *
- * - *Moet er een mens naar kijken?* Daarvoor telt élke openstaande correctie
- *   van deze persoon mee, ook een die bij een andere regeling is opgegeven. Een
- *   inkomenswijziging bij de huurtoeslag verandert immers ook de zorgtoeslag.
- * - *Bij welke zaak hoort deze correctie?* Daarvoor telt alleen de regeling
- *   waarop de correctie is ingediend.
- *
- * Die tweede vraag met het antwoord van de eerste beantwoorden, hangt een
- * correctie voorgoed aan de verkeerde zaak: het veld wordt maar één keer gezet,
- * dus de zaak waar hij wél bij hoort krijgt hem daarna niet meer.
+ * Dezelfde functie en geen nagebouwde kopie: een kopie bewijst alleen dat de
+ * regel klopt zoals hij hier staat, niet dat de winkel hem nog gebruikt. Juist
+ * de fout die dit moet tegenhouden — het `tileLawId`-filter dat wegvalt — zou
+ * een kopie niet zien.
  */
 import { describe, expect, it } from 'vitest';
-
-/** De regel uit `demoStore.resubmitCase`, los van de store getest. */
-function assignOwnership(claims, caseRecord) {
-  for (const claim of claims) {
-    if (!claim.caseId && claim.tileLawId === caseRecord.lawId) claim.caseId = caseRecord.id;
-  }
-  return claims;
-}
+import { assignClaimOwnership as assignOwnership } from './claimOwnership.js';
 
 const claim = (over) => ({ id: 'c1', caseId: null, tileLawId: 'huurtoeslag', ...over });
 

--- a/frontend-demo/src/data/claimOwnership.test.js
+++ b/frontend-demo/src/data/claimOwnership.test.js
@@ -1,0 +1,61 @@
+/**
+ * Welke correcties bij welke zaak horen.
+ *
+ * Twee vragen die op elkaar lijken maar niet hetzelfde zijn, en die in
+ * `resubmitCase` één keer door elkaar liepen:
+ *
+ * - *Moet er een mens naar kijken?* Daarvoor telt élke openstaande correctie
+ *   van deze persoon mee, ook een die bij een andere regeling is opgegeven. Een
+ *   inkomenswijziging bij de huurtoeslag verandert immers ook de zorgtoeslag.
+ * - *Bij welke zaak hoort deze correctie?* Daarvoor telt alleen de regeling
+ *   waarop de correctie is ingediend.
+ *
+ * Die tweede vraag met het antwoord van de eerste beantwoorden, hangt een
+ * correctie voorgoed aan de verkeerde zaak: het veld wordt maar één keer gezet,
+ * dus de zaak waar hij wél bij hoort krijgt hem daarna niet meer.
+ */
+import { describe, expect, it } from 'vitest';
+
+/** De regel uit `demoStore.resubmitCase`, los van de store getest. */
+function assignOwnership(claims, caseRecord) {
+  for (const claim of claims) {
+    if (!claim.caseId && claim.tileLawId === caseRecord.lawId) claim.caseId = caseRecord.id;
+  }
+  return claims;
+}
+
+const claim = (over) => ({ id: 'c1', caseId: null, tileLawId: 'huurtoeslag', ...over });
+
+describe('eigenaarschap van een correctie', () => {
+  it('hangt een correctie aan de zaak van dezelfde regeling', () => {
+    const claims = [claim({ id: 'c1', tileLawId: 'huurtoeslag' })];
+    assignOwnership(claims, { id: 'zaak-1', lawId: 'huurtoeslag' });
+    expect(claims[0].caseId).toBe('zaak-1');
+  });
+
+  it('laat een correctie van een andere regeling met rust', () => {
+    // Deze correctie telt wél mee voor de vraag of er beoordeeld moet worden,
+    // maar hoort in het dossier van de zorgtoeslag en niet hier.
+    const claims = [claim({ id: 'c2', tileLawId: 'zorgtoeslagwet' })];
+    assignOwnership(claims, { id: 'zaak-1', lawId: 'huurtoeslag' });
+    expect(claims[0].caseId).toBeNull();
+  });
+
+  it('laat een correctie die al bij een zaak hoort staan waar hij staat', () => {
+    const claims = [claim({ id: 'c3', caseId: 'zaak-eerder' })];
+    assignOwnership(claims, { id: 'zaak-1', lawId: 'huurtoeslag' });
+    expect(claims[0].caseId).toBe('zaak-eerder');
+  });
+
+  it('houdt twee zaken uit elkaar', () => {
+    // Het geval waar het misging: één persoon, twee lopende regelingen. Wie het
+    // eerst opnieuw indient, mocht niet de correcties van de ander opeisen.
+    const claims = [
+      claim({ id: 'huur', tileLawId: 'huurtoeslag' }),
+      claim({ id: 'zorg', tileLawId: 'zorgtoeslagwet' }),
+    ];
+    assignOwnership(claims, { id: 'zaak-huur', lawId: 'huurtoeslag' });
+    assignOwnership(claims, { id: 'zaak-zorg', lawId: 'zorgtoeslagwet' });
+    expect(claims.map((c) => c.caseId)).toEqual(['zaak-huur', 'zaak-zorg']);
+  });
+});

--- a/frontend-demo/src/store/demoStore.js
+++ b/frontend-demo/src/store/demoStore.js
@@ -499,7 +499,16 @@ function resubmitCase(caseId, evaluation, params = personaParams()) {
         }
       : { at: nowIso(), type: 'DECIDED', text: requirementsMet ? 'Automatisch toegekend.' : 'Automatisch afgewezen.' },
   );
-  for (const claim of pendingClaims) if (!claim.caseId) claim.caseId = c.id;
+  // Alleen de correcties die bij déze regeling horen komen aan deze zaak te
+  // hangen. De lijst hierboven is met opzet breder — een wijziging bij een
+  // andere regeling telt mee voor de vraag óf er beoordeeld moet worden — maar
+  // eigenaarschap is iets anders dan aanleiding. Zonder dit onderscheid raakt
+  // een correctie die bij een heel andere tegel is opgegeven voorgoed aan deze
+  // zaak vast (`if (!claim.caseId)` zet hem maar één keer), en staat hij in het
+  // dossier van een besluit waar hij niets mee te maken heeft.
+  for (const claim of pendingClaims) {
+    if (!claim.caseId && claim.tileLawId === c.lawId) claim.caseId = c.id;
+  }
   reregister();
   return c;
 }
@@ -564,15 +573,23 @@ function caseDrift(lawEntry, evaluation, subject = null) {
  * hetzelfde zijn als "nieuw". De correctiebron gaat er daarom even af en
  * daarna weer op.
  *
+ * `keyField`/`keyValue` zeggen over wie het gaat: een BSN, een KvK-nummer, een
+ * organisatie. Die komen van de correctie zelf, want het onderwerp van een
+ * correctie is niet altijd degene die haar indient.
+ *
  * `null` als het niet lukt — een wet die niet doorrekent mag een correctie niet
  * tegenhouden; er is dan alleen niets om doorgestreept te tonen.
  */
-function currentValueOf(lawId, input, bsn = subjectBsn()) {
+function currentValueOf(lawId, input, keyField, keyValue) {
   const lawEntry = corpus.value?.lawById(lawId);
-  if (!engine.value || !lawEntry) return null;
+  if (!engine.value || !lawEntry || !keyField || keyValue == null) return null;
   try {
     registerClaims(engine.value, []);
-    const result = evaluate(lawEntry, { bsn }, [input]);
+    // Doorrekenen voor het onderwerp waar de correctie over gáát, en niet voor
+    // wie haar indient. Een correctie op een gegeven van een onderneming staat
+    // op het KvK-nummer; die voor de BSN van de gemachtigde doorrekenen levert
+    // de waarde van een ander op, of een parameter die niet past.
+    const result = evaluate(lawEntry, { [keyField]: keyValue }, [input]);
     return result.ok ? result.outputs?.[input] ?? null : null;
   } catch {
     return null;
@@ -627,7 +644,7 @@ function submitClaim({
   // engine, en niet in elk scherm apart. Al bestaande correcties tellen niet
   // mee: de oude waarde is wat er stond, niet wat een eerdere correctie er al
   // van gemaakt had.
-  const oldValueResolved = oldValue ?? currentValueOf(lawId, input, bsn);
+  const oldValueResolved = oldValue ?? currentValueOf(lawId, input, keyField, keyValue);
   // A value no register holds is the citizen's own declaration and applies at
   // once; a correction of a register value waits for the caseworker unless the
   // profile auto-approves. An appeal to a hardship clause always needs a human,

--- a/frontend-demo/src/store/demoStore.js
+++ b/frontend-demo/src/store/demoStore.js
@@ -18,6 +18,7 @@ import {
 } from '../engine/useDemoEngine.js';
 import { DELEGATION_TYPE_LABELS, delegationKey, delegationsFor, maySubmitClaims } from '../data/delegation.js';
 import { verdictOf } from '../data/format.js';
+import { driftOf } from '../data/caseDrift.js';
 
 const STORAGE_KEY = 'rr-demo-state-v1';
 
@@ -31,7 +32,11 @@ function defaultState() {
   return {
     profileKey: null, // null = config default
     referenceDate: today(),
-    manualReview: true,
+    // Uit, zoals in de POC (`SAMPLE_RATE = 0.0`): een aanvraag waarbij de
+    // burger niets gewijzigd heeft, rekent de wet zelf af en wordt direct
+    // toegekend. De presentator kan het aanzetten om te laten zien hoe een
+    // behandelaar dezelfde zaak ziet.
+    manualReview: false,
     cases: [],
     claims: [],
     presenterName: '',
@@ -452,6 +457,53 @@ function submitCase(lawEntry, evaluation, params = personaParams()) {
   return c;
 }
 
+/**
+ * De burger dient dezelfde aanvraag opnieuw in, met de gegevens zoals ze nu
+ * zijn. Dat is de POC's `Case.reset`: geen tweede zaak naast de eerste, maar
+ * dezelfde zaak die opnieuw door dezelfde beoordeling gaat, met het verloop
+ * dat eraan vastzit intact.
+ *
+ * Dit is de weg terug uit `caseDrift`. Dat een gewijzigde aanvraag daarna
+ * vrijwel altijd bij een behandelaar terechtkomt, is geen keuze van de demo:
+ * er ligt een wijziging die nog niet is goedgekeurd, en daar hoort iemand
+ * naar te kijken.
+ */
+function resubmitCase(caseId, evaluation, params = personaParams()) {
+  const c = state.cases.find((x) => x.id === caseId);
+  if (!c || !evaluation?.ok) return null;
+  const verdict = verdictOf(evaluation.outputs);
+  const undecided = verdict === 'unknown';
+  const requirementsMet = verdict === null || verdict === true;
+  // Per BSN, niet per wet: de wijziging die deze zaak raakt kan bij een
+  // andere regeling zijn opgegeven. Dat is precies het geval waar dit voor is.
+  const pendingClaims = state.claims.filter((cl) => cl.bsn === c.bsn && cl.status === 'PENDING');
+  const needsReview = state.manualReview || pendingClaims.length > 0 || undecided;
+  c.parameters = params;
+  c.claimedResult = evaluation.outputs ?? {};
+  c.verifiedResult = null;
+  c.status = needsReview ? 'IN_REVIEW' : 'DECIDED';
+  c.approved = needsReview ? null : requirementsMet;
+  c.reason = needsReview ? null : requirementsMet ? 'Automatisch toegekend op basis van de wet.' : 'Voldoet niet aan de voorwaarden.';
+  c.decidedAt = needsReview ? null : nowIso();
+  c.events.push({ at: nowIso(), type: 'SUBMITTED', text: 'Aanvraag gewijzigd door de burger.' });
+  c.events.push(
+    needsReview
+      ? {
+          at: nowIso(),
+          type: 'IN_REVIEW',
+          text: pendingClaims.length
+            ? 'Handmatige beoordeling: de burger heeft gegevens gewijzigd.'
+            : undecided
+              ? 'Handmatige beoordeling: de wet kan nog geen uitkomst geven, er ontbreken gegevens.'
+              : 'Handmatige beoordeling (steekproef).',
+        }
+      : { at: nowIso(), type: 'DECIDED', text: requirementsMet ? 'Automatisch toegekend.' : 'Automatisch afgewezen.' },
+  );
+  for (const claim of pendingClaims) if (!claim.caseId) claim.caseId = c.id;
+  reregister();
+  return c;
+}
+
 function decideCase(caseId, approved, reason, verifiedResult = null) {
   const c = state.cases.find((x) => x.id === caseId);
   if (!c) return;
@@ -489,6 +541,46 @@ function decideObjection(caseId, upheld, reason) {
   if (upheld) c.approved = !c.approved;
   c.events.push({ at: nowIso(), type: 'OBJECTION_DECIDED', text: `Bezwaar ${upheld ? 'gegrond' : 'ongegrond'}: ${reason}` });
   reregister();
+}
+
+/**
+ * Wat een lopende aanvraag nog waard is, gegeven wat er ná het indienen is
+ * gewijzigd. De vergelijking zelf staat in `data/caseDrift.js`; hier wordt
+ * alleen de zaak erbij gezocht.
+ */
+function caseDrift(lawEntry, evaluation, subject = null) {
+  // De behandelaar heeft de zaak al in handen en geeft hem mee; de portal
+  // zoekt hem op bij het huidige onderwerp.
+  return driftOf(subject?.id ? subject : findCase(lawEntry, subject), evaluation);
+}
+
+/**
+ * De waarde die nu geldt voor één gegeven van één wet, zónder de correcties
+ * die er al liggen.
+ *
+ * Nodig om bij een nieuwe correctie vast te leggen wat er stond. Dat kan niet
+ * uit de gewone doorrekening komen: die telt openstaande correcties mee
+ * (`claimsForEngine`), dus daar staat de nieuwe waarde al in en zou "oud"
+ * hetzelfde zijn als "nieuw". De correctiebron gaat er daarom even af en
+ * daarna weer op.
+ *
+ * `null` als het niet lukt — een wet die niet doorrekent mag een correctie niet
+ * tegenhouden; er is dan alleen niets om doorgestreept te tonen.
+ */
+function currentValueOf(lawId, input, bsn = subjectBsn()) {
+  const lawEntry = corpus.value?.lawById(lawId);
+  if (!engine.value || !lawEntry) return null;
+  try {
+    registerClaims(engine.value, []);
+    const result = evaluate(lawEntry, { bsn }, [input]);
+    return result.ok ? result.outputs?.[input] ?? null : null;
+  } catch {
+    return null;
+  } finally {
+    // Altijd terugzetten: zonder dit rekent de rest van de demo verder zonder
+    // de correcties van de burger.
+    registerClaims(engine.value, claimsForEngine());
+  }
 }
 
 // ---- claims ----------------------------------------------------------------
@@ -529,6 +621,13 @@ function submitClaim({
   approve = null,
 }) {
   const acting = claimant === 'BEHANDELAAR' ? null : actingOn();
+  // Wat er stond vóór deze correctie. De aanroeper weet dat niet altijd — de
+  // wijzigingswizard kent alleen wat de burger invult — en zonder die waarde
+  // valt er later niets te tonen dan "0 → 0". Ze wordt hier uitgerekend, bij de
+  // engine, en niet in elk scherm apart. Al bestaande correcties tellen niet
+  // mee: de oude waarde is wat er stond, niet wat een eerdere correctie er al
+  // van gemaakt had.
+  const oldValueResolved = oldValue ?? currentValueOf(lawId, input, bsn);
   // A value no register holds is the citizen's own declaration and applies at
   // once; a correction of a register value waits for the caseworker unless the
   // profile auto-approves. An appeal to a hardship clause always needs a human,
@@ -542,7 +641,7 @@ function submitClaim({
     input,
     keyField,
     keyValue,
-    oldValue,
+    oldValue: oldValueResolved,
     newValue,
     reason,
     evidence,
@@ -609,7 +708,9 @@ export function useDemo() {
     isLawEnabled,
     evaluate,
     findCase,
+    caseDrift,
     submitCase,
+    resubmitCase,
     decideCase,
     moveCase,
     objectToCase,

--- a/frontend-demo/src/store/demoStore.js
+++ b/frontend-demo/src/store/demoStore.js
@@ -19,6 +19,7 @@ import {
 import { DELEGATION_TYPE_LABELS, delegationKey, delegationsFor, maySubmitClaims } from '../data/delegation.js';
 import { verdictOf } from '../data/format.js';
 import { driftOf } from '../data/caseDrift.js';
+import { assignClaimOwnership } from '../data/claimOwnership.js';
 
 const STORAGE_KEY = 'rr-demo-state-v1';
 
@@ -499,16 +500,11 @@ function resubmitCase(caseId, evaluation, params = personaParams()) {
         }
       : { at: nowIso(), type: 'DECIDED', text: requirementsMet ? 'Automatisch toegekend.' : 'Automatisch afgewezen.' },
   );
-  // Alleen de correcties die bij déze regeling horen komen aan deze zaak te
-  // hangen. De lijst hierboven is met opzet breder — een wijziging bij een
-  // andere regeling telt mee voor de vraag óf er beoordeeld moet worden — maar
-  // eigenaarschap is iets anders dan aanleiding. Zonder dit onderscheid raakt
-  // een correctie die bij een heel andere tegel is opgegeven voorgoed aan deze
-  // zaak vast (`if (!claim.caseId)` zet hem maar één keer), en staat hij in het
-  // dossier van een besluit waar hij niets mee te maken heeft.
-  for (const claim of pendingClaims) {
-    if (!claim.caseId && claim.tileLawId === c.lawId) claim.caseId = c.id;
-  }
+  // De lijst hierboven is met opzet breder dan deze regeling — een wijziging
+  // bij een andere regeling telt mee voor de vraag óf er beoordeeld moet
+  // worden — maar eigenaarschap is iets anders dan aanleiding. Zie
+  // `assignClaimOwnership`.
+  assignClaimOwnership(pendingClaims, c);
   reregister();
   return c;
 }

--- a/frontend-demo/src/views/ZaaksysteemView.vue
+++ b/frontend-demo/src/views/ZaaksysteemView.vue
@@ -140,6 +140,26 @@ function decideObjection(upheld) {
   reason.value = '';
 }
 
+/**
+ * De zaken op dit bord die niet meer kloppen met wat de wet nu zegt.
+ *
+ * Dezelfde vergelijking als in de portal (`caseDrift`), maar dan vanaf de
+ * andere kant: een behandelaar moet kunnen zien dát er iets is veranderd
+ * zonder elke zaak open te klikken. Alleen de zaken van deze organisatie, dus
+ * het rekenwerk blijft beperkt tot wat op het scherm staat.
+ */
+const driftedIds = computed(() => {
+  void dataVersion.value;
+  const ids = new Set();
+  for (const c of cases.value) {
+    const law = lawOf(c);
+    if (!law) continue;
+    const evaluation = demo.evaluate(law, c.parameters);
+    if (demo.caseDrift(law, evaluation, c)) ids.add(c.id);
+  }
+  return ids;
+});
+
 function laneTag(c) {
   if (c.status === 'DECIDED') return c.approved ? { color: 'success', text: 'Toegekend' } : { color: 'critical', text: 'Afgewezen' };
   if (c.objection?.status === 'PENDING') return { color: 'warning', text: 'Bezwaar' };
@@ -182,6 +202,10 @@ function claimLawName(cl) {
                          per letter. In the overline the title keeps the whole card width. -->
                     <nldd-text-cell :text="c.lawName" :supporting-text="`${personaName(c.bsn)} · ${formatDateTime(c.submittedAt)}`">
                       <nldd-tag slot="overline" size="sm" :color="laneTag(c).color" :text="laneTag(c).text"></nldd-tag>
+                      <!-- Er is een gegeven gewijzigd waarmee deze wet nu op iets
+                           anders uitkomt dan waarop besloten is. Het besluit staat
+                           nog; dit zegt alleen dat ernaar gekeken moet worden. -->
+                      <nldd-tag v-if="driftedIds.has(c.id)" slot="overline" size="sm" color="warning" icon="warning" text="Gewijzigd"></nldd-tag>
                     </nldd-text-cell>
                   </nldd-list-item>
                 </nldd-list>


### PR DESCRIPTION
Een aanvraag waarbij de burger niets heeft gewijzigd, ging altijd naar een behandelaar: `manualReview` stond standaard aan. In de POC staat diezelfde schakelaar uit (`SAMPLE_RATE = 0.0`). De zorgtoeslag van een persona die niets aanpast, wordt nu meteen toegekend; "Alle aanvragen handmatig beoordelen" blijft als presentatieknop bestaan.

Daarnaast bewoog na een wijziging elke regeling mee, behalve de regeling waarvoor al een besluit lag. Die bleef "Toegekend" tonen bij een bedrag dat niet meer klopte.

## Hoe

De vergelijking staat in `frontend-demo/src/data/caseDrift.js` en volgt de POC: geen herberekening die iets beslist, maar wat de burger aanvroeg (`claimedResult`) naast wat de wet nú uitrekent, met de tolerantie van 1% uit `CaseManager._results_match`. Een besluit is een vaststelling op een moment; er hoort niets achter de rug van de burger om herrekend te worden. Wat wél moet gebeuren is dat hij ziet dat het niet meer klopt, en dat hij er iets aan kan doen.

Het werkt over de hele breedte omdat correcties per BSN staan en niet per wet: een inkomenswijziging die bij de huurtoeslag is opgegeven, verandert vanzelf de uitkomst van elke andere wet die datzelfde inkomen gebruikt. Geen enkele regeling wordt bij naam gekend, en ook de zin die de burger leest komt uit de wet zelf. De POC had die zin achtmaal overgeschreven met per regeling het veld erin gehardcodeerd.

Te zien op drie plekken, alle drie uit dezelfde functie:

- een waarschuwing op de tegel, boven de uitkomst en niet in plaats daarvan;
- het verschil per uitkomst in de aanvraag, met een knop om te wijzigen (`resubmitCase`, de POC's `Case.reset`: dezelfde zaak opnieuw door dezelfde beoordeling, met het verloop intact);
- een tag "Gewijzigd" op het bord van de behandelaar, zodat die het ziet zonder elke zaak open te klikken.

Uitkomsten die de wet niet kón bepalen (RFC-036) tellen niet mee: een openstaande vraag is geen veranderd recht.

## Verder in dezelfde weg gevonden

- De inklapper in "Gebruikte gegevens" klapte zijn ouder dicht zodra je een geneste rij opende. De kinderen van een rij staan ín die rij (`slot="children"`), dus elke klik bereikte ook elke rij erboven. Hetzelfde gold voor het corrigeren van een waarde: dat klapte het hele paneel dicht.
- Bij een openstaande correctie stond tweemaal hetzelfde bedrag ("€ 0,00 → € 0,00"). De engine rekent openstaande correcties al mee, dus de getoonde waarde ís de nieuwe. De oude waarde komt nu van de correctie zelf, en waar de aanroeper die niet kent (de wijzigingswizard) zoekt de store hem op met de correctiebron even uitgeschakeld.

## Getest

14 nieuwe tests op de vergelijking, met uitkomstnamen uit verschillende wetten, omdat juist dát de eigenschap is die bewezen moet worden. Verder handmatig doorgelopen in de draaiende demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULJcLPEhP1qnSfyJJfafuC
