### PR TITLE
docs: werkpakket aansluiten op bronnen (chronolexografie) uitwerken

### DIFF
--- a/docs/src/content/roadmap/werkpakketten/3cf6a77e-2a9b-46a8-987c-10e72e8cc1a0.md
+++ b/docs/src/content/roadmap/werkpakketten/3cf6a77e-2a9b-46a8-987c-10e72e8cc1a0.md
@@ -69,5 +69,6 @@ rfcs:
   - 10
   - 13
   - 20
-samenhangIds: []
+samenhangIds:
+  - fc7dd6ea-69a9-4926-84d0-edf998fc0271
 ---

--- a/docs/src/content/roadmap/werkpakketten/61523500-1eb0-4141-95fb-dbbd10be9a72.md
+++ b/docs/src/content/roadmap/werkpakketten/61523500-1eb0-4141-95fb-dbbd10be9a72.md
@@ -38,5 +38,6 @@ rfcs:
   - 19
   - 20
   - 22
-samenhangIds: []
+samenhangIds:
+  - fc7dd6ea-69a9-4926-84d0-edf998fc0271
 ---

--- a/docs/src/content/roadmap/werkpakketten/7e100a8c-672a-4cb1-ace9-114c1df9afd1.md
+++ b/docs/src/content/roadmap/werkpakketten/7e100a8c-672a-4cb1-ace9-114c1df9afd1.md
@@ -14,5 +14,6 @@ onderzoek: ''
 bouw: ''
 rfcs: []
 onderzoeksvragen: []
-samenhangIds: []
+samenhangIds:
+  - fc7dd6ea-69a9-4926-84d0-edf998fc0271
 ---

--- a/docs/src/content/roadmap/werkpakketten/ca65747a-023d-4add-ab74-af1d275e13b3.md
+++ b/docs/src/content/roadmap/werkpakketten/ca65747a-023d-4add-ab74-af1d275e13b3.md
@@ -38,5 +38,6 @@ onderzoeksvragen:
 onderzoek: open
 bouw: ''
 rfcs: []
-samenhangIds: []
+samenhangIds:
+  - fc7dd6ea-69a9-4926-84d0-edf998fc0271
 ---

--- a/docs/src/content/roadmap/werkpakketten/fc7dd6ea-69a9-4926-84d0-edf998fc0271.md
+++ b/docs/src/content/roadmap/werkpakketten/fc7dd6ea-69a9-4926-84d0-edf998fc0271.md
@@ -3,16 +3,108 @@ id: fc7dd6ea-69a9-4926-84d0-edf998fc0271
 titel: Aansluiten op bronnen (chronolexografie)
 faseId: wat
 disciplineId: techniek
-prioriteit: ''
-omvang: ''
-categorie: ''
-capability: ''
-capaciteit: ''
-toelichting: ''
+prioriteit: hoog
+omvang: L
+categorie: bet
+capability: implementeren
+capaciteit: 1 architect + 1 engineer; aan uitvoerderskant 1 domeinexpert en 1
+  IT-contact in een wekelijks ritme
+toelichting: |-
+  Een uitvoerbare specificatie levert pas iets op als ze tegen echte feiten
+  draait. Het corpus bevat de wet en de engine rekent een geval door, maar de
+  gegevens waarop dat geval berust liggen bij uitvoeringsorganisaties in
+  systemen die het artikel niet kennen waaruit een bedrag volgt. De burger die
+  dat bedrag krijgt ziet de grondslag niet, de invoer niet, en niet tot wanneer
+  welk rechtsmiddel openstaat.
+
+  Chronolexografie levert hiervoor het begrippenkader: drie soorten vastlegging
+  die nu in gescheiden systemen zitten (het **lexogram**, een wijziging in
+  regelgeving; het **decretogram**, een besluit; het **executogram**, een feit
+  als een betaling of kwijtschelding), gehouden in een **cel** waarin een
+  organisatie haar eigen feiten bijhoudt. Elke vastlegging is procesrelatief:
+  niet "deze persoon woont hier" maar "op moment T heeft X vastgesteld dat".
+  [RFC-022](/rfcs/rfc-022) legt vast hoe dat op RegelRecht landt en staat op
+  Draft; dit werkpakket neemt die status weg of weerlegt hem.
+
+  De eerste aansluiting is een Blauwe-Knop-source: data blijft bij de bron,
+  aggregatie gebeurt on-device. Wat ontbreekt is juridische provenance per
+  vordering. Het [pilotvoorstel](/concepts/cjib-blauwe-knop-source-proposal) zet
+  een engine achter zo'n source, te beginnen bij de Wahv, die *lex specialis* is
+  en dus meteen toetst of de rechtsmiddel-route uit de procedure wordt afgeleid
+  in plaats van ergens ingebakken te zitten.
+
+  **Klaar** als voor één wet bij één organisatie de keten sluit en een
+  domeinexpert bevestigt dat bedrag, termijn en route overeenkomen met het
+  bestaande systeem: een lexogram in het corpus, een chronicle-stream met
+  betaling, kwijtschelding en deurwaardertraject, een draaiende source in een
+  afgeschermde omgeving, en een per artikel gedocumenteerde mapping waarin de
+  mismatches benoemd staan. **Eerstvolgende actie**: een werksessie met de
+  uitvoeringsorganisatie, het team achter de standaard en BZK om de pilotwet
+  vast te pinnen en de rechtsmiddel-routing per type vordering uit te werken.
+  Daarna RFC-022 afmaken, het lexogram en de chronicle-stream schrijven, de
+  source in een sandbox aanzetten, en drie maanden vergelijken.
+
+  **De drie grootste risico's.** Het staat of valt met een uitvoeringsorganisatie
+  die meedoet; zonder domeinexpert en sandbox is er geen baseline en blijft dit
+  een architectuuroefening. De uitvoering onder mandaat kan onmodelleerbaar
+  blijken, waar het rechtsmiddel juridisch naar de opdrachtgever wijst terwijl de
+  burger de uitvoerder belt, en beide moeten kloppen in hetzelfde antwoord; dat
+  is daarom een go/no-go na de baseline. En RFC-022 leunt op RFC-008, RFC-009 en
+  RFC-013 op punten die nog open staan, waarvan het sleutelhergebruik tussen
+  federatie-signing en response-signing een echte beveiligingsvraag is: één wet
+  bij één organisatie toont die afhankelijkheden aan maar put ze niet uit.
 volgorde: 6000
-onderzoek: ''
-bouw: ''
-rfcs: []
-onderzoeksvragen: []
-samenhangIds: []
+onderzoeksvragen:
+  - vraag: >-
+      Wat moet een uitvoeringsorganisatie vastleggen opdat een besluit achteraf
+      reproduceerbaar is: welk feit, door wie vastgesteld, op welke grondslag, op
+      welk moment en via welk kanaal binnengekomen?
+    paper: sec:versionedartifact
+  - vraag: >-
+      Welke feiten hoort een organisatie te registreren als procesrelatieve
+      vaststelling in plaats van als actuele toestand, en wat kost het om een
+      bestaand systeem die kant op te bewegen?
+    paper: sec:versioning
+  - vraag: >-
+      Hoe leidt een engine de rechtsmiddel-route af uit de procedure die een
+      besluit heeft voortgebracht, wanneer die route per wet verschilt en niet
+      altijd Awb-bezwaar is?
+    paper: sec:lifecycle
+  - vraag: >-
+      Wat moet er in een antwoord aan een burger meereizen opdat hij de
+      onderbouwing van een vordering zelf kan nagaan: grondslag, invoer, trace,
+      en de werkelijke einddatum van zijn rechtsmiddel?
+    paper: sec:traceaccess
+  - vraag: >-
+      Waar hoort het bezwaar juridisch thuis bij een vordering die de ene
+      organisatie int namens de andere, waar komt het feitelijk terecht, en
+      kunnen beide kloppen in één antwoord?
+    paper: sec:relying
+  - vraag: >-
+      Wat is de juiste eenheid van autonomie bij het vastleggen van feiten, en
+      wat hoort daar juist niet aan vast te zitten: bevoegd gezag, sleutels,
+      transportkeuze?
+    paper: sec:crossorg
+  - vraag: >-
+      Blijft de decentrale opzet houdbaar wanneer er meer organisaties
+      aansluiten, of ontstaat er alsnog een punt waar het totaalbeeld samenkomt?
+    paper: sec:pathoptimization
+  - >-
+    Wat is er nodig om twee bronnen voor dezelfde vordering naast elkaar te laten
+    draaien zonder dat de burger die vordering dubbel ziet?
+onderzoek: loopt
+bouw: niet
+rfcs:
+  - 2
+  - 7
+  - 8
+  - 9
+  - 10
+  - 13
+  - 22
+samenhangIds:
+  - 61523500-1eb0-4141-95fb-dbbd10be9a72
+  - 3cf6a77e-2a9b-46a8-987c-10e72e8cc1a0
+  - 7e100a8c-672a-4cb1-ace9-114c1df9afd1
+  - ca65747a-023d-4add-ab74-af1d275e13b3
 ---


### PR DESCRIPTION
Het werkpakket "Aansluiten op bronnen (chronolexografie)" stond leeg op de roadmap: alleen een titel, een fase en een discipline. Dit is de uitwerking, conform de opdracht van de teamdag.

De inhoud komt uit wat er al ligt, [RFC-022](https://github.com/MinBZK/regelrecht/blob/main/docs/src/content/rfcs/rfc-022.md) en het [CJIB-pilotvoorstel](https://github.com/MinBZK/regelrecht/blob/main/docs/src/content/docs/concepts/cjib-blauwe-knop-source-proposal.md), niet uit nieuwe bedenksels: de drie typen vastlegging (lexogram, decretogram, executogram), de cel als containment-domein los van bevoegd gezag en veiligheidscontext, en een Blauwe-Knop-source als eerste concrete aansluiting.

## Wat erin zit

**Acht onderzoeksvragen, vooraan**, zeven ervan gekoppeld aan een sectie van *Rules as Executed* (§4.5, §4.8, §4.10, §4.11, §4.12, §7.1, §9.4). De achtste, over deduplicatie tussen twee parallel draaiende bronnen, is te operationeel voor het paper en blijft een gewone string.

**Een toelichting** met de definition of done (keten sluit voor één wet bij één organisatie, gevalideerd door een domeinexpert), de eerstvolgende actie (een werksessie met de uitvoeringsorganisatie, het team achter de standaard en BZK), het stappenplan op hoofdlijnen, en de drie grootste risico's: geen deelnemende uitvoeringsorganisatie, uitvoering onder mandaat die niet te modelleren blijkt, en de open punten in de RFC's waar RFC-022 op leunt.

**De categorieën** voor zover ze te onderbouwen zijn: prioriteit hoog, omvang L, capability implementeren, categorie bet, en capaciteit als vrije tekst. Onderzoek staat op `loopt` en bouw op `niet`, want RFC-022 is Draft en niet geïmplementeerd.

**Samenhang aan beide kanten** met effect over tijd, de verkenning publicatievoorziening, de lakmoesproef met de execution trace, en rechtsbescherming en de execution trace. `samenhangIds` is eenrichtingsverkeer, dus de backlink staat er handmatig bij; dat verklaart de vier eenregelige wijzigingen.

## Lengte

Bewust compact gehouden, in lijn met de rest van de roadmap: de mediaan-toelichting is daar ongeveer tien regels. Wie de details wil, klikt door naar RFC-022 of het pilotvoorstel; die staan er al en hoeven hier niet overgeschreven te worden.

`just docs-build` is groen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oXFQuk1vxShcewR9fyUuS