### PR TITLE
docs: onderzoeksvragen bij analyseren, en RFC-036 en RFC-037 koppelen

### DIFF
--- a/docs/src/content/roadmap/werkpakketten/11d2326e-e367-4c35-a1f4-084331855cf1.md
+++ b/docs/src/content/roadmap/werkpakketten/11d2326e-e367-4c35-a1f4-084331855cf1.md
@@ -93,12 +93,49 @@ toelichting: >-
   dichten? (Door suggesties over het hele corpus te aggregeren, kan men bepalen
   welke functies prioriteit hebben voor ontwikkeling).
 volgorde: 1000
-onderzoeksvragen: []
+onderzoeksvragen:
+  - vraag: >-
+      Wat moet de afhankelijkheidsgraaf vastleggen om analyse over
+      samenhangende regelingen heen mogelijk te maken: bevoegdheid, delegatie,
+      terugwerkende kracht, en verwijzingen over organisatiegrenzen?
+    paper: sec:depgraphs
+  - vraag: >-
+      Is een verwijzing tussen regelingen expliciet in de tekst vermeld, of is
+      het een interpretatiestap die een uitvoeringsorganisatie ongemerkt zelf
+      zet, en hoe maken we dat verschil zichtbaar?
+    paper: sec:depgraphs
+  - vraag: >-
+      Welke van de vier structurele defecten (gaten, tegenstrijdigheden, dode
+      takken, volgorde-gevoeligheid) zijn binnen één specificatie beslisbaar, en
+      welke worden onhaalbaar zodra regelingen elkaar op datum oplossen?
+    paper: sec:structuralanalysis
+  - vraag: >-
+      Wat kan een analyse over het hele corpus zeggen dat een analyse per
+      regeling niet kan, bijvoorbeeld over uiteenlopende definities van hetzelfde
+      begrip in verschillende wetten?
+    paper: sec:structuralanalysis
+  - vraag: >-
+      Welke klassen van vertaalfouten vangen de reverse pass, de fidelity audit
+      en de drift check daadwerkelijk, en welke fout blijft staan wanneer een
+      codering foutloos draait maar iets anders betekent dan het artikel?
+    paper: sec:translation
+  - vraag: >-
+      Welke review-inspanning per artikel is nodig voor verdedigbare adoptie van
+      een machinaal gemaakte codering, en wat is het gemeten foutprofiel ervan
+      tegenover een codering door juridische experts?
+    paper: sec:translation
+  - vraag: >-
+      Welke operaties moeten aan het formaat worden toegevoegd om een bepaling
+      uitdrukbaar te maken die dat nu niet is, en hoe bepaalt aggregatie van
+      untranslatables over het corpus welke daarvan voorrang krijgen?
+    paper: sec:untranslatables
 onderzoek: loopt
 bouw: deels
 rfcs:
   - 3
   - 12
   - 35
-samenhangIds: []
+samenhangIds:
+  - 9f359af7-a6f1-4af3-bdb5-f038ce871325
+  - 992fa816-63d2-4ca9-a768-25af6d8d1991
 ---

--- a/docs/src/content/roadmap/werkpakketten/992fa816-63d2-4ca9-a768-25af6d8d1991.md
+++ b/docs/src/content/roadmap/werkpakketten/992fa816-63d2-4ca9-a768-25af6d8d1991.md
@@ -56,4 +56,5 @@ onderzoek: loopt
 samenhangIds:
   - 413459cd-4f34-48f2-9fbd-ae4ad2dbf67b
   - 9f359af7-a6f1-4af3-bdb5-f038ce871325
+  - 11d2326e-e367-4c35-a1f4-084331855cf1
 ---

--- a/docs/src/content/roadmap/werkpakketten/9f359af7-a6f1-4af3-bdb5-f038ce871325.md
+++ b/docs/src/content/roadmap/werkpakketten/9f359af7-a6f1-4af3-bdb5-f038ce871325.md
@@ -47,6 +47,9 @@ rfcs:
   - 21
   - 23
   - 24
+  - 36
+  - 37
 samenhangIds:
   - 413459cd-4f34-48f2-9fbd-ae4ad2dbf67b
+  - 11d2326e-e367-4c35-a1f4-084331855cf1
 ---


### PR DESCRIPTION
Twee gaten in de roadmap die naast elkaar liggen en samen klein zijn.

## 1. "Analyseren van wet- en regelgeving" had geen onderzoeksvragen

Dit werkpakket had de langste toelichting van de hele roadmap (85 regels) en als enige nul onderzoeksvragen. De doelen stonden er wel al in, maar als opsommingen middenin het lopende proza onder de vier categorieën. Die staan nu in het veld dat ervoor is, elk gekoppeld aan een sectie van *Rules as Executed*:

| Onderwerp | Paper |
|---|---|
| Wat de afhankelijkheidsgraaf moet vastleggen (bevoegdheid, delegatie, terugwerkende kracht) | §5.1 |
| Expliciete verwijzing versus ongemerkte interpretatiestap | §5.1 |
| Welke van de vier structurele defecten beslisbaar blijven zodra regelingen op datum oplossen | §5.2 |
| Wat corpus-brede analyse kan zeggen dat analyse per regeling niet kan | §5.2 |
| Welke vertaalfouten de reverse pass, fidelity audit en drift check echt vangen | §5.3 |
| Review-inspanning per artikel en het gemeten foutprofiel tegenover expert-codering | §5.3 |
| Welke operaties het formaat mist, en hoe aggregatie van untranslatables prioriteert | §5.4 |

`sec:structuralanalysis` hing nog aan geen enkel werkpakket, terwijl het precies over dit werkpakket gaat.

De toelichting zelf is niet aangeraakt. De vragen dupliceren de opsommingen daarin deels; dat leek me beter dan de toelichting herschrijven in dezelfde PR.

## 2. RFC-036 en RFC-037 hingen nergens

Dit waren de laatste twee `Implemented` RFC's zonder werkpakket, de enige twee die `check-roadmap-rfcs.mjs` nog meldde. Beide gaan over het formaat en wat daar statisch over te bewijzen valt (afwezige en onbekende waarden, type checking), dus ze horen bij "Specificatie machine-uitvoerbare regels I", dat al RFC 1, 2, 4, 11, 16, 21, 23 en 24 draagt en naar §9.2 wijst.

Na deze PR:

```
Roadmap-RFC-dekking: alle 18 geïmplementeerde RFC(s) hangen aan een werkpakket (RFC-000 uitgezonderd).
```

## Samenhang

Analyseren is nu wederzijds verbonden met Specificatie I (dezelfde statische analyse, andere kant) en met Discretionaire ruimte (untranslatables). `samenhangIds` is eenrichtingsverkeer, vandaar de twee eenregelige wijzigingen in die bestanden.

`just docs-build` is groen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oXFQuk1vxShcewR9fyUuS